### PR TITLE
perf: incompressible-stretch skip-ahead in the lazy matcher (zstd-style)

### DIFF
--- a/Zip/Native/Deflate.lean
+++ b/Zip/Native/Deflate.lean
@@ -1348,6 +1348,47 @@ theorem lazyAcceptCost_lt {len1 dist1 len2 dist2 : Nat}
   simp only [lazyAcceptCost, Bool.and_eq_true, decide_eq_true_eq] at h
   exact h.1
 
+/-! ## Incompressible-stretch skip-ahead literal runs (Wave 8, #2766)
+
+The lazy matcher's skip-ahead (LZ4/zstd-style) advances `pos` by a growing
+`stride` after a run of positions with no match, emitting every skipped byte as
+a literal. `litRun`/`pushLits`/`pushLitsP` are the three representations of "emit
+the literals for `data[pos .. stop)`": a `List` prepend (`litRun`, for the
+recursive reference matcher), and two `Array`-accumulator pushes (`pushLits` for
+boxed tokens, `pushLitsP` for packed `UInt32`). They advance one byte at a time
+and terminate on `stop - pos`, so `stop = pos + 1` (the disabled `skipShift`) is
+exactly the single-literal step the matchers took before this knob existed.
+`pushLits_eq`/`pushLitsP_eq` (in `LZ77ChainLazyCorrect`/`LZ77PackedCorrect`)
+relate the push forms back to `litRun` so the twin equalities carry through. -/
+
+/-- The literals `data[pos], …, data[stop-1]` as a `List` (empty once `pos`
+    reaches `stop` or the buffer end). The prepend form used by the recursive
+    lazy matcher's skip-ahead miss branch. -/
+def litRun (data : ByteArray) (pos stop : Nat) : List LZ77Token :=
+  if h : pos < stop ∧ pos < data.size then
+    .literal (data[pos]'h.2) :: litRun data (pos + 1) stop
+  else []
+termination_by stop - pos
+
+/-- `litRun` pushed onto a boxed-token accumulator (`Array LZ77Token`). Equal to
+    `acc ++ (litRun data pos stop).toArray` (`pushLits_eq`). -/
+def pushLits (acc : Array LZ77Token) (data : ByteArray) (pos stop : Nat) :
+    Array LZ77Token :=
+  if h : pos < stop ∧ pos < data.size then
+    pushLits (acc.push (.literal (data[pos]'h.2))) data (pos + 1) stop
+  else acc
+termination_by stop - pos
+
+/-- `litRun` pushed onto a packed-token accumulator (`Array UInt32`). Each push is
+    `packTok` of the token `pushLits` pushes, so
+    `pushLitsP (acc.map packTok) = (pushLits acc).map packTok` (`pushLitsP_eq`). -/
+def pushLitsP (acc : Array UInt32) (data : ByteArray) (pos stop : Nat) :
+    Array UInt32 :=
+  if h : pos < stop ∧ pos < data.size then
+    pushLitsP (acc.push (packTok (.literal (data[pos]'h.2)))) data (pos + 1) stop
+  else acc
+termination_by stop - pos
+
 /-- Lazy (one-byte-lookahead, zlib `deflate_slow`-style) variant of `lz77Chain`.
     At each position it finds the best chain match `M` at `pos`; before emitting it
     runs a *second* `chainWalk` at `pos+1` for `M'`. It defers — emits a literal at
@@ -1373,20 +1414,32 @@ theorem lazyAcceptCost_lt {len1 dist1 len2 dist2 : Nat}
     before the lookahead walk (you cannot match a position against itself; matches
     zlib, and is correctness-irrelevant). Reuses `lz77Chain`'s `chainWalk`/
     `updateHashes` and `lz77Greedy.trailing`. Equal-quality contracts proven in
-    `LZ77ChainLazyCorrect`. -/
+    `LZ77ChainLazyCorrect`.
+
+    Skip-ahead (LZ4/zstd-style, #2766): a `missStreak` counter tracks consecutive
+    searched positions with no match. On a miss the loop advances by
+    `stride = 1 + (missStreak >>> skipShift)` instead of one byte, emitting the
+    skipped bytes as literals (`litRun`) without inserting them into the chains,
+    and resets `missStreak` to 0 on every match. `skipShift = 63` (the default)
+    makes `missStreak >>> 63 = missStreak / 2^63 = 0` for every reachable streak
+    (a miss run is bounded by `data.size < 2^63` for any real `ByteArray`), so
+    `stride` stays 1 and the output is the pre-skip output. The stride is a pure
+    heuristic — skipped positions are re-findable at the next searched position and
+    every emitted reference is re-verified at emission — so it never enters the
+    correctness proof (the contracts hold for *any* `skipShift`). -/
 def lz77ChainLazy (data : ByteArray) (maxChain : Nat) (windowSize : Nat := 32768)
     (insertCap : Nat := 1000000000) (goodMatch : Nat := 259) (niceLen : Nat := 258)
-    (lazyDepth : Nat := maxChain) :
+    (lazyDepth : Nat := maxChain) (skipShift : Nat := 63) :
     Array LZ77Token :=
   if data.size < 3 then
     (lz77Greedy.trailing data 0).toArray
   else
     let hashSize := 65536
     (mainLoop data windowSize hashSize maxChain
-      (.replicate hashSize data.size) (.replicate (min chainWinSize data.size) data.size) 0 insertCap goodMatch niceLen lazyDepth).toArray
+      (.replicate hashSize data.size) (.replicate (min chainWinSize data.size) data.size) 0 insertCap goodMatch niceLen lazyDepth skipShift 0).toArray
 where
   mainLoop (data : ByteArray) (windowSize hashSize maxChain : Nat)
-      (hashTable : Array Nat) (prev : Array Nat) (pos insertCap goodMatch niceLen lazyDepth : Nat) : List LZ77Token :=
+      (hashTable : Array Nat) (prev : Array Nat) (pos insertCap goodMatch niceLen lazyDepth skipShift missStreak : Nat) : List LZ77Token :=
     if hlt : pos + 2 < data.size then
       let h := lz77Greedy.hash3 data pos hashSize hlt
       let head := headProbeGuarded hashTable h
@@ -1420,43 +1473,55 @@ where
                     lz77Chain.updateHashes data hashSize hashTable prev pos 1 (matchLen2 + 1) insertCap
                   .literal (data[pos]'(by omega)) ::
                     .reference matchLen2 (pos + 1 - matchPos2) ::
-                    mainLoop data windowSize hashSize maxChain hashTable prev (pos + 1 + matchLen2) insertCap goodMatch niceLen lazyDepth
+                    mainLoop data windowSize hashSize maxChain hashTable prev (pos + 1 + matchLen2) insertCap goodMatch niceLen lazyDepth skipShift 0
                 else
                   -- matchLen2 spills past data: keep match at pos
                   have : data.size - (pos + matchLen) < data.size - pos := by omega
                   let (hashTable, prev) :=
                     lz77Chain.updateHashes data hashSize hashTable prev pos 1 matchLen insertCap
                   .reference matchLen (pos - matchPos) ::
-                    mainLoop data windowSize hashSize maxChain hashTable prev (pos + matchLen) insertCap goodMatch niceLen lazyDepth
+                    mainLoop data windowSize hashSize maxChain hashTable prev (pos + matchLen) insertCap goodMatch niceLen lazyDepth skipShift 0
               else
                 -- No better match at pos+1: keep match at pos
                 have : data.size - (pos + matchLen) < data.size - pos := by omega
                 let (hashTable, prev) :=
                   lz77Chain.updateHashes data hashSize hashTable prev pos 1 matchLen insertCap
                 .reference matchLen (pos - matchPos) ::
-                  mainLoop data windowSize hashSize maxChain hashTable prev (pos + matchLen) insertCap goodMatch niceLen lazyDepth
+                  mainLoop data windowSize hashSize maxChain hashTable prev (pos + matchLen) insertCap goodMatch niceLen lazyDepth skipShift 0
             else
               -- Gated: long first match, skip the lookahead; still insert interior hashes.
               have : data.size - (pos + matchLen) < data.size - pos := by omega
               let (hashTable, prev) :=
                 lz77Chain.updateHashes data hashSize hashTable prev pos 1 matchLen insertCap
               .reference matchLen (pos - matchPos) ::
-                mainLoop data windowSize hashSize maxChain hashTable prev (pos + matchLen) insertCap goodMatch niceLen lazyDepth
+                mainLoop data windowSize hashSize maxChain hashTable prev (pos + matchLen) insertCap goodMatch niceLen lazyDepth skipShift 0
           else
             -- Near end of data: keep match at pos
             have : data.size - (pos + matchLen) < data.size - pos := by omega
             .reference matchLen (pos - matchPos) ::
-              mainLoop data windowSize hashSize maxChain hashTable prev (pos + matchLen) insertCap goodMatch niceLen lazyDepth
+              mainLoop data windowSize hashSize maxChain hashTable prev (pos + matchLen) insertCap goodMatch niceLen lazyDepth skipShift 0
         else
+          -- matchLen ≥ 3 but spills past data (unreachable: chainWalk caps at
+          -- maxLen ≤ data.size - pos, so pos + matchLen ≤ data.size always). This
+          -- defensive branch emits one literal and advances one byte; it is neither
+          -- a match (no reference) nor a searched miss (no stride), so it leaves the
+          -- streak as-is rather than resetting or growing it.
           .literal (data[pos]'(by omega)) ::
-            mainLoop data windowSize hashSize maxChain hashTable prev (pos + 1) insertCap goodMatch niceLen lazyDepth
+            mainLoop data windowSize hashSize maxChain hashTable prev (pos + 1) insertCap goodMatch niceLen lazyDepth skipShift missStreak
       else
-        .literal (data[pos]'(by omega)) ::
-          mainLoop data windowSize hashSize maxChain hashTable prev (pos + 1) insertCap goodMatch niceLen lazyDepth
+        -- No match at `pos` (the incompressible-stretch case): skip ahead by
+        -- `stride`, emitting the skipped bytes as literals, and grow the streak.
+        let stride := 1 + (missStreak >>> skipShift)
+        let stop := min data.size (pos + stride)
+        litRun data pos stop ++
+          mainLoop data windowSize hashSize maxChain hashTable prev stop insertCap goodMatch niceLen lazyDepth skipShift (missStreak + 1)
     else
       lz77Greedy.trailing data pos
   termination_by data.size - pos
-  decreasing_by all_goals omega
+  decreasing_by
+    all_goals first
+      | omega
+      | (generalize missStreak >>> skipShift = t; omega)
 
 /-- Iterative (tail-recursive, `Array`-accumulating) version of `lz77ChainLazy`.
     Same output, no stack overflow on large inputs. Reuses `lz77Chain`'s
@@ -1465,17 +1530,17 @@ where
     `lz77ChainLazy` in `LZ77ChainLazyCorrect`. -/
 def lz77ChainLazyIter (data : ByteArray) (maxChain : Nat) (windowSize : Nat := 32768)
     (insertCap : Nat := 1000000000) (goodMatch : Nat := 259) (niceLen : Nat := 258)
-    (lazyDepth : Nat := maxChain) :
+    (lazyDepth : Nat := maxChain) (skipShift : Nat := 63) :
     Array LZ77Token :=
   if data.size < 3 then
     lz77GreedyIter.trailing data 0 #[]
   else
     let hashSize := 65536
-    mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth
-      (.replicate hashSize data.size) (.replicate (min chainWinSize data.size) data.size) 0 #[]
+    mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth skipShift
+      (.replicate hashSize data.size) (.replicate (min chainWinSize data.size) data.size) 0 0 #[]
 where
-  mainLoop (data : ByteArray) (windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth : Nat)
-      (hashTable : Array Nat) (prev : Array Nat) (pos : Nat) (acc : Array LZ77Token) :
+  mainLoop (data : ByteArray) (windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth skipShift : Nat)
+      (hashTable : Array Nat) (prev : Array Nat) (pos missStreak : Nat) (acc : Array LZ77Token) :
       Array LZ77Token :=
     if hlt : pos + 2 < data.size then
       let h := lz77Greedy.hash3 data pos hashSize hlt
@@ -1506,42 +1571,50 @@ where
                   have : data.size - (pos + 1 + matchLen2) < data.size - pos := by omega
                   let (hashTable, prev) :=
                     updateHashesGuarded data hashSize hashTable prev pos 1 (matchLen2 + 1) insertCap
-                  mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth hashTable prev (pos + 1 + matchLen2)
+                  mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth skipShift hashTable prev (pos + 1 + matchLen2) 0
                     (acc.push (.literal (data[pos]'(by omega))) |>.push
                       (.reference matchLen2 (pos + 1 - matchPos2)))
                 else
                   have : data.size - (pos + matchLen) < data.size - pos := by omega
                   let (hashTable, prev) :=
                     updateHashesGuarded data hashSize hashTable prev pos 1 matchLen insertCap
-                  mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth hashTable prev (pos + matchLen)
+                  mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth skipShift hashTable prev (pos + matchLen) 0
                     (acc.push (.reference matchLen (pos - matchPos)))
               else
                 have : data.size - (pos + matchLen) < data.size - pos := by omega
                 let (hashTable, prev) :=
                   updateHashesGuarded data hashSize hashTable prev pos 1 matchLen insertCap
-                mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth hashTable prev (pos + matchLen)
+                mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth skipShift hashTable prev (pos + matchLen) 0
                   (acc.push (.reference matchLen (pos - matchPos)))
             else
               -- Gated: long first match, skip the lookahead; still insert interior hashes.
               have : data.size - (pos + matchLen) < data.size - pos := by omega
               let (hashTable, prev) :=
                 updateHashesGuarded data hashSize hashTable prev pos 1 matchLen insertCap
-              mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth hashTable prev (pos + matchLen)
+              mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth skipShift hashTable prev (pos + matchLen) 0
                 (acc.push (.reference matchLen (pos - matchPos)))
           else
             have : data.size - (pos + matchLen) < data.size - pos := by omega
-            mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth hashTable prev (pos + matchLen)
+            mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth skipShift hashTable prev (pos + matchLen) 0
               (acc.push (.reference matchLen (pos - matchPos)))
         else
-          mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth hashTable prev (pos + 1)
+          -- matchLen ≥ 3 but spills past data (unreachable: chainWalk caps at maxLen).
+          -- Defensive: one literal, neither match nor searched miss, so streak untouched.
+          mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth skipShift hashTable prev (pos + 1) missStreak
             (acc.push (.literal (data[pos]'(by omega))))
       else
-        mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth hashTable prev (pos + 1)
-          (acc.push (.literal (data[pos]'(by omega))))
+        -- No match at `pos`: skip-ahead by `stride`, emitting skipped bytes as literals.
+        let stride := 1 + (missStreak >>> skipShift)
+        let stop := min data.size (pos + stride)
+        mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth skipShift hashTable prev stop (missStreak + 1)
+          (pushLits acc data pos stop)
     else
       lz77GreedyIter.trailing data pos acc
   termination_by data.size - pos
-  decreasing_by all_goals omega
+  decreasing_by
+    all_goals first
+      | omega
+      | (generalize missStreak >>> skipShift = t; omega)
 
 /-! ## Packed-token matcher twins (Wave 3b stage A)
 
@@ -1611,18 +1684,18 @@ where
     Equal to `(lz77ChainLazyIter ..).map packTok` (`lz77ChainLazyIterP_eq`). -/
 def lz77ChainLazyIterP (data : ByteArray) (maxChain : Nat) (windowSize : Nat := 32768)
     (insertCap : Nat := 1000000000) (goodMatch : Nat := 259) (niceLen : Nat := 258)
-    (lazyDepth : Nat := maxChain) :
+    (lazyDepth : Nat := maxChain) (skipShift : Nat := 63) :
     Array UInt32 :=
   if data.size < 3 then
     trailingP data 0 #[]
   else
     let hashSize := 65536
-    mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth
-      (.replicate hashSize data.size) (.replicate (min chainWinSize data.size) data.size) 0
+    mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth skipShift
+      (.replicate hashSize data.size) (.replicate (min chainWinSize data.size) data.size) 0 0
       (Array.emptyWithCapacity data.size)
 where
-  mainLoop (data : ByteArray) (windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth : Nat)
-      (hashTable : Array Nat) (prev : Array Nat) (pos : Nat) (acc : Array UInt32) :
+  mainLoop (data : ByteArray) (windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth skipShift : Nat)
+      (hashTable : Array Nat) (prev : Array Nat) (pos missStreak : Nat) (acc : Array UInt32) :
       Array UInt32 :=
     if hlt : pos + 2 < data.size then
       let h := lz77Greedy.hash3 data pos hashSize hlt
@@ -1656,20 +1729,20 @@ where
                   have : data.size - (pos + 1 + matchLen2) < data.size - pos := by omega
                   let (hashTable, prev) :=
                     updateHashesGuarded data hashSize hashTable prev pos 1 (matchLen2 + 1) insertCap
-                  mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth hashTable prev (pos + 1 + matchLen2)
+                  mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth skipShift hashTable prev (pos + 1 + matchLen2) 0
                     (acc.push (packTok (.literal (data[pos]'(by omega)))) |>.push
                       (packTok (.reference matchLen2 (pos + 1 - matchPos2))))
                 else
                   have : data.size - (pos + matchLen) < data.size - pos := by omega
                   let (hashTable, prev) :=
                     updateHashesGuarded data hashSize hashTable prev pos 1 matchLen insertCap
-                  mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth hashTable prev (pos + matchLen)
+                  mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth skipShift hashTable prev (pos + matchLen) 0
                     (acc.push (packTok (.reference matchLen (pos - matchPos))))
               else
                 have : data.size - (pos + matchLen) < data.size - pos := by omega
                 let (hashTable, prev) :=
                   updateHashesGuarded data hashSize hashTable prev pos 1 matchLen insertCap
-                mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth hashTable prev (pos + matchLen)
+                mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth skipShift hashTable prev (pos + matchLen) 0
                   (acc.push (packTok (.reference matchLen (pos - matchPos))))
             else
               -- Gated: first match already long; skip the lookahead, but still insert
@@ -1677,22 +1750,30 @@ where
               have : data.size - (pos + matchLen) < data.size - pos := by omega
               let (hashTable, prev) :=
                 updateHashesGuarded data hashSize hashTable prev pos 1 matchLen insertCap
-              mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth hashTable prev (pos + matchLen)
+              mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth skipShift hashTable prev (pos + matchLen) 0
                 (acc.push (packTok (.reference matchLen (pos - matchPos))))
           else
             have : data.size - (pos + matchLen) < data.size - pos := by omega
-            mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth hashTable prev (pos + matchLen)
+            mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth skipShift hashTable prev (pos + matchLen) 0
               (acc.push (packTok (.reference matchLen (pos - matchPos))))
         else
-          mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth hashTable prev (pos + 1)
+          -- matchLen ≥ 3 but spills past data (unreachable: chainWalk caps at maxLen).
+          -- Defensive: one literal, neither match nor searched miss, so streak untouched.
+          mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth skipShift hashTable prev (pos + 1) missStreak
             (acc.push (packTok (.literal (data[pos]'(by omega)))))
       else
-        mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth hashTable prev (pos + 1)
-          (acc.push (packTok (.literal (data[pos]'(by omega)))))
+        -- No match at `pos`: skip-ahead by `stride`, emitting skipped bytes as literals.
+        let stride := 1 + (missStreak >>> skipShift)
+        let stop := min data.size (pos + stride)
+        mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth skipShift hashTable prev stop (missStreak + 1)
+          (pushLitsP acc data pos stop)
     else
       trailingP data pos acc
   termination_by data.size - pos
-  decreasing_by all_goals omega
+  decreasing_by
+    all_goals first
+      | omega
+      | (generalize missStreak >>> skipShift = t; omega)
 
 /-- Emit LZ77 tokens as fixed Huffman codes into a BitWriter. -/
 def emitTokens (bw : BitWriter) (tokens : Array LZ77Token) (i : Nat) : BitWriter :=

--- a/Zip/Native/DeflateDynamic.lean
+++ b/Zip/Native/DeflateDynamic.lean
@@ -673,6 +673,25 @@ def niceLen (level : UInt8) : Nat :=
 def lazyDepth (level : UInt8) : Nat :=
   chainDepth level / 2
 
+/-- Incompressible-stretch skip-ahead shift (LZ4/zstd-style, #2766): on a run of
+    positions with no match, the lazy matcher advances by
+    `stride = 1 + (missStreak >>> skipShift)`, emitting the skipped bytes as
+    literals. A larger shift needs a longer miss run before the stride grows, so
+    it is more conservative; `63` disables skip-ahead for every practical input
+    (`missStreak / 2^63 = 0` while the miss run stays below `2^63`, i.e. always).
+
+    Only the lazy tier (levels ≥ 4) consults this; the greedy matcher (1–3) has no
+    miss-streak state. `7` is the measured near-noise setting: on the Silesia
+    binary members (chain 64) it costs ≤0.1 % ratio on x-ray, 0.06 % on mozilla,
+    and nothing on sao or text (the threshold rarely triggers on dense-match
+    data), while cutting the chain-walk cost on incompressible stretches. The
+    stride is a pure heuristic — every emitted reference is re-verified at
+    emission and skipped positions are re-findable at the next searched position —
+    so any value keeps the encoder contracts (`lzMatch_{encodable,resolves,empty}`
+    hold ∀ `skipShift`). -/
+def skipShift (level : UInt8) : Nat :=
+  if 4 ≤ level then 7 else 63
+
 /-- The per-level LZ77 matcher (zlib-faithful): levels 1–3 (`deflate_fast`) use the
     greedy hash-chain matcher; levels ≥ 4 (`deflate_slow`) use the one-byte-lookahead
     lazy variant, which improves ratio at equal window/chain depth. Both share the
@@ -681,7 +700,7 @@ def lazyDepth (level : UInt8) : Nat :=
     choice is transparent to the roundtrip proof. The lazy tier probes its `pos+1`
     lookahead at `lazyDepth` (half-depth), a heuristic knob invisible to the proof. -/
 def lzMatch (data : ByteArray) (level : UInt8) : Array LZ77Token :=
-  if 4 ≤ level then lz77ChainLazyIter data (chainDepth level) 32768 (insertCap level) (goodMatch level) (niceLen level) (lazyDepth level)
+  if 4 ≤ level then lz77ChainLazyIter data (chainDepth level) 32768 (insertCap level) (goodMatch level) (niceLen level) (lazyDepth level) (skipShift level)
   else lz77ChainIter data (chainDepth level) 32768 (insertCap level) (niceLen level)
 
 /-- Packed-token form of `lzMatch` (Wave 3b stage A): the same per-level
@@ -690,7 +709,7 @@ def lzMatch (data : ByteArray) (level : UInt8) : Array LZ77Token :=
     `lzMatch` exactly (`lzMatchP_map` in `Zip/Spec/LZ77PackedCorrect.lean`);
     downstream consumers still run on `lzMatch` — stage B moves them here. -/
 def lzMatchP (data : ByteArray) (level : UInt8) : Array UInt32 :=
-  if 4 ≤ level then lz77ChainLazyIterP data (chainDepth level) 32768 (insertCap level) (goodMatch level) (niceLen level) (lazyDepth level)
+  if 4 ≤ level then lz77ChainLazyIterP data (chainDepth level) 32768 (insertCap level) (goodMatch level) (niceLen level) (lazyDepth level) (skipShift level)
   else lz77ChainIterP data (chainDepth level) 32768 (insertCap level) (niceLen level)
 
 /-! ## Self-contained block-split dynamic compression

--- a/Zip/Spec/DeflateBlockSplit.lean
+++ b/Zip/Spec/DeflateBlockSplit.lean
@@ -34,7 +34,7 @@ theorem lzMatch_encodable (data : ByteArray) (level : UInt8) :
       | .reference len dist => 3 ≤ len ∧ len ≤ 258 ∧ 1 ≤ dist ∧ dist ≤ 32768 := by
   unfold lzMatch
   split
-  · exact lz77ChainLazyIter_encodable data (chainDepth level) 32768 (insertCap level) (goodMatch level) (niceLen level) (lazyDepth level)
+  · exact lz77ChainLazyIter_encodable data (chainDepth level) 32768 (insertCap level) (goodMatch level) (niceLen level) (lazyDepth level) (skipShift level)
       (by omega) (by omega)
   · exact lz77ChainIter_encodable data (chainDepth level) 32768 (insertCap level) (niceLen level)
       (by omega) (by omega)
@@ -43,7 +43,7 @@ theorem lzMatch_empty (data : ByteArray) (level : UInt8) (hz : data.size = 0) :
     lzMatch data level = #[] := by
   unfold lzMatch
   split
-  · exact lz77ChainLazyIter_empty data (chainDepth level) 32768 (insertCap level) (goodMatch level) (niceLen level) (lazyDepth level) hz
+  · exact lz77ChainLazyIter_empty data (chainDepth level) 32768 (insertCap level) (goodMatch level) (niceLen level) (lazyDepth level) (skipShift level) hz
   · exact lz77ChainIter_empty data (chainDepth level) 32768 (insertCap level) (niceLen level) hz
 
 theorem lzMatch_resolves (data : ByteArray) (level : UInt8) :
@@ -51,7 +51,7 @@ theorem lzMatch_resolves (data : ByteArray) (level : UInt8) :
       some data.data.toList := by
   unfold lzMatch
   split
-  · exact lz77ChainLazyIter_resolves data (chainDepth level) 32768 (insertCap level) (goodMatch level) (niceLen level) (lazyDepth level) (by omega)
+  · exact lz77ChainLazyIter_resolves data (chainDepth level) 32768 (insertCap level) (goodMatch level) (niceLen level) (lazyDepth level) (skipShift level) (by omega)
   · exact lz77ChainIter_resolves data (chainDepth level) 32768 (insertCap level) (niceLen level) (by omega)
 
 set_option maxHeartbeats 800000 in

--- a/Zip/Spec/LZ77ChainLazyCorrect.lean
+++ b/Zip/Spec/LZ77ChainLazyCorrect.lean
@@ -20,14 +20,34 @@ open Zip.Native.Deflate (lz77ChainLazy lz77Chain lz77Greedy)
 
 /-! ## Validity -/
 
+/-- Prepending the literal run `data[pos .. stop)` to a valid decomposition from
+    `stop` gives a valid decomposition from `pos` — the skip-ahead miss branch is
+    "more literals before continuing". Mirrors `trailing_valid`, but bounded. -/
+theorem litRun_valid (data : ByteArray) (pos stop : Nat) (rest : List LZ77Token)
+    (hstop : stop ≤ data.size) (hps : pos ≤ stop) (hrest : ValidDecomp data stop rest) :
+    ValidDecomp data pos (litRun data pos stop ++ rest) := by
+  rw [litRun]
+  split
+  · rename_i h
+    rw [List.cons_append]
+    exact .literal h.2 (getElem!_pos data pos h.2)
+      (litRun_valid data (pos + 1) stop rest hstop (by omega) hrest)
+  · rename_i h
+    -- guard false, `pos ≤ stop ≤ data.size` ⇒ `pos = stop`
+    have hpe : pos = stop := by omega
+    rw [List.nil_append, hpe]; exact hrest
+termination_by stop - pos
+decreasing_by omega
+
 set_option backward.split false in
 /-- `lz77ChainLazy.mainLoop` produces a valid decomposition from `pos`. The
     reference cases use `chainWalk_spec` (at `pos`, and again at `pos+1` for the
-    lookahead) exactly as `lz77Chain_mainLoop_valid` does for the single match. -/
+    lookahead) exactly as `lz77Chain_mainLoop_valid` does for the single match.
+    The no-match branch emits the skip-ahead literal run (`litRun_valid`). -/
 theorem lz77ChainLazy_mainLoop_valid (data : ByteArray) (windowSize hashSize maxChain : Nat)
-    (hashTable : Array Nat) (prev : Array Nat) (pos insertCap goodMatch niceLen lazyDepth : Nat) (hw : windowSize > 0) :
+    (hashTable : Array Nat) (prev : Array Nat) (pos insertCap goodMatch niceLen lazyDepth skipShift missStreak : Nat) (hw : windowSize > 0) :
     ValidDecomp data pos
-      (lz77ChainLazy.mainLoop data windowSize hashSize maxChain hashTable prev pos insertCap goodMatch niceLen lazyDepth) := by
+      (lz77ChainLazy.mainLoop data windowSize hashSize maxChain hashTable prev pos insertCap goodMatch niceLen lazyDepth skipShift missStreak) := by
   unfold lz77ChainLazy.mainLoop
   split
   · rename_i hlt
@@ -63,38 +83,43 @@ theorem lz77ChainLazy_mainLoop_valid (data : ByteArray) (windowSize hashSize max
                   · exact .literal (by omega) (getElem!_pos data pos (by omega))
                       (lazyRef_at_pos data (pos + 1) _ _ hQ2.1 (by omega) hle2
                         (fun i hi => hQ2.2.2.2.1 i hi)
-                        (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ _ _ _ hw))
+                        (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ _ _ _ _ _ hw))
                 · exact lazyRef_at_pos data pos _ _ hQ.1 hge hle (fun i hi => hQ.2.2.2.1 i hi)
-                    (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ _ _ _ hw)
+                    (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ _ _ _ _ _ hw)
               · exact lazyRef_at_pos data pos _ _ hQ.1 hge hle (fun i hi => hQ.2.2.2.1 i hi)
-                  (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ _ _ _ hw)
+                  (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ _ _ _ _ _ hw)
             · exact lazyRef_at_pos data pos _ _ hQ.1 hge hle (fun i hi => hQ.2.2.2.1 i hi)
-                (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ _ _ _ hw)
+                (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ _ _ _ _ _ hw)
           · exact lazyRef_at_pos data pos _ _ hQ.1 hge hle (fun i hi => hQ.2.2.2.1 i hi)
-              (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ _ _ _ hw)
+              (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ _ _ _ _ _ hw)
       · exact .literal (by omega) (getElem!_pos data pos (by omega))
-          (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ _ _ _ hw)
-    · exact .literal (by omega) (getElem!_pos data pos (by omega))
-        (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ _ _ _ hw)
+          (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ _ _ _ _ _ hw)
+    · -- No match: skip-ahead literal run to `stop`, then continue.
+      exact litRun_valid data pos _ _ (by generalize missStreak >>> skipShift = t; omega)
+        (by generalize missStreak >>> skipShift = t; omega)
+        (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ _ _ _ _ _ hw)
   · exact trailing_valid data pos
 termination_by data.size - pos
-decreasing_by all_goals omega
+decreasing_by
+  all_goals first
+    | omega
+    | (generalize missStreak >>> skipShift = t; omega)
 
 /-- `lz77ChainLazy` produces a valid decomposition of the input data. -/
-theorem lz77ChainLazy_valid (data : ByteArray) (maxChain windowSize insertCap goodMatch niceLen lazyDepth : Nat)
+theorem lz77ChainLazy_valid (data : ByteArray) (maxChain windowSize insertCap goodMatch niceLen lazyDepth skipShift : Nat)
     (hw : windowSize > 0) :
-    ValidDecomp data 0 (lz77ChainLazy data maxChain windowSize insertCap goodMatch niceLen lazyDepth).toList := by
+    ValidDecomp data 0 (lz77ChainLazy data maxChain windowSize insertCap goodMatch niceLen lazyDepth skipShift).toList := by
   simp only [lz77ChainLazy]
   split
   · simp only; exact trailing_valid data 0
-  · simp only; exact lz77ChainLazy_mainLoop_valid data windowSize 65536 maxChain _ _ 0 insertCap goodMatch niceLen lazyDepth hw
+  · simp only; exact lz77ChainLazy_mainLoop_valid data windowSize 65536 maxChain _ _ 0 insertCap goodMatch niceLen lazyDepth skipShift 0 hw
 
 /-- Resolving the LZ77 tokens produced by `lz77ChainLazy` recovers the original data. -/
-theorem lz77ChainLazy_resolves (data : ByteArray) (maxChain windowSize insertCap goodMatch niceLen lazyDepth : Nat)
+theorem lz77ChainLazy_resolves (data : ByteArray) (maxChain windowSize insertCap goodMatch niceLen lazyDepth skipShift : Nat)
     (hw : windowSize > 0) :
-    Deflate.Spec.resolveLZ77 (tokensToSymbols (lz77ChainLazy data maxChain windowSize insertCap goodMatch niceLen lazyDepth)) [] =
+    Deflate.Spec.resolveLZ77 (tokensToSymbols (lz77ChainLazy data maxChain windowSize insertCap goodMatch niceLen lazyDepth skipShift)) [] =
       some data.data.toList :=
-  validDecomp_resolves data _ (lz77ChainLazy_valid data maxChain windowSize insertCap goodMatch niceLen lazyDepth hw)
+  validDecomp_resolves data _ (lz77ChainLazy_valid data maxChain windowSize insertCap goodMatch niceLen lazyDepth skipShift hw)
 
 /-! ## Encodability -/
 
@@ -104,10 +129,23 @@ private def Enc (t : LZ77Token) : Prop :=
   | .literal _ => True
   | .reference len dist => 3 ≤ len ∧ len ≤ 258 ∧ 1 ≤ dist ∧ dist ≤ 32768
 
+/-- Every token in a skip-ahead literal run is a literal, hence encodable. -/
+private theorem litRun_enc (data : ByteArray) (pos stop : Nat) :
+    ∀ t ∈ litRun data pos stop, Enc t := by
+  rw [litRun]
+  split
+  · intro t ht
+    cases ht with
+    | head => exact True.intro
+    | tail _ h => exact litRun_enc data (pos + 1) stop t h
+  · intro t ht; simp at ht
+termination_by stop - pos
+decreasing_by omega
+
 set_option backward.split false in
 theorem lz77ChainLazy_mainLoop_encodable (data : ByteArray) (windowSize hashSize maxChain : Nat)
-    (hashTable : Array Nat) (prev : Array Nat) (pos insertCap goodMatch niceLen lazyDepth : Nat) (hw : windowSize > 0) (hws : windowSize ≤ 32768) :
-    ∀ t ∈ lz77ChainLazy.mainLoop data windowSize hashSize maxChain hashTable prev pos insertCap goodMatch niceLen lazyDepth, Enc t := by
+    (hashTable : Array Nat) (prev : Array Nat) (pos insertCap goodMatch niceLen lazyDepth skipShift missStreak : Nat) (hw : windowSize > 0) (hws : windowSize ≤ 32768) :
+    ∀ t ∈ lz77ChainLazy.mainLoop data windowSize hashSize maxChain hashTable prev pos insertCap goodMatch niceLen lazyDepth skipShift missStreak, Enc t := by
   unfold lz77ChainLazy.mainLoop
   split
   · rename_i hlt
@@ -146,40 +184,45 @@ theorem lz77ChainLazy_mainLoop_encodable (data : ByteArray) (windowSize hashSize
                     | tail _ h =>
                       cases h with
                       | head => exact ⟨by omega, by omega, by omega, by omega⟩
-                      | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ _ _ _ hw hws t h
+                      | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ _ _ _ _ _ hw hws t h
                 · intro t ht
                   cases ht with
                   | head => exact ⟨hge, by omega, by omega, by omega⟩
-                  | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ _ _ _ hw hws t h
+                  | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ _ _ _ _ _ hw hws t h
               · intro t ht
                 cases ht with
                 | head => exact ⟨hge, by omega, by omega, by omega⟩
-                | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ _ _ _ hw hws t h
+                | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ _ _ _ _ _ hw hws t h
             · intro t ht
               cases ht with
               | head => exact ⟨hge, by omega, by omega, by omega⟩
-              | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ _ _ _ hw hws t h
+              | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ _ _ _ _ _ hw hws t h
           · intro t ht
             cases ht with
             | head => exact ⟨hge, by omega, by omega, by omega⟩
-            | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ _ _ _ hw hws t h
+            | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ _ _ _ _ _ hw hws t h
       · intro t ht
         cases ht with
         | head => trivial
-        | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ _ _ _ hw hws t h
-    · intro t ht
+        | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ _ _ _ _ _ hw hws t h
+    · -- No match: literal run ++ continuation.
+      intro t ht
+      rw [List.mem_append] at ht
       cases ht with
-      | head => trivial
-      | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ _ _ _ hw hws t h
+      | inl h => exact litRun_enc data pos _ t h
+      | inr h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ _ _ _ _ _ hw hws t h
   · intro t ht
     exact trailing_encodable data pos t ht
 termination_by data.size - pos
-decreasing_by all_goals omega
+decreasing_by
+  all_goals first
+    | omega
+    | (generalize missStreak >>> skipShift = t; omega)
 
 /-- Every token `lz77ChainLazy` emits satisfies the encoder bounds. -/
-theorem lz77ChainLazy_encodable (data : ByteArray) (maxChain windowSize insertCap goodMatch niceLen lazyDepth : Nat)
+theorem lz77ChainLazy_encodable (data : ByteArray) (maxChain windowSize insertCap goodMatch niceLen lazyDepth skipShift : Nat)
     (hw : windowSize > 0) (hws : windowSize ≤ 32768) :
-    ∀ t ∈ (lz77ChainLazy data maxChain windowSize insertCap goodMatch niceLen lazyDepth).toList,
+    ∀ t ∈ (lz77ChainLazy data maxChain windowSize insertCap goodMatch niceLen lazyDepth skipShift).toList,
       match t with
       | .literal _ => True
       | .reference len dist => 3 ≤ len ∧ len ≤ 258 ∧ 1 ≤ dist ∧ dist ≤ 32768 := by
@@ -188,18 +231,31 @@ theorem lz77ChainLazy_encodable (data : ByteArray) (maxChain windowSize insertCa
   · intro t ht
     exact trailing_encodable data 0 t ht
   · intro t ht
-    exact lz77ChainLazy_mainLoop_encodable data windowSize 65536 maxChain _ _ 0 insertCap goodMatch niceLen lazyDepth hw hws t ht
+    exact lz77ChainLazy_mainLoop_encodable data windowSize 65536 maxChain _ _ 0 insertCap goodMatch niceLen lazyDepth skipShift 0 hw hws t ht
 
 /-! ## Iterative version: equivalence + transferred contracts -/
 
+/-- The boxed-token push form of a skip-ahead literal run is the accumulator
+    prepended to `litRun` — the accumulator bridge for the miss branch. -/
+theorem pushLits_eq (data : ByteArray) (pos stop : Nat) (acc : Array LZ77Token) :
+    pushLits acc data pos stop = acc ++ (litRun data pos stop).toArray := by
+  rw [pushLits, litRun]
+  split
+  · rename_i h
+    rw [pushLits_eq data (pos + 1) stop, List.toArray_cons,
+      ← Array.append_assoc, Array.push_eq_append]
+  · simp
+termination_by stop - pos
+decreasing_by omega
+
 /-- The iterative lazy chain `mainLoop` is the accumulator form of the recursive
     one — identical branch structure, push vs. cons at each emission (two pushes in
-    the lookahead arm). -/
-private theorem mainLoop_eq_chainLazy (data : ByteArray) (windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth : Nat)
-    (hashTable : Array Nat) (prev : Array Nat) (pos : Nat) (acc : Array LZ77Token) :
-    lz77ChainLazyIter.mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth hashTable prev pos acc =
-    acc ++ (lz77ChainLazy.mainLoop data windowSize hashSize maxChain hashTable prev pos insertCap goodMatch niceLen lazyDepth).toArray := by
-  induction h : data.size - pos using Nat.strongRecOn generalizing pos acc hashTable prev with
+    the lookahead arm, a `litRun`/`pushLits` run in the skip-ahead miss arm). -/
+private theorem mainLoop_eq_chainLazy (data : ByteArray) (windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth skipShift : Nat)
+    (hashTable : Array Nat) (prev : Array Nat) (pos missStreak : Nat) (acc : Array LZ77Token) :
+    lz77ChainLazyIter.mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth skipShift hashTable prev pos missStreak acc =
+    acc ++ (lz77ChainLazy.mainLoop data windowSize hashSize maxChain hashTable prev pos insertCap goodMatch niceLen lazyDepth skipShift missStreak).toArray := by
+  induction h : data.size - pos using Nat.strongRecOn generalizing pos acc hashTable prev missStreak with
   | _ n ih =>
     unfold lz77ChainLazyIter.mainLoop lz77ChainLazy.mainLoop
     simp only [chainWalkGuardedPacked_mod, chainWalkGuardedPacked_div, min258_le_511,
@@ -219,63 +275,63 @@ private theorem mainLoop_eq_chainLazy (data : ByteArray) (windowSize hashSize ma
               · -- matchLen2 > matchLen
                 split
                 · -- hle2 : lookahead emits literal + reference(matchLen2), two pushes
-                  rw [ih _ (by omega) _ _ _ _ rfl,
+                  rw [ih _ (by omega) _ _ _ _ _ rfl,
                     Array.push_eq_append, Array.push_eq_append,
                     Array.append_assoc, Array.append_assoc,
                     ← List.toArray_cons, ← List.toArray_cons]
                 · -- ¬hle2 : reference(matchLen) at pos
-                  rw [ih _ (by omega) _ _ _ _ rfl, List.toArray_cons,
+                  rw [ih _ (by omega) _ _ _ _ _ rfl, List.toArray_cons,
                     ← Array.append_assoc, Array.push_eq_append]
               · -- matchLen2 ≤ matchLen : reference(matchLen) at pos
-                rw [ih _ (by omega) _ _ _ _ rfl, List.toArray_cons,
+                rw [ih _ (by omega) _ _ _ _ _ rfl, List.toArray_cons,
                   ← Array.append_assoc, Array.push_eq_append]
             · -- matchLen ≥ goodMatch (gated) : reference(matchLen) at pos
-              rw [ih _ (by omega) _ _ _ _ rfl, List.toArray_cons,
+              rw [ih _ (by omega) _ _ _ _ _ rfl, List.toArray_cons,
                 ← Array.append_assoc, Array.push_eq_append]
           · -- ¬h3lt : reference(matchLen) at pos (near end)
-            rw [ih _ (by omega) _ _ _ _ rfl, List.toArray_cons,
+            rw [ih _ (by omega) _ _ _ _ _ rfl, List.toArray_cons,
               ← Array.append_assoc, Array.push_eq_append]
-        · -- ¬hle : literal
-          rw [ih _ (by omega) _ _ _ _ rfl, List.toArray_cons,
+        · -- ¬hle : single literal (boundary, unreachable)
+          rw [ih _ (by omega) _ _ _ _ _ rfl, List.toArray_cons,
             ← Array.append_assoc, Array.push_eq_append]
-      · -- ¬hge : literal
-        rw [ih _ (by omega) _ _ _ _ rfl, List.toArray_cons,
-          ← Array.append_assoc, Array.push_eq_append]
+      · -- ¬hge : skip-ahead literal run (`pushLits` vs `litRun`)
+        rw [ih _ (by generalize missStreak >>> skipShift = t; omega) _ _ _ _ _ rfl]
+        simp only [pushLits_eq, List.append_toArray, Array.append_assoc]
     · simp only [hlt, ↓reduceDIte]
       exact trailing_eq data pos acc
 
 /-- `lz77ChainLazyIter` produces exactly the same tokens as `lz77ChainLazy`. -/
-theorem lz77ChainLazyIter_eq_lz77ChainLazy (data : ByteArray) (maxChain windowSize insertCap goodMatch niceLen lazyDepth : Nat) :
-    lz77ChainLazyIter data maxChain windowSize insertCap goodMatch niceLen lazyDepth =
-      lz77ChainLazy data maxChain windowSize insertCap goodMatch niceLen lazyDepth := by
+theorem lz77ChainLazyIter_eq_lz77ChainLazy (data : ByteArray) (maxChain windowSize insertCap goodMatch niceLen lazyDepth skipShift : Nat) :
+    lz77ChainLazyIter data maxChain windowSize insertCap goodMatch niceLen lazyDepth skipShift =
+      lz77ChainLazy data maxChain windowSize insertCap goodMatch niceLen lazyDepth skipShift := by
   unfold lz77ChainLazyIter lz77ChainLazy
   split
   · rw [trailing_eq]; simp only [List.append_toArray, List.nil_append]
   · rw [mainLoop_eq_chainLazy]; simp only [List.append_toArray, List.nil_append]
 
-theorem lz77ChainLazyIter_valid (data : ByteArray) (maxChain windowSize insertCap goodMatch niceLen lazyDepth : Nat)
+theorem lz77ChainLazyIter_valid (data : ByteArray) (maxChain windowSize insertCap goodMatch niceLen lazyDepth skipShift : Nat)
     (hw : windowSize > 0) :
-    ValidDecomp data 0 (lz77ChainLazyIter data maxChain windowSize insertCap goodMatch niceLen lazyDepth).toList := by
-  rw [lz77ChainLazyIter_eq_lz77ChainLazy]; exact lz77ChainLazy_valid data maxChain windowSize insertCap goodMatch niceLen lazyDepth hw
+    ValidDecomp data 0 (lz77ChainLazyIter data maxChain windowSize insertCap goodMatch niceLen lazyDepth skipShift).toList := by
+  rw [lz77ChainLazyIter_eq_lz77ChainLazy]; exact lz77ChainLazy_valid data maxChain windowSize insertCap goodMatch niceLen lazyDepth skipShift hw
 
-theorem lz77ChainLazyIter_resolves (data : ByteArray) (maxChain windowSize insertCap goodMatch niceLen lazyDepth : Nat)
+theorem lz77ChainLazyIter_resolves (data : ByteArray) (maxChain windowSize insertCap goodMatch niceLen lazyDepth skipShift : Nat)
     (hw : windowSize > 0) :
-    Deflate.Spec.resolveLZ77 (tokensToSymbols (lz77ChainLazyIter data maxChain windowSize insertCap goodMatch niceLen lazyDepth)) [] =
+    Deflate.Spec.resolveLZ77 (tokensToSymbols (lz77ChainLazyIter data maxChain windowSize insertCap goodMatch niceLen lazyDepth skipShift)) [] =
       some data.data.toList := by
-  rw [lz77ChainLazyIter_eq_lz77ChainLazy]; exact lz77ChainLazy_resolves data maxChain windowSize insertCap goodMatch niceLen lazyDepth hw
+  rw [lz77ChainLazyIter_eq_lz77ChainLazy]; exact lz77ChainLazy_resolves data maxChain windowSize insertCap goodMatch niceLen lazyDepth skipShift hw
 
-theorem lz77ChainLazyIter_encodable (data : ByteArray) (maxChain windowSize insertCap goodMatch niceLen lazyDepth : Nat)
+theorem lz77ChainLazyIter_encodable (data : ByteArray) (maxChain windowSize insertCap goodMatch niceLen lazyDepth skipShift : Nat)
     (hw : windowSize > 0) (hws : windowSize ≤ 32768) :
-    ∀ t ∈ (lz77ChainLazyIter data maxChain windowSize insertCap goodMatch niceLen lazyDepth).toList,
+    ∀ t ∈ (lz77ChainLazyIter data maxChain windowSize insertCap goodMatch niceLen lazyDepth skipShift).toList,
       match t with
       | .literal _ => True
       | .reference len dist => 3 ≤ len ∧ len ≤ 258 ∧ 1 ≤ dist ∧ dist ≤ 32768 := by
   rw [lz77ChainLazyIter_eq_lz77ChainLazy]
-  exact lz77ChainLazy_encodable data maxChain windowSize insertCap goodMatch niceLen lazyDepth hw hws
+  exact lz77ChainLazy_encodable data maxChain windowSize insertCap goodMatch niceLen lazyDepth skipShift hw hws
 
 /-- The lazy chain matcher emits no tokens on empty input. -/
-theorem lz77ChainLazyIter_empty (data : ByteArray) (maxChain windowSize insertCap goodMatch niceLen lazyDepth : Nat)
-    (hzero : data.size = 0) : lz77ChainLazyIter data maxChain windowSize insertCap goodMatch niceLen lazyDepth = #[] := by
+theorem lz77ChainLazyIter_empty (data : ByteArray) (maxChain windowSize insertCap goodMatch niceLen lazyDepth skipShift : Nat)
+    (hzero : data.size = 0) : lz77ChainLazyIter data maxChain windowSize insertCap goodMatch niceLen lazyDepth skipShift = #[] := by
   rw [lz77ChainLazyIter_eq_lz77ChainLazy]
   simp only [lz77ChainLazy, show data.size < 3 from by omega, ↓reduceIte]
   have htrail : lz77Greedy.trailing data 0 = [] := by

--- a/Zip/Spec/LZ77PackedCorrect.lean
+++ b/Zip/Spec/LZ77PackedCorrect.lean
@@ -77,22 +77,34 @@ theorem lz77ChainIterP_eq (data : ByteArray) (maxChain windowSize insertCap nice
   · simpa only [List.map_toArray, List.map_nil, Array.emptyWithCapacity_eq] using
       mainLoopP_eq data windowSize 65536 maxChain insertCap niceLen _ _ 0 #[]
 
+/-- The packed skip-ahead literal run is the packed image of the boxed one. -/
+private theorem pushLitsP_eq (data : ByteArray) (pos stop : Nat) (acc : Array LZ77Token) :
+    pushLitsP (acc.map packTok) data pos stop = (pushLits acc data pos stop).map packTok := by
+  induction h : stop - pos using Nat.strongRecOn generalizing pos acc with
+  | _ n ih =>
+    unfold pushLitsP pushLits
+    by_cases hc : pos < stop ∧ pos < data.size
+    · simp only [hc, and_self, ↓reduceDIte]
+      rw [← Array.map_push, ih _ (by omega) _ _ rfl]
+    · simp only [hc, ↓reduceDIte]
+
 /-- The packed lazy `mainLoop` is the packed image of the boxed one. The gate
     (`matchLen < goodMatch`) is applied identically in both, so the branch tree
-    stays in lockstep — one extra split versus the ungated proof. -/
-private theorem mainLoopLazyP_eq (data : ByteArray) (windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth : Nat)
-    (hashTable : Array Nat) (prev : Array Nat) (pos : Nat) (acc : Array LZ77Token) :
-    lz77ChainLazyIterP.mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth hashTable prev pos
+    stays in lockstep — one extra split versus the ungated proof. The no-match
+    arm emits a `pushLitsP`/`pushLits` skip-ahead run (`pushLitsP_eq`). -/
+private theorem mainLoopLazyP_eq (data : ByteArray) (windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth skipShift : Nat)
+    (hashTable : Array Nat) (prev : Array Nat) (pos missStreak : Nat) (acc : Array LZ77Token) :
+    lz77ChainLazyIterP.mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth skipShift hashTable prev pos missStreak
         (acc.map packTok) =
-      (lz77ChainLazyIter.mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth hashTable prev pos
+      (lz77ChainLazyIter.mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth skipShift hashTable prev pos missStreak
         acc).map packTok := by
-  induction h : data.size - pos using Nat.strongRecOn generalizing pos acc hashTable prev with
+  induction h : data.size - pos using Nat.strongRecOn generalizing pos acc hashTable prev missStreak with
   | _ n ih =>
     unfold lz77ChainLazyIterP.mainLoop lz77ChainLazyIter.mainLoop
     simp only [chainWalkGuardedPackedU_eq]
     by_cases hlt : pos + 2 < data.size
     · simp only [hlt, ↓reduceDIte]
-      -- Branch tree: hge / hle / h3lt / gate / deferral / hle2
+      -- Branch tree: hge / hle / h3lt / gate / deferral / hle2 / (¬hge miss)
       split
       · split
         · split
@@ -100,27 +112,29 @@ private theorem mainLoopLazyP_eq (data : ByteArray) (windowSize hashSize maxChai
             · split
               · split
                 · -- deferral arm: literal + reference, two pushes
-                  rw [← Array.map_push, ← Array.map_push, ih _ (by omega) _ _ _ _ rfl]
-                · rw [← Array.map_push, ih _ (by omega) _ _ _ _ rfl]
-              · rw [← Array.map_push, ih _ (by omega) _ _ _ _ rfl]
+                  rw [← Array.map_push, ← Array.map_push, ih _ (by omega) _ _ _ _ _ rfl]
+                · rw [← Array.map_push, ih _ (by omega) _ _ _ _ _ rfl]
+              · rw [← Array.map_push, ih _ (by omega) _ _ _ _ _ rfl]
             · -- gated: reference(matchLen)
-              rw [← Array.map_push, ih _ (by omega) _ _ _ _ rfl]
-          · rw [← Array.map_push, ih _ (by omega) _ _ _ _ rfl]
-        · rw [← Array.map_push, ih _ (by omega) _ _ _ _ rfl]
-      · rw [← Array.map_push, ih _ (by omega) _ _ _ _ rfl]
+              rw [← Array.map_push, ih _ (by omega) _ _ _ _ _ rfl]
+          · rw [← Array.map_push, ih _ (by omega) _ _ _ _ _ rfl]
+        · -- ¬hle : single literal (boundary)
+          rw [← Array.map_push, ih _ (by omega) _ _ _ _ _ rfl]
+      · -- ¬hge : skip-ahead literal run (`pushLitsP` vs `pushLits`)
+        rw [pushLitsP_eq, ih _ (by generalize missStreak >>> skipShift = t; omega) _ _ _ _ _ rfl]
     · simp only [hlt, ↓reduceDIte]
       exact trailingP_eq data pos acc
 
 /-- `lz77ChainLazyIterP` produces exactly the `packTok` image of
     `lz77ChainLazyIter`. -/
-theorem lz77ChainLazyIterP_eq (data : ByteArray) (maxChain windowSize insertCap goodMatch niceLen lazyDepth : Nat) :
-    lz77ChainLazyIterP data maxChain windowSize insertCap goodMatch niceLen lazyDepth =
-      (lz77ChainLazyIter data maxChain windowSize insertCap goodMatch niceLen lazyDepth).map packTok := by
+theorem lz77ChainLazyIterP_eq (data : ByteArray) (maxChain windowSize insertCap goodMatch niceLen lazyDepth skipShift : Nat) :
+    lz77ChainLazyIterP data maxChain windowSize insertCap goodMatch niceLen lazyDepth skipShift =
+      (lz77ChainLazyIter data maxChain windowSize insertCap goodMatch niceLen lazyDepth skipShift).map packTok := by
   unfold lz77ChainLazyIterP lz77ChainLazyIter
   split
   · simpa only [List.map_toArray, List.map_nil] using trailingP_eq data 0 #[]
   · simpa only [List.map_toArray, List.map_nil, Array.emptyWithCapacity_eq] using
-      mainLoopLazyP_eq data windowSize 65536 maxChain insertCap goodMatch niceLen lazyDepth _ _ 0 #[]
+      mainLoopLazyP_eq data windowSize 65536 maxChain insertCap goodMatch niceLen lazyDepth skipShift _ _ 0 0 #[]
 
 /-! ## View direction: the boxed view recovers the boxed matchers
 
@@ -140,15 +154,15 @@ theorem lz77ChainIterP_map (data : ByteArray) (maxChain windowSize insertCap nic
   rw [hcongr, Array.map_id]
 
 /-- The boxed view of the packed lazy matcher is the boxed lazy matcher. -/
-theorem lz77ChainLazyIterP_map (data : ByteArray) (maxChain windowSize insertCap goodMatch niceLen lazyDepth : Nat)
+theorem lz77ChainLazyIterP_map (data : ByteArray) (maxChain windowSize insertCap goodMatch niceLen lazyDepth skipShift : Nat)
     (hw : windowSize > 0) (hws : windowSize ≤ 32768) :
-    (lz77ChainLazyIterP data maxChain windowSize insertCap goodMatch niceLen lazyDepth).map unpackTok =
-      lz77ChainLazyIter data maxChain windowSize insertCap goodMatch niceLen lazyDepth := by
-  have henc := lz77ChainLazyIter_encodable data maxChain windowSize insertCap goodMatch niceLen lazyDepth hw hws
+    (lz77ChainLazyIterP data maxChain windowSize insertCap goodMatch niceLen lazyDepth skipShift).map unpackTok =
+      lz77ChainLazyIter data maxChain windowSize insertCap goodMatch niceLen lazyDepth skipShift := by
+  have henc := lz77ChainLazyIter_encodable data maxChain windowSize insertCap goodMatch niceLen lazyDepth skipShift hw hws
   rw [lz77ChainLazyIterP_eq, Array.map_map]
   have hcongr : Array.map (unpackTok ∘ packTok)
-        (lz77ChainLazyIter data maxChain windowSize insertCap goodMatch niceLen lazyDepth) =
-      Array.map id (lz77ChainLazyIter data maxChain windowSize insertCap goodMatch niceLen lazyDepth) :=
+        (lz77ChainLazyIter data maxChain windowSize insertCap goodMatch niceLen lazyDepth skipShift) =
+      Array.map id (lz77ChainLazyIter data maxChain windowSize insertCap goodMatch niceLen lazyDepth skipShift) :=
     Array.map_congr_left fun t ht => unpackTok_packTok t (henc t (by simpa only [Array.mem_toList_iff] using ht))
   rw [hcongr, Array.map_id]
 
@@ -159,7 +173,7 @@ theorem lzMatchP_eq (data : ByteArray) (level : UInt8) :
     lzMatchP data level = (lzMatch data level).map packTok := by
   unfold lzMatchP lzMatch
   split
-  · exact lz77ChainLazyIterP_eq data (chainDepth level) 32768 (insertCap level) (goodMatch level) (niceLen level) (lazyDepth level)
+  · exact lz77ChainLazyIterP_eq data (chainDepth level) 32768 (insertCap level) (goodMatch level) (niceLen level) (lazyDepth level) (skipShift level)
   · exact lz77ChainIterP_eq data (chainDepth level) 32768 (insertCap level) (niceLen level)
 
 /-- The boxed view of the packed token stream is exactly `lzMatch`'s stream:
@@ -169,7 +183,7 @@ theorem lzMatchP_map (data : ByteArray) (level : UInt8) :
     (lzMatchP data level).map unpackTok = lzMatch data level := by
   unfold lzMatchP lzMatch
   split
-  · exact lz77ChainLazyIterP_map data (chainDepth level) 32768 (insertCap level) (goodMatch level) (niceLen level) (lazyDepth level)
+  · exact lz77ChainLazyIterP_map data (chainDepth level) 32768 (insertCap level) (goodMatch level) (niceLen level) (lazyDepth level) (skipShift level)
       (by omega) (by omega)
   · exact lz77ChainIterP_map data (chainDepth level) 32768 (insertCap level) (niceLen level)
       (by omega) (by omega)

--- a/ZipTest/NativeDeflate.lean
+++ b/ZipTest/NativeDeflate.lean
@@ -406,6 +406,34 @@ def ZipTest.NativeDeflate.tests : IO Unit := do
       throw (IO.userError s!"lz77ChainLazyIterP vs lz77ChainLazyIter (lazyDepth=32) mismatch on {name}: \
         {packedShallow.size} vs {iterShallow.size} tokens")
 
+  -- Incompressible-stretch skip-ahead (#2766): after a run of misses the matcher
+  -- advances by a growing stride. The three twins must stay in lockstep at every
+  -- `skipShift`, and every stride still emits a valid, roundtrippable stream. The
+  -- shapes include prng (incompressible → skip-ahead actually triggers) and edge
+  -- cases; `skipShift = 63` reproduces the pre-skip (disabled) output exactly.
+  for (name, data) in [("empty", ByteArray.empty), ("single", singleByte),
+                        ("hello", helloBytes), ("big", big),
+                        ("cyclic4K", mkCyclicData 4096), ("prng8K", mkPrngData 8192),
+                        ("text4K", mkTextData 4096)] do
+    -- Disabled skip-ahead (shift 63) equals the default matcher argument, byte-identical.
+    let disabled := Zip.Native.Deflate.lz77ChainLazyIter data 64 32768 1000000000 259 258 32 63
+    unless disabled == Zip.Native.Deflate.lz77ChainLazyIter data 64 32768 1000000000 259 258 32 do
+      throw (IO.userError s!"skipShift=63 not identity to default on {name}")
+    for shift in [4, 6, 7, 63] do
+      let iter := Zip.Native.Deflate.lz77ChainLazyIter data 64 32768 1000000000 259 258 32 shift
+      let rec' := Zip.Native.Deflate.lz77ChainLazy data 64 32768 1000000000 259 258 32 shift
+      unless iter == rec' do
+        throw (IO.userError s!"lz77ChainLazyIter vs lz77ChainLazy (skipShift={shift}) mismatch on {name}")
+      let packed := Zip.Native.Deflate.lz77ChainLazyIterP data 64 32768 1000000000 259 258 32 shift
+      unless packed == iter.map Zip.Native.Deflate.packTok do
+        throw (IO.userError s!"lz77ChainLazyIterP vs lz77ChainLazyIter (skipShift={shift}) mismatch on {name}")
+      -- End-to-end: emit the skip-ahead tokens as a fixed block and inflate back.
+      let raw := Zip.Native.Deflate.deflateFixedBlock data iter
+      match Zip.Native.Inflate.inflate raw with
+      | .ok result => unless result == data do
+          throw (IO.userError s!"skip-ahead(shift={shift})→native inflate mismatch on {name}")
+      | .error e => throw (IO.userError s!"skip-ahead(shift={shift})→native inflate failed on {name}: {e}")
+
   -- deflateRaw at every lazy level (4–9) → native inflate AND FFI decompress, on
   -- varied shapes incl. edge cases. Exercises the lazy path end to end.
   let lazyShapes : List (String × ByteArray) :=

--- a/bench/ZipSkipSpike.lean
+++ b/bench/ZipSkipSpike.lean
@@ -1,0 +1,80 @@
+import Zip
+
+/-! # skip-sweep — incompressible-stretch skip-ahead ladder sweep (#2766)
+
+Sweeps the LZ4/zstd-style skip-ahead shift (`DeflateDynamic.skipShift`) of the
+lazy matcher over corpus members, for tuning the per-level ladder. Uses the
+shipped, proven matcher `lz77ChainLazyIterP` directly (the `skipShift` argument
+is the last positional parameter); `skipShift = 63` disables skip-ahead and
+reproduces the pre-skip output.
+
+On a run of positions with no match the matcher advances by
+`stride = 1 + (missStreak >>> skipShift)`, emitting the skipped bytes as
+literals. A smaller shift lets the stride grow sooner (faster, more ratio cost);
+the threshold rarely triggers on dense-match data (text, `sao`), so those pay
+almost nothing. See the PR discussion for the measured speed/ratio table that
+chose the shipped ladder.
+
+Usage: lake exe skip-spike <file> [<file> ...]          # ratio (deterministic)
+       lake exe skip-spike --time <file> [<file> ...]   # speed (pin the core)
+-/
+
+open Zip.Native.Deflate
+
+/-- One sweep config: matcher knobs plus the skip-ahead shift (`63` disables). -/
+structure SkipConfig where
+  label : String
+  chain : Nat
+  gm : Nat
+  nl : Nat
+  shift : Nat
+
+/-- Compress under one config with the shipped lazy matcher (skip-ahead at
+    `cfg.shift`, half-depth lookahead like production), returning the single-block
+    size. -/
+def runSkip (cfg : SkipConfig) (data : ByteArray) : Nat :=
+  let ptoks := lz77ChainLazyIterP data cfg.chain 32768 1000000000 cfg.gm cfg.nl (cfg.chain / 2) cfg.shift
+  (deflateRawBaseP data ptoks).size
+
+/-- The shift ladder swept per corpus member: disabled, then progressively more
+    aggressive skip-ahead (smaller shift → the stride grows sooner). -/
+def skipConfigs (chain gm nl : Nat) : List SkipConfig :=
+  [ ⟨s!"off", chain, gm, nl, 63⟩,
+    ⟨s!"sh7", chain, gm, nl, 7⟩,
+    ⟨s!"sh6", chain, gm, nl, 6⟩,
+    ⟨s!"sh5", chain, gm, nl, 5⟩,
+    ⟨s!"sh4", chain, gm, nl, 4⟩ ]
+
+/-- L6-like production slot (chain 64, gate off, nice 65), the issue's target. -/
+def sweepConfigs : List SkipConfig := skipConfigs 64 259 65
+
+def timeMain (paths : List String) : IO Unit := do
+  let mut files : List ByteArray := []
+  for path in paths do
+    files := files ++ [← IO.FS.readBinFile path]
+  let total := files.foldl (fun a f => a + f.size) 0
+  IO.println s!"corpus: {paths.length} files, {total} bytes"
+  for rep in [0:3] do
+    for cfg in sweepConfigs do
+      let t0 ← IO.monoNanosNow
+      let mut sink := 0
+      for f in files do
+        sink := sink + runSkip cfg f
+      let t1 ← IO.monoNanosNow
+      let mbps := total.toFloat / 1048576.0 / ((t1 - t0).toFloat / 1.0e9)
+      IO.println s!"rep {rep} {cfg.label}: {mbps} MB/s (out {sink})"
+      (← IO.getStdout).flush
+
+def main (args : List String) : IO Unit := do
+  if args.head? == some "--time" then
+    timeMain args.tail
+    return
+  IO.println "file,config,inBytes,outBytes,ratio"
+  for path in args do
+    let data ← IO.FS.readBinFile path
+    let name := (path.splitOn "/").getLastD path
+    for cfg in sweepConfigs do
+      let out := runSkip cfg data
+      let ratio := data.size.toFloat / out.toFloat
+      IO.println s!"{name},{cfg.label},{data.size},{out},{ratio}"
+      (← IO.getStdout).flush

--- a/bench/ZipSkipSpike.lean
+++ b/bench/ZipSkipSpike.lean
@@ -65,7 +65,56 @@ def timeMain (paths : List String) : IO Unit := do
       IO.println s!"rep {rep} {cfg.label}: {mbps} MB/s (out {sink})"
       (← IO.getStdout).flush
 
+/-- Faithful copy of `deflateRaw`'s level-6 path (base vs observation-divergence
+    split, size-arbitrated) with an explicit `skipShift` so the only variable in
+    an A/B is skip-ahead on vs off. Mirrors `DeflateDynamic.deflateRaw` levels 6-8. -/
+def prodL6 (data : ByteArray) (skipShift : Nat) : Nat :=
+  let ptokens := lz77ChainLazyIterP data (chainDepth 6) 32768 (insertCap 6) (goodMatch 6) (niceLen 6) (lazyDepth 6) skipShift
+  let basePrep := deflateRawBasePPrep data ptokens
+  let cuts := chooseSplitsHeuristicP ptokens data.size
+  let withObs : Nat × (Unit → ByteArray) :=
+    if cuts.isEmpty then basePrep
+    else
+      let obsPrep := deflateDynamicBlocksSharedAtSizedP data ptokens cuts
+      if basePrep.1 < obsPrep.1 then basePrep else obsPrep
+  (withObs.2 ()).size
+
+/-- Just the matcher (`lzMatchP`-equivalent for L6) at a given `skipShift` — the
+    83-84% of `deflateRaw` where 100% of the skip-ahead effect lives. -/
+def matcherL6 (data : ByteArray) (skipShift : Nat) : Nat :=
+  (lz77ChainLazyIterP data (chainDepth 6) 32768 (insertCap 6) (goodMatch 6) (niceLen 6) (lazyDepth 6) skipShift).size
+
+/-- Controlled same-binary A/B: for each file, time skip-ahead OFF (63) vs the
+    shipped shift (7) for both the matcher alone and the full L6 `deflateRaw` path,
+    interleaved per rep (so drift cancels). The ONLY variable is `skipShift`. -/
+def abMain (paths : List String) (shift : Nat) (reps : Nat) : IO Unit := do
+  let mut files : List (String × ByteArray) := []
+  for path in paths do
+    files := files ++ [((path.splitOn "/").getLastD path, ← IO.FS.readBinFile path)]
+  IO.println s!"same-binary A/B: skip OFF (shift 63) vs ON (shift {shift}); {reps} reps interleaved"
+  let time (f : ByteArray → Nat) (d : ByteArray) : IO Float := do
+    let t0 ← IO.monoNanosNow
+    let mut s := 0
+    for _ in [0:1] do s := s + f d
+    let t1 ← IO.monoNanosNow
+    return ((t1 - t0).toFloat / 1.0e6) + (s.toFloat * 0.0)
+  for (name, d) in files do
+    let mut mOff := #[]; let mut mOn := #[]; let mut pOff := #[]; let mut pOn := #[]
+    for _ in [0:reps] do
+      -- interleave off/on each rep so slow drift cancels
+      mOff := mOff.push (← time (matcherL6 · 63) d)
+      mOn  := mOn.push  (← time (matcherL6 · shift) d)
+      pOff := pOff.push (← time (prodL6 · 63) d)
+      pOn  := pOn.push  (← time (prodL6 · shift) d)
+    let med (a : Array Float) : Float := (a.qsort (· < ·))[a.size / 2]!
+    let mo := med mOff; let mn := med mOn; let po := med pOff; let pn := med pOn
+    IO.println s!"{name}: matcher off={mo}ms on={mn}ms → {(mo/mn - 1.0)*100.0}% | prodL6 off={po}ms on={pn}ms → {(po/pn - 1.0)*100.0}%"
+    (← IO.getStdout).flush
+
 def main (args : List String) : IO Unit := do
+  if args.head? == some "--ab" then
+    abMain (args.tail.drop 1) ((args.tail.head?.bind (·.toNat?)).getD 7) 7
+    return
   if args.head? == some "--time" then
     timeMain args.tail
     return

--- a/bench/graphs/canterbury_compress_heatmap.svg
+++ b/bench/graphs/canterbury_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#pa3d5af2ea2)">
+   <g clip-path="url(#pe23b1c6552)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJEElEQVR4nO3YvYpdVQCG4TmZM5qYMQTBGBIIgoKNYKWN9vZeiFdg4zV4ByLYi2BhbWMpNgqCRAmIIdH8TCYn58dC8ArexTKb57mCb7PY67xnr/Z/f3k44vly/mj2gnGeLvPZDpvz2ROGWV25NnvCGC++NHvBOKsLsxeM8Wy579lSz+xw7/fZE4ZZ5okBAEwksAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYuvbq3uzNwyx2Z3PnjDM9auvz54wzOn+2uwJQ6yePJg9YZjvnvw0e8IQN154dfaEYXb77ewJQzzcns2eMMz2sJs9YYh3X745e8IwvmABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBAbH16cnX2hiH26/3sCcOcHl2cPWGcv27PXjDE4cmD2ROGee/W+7MnDHG2Xe6ZPV7os715+vbsCcNsVtvZE4Y4/PrD7AnD+IIFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAsfWl49PZG4Y4353NnjDOasFdfPHK7AVDrBZ8Zifb7ewJQyz5zC6vl/me/bG5M3vCMNv9ZvaEIW5evjp7wjDLvUEAACYRWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABBb7X789DB7BPxnv5+9AP51wf/P5477g/8RNwgAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDE1h//eXv2hiEePN3NnjDM93cezp4wzNcffTB7whCvXbo1e8Iw73z+xewJQ3z4xiuzJwzzy/0nsycMcWl9PHvCMF998/PsCUOcffbJ7AnD+IIFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAsdV2/+1h9ogRdvvt7AnDXFgtt4uPz89mTxjjeD17wTiP781eMMTu6vXZE4bZH/azJwxxslrue/bssMzftJPtMp/r6MgXLACAnMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIitLyy0sXazBwx0fP/O7AnjPLo7e8EQh82z2ROGWd14a/aEIVarZd6NR0dHR5vd2ewJQ5xs9rMnDHOyWeaZHe7+NnvCMMu9QQAAJhFYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAACxfwA96YLnynppnQAAAABJRU5ErkJggg==" id="image72c8e5d870" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJD0lEQVR4nO3YvYpdVQCG4TmZM5qYMQyCMSQQBAUbwUob7e29EK/AxmvwDkSwF8HC2sZSbBQECRoQNdH8zEwm58dC8ArexTKb57mCb7PY67xnr3Z/f74/4Nly/mj2gnGeLPPZ9hfnsycMs7p2ffaEMZ5/YfaCcVaXZi8Y4+ly37Olntn+3i+zJwyzzBMDAJhIYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxNZ3VvdmbxjiYns+e8IwN05enT1hmOPd9dkThlidPZg9YZhvzn6YPWGIm8+9PHvCMNvdZvaEIR5uTmdPGGaz386eMMTbL96aPWEYX7AAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgtj4+Opm9YYjdejd7wjDHB5dnTxjnrzuzFwyxP3swe8Iw79x+d/aEIU43yz2zxwt9tteP35w9YZiL1Wb2hCH2P383e8IwvmABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBAbH3l8Hj2hiHOt6ezJ4yzWnAXX742e8EQqwWf2dFmM3vCEEs+s6vrZb5nv13cnT1hmM3uYvaEIW5dPZk9YZjl3iAAAJMILACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIittt9/vJ89Av6z281eAP+65P/nM8f9wf+IGwQAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABi6w9/vzN7wxAPnmxnTxjm27sPZ08Y5ssP3ps9YYhXrtyePWGYtz79bPaEId5/7aXZE4b56f7Z7AlDXFkfzp4wzBdf/Th7whCnn3w0e8IwvmABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBAbLXZfb2fPWKE7W4ze8Iwl1bL7eLD89PZE8Y4XM9eMM7je7MXDLE9uTF7wjC7/W72hCGOVst9z57ul/mbdrRZ5nMdHPiCBQCQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAALH1pYU21n61zOc6ODg4OLx/d/aEcR79MXvBEPuLp7MnDLO6+cbsCUOsFnyHXGxPZ08Y4ujJZvaEYY4ulnlm+z9/nT1hmOXeIAAAkwgsAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAIDYPy7nguw0S/v6AAAAAElFTkSuQmCC" id="imageb4572e8c91" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m5d4d1686df" d="M 0 0 
+       <path id="m8f8f5931d5" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m5d4d1686df" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8f8f5931d5" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m5d4d1686df" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8f8f5931d5" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m5d4d1686df" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8f8f5931d5" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m5d4d1686df" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8f8f5931d5" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m5d4d1686df" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8f8f5931d5" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m5d4d1686df" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8f8f5931d5" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m5d4d1686df" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8f8f5931d5" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m5d4d1686df" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8f8f5931d5" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m5d4d1686df" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8f8f5931d5" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m5d4d1686df" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8f8f5931d5" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m5d4d1686df" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8f8f5931d5" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="md442f3e4b2" d="M 0 0 
+       <path id="mb59b1c8850" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#md442f3e4b2" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb59b1c8850" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#md442f3e4b2" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb59b1c8850" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#md442f3e4b2" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb59b1c8850" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#md442f3e4b2" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb59b1c8850" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#md442f3e4b2" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb59b1c8850" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#md442f3e4b2" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb59b1c8850" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#md442f3e4b2" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb59b1c8850" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#md442f3e4b2" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb59b1c8850" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1303,7 +1303,7 @@ L 527.435033 49.4355
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_20">
-    <!-- +2 -->
+    <!-- +1 -->
     <g transform="translate(110.510438 68.904519) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-2b" d="M 2944 4013 
@@ -1323,7 +1323,7 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_21">
@@ -1334,7 +1334,7 @@ z
     </g>
    </g>
    <g id="text_22">
-    <!-- -47 -->
+    <!-- -48 -->
     <g transform="translate(188.495082 68.904519) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
@@ -1356,34 +1356,6 @@ L 313 1709
 L 2253 4666 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_23">
-    <!-- -79 -->
-    <g transform="translate(227.74588 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_24">
-    <!-- -88 -->
-    <g transform="translate(266.996679 68.904519) scale(0.065 -0.065)">
-     <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
 Q 1069 1734 1069 1313 
@@ -1425,23 +1397,83 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
     </g>
    </g>
+   <g id="text_23">
+    <!-- -79 -->
+    <g transform="translate(227.74588 68.904519) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_24">
+    <!-- -89 -->
+    <g transform="translate(266.996679 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
    <g id="text_25">
-    <!-- -25 -->
+    <!-- -26 -->
     <g transform="translate(306.247477 68.904519) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_26">
-    <!-- +4 -->
+    <!-- +5 -->
     <g transform="translate(346.015229 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_27">
@@ -1487,19 +1519,19 @@ z
     </g>
    </g>
    <g id="text_28">
-    <!-- -27 -->
+    <!-- -29 -->
     <g transform="translate(423.999873 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_29">
-    <!-- -43 -->
+    <!-- -45 -->
     <g transform="translate(463.250671 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_30">
@@ -1632,38 +1664,6 @@ z
    <g id="text_46">
     <!-- +26 -->
     <g transform="translate(265.44582 139.606222) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-36" d="M 2113 2584 
-Q 1688 2584 1439 2293 
-Q 1191 2003 1191 1497 
-Q 1191 994 1439 701 
-Q 1688 409 2113 409 
-Q 2538 409 2786 701 
-Q 3034 994 3034 1497 
-Q 3034 2003 2786 2293 
-Q 2538 2584 2113 2584 
-z
-M 3366 4563 
-L 3366 3988 
-Q 3128 4100 2886 4159 
-Q 2644 4219 2406 4219 
-Q 1781 4219 1451 3797 
-Q 1122 3375 1075 2522 
-Q 1259 2794 1537 2939 
-Q 1816 3084 2150 3084 
-Q 2853 3084 3261 2657 
-Q 3669 2231 3669 1497 
-Q 3669 778 3244 343 
-Q 2819 -91 2113 -91 
-Q 1303 -91 875 529 
-Q 447 1150 447 2328 
-Q 447 3434 972 4092 
-Q 1497 4750 2381 4750 
-Q 2619 4750 2861 4703 
-Q 3103 4656 3366 4563 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
@@ -2178,18 +2178,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="imageef13f3935c" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
+iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="imagea2f79b0726" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="m90dca1805f" d="M 0 0 
+       <path id="m06db35a3c5" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m90dca1805f" x="547.779688" y="276.293905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m06db35a3c5" x="547.779688" y="276.293905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
@@ -2212,7 +2212,7 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m90dca1805f" x="547.779688" y="247.808905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m06db35a3c5" x="547.779688" y="247.808905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
@@ -2226,7 +2226,7 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m90dca1805f" x="547.779688" y="219.323905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m06db35a3c5" x="547.779688" y="219.323905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
@@ -2240,7 +2240,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m90dca1805f" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m06db35a3c5" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
@@ -2253,7 +2253,7 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m90dca1805f" x="547.779688" y="162.353904" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m06db35a3c5" x="547.779688" y="162.353904" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_112">
@@ -2266,7 +2266,7 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m90dca1805f" x="547.779688" y="133.868904" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m06db35a3c5" x="547.779688" y="133.868904" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
@@ -2279,7 +2279,7 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m90dca1805f" x="547.779688" y="105.383904" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m06db35a3c5" x="547.779688" y="105.383904" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
@@ -2940,8 +2940,8 @@ z
    </g>
   </g>
   <g id="text_117">
-   <!-- 2026-07-06T07:54:18Z  ·  Linux chungus2 x86_64  ·  commit 38a6ad15  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(16.549375 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-06T10:45:22Z  ·  Linux chungus2 x86_64  ·  commit 8a6bc577  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(16.769766 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -3010,14 +3010,14 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3057,109 +3057,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3260.400391 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3324.023438 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3385.302734 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3448.779297 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3512.402344 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3576.025391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3607.8125 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3639.599609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3671.386719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3703.173828 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3734.960938 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3762.744141 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3824.267578 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3885.546875 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3948.925781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4012.402344 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4051.265625 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4112.447266 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4171.626953 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4233.150391 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4274.263672 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4307.955078 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4335.738281 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4397.261719 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4458.541016 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4521.919922 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4585.542969 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4619.234375 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4678.414062 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4742.037109 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4773.824219 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4837.447266 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4901.070312 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4932.857422 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4996.480469 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5032.564453 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5071.427734 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5126.408203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5190.03125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5221.818359 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5253.605469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5285.392578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5317.179688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5348.966797 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5388.175781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5451.554688 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5490.417969 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5551.599609 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5614.978516 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5678.455078 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5741.833984 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5805.310547 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5868.689453 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5907.898438 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5939.685547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6023.474609 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6055.261719 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6152.673828 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6214.197266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6277.673828 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6305.457031 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6366.736328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6430.115234 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6461.902344 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6514.001953 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6577.380859 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6638.660156 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6702.136719 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6754.236328 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6817.615234 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6878.796875 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6918.005859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6951.697266 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6983.484375 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7024.597656 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7085.876953 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7125.085938 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7152.869141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7214.050781 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7245.837891 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7273.621094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7325.720703 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7357.507812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7420.984375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7482.507812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7521.716797 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7583.240234 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7622.603516 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7720.015625 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7747.798828 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7811.177734 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7838.960938 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7891.060547 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7930.269531 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7958.052734 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3196.777344 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3260.400391 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3323.876953 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3378.857422 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3442.480469 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3506.103516 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3569.726562 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3601.513672 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3633.300781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3665.087891 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3696.875 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3728.662109 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3756.445312 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3817.96875 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3879.248047 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3942.626953 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4006.103516 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4044.966797 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4106.148438 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4165.328125 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4226.851562 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4267.964844 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4301.65625 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4329.439453 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4390.962891 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4452.242188 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4515.621094 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4579.244141 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4612.935547 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4672.115234 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4735.738281 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4767.525391 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4831.148438 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4894.771484 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4926.558594 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4990.181641 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5026.265625 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5065.128906 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5120.109375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5183.732422 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5215.519531 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5247.306641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5279.09375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5310.880859 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5342.667969 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5381.876953 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5445.255859 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5484.119141 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5545.300781 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5608.679688 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5672.15625 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5735.535156 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5799.011719 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5862.390625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5901.599609 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5933.386719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6017.175781 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6048.962891 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6146.375 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6207.898438 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6271.375 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6299.158203 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6360.4375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6423.816406 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6455.603516 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6507.703125 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6571.082031 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6632.361328 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6695.837891 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6747.9375 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6811.316406 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6872.498047 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6911.707031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6945.398438 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6977.185547 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7018.298828 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7079.578125 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7118.787109 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7146.570312 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7207.751953 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7239.539062 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7267.322266 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7319.421875 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7351.208984 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7414.685547 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7476.208984 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7515.417969 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7576.941406 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7616.304688 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7713.716797 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7741.5 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7804.878906 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7832.662109 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7884.761719 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7923.970703 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7951.753906 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pa3d5af2ea2">
+  <clipPath id="pe23b1c6552">
    <rect x="95.67625" y="49.4355" width="431.758783" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_compress_pareto.svg
+++ b/bench/graphs/canterbury_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 79.118387 412.80375 
 L 79.118387 48.323125 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m75222e753f" d="M 0 0 
+       <path id="m9396782769" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m75222e753f" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9396782769" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -161,11 +161,11 @@ z
      <g id="line2d_3">
       <path d="M 166.481434 412.80375 
 L 166.481434 48.323125 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m75222e753f" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9396782769" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -216,11 +216,11 @@ z
      <g id="line2d_5">
       <path d="M 253.844481 412.80375 
 L 253.844481 48.323125 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m75222e753f" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9396782769" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -237,11 +237,11 @@ L 253.844481 48.323125
      <g id="line2d_7">
       <path d="M 341.207528 412.80375 
 L 341.207528 48.323125 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m75222e753f" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9396782769" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -279,11 +279,11 @@ z
      <g id="line2d_9">
       <path d="M 428.570575 412.80375 
 L 428.570575 48.323125 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m75222e753f" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9396782769" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -332,11 +332,11 @@ z
      <g id="line2d_11">
       <path d="M 515.933622 412.80375 
 L 515.933622 48.323125 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m75222e753f" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9396782769" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -353,11 +353,11 @@ L 515.933622 48.323125
      <g id="line2d_13">
       <path d="M 603.296669 412.80375 
 L 603.296669 48.323125 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m75222e753f" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9396782769" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -854,16 +854,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 347.786382 
 L 637.2 347.786382 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="m3ba0ddfe55" d="M 0 0 
+       <path id="m4c3cb94cce" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m3ba0ddfe55" x="49.078125" y="347.786382" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4c3cb94cce" x="49.078125" y="347.786382" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -895,11 +895,11 @@ z
      <g id="line2d_17">
       <path d="M 49.078125 238.646289 
 L 637.2 238.646289 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m3ba0ddfe55" x="49.078125" y="238.646289" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4c3cb94cce" x="49.078125" y="238.646289" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -915,11 +915,11 @@ L 637.2 238.646289
      <g id="line2d_19">
       <path d="M 49.078125 129.506196 
 L 637.2 129.506196 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m3ba0ddfe55" x="49.078125" y="129.506196" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4c3cb94cce" x="49.078125" y="129.506196" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -935,16 +935,16 @@ L 637.2 129.506196
      <g id="line2d_21">
       <path d="M 49.078125 404.853417 
 L 637.2 404.853417 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="m3dffaf441f" d="M 0 0 
+       <path id="m828ecb6bff" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m3dffaf441f" x="49.078125" y="404.853417" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m828ecb6bff" x="49.078125" y="404.853417" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -952,11 +952,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 391.217592 
 L 637.2 391.217592 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m3dffaf441f" x="49.078125" y="391.217592" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m828ecb6bff" x="49.078125" y="391.217592" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -964,11 +964,11 @@ L 637.2 391.217592
      <g id="line2d_25">
       <path d="M 49.078125 380.640824 
 L 637.2 380.640824 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m3dffaf441f" x="49.078125" y="380.640824" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m828ecb6bff" x="49.078125" y="380.640824" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -976,11 +976,11 @@ L 637.2 380.640824
      <g id="line2d_27">
       <path d="M 49.078125 371.998975 
 L 637.2 371.998975 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m3dffaf441f" x="49.078125" y="371.998975" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m828ecb6bff" x="49.078125" y="371.998975" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -988,11 +988,11 @@ L 637.2 371.998975
      <g id="line2d_29">
       <path d="M 49.078125 364.692396 
 L 637.2 364.692396 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m3dffaf441f" x="49.078125" y="364.692396" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m828ecb6bff" x="49.078125" y="364.692396" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1000,11 +1000,11 @@ L 637.2 364.692396
      <g id="line2d_31">
       <path d="M 49.078125 358.36315 
 L 637.2 358.36315 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m3dffaf441f" x="49.078125" y="358.36315" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m828ecb6bff" x="49.078125" y="358.36315" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1012,11 +1012,11 @@ L 637.2 358.36315
      <g id="line2d_33">
       <path d="M 49.078125 352.780359 
 L 637.2 352.780359 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m3dffaf441f" x="49.078125" y="352.780359" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m828ecb6bff" x="49.078125" y="352.780359" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1024,11 +1024,11 @@ L 637.2 352.780359
      <g id="line2d_35">
       <path d="M 49.078125 314.93194 
 L 637.2 314.93194 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m3dffaf441f" x="49.078125" y="314.93194" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m828ecb6bff" x="49.078125" y="314.93194" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1036,11 +1036,11 @@ L 637.2 314.93194
      <g id="line2d_37">
       <path d="M 49.078125 295.713324 
 L 637.2 295.713324 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m3dffaf441f" x="49.078125" y="295.713324" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m828ecb6bff" x="49.078125" y="295.713324" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1048,11 +1048,11 @@ L 637.2 295.713324
      <g id="line2d_39">
       <path d="M 49.078125 282.077499 
 L 637.2 282.077499 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m3dffaf441f" x="49.078125" y="282.077499" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m828ecb6bff" x="49.078125" y="282.077499" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1060,11 +1060,11 @@ L 637.2 282.077499
      <g id="line2d_41">
       <path d="M 49.078125 271.500731 
 L 637.2 271.500731 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m3dffaf441f" x="49.078125" y="271.500731" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m828ecb6bff" x="49.078125" y="271.500731" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1072,11 +1072,11 @@ L 637.2 271.500731
      <g id="line2d_43">
       <path d="M 49.078125 262.858882 
 L 637.2 262.858882 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m3dffaf441f" x="49.078125" y="262.858882" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m828ecb6bff" x="49.078125" y="262.858882" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1084,11 +1084,11 @@ L 637.2 262.858882
      <g id="line2d_45">
       <path d="M 49.078125 255.552304 
 L 637.2 255.552304 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m3dffaf441f" x="49.078125" y="255.552304" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m828ecb6bff" x="49.078125" y="255.552304" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1096,11 +1096,11 @@ L 637.2 255.552304
      <g id="line2d_47">
       <path d="M 49.078125 249.223057 
 L 637.2 249.223057 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m3dffaf441f" x="49.078125" y="249.223057" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m828ecb6bff" x="49.078125" y="249.223057" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1108,11 +1108,11 @@ L 637.2 249.223057
      <g id="line2d_49">
       <path d="M 49.078125 243.640266 
 L 637.2 243.640266 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m3dffaf441f" x="49.078125" y="243.640266" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m828ecb6bff" x="49.078125" y="243.640266" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1120,11 +1120,11 @@ L 637.2 243.640266
      <g id="line2d_51">
       <path d="M 49.078125 205.791848 
 L 637.2 205.791848 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m3dffaf441f" x="49.078125" y="205.791848" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m828ecb6bff" x="49.078125" y="205.791848" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1132,11 +1132,11 @@ L 637.2 205.791848
      <g id="line2d_53">
       <path d="M 49.078125 186.573231 
 L 637.2 186.573231 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#m3dffaf441f" x="49.078125" y="186.573231" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m828ecb6bff" x="49.078125" y="186.573231" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1144,11 +1144,11 @@ L 637.2 186.573231
      <g id="line2d_55">
       <path d="M 49.078125 172.937406 
 L 637.2 172.937406 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#m3dffaf441f" x="49.078125" y="172.937406" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m828ecb6bff" x="49.078125" y="172.937406" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1156,11 +1156,11 @@ L 637.2 172.937406
      <g id="line2d_57">
       <path d="M 49.078125 162.360638 
 L 637.2 162.360638 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#m3dffaf441f" x="49.078125" y="162.360638" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m828ecb6bff" x="49.078125" y="162.360638" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1168,11 +1168,11 @@ L 637.2 162.360638
      <g id="line2d_59">
       <path d="M 49.078125 153.71879 
 L 637.2 153.71879 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#m3dffaf441f" x="49.078125" y="153.71879" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m828ecb6bff" x="49.078125" y="153.71879" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1180,11 +1180,11 @@ L 637.2 153.71879
      <g id="line2d_61">
       <path d="M 49.078125 146.412211 
 L 637.2 146.412211 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#m3dffaf441f" x="49.078125" y="146.412211" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m828ecb6bff" x="49.078125" y="146.412211" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1192,11 +1192,11 @@ L 637.2 146.412211
      <g id="line2d_63">
       <path d="M 49.078125 140.082964 
 L 637.2 140.082964 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#m3dffaf441f" x="49.078125" y="140.082964" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m828ecb6bff" x="49.078125" y="140.082964" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1204,11 +1204,11 @@ L 637.2 140.082964
      <g id="line2d_65">
       <path d="M 49.078125 134.500173 
 L 637.2 134.500173 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#m3dffaf441f" x="49.078125" y="134.500173" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m828ecb6bff" x="49.078125" y="134.500173" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1216,11 +1216,11 @@ L 637.2 134.500173
      <g id="line2d_67">
       <path d="M 49.078125 96.651755 
 L 637.2 96.651755 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_68">
       <g>
-       <use xlink:href="#m3dffaf441f" x="49.078125" y="96.651755" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m828ecb6bff" x="49.078125" y="96.651755" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1228,11 +1228,11 @@ L 637.2 96.651755
      <g id="line2d_69">
       <path d="M 49.078125 77.433138 
 L 637.2 77.433138 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_70">
       <g>
-       <use xlink:href="#m3dffaf441f" x="49.078125" y="77.433138" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m828ecb6bff" x="49.078125" y="77.433138" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1240,11 +1240,11 @@ L 637.2 77.433138
      <g id="line2d_71">
       <path d="M 49.078125 63.797313 
 L 637.2 63.797313 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_72">
       <g>
-       <use xlink:href="#m3dffaf441f" x="49.078125" y="63.797313" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m828ecb6bff" x="49.078125" y="63.797313" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1252,11 +1252,11 @@ L 637.2 63.797313
      <g id="line2d_73">
       <path d="M 49.078125 53.220545 
 L 637.2 53.220545 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_74">
       <g>
-       <use xlink:href="#m3dffaf441f" x="49.078125" y="53.220545" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m828ecb6bff" x="49.078125" y="53.220545" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1378,7 +1378,7 @@ L 637.2 48.323125
    </g>
    <g id="text_13">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(294.669676 147.165393) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(294.669676 147.921468) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1410,7 +1410,7 @@ z
    </g>
    <g id="text_14">
     <!-- L10 -->
-    <g style="fill: #d62728" transform="translate(104.852312 296.848926) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(104.852312 297.212258) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1732,23 +1732,23 @@ z
    </g>
    <g id="line2d_75">
     <defs>
-     <path id="mdab724900d" d="M -2.5 2.5 
+     <path id="m62e051409e" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p15e0ad6792)">
-     <use xlink:href="#mdab724900d" x="355.479835" y="95.382063" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdab724900d" x="308.273931" y="102.754513" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdab724900d" x="271.230161" y="116.528062" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdab724900d" x="217.83458" y="120.013651" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdab724900d" x="177.077692" y="138.43462" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdab724900d" x="162.880539" y="157.778627" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdab724900d" x="160.741445" y="165.196647" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdab724900d" x="153.966678" y="183.405761" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdab724900d" x="151.589614" y="194.488118" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p63a9d83c72)">
+     <use xlink:href="#m62e051409e" x="355.479835" y="95.382063" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m62e051409e" x="308.273931" y="102.754513" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m62e051409e" x="271.230161" y="116.528062" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m62e051409e" x="217.83458" y="120.013651" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m62e051409e" x="177.077692" y="138.43462" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m62e051409e" x="162.880539" y="157.778627" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m62e051409e" x="160.741445" y="165.196647" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m62e051409e" x="153.966678" y="183.405761" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m62e051409e" x="151.589614" y="194.488118" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_76">
@@ -1801,7 +1801,7 @@ L 311.2243 102.325849
 L 310.240844 102.469168 
 L 309.257387 102.612055 
 L 308.273931 102.754513 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_77">
     <path d="M 308.273931 102.754513 
@@ -1853,7 +1853,7 @@ L 273.545396 115.775058
 L 272.773651 116.027391 
 L 272.001906 116.278388 
 L 271.230161 116.528062 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_78">
     <path d="M 271.230161 116.528062 
@@ -1905,7 +1905,7 @@ L 221.171803 119.803152
 L 220.059395 119.873422 
 L 218.946988 119.943588 
 L 217.83458 120.013651 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_79">
     <path d="M 217.83458 120.013651 
@@ -1957,7 +1957,7 @@ L 179.624997 137.470928
 L 178.775895 137.79434 
 L 177.926794 138.115561 
 L 177.077692 138.43462 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_80">
     <path d="M 177.077692 138.43462 
@@ -2009,7 +2009,7 @@ L 163.767861 156.775388
 L 163.472087 157.112166 
 L 163.176313 157.446568 
 L 162.880539 157.778627 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_81">
     <path d="M 162.880539 157.778627 
@@ -2061,7 +2061,7 @@ L 160.875139 164.765525
 L 160.830574 164.909668 
 L 160.78601 165.053375 
 L 160.741445 165.196647 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_82">
     <path d="M 160.741445 165.196647 
@@ -2113,7 +2113,7 @@ L 154.390101 182.45125
 L 154.24896 182.771561 
 L 154.107819 183.089721 
 L 153.966678 183.405761 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_83">
     <path d="M 153.966678 183.405761 
@@ -2165,26 +2165,26 @@ L 151.73818 193.866427
 L 151.688658 194.074564 
 L 151.639136 194.281792 
 L 151.589614 194.488118 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_84">
     <defs>
-     <path id="m72e792c3e8" d="M 0 -2.5 
+     <path id="mf3501609be" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p15e0ad6792)">
-     <use xlink:href="#m72e792c3e8" x="531.649087" y="75.963093" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m72e792c3e8" x="283.721324" y="99.020035" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m72e792c3e8" x="218.882044" y="121.069315" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m72e792c3e8" x="187.447228" y="127.10685" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m72e792c3e8" x="176.342474" y="138.36311" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m72e792c3e8" x="163.054314" y="161.312135" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m72e792c3e8" x="162.210539" y="168.753955" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m72e792c3e8" x="159.303811" y="175.753345" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m72e792c3e8" x="157.793928" y="179.494802" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p63a9d83c72)">
+     <use xlink:href="#mf3501609be" x="531.649087" y="75.963093" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf3501609be" x="283.721324" y="99.020035" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf3501609be" x="218.882044" y="121.069315" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf3501609be" x="187.447228" y="127.10685" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf3501609be" x="176.342474" y="138.36311" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf3501609be" x="163.054314" y="161.312135" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf3501609be" x="162.210539" y="168.753955" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf3501609be" x="159.303811" y="175.753345" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf3501609be" x="157.793928" y="179.494802" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_85">
@@ -2237,7 +2237,7 @@ L 299.21681 97.864971
 L 294.051648 98.253128 
 L 288.886486 98.638133 
 L 283.721324 99.020035 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_86">
     <path d="M 283.721324 99.020035 
@@ -2289,7 +2289,7 @@ L 222.934499 119.954333
 L 221.583681 120.328916 
 L 220.232863 120.700561 
 L 218.882044 121.069315 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_87">
     <path d="M 218.882044 121.069315 
@@ -2341,7 +2341,7 @@ L 189.411904 126.751217
 L 188.757012 126.870058 
 L 188.10212 126.988602 
 L 187.447228 127.10685 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_88">
     <path d="M 187.447228 127.10685 
@@ -2393,7 +2393,7 @@ L 177.036521 137.732718
 L 176.805172 137.943781 
 L 176.573823 138.153909 
 L 176.342474 138.36311 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_89">
     <path d="M 176.342474 138.36311 
@@ -2445,7 +2445,7 @@ L 163.884824 160.161325
 L 163.607987 160.548041 
 L 163.33115 160.931628 
 L 163.054314 161.312135 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_90">
     <path d="M 163.054314 161.312135 
@@ -2497,7 +2497,7 @@ L 162.263275 168.321549
 L 162.245696 168.466124 
 L 162.228118 168.610258 
 L 162.210539 168.753955 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_91">
     <path d="M 162.210539 168.753955 
@@ -2549,7 +2549,7 @@ L 159.485481 175.344896
 L 159.424925 175.481437 
 L 159.364368 175.617586 
 L 159.303811 175.753345 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_92">
     <path d="M 159.303811 175.753345 
@@ -2601,30 +2601,30 @@ L 157.888296 179.269417
 L 157.85684 179.344665 
 L 157.825384 179.419793 
 L 157.793928 179.494802 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_93">
     <defs>
-     <path id="m64c6c9ec2a" d="M -0 3.535534 
+     <path id="m2c874f2dab" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p15e0ad6792)">
-     <use xlink:href="#m64c6c9ec2a" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m64c6c9ec2a" x="203.775848" y="81.750179" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m64c6c9ec2a" x="186.982691" y="88.344921" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m64c6c9ec2a" x="179.779306" y="91.045312" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m64c6c9ec2a" x="157.610419" y="99.395085" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m64c6c9ec2a" x="148.722526" y="107.864022" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m64c6c9ec2a" x="144.388162" y="121.237794" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m64c6c9ec2a" x="127.071247" y="144.560664" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m64c6c9ec2a" x="124.491988" y="152.083585" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m64c6c9ec2a" x="92.613662" y="207.637263" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m64c6c9ec2a" x="87.348715" y="225.457654" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m64c6c9ec2a" x="86.053433" y="242.017529" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p63a9d83c72)">
+     <use xlink:href="#m2c874f2dab" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2c874f2dab" x="203.775848" y="81.750179" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2c874f2dab" x="186.982691" y="88.344921" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2c874f2dab" x="179.779306" y="91.045312" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2c874f2dab" x="157.610419" y="99.395085" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2c874f2dab" x="148.722526" y="107.864022" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2c874f2dab" x="144.388162" y="121.237794" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2c874f2dab" x="127.071247" y="144.560664" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2c874f2dab" x="124.491988" y="152.083585" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2c874f2dab" x="92.613662" y="207.637263" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2c874f2dab" x="87.348715" y="225.457654" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2c874f2dab" x="86.053433" y="242.017529" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_94">
@@ -2677,7 +2677,7 @@ L 206.762331 80.855075
 L 205.766837 81.155325 
 L 204.771342 81.453685 
 L 203.775848 81.750179 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_95">
     <path d="M 203.775848 81.750179 
@@ -2729,7 +2729,7 @@ L 188.032264 87.958568
 L 187.682406 88.087703 
 L 187.332549 88.216487 
 L 186.982691 88.344921 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_96">
     <path d="M 186.982691 88.344921 
@@ -2781,7 +2781,7 @@ L 180.229518 90.88097
 L 180.079447 90.935814 
 L 179.929376 90.990595 
 L 179.779306 91.045312 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_97">
     <path d="M 179.779306 91.045312 
@@ -2833,7 +2833,7 @@ L 158.995974 98.914174
 L 158.534122 99.075021 
 L 158.07227 99.235323 
 L 157.610419 99.395085 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_98">
     <path d="M 157.610419 99.395085 
@@ -2885,7 +2885,7 @@ L 149.27802 107.37681
 L 149.092855 107.539771 
 L 148.907691 107.702174 
 L 148.722526 107.864022 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_99">
     <path d="M 148.722526 107.864022 
@@ -2937,7 +2937,7 @@ L 144.65906 120.50385
 L 144.568761 120.749763 
 L 144.478462 120.994407 
 L 144.388162 121.237794 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_100">
     <path d="M 144.388162 121.237794 
@@ -2989,7 +2989,7 @@ L 128.153555 143.395158
 L 127.792786 143.786853 
 L 127.432016 144.175338 
 L 127.071247 144.560664 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_101">
     <path d="M 127.071247 144.560664 
@@ -3041,7 +3041,7 @@ L 124.653192 151.646811
 L 124.599457 151.79285 
 L 124.545723 151.93844 
 L 124.491988 152.083585 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_102">
     <path d="M 124.491988 152.083585 
@@ -3093,7 +3093,7 @@ L 94.606058 205.546972
 L 93.941926 206.254028 
 L 93.277794 206.950691 
 L 92.613662 207.637263 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_103">
     <path d="M 92.613662 207.637263 
@@ -3145,7 +3145,7 @@ L 87.677774 224.520091
 L 87.568088 224.834677 
 L 87.458402 225.147189 
 L 87.348715 225.457654 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_104">
     <path d="M 87.348715 225.457654 
@@ -3197,23 +3197,23 @@ L 86.134388 241.135848
 L 86.107403 241.431568 
 L 86.080418 241.725454 
 L 86.053433 242.017529 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_105">
     <defs>
-     <path id="m042b507434" d="M -0 2.5 
+     <path id="ma1ebf0d29a" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p15e0ad6792)">
-     <use xlink:href="#m042b507434" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p63a9d83c72)">
+     <use xlink:href="#ma1ebf0d29a" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_106">
     <defs>
-     <path id="m21fb7bcda3" d="M -0.833333 2.5 
+     <path id="maef2cbcc2e" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -3228,16 +3228,16 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p15e0ad6792)">
-     <use xlink:href="#m21fb7bcda3" x="362.865999" y="115.428618" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m21fb7bcda3" x="278.798176" y="122.858526" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m21fb7bcda3" x="251.17632" y="128.261574" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m21fb7bcda3" x="200.806828" y="131.522849" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m21fb7bcda3" x="169.803221" y="147.931404" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m21fb7bcda3" x="161.916638" y="160.718659" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m21fb7bcda3" x="158.697104" y="167.705569" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m21fb7bcda3" x="154.26679" y="181.026105" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m21fb7bcda3" x="153.096464" y="191.924265" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p63a9d83c72)">
+     <use xlink:href="#maef2cbcc2e" x="362.865999" y="115.428618" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#maef2cbcc2e" x="278.798176" y="122.858526" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#maef2cbcc2e" x="251.17632" y="128.261574" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#maef2cbcc2e" x="200.806828" y="131.522849" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#maef2cbcc2e" x="169.803221" y="147.931404" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#maef2cbcc2e" x="161.916638" y="160.718659" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#maef2cbcc2e" x="158.697104" y="167.705569" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#maef2cbcc2e" x="154.26679" y="181.026105" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#maef2cbcc2e" x="153.096464" y="191.924265" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_107">
@@ -3290,7 +3290,7 @@ L 284.052415 122.426763
 L 282.301002 122.571121 
 L 280.549589 122.715042 
 L 278.798176 122.858526 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_108">
     <path d="M 278.798176 122.858526 
@@ -3342,7 +3342,7 @@ L 252.902686 127.94134
 L 252.327231 128.048325 
 L 251.751776 128.155069 
 L 251.17632 128.261574 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_109">
     <path d="M 251.17632 128.261574 
@@ -3394,7 +3394,7 @@ L 203.954921 131.325463
 L 202.905557 131.39135 
 L 201.856192 131.457145 
 L 200.806828 131.522849 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_110">
     <path d="M 200.806828 131.522849 
@@ -3446,7 +3446,7 @@ L 171.740947 147.056528
 L 171.095038 147.349951 
 L 170.44913 147.64157 
 L 169.803221 147.931404 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_111">
     <path d="M 169.803221 147.931404 
@@ -3498,7 +3498,7 @@ L 162.409549 160.012958
 L 162.245246 160.249361 
 L 162.080942 160.484591 
 L 161.916638 160.718659 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_112">
     <path d="M 161.916638 160.718659 
@@ -3550,7 +3550,7 @@ L 158.898325 167.297798
 L 158.831251 167.434112 
 L 158.764178 167.570034 
 L 158.697104 167.705569 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_113">
     <path d="M 158.697104 167.705569 
@@ -3602,7 +3602,7 @@ L 154.543684 180.294711
 L 154.451386 180.539765 
 L 154.359088 180.783558 
 L 154.26679 181.026105 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_114">
     <path d="M 154.26679 181.026105 
@@ -3654,11 +3654,11 @@ L 153.16961 191.311823
 L 153.145228 191.516851 
 L 153.120846 191.720996 
 L 153.096464 191.924265 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_115">
     <defs>
-     <path id="m485e56205e" d="M -1.25 2.5 
+     <path id="mc20a948475" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -3673,16 +3673,16 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p15e0ad6792)">
-     <use xlink:href="#m485e56205e" x="301.619021" y="150.561849" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m485e56205e" x="250.236474" y="156.671134" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m485e56205e" x="225.418659" y="160.842551" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m485e56205e" x="212.328936" y="161.382211" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m485e56205e" x="209.030149" y="166.25091" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m485e56205e" x="197.547749" y="171.432451" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m485e56205e" x="194.819287" y="175.129495" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m485e56205e" x="193.12279" y="181.606362" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m485e56205e" x="192.79794" y="189.451167" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p63a9d83c72)">
+     <use xlink:href="#mc20a948475" x="301.619021" y="150.561849" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc20a948475" x="250.236474" y="156.671134" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc20a948475" x="225.418659" y="160.842551" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc20a948475" x="212.328936" y="161.382211" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc20a948475" x="209.030149" y="166.25091" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc20a948475" x="197.547749" y="171.432451" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc20a948475" x="194.819287" y="175.129495" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc20a948475" x="193.12279" y="181.606362" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc20a948475" x="192.79794" y="189.451167" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_116">
@@ -3735,7 +3735,7 @@ L 253.447883 156.311526
 L 252.377414 156.431699 
 L 251.306944 156.551567 
 L 250.236474 156.671134 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_117">
     <path d="M 250.236474 156.671134 
@@ -3787,7 +3787,7 @@ L 226.969772 160.592321
 L 226.452735 160.675878 
 L 225.935697 160.759287 
 L 225.418659 160.842551 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_118">
     <path d="M 225.418659 160.842551 
@@ -3839,7 +3839,7 @@ L 213.147044 161.348661
 L 212.874341 161.359847 
 L 212.601639 161.37103 
 L 212.328936 161.382211 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_119">
     <path d="M 212.328936 161.382211 
@@ -3891,7 +3891,7 @@ L 209.236323 165.960837
 L 209.167599 166.057725 
 L 209.098874 166.154416 
 L 209.030149 166.25091 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_120">
     <path d="M 209.030149 166.25091 
@@ -3943,7 +3943,7 @@ L 198.265399 171.124681
 L 198.026182 171.227493 
 L 197.786966 171.330083 
 L 197.547749 171.432451 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_121">
     <path d="M 197.547749 171.432451 
@@ -3995,7 +3995,7 @@ L 194.989815 174.906688
 L 194.932972 174.981074 
 L 194.876129 175.055342 
 L 194.819287 175.129495 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_122">
     <path d="M 194.819287 175.129495 
@@ -4047,7 +4047,7 @@ L 193.228821 181.226479
 L 193.193478 181.353445 
 L 193.158134 181.480072 
 L 193.12279 181.606362 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_123">
     <path d="M 193.12279 181.606362 
@@ -4099,11 +4099,11 @@ L 192.818243 188.997124
 L 192.811475 189.148955 
 L 192.804707 189.300302 
 L 192.79794 189.451167 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_124">
     <defs>
-     <path id="maa8c4e1634" d="M 0 -2.5 
+     <path id="mdaec62a252" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -4116,16 +4116,16 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p15e0ad6792)">
-     <use xlink:href="#maa8c4e1634" x="206.45578" y="118.584066" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#maa8c4e1634" x="206.45578" y="118.258949" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#maa8c4e1634" x="206.45578" y="118.759361" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#maa8c4e1634" x="206.45578" y="118.234957" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#maa8c4e1634" x="171.767499" y="134.097889" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#maa8c4e1634" x="163.54283" y="144.663903" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#maa8c4e1634" x="160.174881" y="151.505345" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#maa8c4e1634" x="154.179217" y="169.303726" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#maa8c4e1634" x="152.4406" y="178.584542" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p63a9d83c72)">
+     <use xlink:href="#mdaec62a252" x="206.45578" y="118.584066" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mdaec62a252" x="206.45578" y="118.258949" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mdaec62a252" x="206.45578" y="118.759361" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mdaec62a252" x="206.45578" y="118.234957" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mdaec62a252" x="171.767499" y="134.097889" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mdaec62a252" x="163.54283" y="144.663903" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mdaec62a252" x="160.174881" y="151.505345" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mdaec62a252" x="154.179217" y="169.303726" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mdaec62a252" x="152.4406" y="178.584542" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_125">
@@ -4178,7 +4178,7 @@ L 206.45578 118.279335
 L 206.45578 118.27254 
 L 206.45578 118.265745 
 L 206.45578 118.258949 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_126">
     <path d="M 206.45578 118.258949 
@@ -4230,7 +4230,7 @@ L 206.45578 118.728239
 L 206.45578 118.738615 
 L 206.45578 118.748989 
 L 206.45578 118.759361 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_127">
     <path d="M 206.45578 118.759361 
@@ -4282,7 +4282,7 @@ L 206.45578 118.267903
 L 206.45578 118.256924 
 L 206.45578 118.245942 
 L 206.45578 118.234957 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_128">
     <path d="M 206.45578 118.234957 
@@ -4334,7 +4334,7 @@ L 173.935517 133.247721
 L 173.212844 133.532808 
 L 172.490172 133.816191 
 L 171.767499 134.097889 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_129">
     <path d="M 171.767499 134.097889 
@@ -4386,7 +4386,7 @@ L 164.056872 144.068227
 L 163.885524 144.267619 
 L 163.714177 144.466175 
 L 163.54283 144.663903 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_130">
     <path d="M 163.54283 144.663903 
@@ -4438,7 +4438,7 @@ L 160.385378 151.105499
 L 160.315212 151.239156 
 L 160.245047 151.372438 
 L 160.174881 151.505345 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_131">
     <path d="M 160.174881 151.505345 
@@ -4490,7 +4490,7 @@ L 154.553946 168.367127
 L 154.429036 168.681387 
 L 154.304126 168.993578 
 L 154.179217 169.303726 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_132">
     <path d="M 154.179217 169.303726 
@@ -4542,11 +4542,11 @@ L 152.549264 178.054798
 L 152.513043 178.232038 
 L 152.476822 178.408618 
 L 152.4406 178.584542 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_133">
     <defs>
-     <path id="mb8ceae57b7" d="M 0 -2.5 
+     <path id="m2d001c9e0a" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -4555,16 +4555,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p15e0ad6792)">
-     <use xlink:href="#mb8ceae57b7" x="610.467188" y="172.829682" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb8ceae57b7" x="592.067397" y="173.763838" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb8ceae57b7" x="534.807821" y="180.385179" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb8ceae57b7" x="327.802209" y="176.172104" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb8ceae57b7" x="275.83761" y="186.734601" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb8ceae57b7" x="258.25125" y="198.783148" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb8ceae57b7" x="256.777056" y="203.737732" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb8ceae57b7" x="248.769854" y="217.74136" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb8ceae57b7" x="246.264594" y="227.740017" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p63a9d83c72)">
+     <use xlink:href="#m2d001c9e0a" x="610.467188" y="172.829682" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2d001c9e0a" x="592.067397" y="173.763838" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2d001c9e0a" x="534.807821" y="180.385179" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2d001c9e0a" x="327.802209" y="176.172104" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2d001c9e0a" x="275.83761" y="186.734601" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2d001c9e0a" x="258.25125" y="198.783148" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2d001c9e0a" x="256.777056" y="203.737732" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2d001c9e0a" x="248.769854" y="217.74136" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2d001c9e0a" x="246.264594" y="227.740017" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_134">
@@ -4617,7 +4617,7 @@ L 593.217384 173.705989
 L 592.834055 173.72528 
 L 592.450726 173.744563 
 L 592.067397 173.763838 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_135">
     <path d="M 592.067397 173.763838 
@@ -4669,7 +4669,7 @@ L 538.386544 179.997367
 L 537.193636 180.126991 
 L 536.000728 180.25626 
 L 534.807821 180.385179 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_136">
     <path d="M 534.807821 180.385179 
@@ -4721,7 +4721,7 @@ L 340.74006 176.446681
 L 336.427443 176.355332 
 L 332.114826 176.263806 
 L 327.802209 176.172104 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_137">
     <path d="M 327.802209 176.172104 
@@ -4773,7 +4773,7 @@ L 279.085397 186.139102
 L 278.002801 186.338434 
 L 276.920205 186.536931 
 L 275.83761 186.734601 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_138">
     <path d="M 275.83761 186.734601 
@@ -4825,7 +4825,7 @@ L 259.350398 198.113494
 L 258.984015 198.337765 
 L 258.617633 198.560979 
 L 258.25125 198.783148 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_139">
     <path d="M 258.25125 198.783148 
@@ -4877,7 +4877,7 @@ L 256.869193 203.442789
 L 256.838481 203.541307 
 L 256.807768 203.639621 
 L 256.777056 203.737732 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_140">
     <path d="M 256.777056 203.737732 
@@ -4929,7 +4929,7 @@ L 249.270304 216.977455
 L 249.103487 217.23346 
 L 248.93667 217.48809 
 L 248.769854 217.74136 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_141">
     <path d="M 248.769854 217.74136 
@@ -4981,7 +4981,7 @@ L 246.421172 227.173237
 L 246.368979 227.362918 
 L 246.316786 227.551842 
 L 246.264594 227.740017 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="legend_1">
     <g id="patch_7">
@@ -4999,7 +4999,7 @@ z
     </g>
     <g id="line2d_142">
      <defs>
-      <path id="m39d500ea4b" d="M 0 3.5 
+      <path id="m5c58093e45" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -5012,7 +5012,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m39d500ea4b" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m5c58093e45" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -5071,7 +5071,7 @@ z
     </g>
     <g id="line2d_143">
      <g>
-      <use xlink:href="#mdab724900d" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m62e051409e" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -5085,7 +5085,7 @@ z
     </g>
     <g id="line2d_144">
      <g>
-      <use xlink:href="#m72e792c3e8" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mf3501609be" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -5130,7 +5130,7 @@ z
     </g>
     <g id="line2d_145">
      <g>
-      <use xlink:href="#m64c6c9ec2a" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m2c874f2dab" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -5173,7 +5173,7 @@ z
     </g>
     <g id="line2d_146">
      <g>
-      <use xlink:href="#m042b507434" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#ma1ebf0d29a" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -5189,7 +5189,7 @@ z
     </g>
     <g id="line2d_147">
      <g>
-      <use xlink:href="#m21fb7bcda3" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#maef2cbcc2e" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -5243,7 +5243,7 @@ z
     </g>
     <g id="line2d_148">
      <g>
-      <use xlink:href="#m485e56205e" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mc20a948475" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -5308,7 +5308,7 @@ z
     </g>
     <g id="line2d_149">
      <g>
-      <use xlink:href="#maa8c4e1634" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#mdaec62a252" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -5346,7 +5346,7 @@ z
     </g>
     <g id="line2d_150">
      <g>
-      <use xlink:href="#mb8ceae57b7" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m2d001c9e0a" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -5416,486 +5416,486 @@ z
     </g>
    </g>
    <g id="line2d_151">
-    <g clip-path="url(#p15e0ad6792)">
-     <use xlink:href="#m39d500ea4b" x="289.669676" y="152.165393" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m39d500ea4b" x="223.847406" y="163.064493" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m39d500ea4b" x="212.215046" y="166.847868" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m39d500ea4b" x="181.367844" y="175.342151" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m39d500ea4b" x="165.231972" y="183.240515" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m39d500ea4b" x="153.327587" y="189.275935" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m39d500ea4b" x="148.576453" y="195.237082" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m39d500ea4b" x="145.287154" y="198.147124" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m39d500ea4b" x="115.00257" y="275.537627" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m39d500ea4b" x="99.852312" y="301.848926" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <g clip-path="url(#p63a9d83c72)">
+     <use xlink:href="#m5c58093e45" x="289.669676" y="152.921468" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m5c58093e45" x="223.847406" y="163.784863" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m5c58093e45" x="212.215046" y="167.662068" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m5c58093e45" x="181.367844" y="176.735792" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m5c58093e45" x="165.231972" y="184.486813" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m5c58093e45" x="153.327587" y="190.494522" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m5c58093e45" x="148.576453" y="196.348889" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m5c58093e45" x="145.287154" y="199.248393" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m5c58093e45" x="115.00257" y="276.099302" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m5c58093e45" x="99.852312" y="302.212258" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
    <g id="line2d_152">
-    <path d="M 289.669676 152.165393 
-L 288.298379 152.42 
-L 286.927082 152.673247 
-L 285.555784 152.925148 
-L 284.184487 153.175717 
-L 282.81319 153.424968 
-L 281.441892 153.672916 
-L 280.070595 153.919574 
-L 278.699298 154.164954 
-L 277.328 154.409071 
-L 275.956703 154.651937 
-L 274.585406 154.893565 
-L 273.214109 155.133967 
-L 271.842811 155.373156 
-L 270.471514 155.611144 
-L 269.100217 155.847944 
-L 267.728919 156.083566 
-L 266.357622 156.318022 
-L 264.986325 156.551325 
-L 263.615028 156.783485 
-L 262.24373 157.014513 
-L 260.872433 157.244421 
-L 259.501136 157.473219 
-L 258.129838 157.700918 
-L 256.758541 157.927528 
-L 255.387244 158.15306 
-L 254.015947 158.377524 
-L 252.644649 158.60093 
-L 251.273352 158.823288 
-L 249.902055 159.044607 
-L 248.530757 159.264898 
-L 247.15946 159.48417 
-L 245.788163 159.702432 
-L 244.416866 159.919694 
-L 243.045568 160.135965 
-L 241.674271 160.351253 
-L 240.302974 160.565568 
-L 238.931676 160.778918 
-L 237.560379 160.991312 
-L 236.189082 161.202758 
-L 234.817784 161.413266 
-L 233.446487 161.622842 
-L 232.07519 161.831497 
-L 230.703893 162.039236 
-L 229.332595 162.246069 
-L 227.961298 162.452004 
-L 226.590001 162.657047 
-L 225.218703 162.861208 
-L 223.847406 163.064493 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 289.669676 152.921468 
+L 288.298379 153.175145 
+L 286.927082 153.427471 
+L 285.555784 153.67846 
+L 284.184487 153.928128 
+L 282.81319 154.176487 
+L 281.441892 154.423552 
+L 280.070595 154.669336 
+L 278.699298 154.913852 
+L 277.328 155.157113 
+L 275.956703 155.399132 
+L 274.585406 155.639921 
+L 273.214109 155.879493 
+L 271.842811 156.117861 
+L 270.471514 156.355035 
+L 269.100217 156.591029 
+L 267.728919 156.825854 
+L 266.357622 157.059521 
+L 264.986325 157.292042 
+L 263.615028 157.523428 
+L 262.24373 157.753689 
+L 260.872433 157.982838 
+L 259.501136 158.210884 
+L 258.129838 158.437838 
+L 256.758541 158.66371 
+L 255.387244 158.888512 
+L 254.015947 159.112252 
+L 252.644649 159.334941 
+L 251.273352 159.556588 
+L 249.902055 159.777204 
+L 248.530757 159.996798 
+L 247.15946 160.215379 
+L 245.788163 160.432957 
+L 244.416866 160.649541 
+L 243.045568 160.865139 
+L 241.674271 161.079761 
+L 240.302974 161.293416 
+L 238.931676 161.506112 
+L 237.560379 161.717858 
+L 236.189082 161.928662 
+L 234.817784 162.138533 
+L 233.446487 162.347479 
+L 232.07519 162.555507 
+L 230.703893 162.762627 
+L 229.332595 162.968845 
+L 227.961298 163.17417 
+L 226.590001 163.37861 
+L 225.218703 163.582172 
+L 223.847406 163.784863 
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_153">
-    <path d="M 223.847406 163.064493 
-L 223.605065 163.146473 
-L 223.362724 163.228312 
-L 223.120384 163.31001 
-L 222.878043 163.391567 
-L 222.635702 163.472985 
-L 222.393361 163.554262 
-L 222.15102 163.635401 
-L 221.908679 163.716401 
-L 221.666339 163.797262 
-L 221.423998 163.877986 
-L 221.181657 163.958573 
-L 220.939316 164.039023 
-L 220.696975 164.119336 
-L 220.454635 164.199514 
-L 220.212294 164.279556 
-L 219.969953 164.359464 
-L 219.727612 164.439237 
-L 219.485271 164.518875 
-L 219.24293 164.598381 
-L 219.00059 164.677753 
-L 218.758249 164.756992 
-L 218.515908 164.8361 
-L 218.273567 164.915075 
-L 218.031226 164.993919 
-L 217.788885 165.072632 
-L 217.546545 165.151215 
-L 217.304204 165.229667 
-L 217.061863 165.30799 
-L 216.819522 165.386184 
-L 216.577181 165.464249 
-L 216.33484 165.542185 
-L 216.0925 165.619994 
-L 215.850159 165.697675 
-L 215.607818 165.775229 
-L 215.365477 165.852656 
-L 215.123136 165.929957 
-L 214.880795 166.007132 
-L 214.638455 166.084182 
-L 214.396114 166.161107 
-L 214.153773 166.237907 
-L 213.911432 166.314583 
-L 213.669091 166.391135 
-L 213.42675 166.467563 
-L 213.18441 166.543869 
-L 212.942069 166.620051 
-L 212.699728 166.696112 
-L 212.457387 166.772051 
-L 212.215046 166.847868 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 223.847406 163.784863 
+L 223.605065 163.868959 
+L 223.362724 163.952906 
+L 223.120384 164.036705 
+L 222.878043 164.120355 
+L 222.635702 164.203859 
+L 222.393361 164.287216 
+L 222.15102 164.370426 
+L 221.908679 164.45349 
+L 221.666339 164.536409 
+L 221.423998 164.619184 
+L 221.181657 164.701814 
+L 220.939316 164.7843 
+L 220.696975 164.866643 
+L 220.454635 164.948843 
+L 220.212294 165.030901 
+L 219.969953 165.112817 
+L 219.727612 165.194592 
+L 219.485271 165.276226 
+L 219.24293 165.357719 
+L 219.00059 165.439073 
+L 218.758249 165.520287 
+L 218.515908 165.601363 
+L 218.273567 165.682299 
+L 218.031226 165.763098 
+L 217.788885 165.84376 
+L 217.546545 165.924284 
+L 217.304204 166.004672 
+L 217.061863 166.084924 
+L 216.819522 166.16504 
+L 216.577181 166.245021 
+L 216.33484 166.324867 
+L 216.0925 166.404579 
+L 215.850159 166.484157 
+L 215.607818 166.563601 
+L 215.365477 166.642913 
+L 215.123136 166.722092 
+L 214.880795 166.80114 
+L 214.638455 166.880055 
+L 214.396114 166.95884 
+L 214.153773 167.037493 
+L 213.911432 167.116017 
+L 213.669091 167.19441 
+L 213.42675 167.272674 
+L 213.18441 167.350809 
+L 212.942069 167.428816 
+L 212.699728 167.506694 
+L 212.457387 167.584445 
+L 212.215046 167.662068 
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_154">
-    <path d="M 212.215046 166.847868 
-L 211.572396 167.041285 
-L 210.929746 167.233916 
-L 210.287096 167.425767 
-L 209.644446 167.616845 
-L 209.001796 167.807156 
-L 208.359146 167.996705 
-L 207.716496 168.1855 
-L 207.073846 168.373546 
-L 206.431196 168.560848 
-L 205.788546 168.747414 
-L 205.145896 168.933247 
-L 204.503246 169.118355 
-L 203.860596 169.302744 
-L 203.217946 169.486417 
-L 202.575296 169.669381 
-L 201.932645 169.851642 
-L 201.289995 170.033205 
-L 200.647345 170.214075 
-L 200.004695 170.394258 
-L 199.362045 170.573758 
-L 198.719395 170.75258 
-L 198.076745 170.930731 
-L 197.434095 171.108215 
-L 196.791445 171.285036 
-L 196.148795 171.461201 
-L 195.506145 171.636713 
-L 194.863495 171.811577 
-L 194.220845 171.985799 
-L 193.578195 172.159383 
-L 192.935545 172.332333 
-L 192.292895 172.504655 
-L 191.650245 172.676352 
-L 191.007595 172.84743 
-L 190.364945 173.017893 
-L 189.722294 173.187744 
-L 189.079644 173.356989 
-L 188.436994 173.525632 
-L 187.794344 173.693677 
-L 187.151694 173.861129 
-L 186.509044 174.027991 
-L 185.866394 174.194267 
-L 185.223744 174.359962 
-L 184.581094 174.525081 
-L 183.938444 174.689625 
-L 183.295794 174.853601 
-L 182.653144 175.017011 
-L 182.010494 175.17986 
-L 181.367844 175.342151 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 212.215046 167.662068 
+L 211.572396 167.869953 
+L 210.929746 168.076931 
+L 210.287096 168.283008 
+L 209.644446 168.488194 
+L 209.001796 168.692495 
+L 208.359146 168.895919 
+L 207.716496 169.098474 
+L 207.073846 169.300167 
+L 206.431196 169.501006 
+L 205.788546 169.700997 
+L 205.145896 169.900147 
+L 204.503246 170.098465 
+L 203.860596 170.295956 
+L 203.217946 170.492628 
+L 202.575296 170.688487 
+L 201.932645 170.88354 
+L 201.289995 171.077794 
+L 200.647345 171.271255 
+L 200.004695 171.463929 
+L 199.362045 171.655823 
+L 198.719395 171.846944 
+L 198.076745 172.037297 
+L 197.434095 172.226889 
+L 196.791445 172.415725 
+L 196.148795 172.603812 
+L 195.506145 172.791156 
+L 194.863495 172.977762 
+L 194.220845 173.163636 
+L 193.578195 173.348785 
+L 192.935545 173.533212 
+L 192.292895 173.716925 
+L 191.650245 173.899929 
+L 191.007595 174.082229 
+L 190.364945 174.26383 
+L 189.722294 174.444739 
+L 189.079644 174.624959 
+L 188.436994 174.804497 
+L 187.794344 174.983357 
+L 187.151694 175.161545 
+L 186.509044 175.339066 
+L 185.866394 175.515924 
+L 185.223744 175.692125 
+L 184.581094 175.867673 
+L 183.938444 176.042573 
+L 183.295794 176.216831 
+L 182.653144 176.39045 
+L 182.010494 176.563435 
+L 181.367844 176.735792 
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_155">
-    <path d="M 181.367844 175.342151 
-L 181.03168 175.520868 
-L 180.695516 175.698912 
-L 180.359352 175.876291 
-L 180.023188 176.053008 
-L 179.687024 176.229069 
-L 179.35086 176.404478 
-L 179.014696 176.579241 
-L 178.678532 176.753361 
-L 178.342368 176.926844 
-L 178.006204 177.099695 
-L 177.67004 177.271918 
-L 177.333876 177.443517 
-L 176.997712 177.614497 
-L 176.661548 177.784862 
-L 176.325384 177.954617 
-L 175.98922 178.123767 
-L 175.653056 178.292315 
-L 175.316892 178.460266 
-L 174.980728 178.627624 
-L 174.644564 178.794393 
-L 174.3084 178.960577 
-L 173.972236 179.12618 
-L 173.636072 179.291208 
-L 173.299908 179.455662 
-L 172.963744 179.619548 
-L 172.62758 179.782869 
-L 172.291416 179.945629 
-L 171.955252 180.107833 
-L 171.619088 180.269483 
-L 171.282924 180.430584 
-L 170.94676 180.591139 
-L 170.610596 180.751152 
-L 170.274432 180.910627 
-L 169.938268 181.069567 
-L 169.602104 181.227975 
-L 169.26594 181.385856 
-L 168.929776 181.543213 
-L 168.593612 181.70005 
-L 168.257448 181.856369 
-L 167.921284 182.012174 
-L 167.58512 182.167469 
-L 167.248956 182.322256 
-L 166.912792 182.47654 
-L 166.576628 182.630323 
-L 166.240464 182.783609 
-L 165.9043 182.936401 
-L 165.568136 183.088702 
-L 165.231972 183.240515 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 181.367844 176.735792 
+L 181.03168 176.910901 
+L 180.695516 177.085365 
+L 180.359352 177.25919 
+L 180.023188 177.432379 
+L 179.687024 177.604938 
+L 179.35086 177.776871 
+L 179.014696 177.948183 
+L 178.678532 178.118878 
+L 178.342368 178.28896 
+L 178.006204 178.458434 
+L 177.67004 178.627304 
+L 177.333876 178.795575 
+L 176.997712 178.963251 
+L 176.661548 179.130335 
+L 176.325384 179.296833 
+L 175.98922 179.462748 
+L 175.653056 179.628084 
+L 175.316892 179.792845 
+L 174.980728 179.957036 
+L 174.644564 180.120659 
+L 174.3084 180.28372 
+L 173.972236 180.446222 
+L 173.636072 180.608169 
+L 173.299908 180.769564 
+L 172.963744 180.930411 
+L 172.62758 181.090715 
+L 172.291416 181.250478 
+L 171.955252 181.409705 
+L 171.619088 181.568398 
+L 171.282924 181.726562 
+L 170.94676 181.8842 
+L 170.610596 182.041315 
+L 170.274432 182.197911 
+L 169.938268 182.353992 
+L 169.602104 182.50956 
+L 169.26594 182.66462 
+L 168.929776 182.819173 
+L 168.593612 182.973225 
+L 168.257448 183.126777 
+L 167.921284 183.279834 
+L 167.58512 183.432398 
+L 167.248956 183.584472 
+L 166.912792 183.73606 
+L 166.576628 183.887165 
+L 166.240464 184.03779 
+L 165.9043 184.187937 
+L 165.568136 184.337611 
+L 165.231972 184.486813 
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_156">
-    <path d="M 165.231972 183.240515 
-L 164.983964 183.37442 
-L 164.735956 183.507947 
-L 164.487948 183.6411 
-L 164.23994 183.773879 
-L 163.991932 183.906287 
-L 163.743924 184.038327 
-L 163.495916 184.17 
-L 163.247908 184.301308 
-L 162.9999 184.432253 
-L 162.751892 184.562838 
-L 162.503884 184.693064 
-L 162.255876 184.822933 
-L 162.007868 184.952447 
-L 161.75986 185.081608 
-L 161.511852 185.210418 
-L 161.263844 185.338879 
-L 161.015836 185.466993 
-L 160.767828 185.594762 
-L 160.51982 185.722187 
-L 160.271812 185.84927 
-L 160.023804 185.976014 
-L 159.775796 186.102419 
-L 159.527788 186.228488 
-L 159.27978 186.354223 
-L 159.031772 186.479626 
-L 158.783764 186.604697 
-L 158.535756 186.729439 
-L 158.287748 186.853854 
-L 158.03974 186.977943 
-L 157.791732 187.101708 
-L 157.543724 187.225151 
-L 157.295716 187.348273 
-L 157.047708 187.471076 
-L 156.7997 187.593562 
-L 156.551691 187.715732 
-L 156.303683 187.837588 
-L 156.055675 187.959131 
-L 155.807667 188.080364 
-L 155.559659 188.201287 
-L 155.311651 188.321903 
-L 155.063643 188.442212 
-L 154.815635 188.562217 
-L 154.567627 188.681919 
-L 154.319619 188.801319 
-L 154.071611 188.92042 
-L 153.823603 189.039221 
-L 153.575595 189.157726 
-L 153.327587 189.275935 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 165.231972 184.486813 
+L 164.983964 184.620064 
+L 164.735956 184.752941 
+L 164.487948 184.885447 
+L 164.23994 185.017584 
+L 163.991932 185.149353 
+L 163.743924 185.280757 
+L 163.495916 185.411798 
+L 163.247908 185.542477 
+L 162.9999 185.672798 
+L 162.751892 185.80276 
+L 162.503884 185.932368 
+L 162.255876 186.061622 
+L 162.007868 186.190524 
+L 161.75986 186.319077 
+L 161.511852 186.447282 
+L 161.263844 186.575142 
+L 161.015836 186.702657 
+L 160.767828 186.82983 
+L 160.51982 186.956663 
+L 160.271812 187.083158 
+L 160.023804 187.209316 
+L 159.775796 187.335138 
+L 159.527788 187.460628 
+L 159.27978 187.585787 
+L 159.031772 187.710615 
+L 158.783764 187.835116 
+L 158.535756 187.959291 
+L 158.287748 188.083141 
+L 158.03974 188.206669 
+L 157.791732 188.329875 
+L 157.543724 188.452762 
+L 157.295716 188.575332 
+L 157.047708 188.697585 
+L 156.7997 188.819523 
+L 156.551691 188.941149 
+L 156.303683 189.062463 
+L 156.055675 189.183468 
+L 155.807667 189.304165 
+L 155.559659 189.424555 
+L 155.311651 189.54464 
+L 155.063643 189.664421 
+L 154.815635 189.783901 
+L 154.567627 189.90308 
+L 154.319619 190.02196 
+L 154.071611 190.140543 
+L 153.823603 190.25883 
+L 153.575595 190.376823 
+L 153.327587 190.494522 
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_157">
-    <path d="M 153.327587 189.275935 
-L 153.228605 189.408089 
-L 153.129623 189.539875 
-L 153.030641 189.671296 
-L 152.931659 189.802353 
-L 152.832678 189.933049 
-L 152.733696 190.063386 
-L 152.634714 190.193365 
-L 152.535732 190.322988 
-L 152.43675 190.452259 
-L 152.337768 190.581177 
-L 152.238786 190.709746 
-L 152.139804 190.837967 
-L 152.040822 190.965842 
-L 151.94184 191.093374 
-L 151.842858 191.220562 
-L 151.743876 191.347411 
-L 151.644894 191.473921 
-L 151.545912 191.600094 
-L 151.44693 191.725932 
-L 151.347948 191.851437 
-L 151.248966 191.976611 
-L 151.149984 192.101455 
-L 151.051002 192.225971 
-L 150.95202 192.35016 
-L 150.853038 192.474026 
-L 150.754056 192.597568 
-L 150.655074 192.720789 
-L 150.556093 192.843691 
-L 150.457111 192.966274 
-L 150.358129 193.088542 
-L 150.259147 193.210495 
-L 150.160165 193.332135 
-L 150.061183 193.453464 
-L 149.962201 193.574483 
-L 149.863219 193.695193 
-L 149.764237 193.815597 
-L 149.665255 193.935696 
-L 149.566273 194.055492 
-L 149.467291 194.174985 
-L 149.368309 194.294178 
-L 149.269327 194.413072 
-L 149.170345 194.531668 
-L 149.071363 194.649969 
-L 148.972381 194.767975 
-L 148.873399 194.885688 
-L 148.774417 195.003109 
-L 148.675435 195.12024 
-L 148.576453 195.237082 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 153.327587 190.494522 
+L 153.228605 190.624163 
+L 153.129623 190.75345 
+L 153.030641 190.882385 
+L 152.931659 191.01097 
+L 152.832678 191.139208 
+L 152.733696 191.2671 
+L 152.634714 191.394647 
+L 152.535732 191.521852 
+L 152.43675 191.648717 
+L 152.337768 191.775243 
+L 152.238786 191.901432 
+L 152.139804 192.027287 
+L 152.040822 192.152807 
+L 151.94184 192.277997 
+L 151.842858 192.402856 
+L 151.743876 192.527388 
+L 151.644894 192.651593 
+L 151.545912 192.775474 
+L 151.44693 192.899031 
+L 151.347948 193.022268 
+L 151.248966 193.145185 
+L 151.149984 193.267783 
+L 151.051002 193.390066 
+L 150.95202 193.512034 
+L 150.853038 193.633689 
+L 150.754056 193.755032 
+L 150.655074 193.876066 
+L 150.556093 193.996791 
+L 150.457111 194.11721 
+L 150.358129 194.237323 
+L 150.259147 194.357133 
+L 150.160165 194.476641 
+L 150.061183 194.595848 
+L 149.962201 194.714756 
+L 149.863219 194.833367 
+L 149.764237 194.951682 
+L 149.665255 195.069702 
+L 149.566273 195.187428 
+L 149.467291 195.304864 
+L 149.368309 195.422009 
+L 149.269327 195.538865 
+L 149.170345 195.655433 
+L 149.071363 195.771716 
+L 148.972381 195.887714 
+L 148.873399 196.003429 
+L 148.774417 196.118862 
+L 148.675435 196.234015 
+L 148.576453 196.348889 
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_158">
-    <path d="M 148.576453 195.237082 
-L 148.507926 195.299567 
-L 148.439399 195.361969 
-L 148.370872 195.424289 
-L 148.302345 195.486527 
-L 148.233818 195.548684 
-L 148.165291 195.610759 
-L 148.096764 195.672753 
-L 148.028237 195.734666 
-L 147.95971 195.796498 
-L 147.891183 195.85825 
-L 147.822656 195.919922 
-L 147.754129 195.981513 
-L 147.685602 196.043024 
-L 147.617074 196.104456 
-L 147.548547 196.165808 
-L 147.48002 196.227081 
-L 147.411493 196.288274 
-L 147.342966 196.349389 
-L 147.274439 196.410425 
-L 147.205912 196.471383 
-L 147.137385 196.532262 
-L 147.068858 196.593063 
-L 147.000331 196.653787 
-L 146.931804 196.714432 
-L 146.863277 196.775 
-L 146.79475 196.835491 
-L 146.726223 196.895905 
-L 146.657696 196.956242 
-L 146.589169 197.016502 
-L 146.520641 197.076685 
-L 146.452114 197.136792 
-L 146.383587 197.196824 
-L 146.31506 197.256779 
-L 146.246533 197.316658 
-L 146.178006 197.376462 
-L 146.109479 197.436191 
-L 146.040952 197.495844 
-L 145.972425 197.555423 
-L 145.903898 197.614926 
-L 145.835371 197.674355 
-L 145.766844 197.73371 
-L 145.698317 197.79299 
-L 145.62979 197.852196 
-L 145.561263 197.911329 
-L 145.492735 197.970388 
-L 145.424208 198.029373 
-L 145.355681 198.088285 
-L 145.287154 198.147124 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 148.576453 196.348889 
+L 148.507926 196.41114 
+L 148.439399 196.47331 
+L 148.370872 196.535398 
+L 148.302345 196.597405 
+L 148.233818 196.659331 
+L 148.165291 196.721176 
+L 148.096764 196.782941 
+L 148.028237 196.844625 
+L 147.95971 196.906229 
+L 147.891183 196.967753 
+L 147.822656 197.029197 
+L 147.754129 197.090562 
+L 147.685602 197.151847 
+L 147.617074 197.213054 
+L 147.548547 197.274181 
+L 147.48002 197.33523 
+L 147.411493 197.3962 
+L 147.342966 197.457092 
+L 147.274439 197.517905 
+L 147.205912 197.578641 
+L 147.137385 197.639299 
+L 147.068858 197.699879 
+L 147.000331 197.760383 
+L 146.931804 197.820809 
+L 146.863277 197.881158 
+L 146.79475 197.94143 
+L 146.726223 198.001626 
+L 146.657696 198.061745 
+L 146.589169 198.121789 
+L 146.520641 198.181756 
+L 146.452114 198.241647 
+L 146.383587 198.301463 
+L 146.31506 198.361204 
+L 146.246533 198.420869 
+L 146.178006 198.48046 
+L 146.109479 198.539975 
+L 146.040952 198.599416 
+L 145.972425 198.658783 
+L 145.903898 198.718075 
+L 145.835371 198.777293 
+L 145.766844 198.836437 
+L 145.698317 198.895508 
+L 145.62979 198.954505 
+L 145.561263 199.013428 
+L 145.492735 199.072279 
+L 145.424208 199.131056 
+L 145.355681 199.189761 
+L 145.287154 199.248393 
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_159">
-    <path d="M 145.287154 198.147124 
-L 144.656225 202.048425 
-L 144.025297 205.652896 
-L 143.394368 209.002528 
-L 142.763439 212.13099 
-L 142.13251 215.065687 
-L 141.501581 217.829229 
-L 140.870652 220.440483 
-L 140.239723 222.915362 
-L 139.608795 225.267405 
-L 138.977866 227.508231 
-L 138.346937 229.647885 
-L 137.716008 231.69511 
-L 137.085079 233.657561 
-L 136.45415 235.541981 
-L 135.823222 237.354339 
-L 135.192293 239.099943 
-L 134.561364 240.783538 
-L 133.930435 242.409377 
-L 133.299506 243.981293 
-L 132.668577 245.502747 
-L 132.037648 246.97688 
-L 131.40672 248.406545 
-L 130.775791 249.794348 
-L 130.144862 251.142671 
-L 129.513933 252.453697 
-L 128.883004 253.729435 
-L 128.252075 254.971735 
-L 127.621147 256.182304 
-L 126.990218 257.362724 
-L 126.359289 258.51446 
-L 125.72836 259.638872 
-L 125.097431 260.737228 
-L 124.466502 261.810708 
-L 123.835573 262.860413 
-L 123.204645 263.887374 
-L 122.573716 264.892555 
-L 121.942787 265.876862 
-L 121.311858 266.841143 
-L 120.680929 267.786197 
-L 120.05 268.712777 
-L 119.419071 269.62159 
-L 118.788143 270.513305 
-L 118.157214 271.388553 
-L 117.526285 272.247932 
-L 116.895356 273.092007 
-L 116.264427 273.921314 
-L 115.633498 274.736359 
-L 115.00257 275.537627 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 145.287154 199.248393 
+L 144.656225 203.096978 
+L 144.025297 206.656406 
+L 143.394368 209.967108 
+L 142.763439 213.061587 
+L 142.13251 215.966361 
+L 141.501581 218.703353 
+L 140.870652 221.290892 
+L 140.239723 223.744458 
+L 139.608795 226.077243 
+L 138.977866 228.300583 
+L 138.346937 230.42429 
+L 137.716008 232.45691 
+L 137.085079 234.405937 
+L 136.45415 236.277977 
+L 135.823222 238.07888 
+L 135.192293 239.813856 
+L 134.561364 241.487561 
+L 133.930435 243.104177 
+L 133.299506 244.667468 
+L 132.668577 246.180842 
+L 132.037648 247.647388 
+L 131.40672 249.069916 
+L 130.775791 250.450993 
+L 130.144862 251.792966 
+L 129.513933 253.097988 
+L 128.883004 254.36804 
+L 128.252075 255.604947 
+L 127.621147 256.810396 
+L 126.990218 257.985946 
+L 126.359289 259.133046 
+L 125.72836 260.253039 
+L 125.097431 261.347178 
+L 124.466502 262.416628 
+L 123.835573 263.462481 
+L 123.204645 264.485754 
+L 122.573716 265.487402 
+L 121.942787 266.468321 
+L 121.311858 267.42935 
+L 120.680929 268.371281 
+L 120.05 269.294857 
+L 119.419071 270.200781 
+L 118.788143 271.089714 
+L 118.157214 271.962283 
+L 117.526285 272.819078 
+L 116.895356 273.66066 
+L 116.264427 274.48756 
+L 115.633498 275.300281 
+L 115.00257 276.099302 
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_160">
-    <path d="M 115.00257 275.537627 
-L 114.686939 276.264847 
-L 114.371309 276.981078 
-L 114.055678 277.686648 
-L 113.740048 278.381868 
-L 113.424418 279.067039 
-L 113.108787 279.742446 
-L 112.793157 280.408364 
-L 112.477527 281.065056 
-L 112.161896 281.712774 
-L 111.846266 282.35176 
-L 111.530636 282.982246 
-L 111.215005 283.604455 
-L 110.899375 284.218603 
-L 110.583745 284.824894 
-L 110.268114 285.423529 
-L 109.952484 286.014696 
-L 109.636853 286.598582 
-L 109.321223 287.175362 
-L 109.005593 287.745208 
-L 108.689962 288.308285 
-L 108.374332 288.86475 
-L 108.058702 289.414759 
-L 107.743071 289.958459 
-L 107.427441 290.495992 
-L 107.111811 291.027498 
-L 106.79618 291.55311 
-L 106.48055 292.072957 
-L 106.16492 292.587165 
-L 105.849289 293.095854 
-L 105.533659 293.599141 
-L 105.218028 294.097141 
-L 104.902398 294.589963 
-L 104.586768 295.077713 
-L 104.271137 295.560496 
-L 103.955507 296.038411 
-L 103.639877 296.511555 
-L 103.324246 296.980022 
-L 103.008616 297.443905 
-L 102.692986 297.903292 
-L 102.377355 298.358269 
-L 102.061725 298.80892 
-L 101.746095 299.255328 
-L 101.430464 299.69757 
-L 101.114834 300.135724 
-L 100.799203 300.569864 
-L 100.483573 301.000065 
-L 100.167943 301.426395 
-L 99.852312 301.848926 
-" clip-path="url(#p15e0ad6792)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 115.00257 276.099302 
+L 114.686939 276.819447 
+L 114.371309 277.528815 
+L 114.055678 278.227723 
+L 113.740048 278.916475 
+L 113.424418 279.595361 
+L 113.108787 280.264662 
+L 112.793157 280.924643 
+L 112.477527 281.57556 
+L 112.161896 282.217659 
+L 111.846266 282.851177 
+L 111.530636 283.476338 
+L 111.215005 284.093361 
+L 110.899375 284.702455 
+L 110.583745 285.303821 
+L 110.268114 285.897653 
+L 109.952484 286.484138 
+L 109.636853 287.063454 
+L 109.321223 287.635775 
+L 109.005593 288.201267 
+L 108.689962 288.760093 
+L 108.374332 289.312407 
+L 108.058702 289.858359 
+L 107.743071 290.398094 
+L 107.427441 290.931752 
+L 107.111811 291.459469 
+L 106.79618 291.981375 
+L 106.48055 292.497597 
+L 106.16492 293.008258 
+L 105.849289 293.513475 
+L 105.533659 294.013364 
+L 105.218028 294.508036 
+L 104.902398 294.997598 
+L 104.586768 295.482156 
+L 104.271137 295.96181 
+L 103.955507 296.436659 
+L 103.639877 296.906798 
+L 103.324246 297.37232 
+L 103.008616 297.833314 
+L 102.692986 298.289867 
+L 102.377355 298.742065 
+L 102.061725 299.18999 
+L 101.746095 299.633721 
+L 101.430464 300.073336 
+L 101.114834 300.508912 
+L 100.799203 300.940522 
+L 100.483573 301.368236 
+L 100.167943 301.792126 
+L 99.852312 302.212258 
+" clip-path="url(#p63a9d83c72)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
   </g>
   <g id="text_25">
@@ -6254,8 +6254,8 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-07-06T07:54:18Z  ·  Linux chungus2 x86_64  ·  commit 38a6ad15  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(43.549375 465.66) scale(0.07 -0.07)">
+   <!-- 2026-07-06T10:45:22Z  ·  Linux chungus2 x86_64  ·  commit 8a6bc577  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(43.769766 465.66) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -6413,14 +6413,14 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -6460,109 +6460,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3260.400391 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3324.023438 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3385.302734 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3448.779297 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3512.402344 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3576.025391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3607.8125 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3639.599609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3671.386719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3703.173828 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3734.960938 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3762.744141 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3824.267578 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3885.546875 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3948.925781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4012.402344 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4051.265625 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4112.447266 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4171.626953 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4233.150391 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4274.263672 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4307.955078 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4335.738281 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4397.261719 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4458.541016 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4521.919922 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4585.542969 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4619.234375 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4678.414062 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4742.037109 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4773.824219 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4837.447266 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4901.070312 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4932.857422 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4996.480469 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5032.564453 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5071.427734 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5126.408203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5190.03125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5221.818359 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5253.605469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5285.392578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5317.179688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5348.966797 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5388.175781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5451.554688 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5490.417969 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5551.599609 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5614.978516 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5678.455078 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5741.833984 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5805.310547 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5868.689453 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5907.898438 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5939.685547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6023.474609 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6055.261719 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6152.673828 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6214.197266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6277.673828 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6305.457031 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6366.736328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6430.115234 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6461.902344 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6514.001953 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6577.380859 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6638.660156 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6702.136719 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6754.236328 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6817.615234 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6878.796875 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6918.005859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6951.697266 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6983.484375 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7024.597656 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7085.876953 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7125.085938 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7152.869141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7214.050781 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7245.837891 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7273.621094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7325.720703 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7357.507812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7420.984375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7482.507812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7521.716797 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7583.240234 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7622.603516 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7720.015625 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7747.798828 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7811.177734 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7838.960938 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7891.060547 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7930.269531 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7958.052734 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3196.777344 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3260.400391 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3323.876953 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3378.857422 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3442.480469 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3506.103516 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3569.726562 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3601.513672 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3633.300781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3665.087891 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3696.875 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3728.662109 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3756.445312 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3817.96875 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3879.248047 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3942.626953 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4006.103516 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4044.966797 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4106.148438 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4165.328125 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4226.851562 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4267.964844 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4301.65625 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4329.439453 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4390.962891 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4452.242188 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4515.621094 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4579.244141 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4612.935547 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4672.115234 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4735.738281 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4767.525391 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4831.148438 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4894.771484 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4926.558594 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4990.181641 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5026.265625 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5065.128906 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5120.109375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5183.732422 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5215.519531 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5247.306641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5279.09375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5310.880859 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5342.667969 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5381.876953 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5445.255859 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5484.119141 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5545.300781 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5608.679688 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5672.15625 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5735.535156 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5799.011719 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5862.390625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5901.599609 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5933.386719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6017.175781 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6048.962891 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6146.375 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6207.898438 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6271.375 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6299.158203 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6360.4375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6423.816406 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6455.603516 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6507.703125 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6571.082031 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6632.361328 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6695.837891 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6747.9375 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6811.316406 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6872.498047 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6911.707031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6945.398438 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6977.185547 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7018.298828 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7079.578125 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7118.787109 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7146.570312 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7207.751953 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7239.539062 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7267.322266 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7319.421875 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7351.208984 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7414.685547 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7476.208984 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7515.417969 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7576.941406 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7616.304688 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7713.716797 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7741.5 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7804.878906 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7832.662109 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7884.761719 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7923.970703 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7951.753906 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p15e0ad6792">
+  <clipPath id="p63a9d83c72">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_ratio_heatmap.svg
+++ b/bench/graphs/canterbury_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p7bf2830879)">
+   <g clip-path="url(#p8048062d4c)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAI/UlEQVR4nO3YwYqkVx2H4aqe7qYn4oAyashScCfBhRtn49o7yRW4DNl7HcYbEEQk2Yjixo24E3ciISRjnMyE7p7q78sljMKRv9T7PFfwO3zUqZdz3P71y/1wbl5+Nr1gqf3z8zrP4XA4/OPnv56esNTf//JqesJyP/3wZ9MTljv+6MfTE9Y6XkwvWO/FJ9ML1rt5Mr1gqV997xfTE5Y7w18SAMB/TgwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKQd706/2adHrLYftukJSx3PsFmvLq6nJyx1v91OT1ju6q9/mp6w3OmHz6YnLHXa7qcnLPfq9GJ6wnJPz+x6eP3k6fSE5c7vXxYA4L8ghgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0i6vXn0xvWG9u6+mF6y1b9ML1nv8ZHrBUtfTA/4H9hevpicsd/Xl8+kJS11tp+kJyz0+x/vu9uX0gqWuLs/vxvMyBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgLTjafvdPj1itX3fpicstZ3ZeQ6Hw+Hq4np6wlIP+2l6wnKPXj6fnrDeN787vWCp19v99ITlPr/95/SE5d6+u5yesNT2rXemJyznZQgASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASLv886d/mN6w3MXhOD1hqe+89XR6wnIP22l6wlLXj26mJyz33se/n56w3Ac/+cH0hKVO+zY9Ybn3//i36QnLPXvnG9MTlnrv3WfTE5bzMgQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIC04+uH3+7TI1a7f7idnrDU4+PN9ATe4P54mp6w3L/vPpuesNy3b96enrDUtm/TE5b74u7T6QnLPb/7ZHrCUt9/8u70hOW8DAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACDtuG0f7dMjgP9Dp/vpBetdXk8v4A1uH76anrDczaO3pifwBl6GAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkHZ5v91Ob1juYTtNT1jq8uJ6esJyV2d2ptfb/fSE5faLbXrCcscz+04P+3nddYfD4fDl/fPpCctdP76ZnrDUvp/f3eBlCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGlfA43TkfjdNPLgAAAAAElFTkSuQmCC" id="imagef693b1fde0" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAI/UlEQVR4nO3YwYqkVx2H4aqe7qYn4oAyashScCfBhRtn49o7yRW4DNl7HcYbEEQk2Yjixo24E3ciISRjnMyE7p7q78sljMKRv9T7PFfwO3zUqZdz3P71y/1wbl5+Nr1gqf3z8zrP4XA4/OPnv56esNTf//JqesJyP/3wZ9MTljv+6MfTE9Y6XkwvWO/FJ9ML1rt5Mr1gqV997xfTE5Y7w18SAMB/TgwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKQd706/2adHrLYftukJSx3PsFmvLq6nJyx1v91OT1ju6q9/mp6w3OmHz6YnLHXa7qcnLPfq9GJ6wnJPz+x6eP3k6fSE5c7vXxYA4L8ghgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0i6vXn0xvWG9u6+mF6y1b9ML1nv8ZHrBUtfTA/4H9hevpicsd/Xl8+kJS11tp+kJyz0+x/vu9uX0gqWuLs/vxvMyBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgLTjafvdPj1itX3fpicstZ3ZeQ6Hw+Hq4np6wlIP+2l6wnKPXj6fnrDeN787vWCp19v99ITlPr/95/SE5d6+u5yesNT2rXemJyznZQgASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASLv886d/mN6w3MXhOD1hqe+89XR6wnIP22l6wlLXj26mJyz33se/n56w3Ac/+cH0hKVO+zY9Ybn3//i36QnLPXvnG9MTlnrv3WfTE5bzMgQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIC04+uH3+7TI1a7f7idnrDU4+PN9ATe4P54mp6w3L/vPpuesNy3b96enrDUtm/TE5b74u7T6QnLPb/7ZHrCUt9/8u70hOW8DAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACDtuG0f7dMjgP9Dp/vpBetdXk8v4A1uH76anrDczaO3pifwBl6GAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkHZ5v91Ob1juYTtNT1jq8uJ6esJyV2d2ptfb/fSE5faLbXrCcscz+04P+3nddYfD4fDl/fPpCctdP76ZnrDUvp/f3eBlCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGlfA43TkfjdNPLgAAAAAElFTkSuQmCC" id="image236779dff3" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m3939b8dfd9" d="M 0 0 
+       <path id="m4dc61ab588" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m3939b8dfd9" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4dc61ab588" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m3939b8dfd9" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4dc61ab588" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m3939b8dfd9" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4dc61ab588" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m3939b8dfd9" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4dc61ab588" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m3939b8dfd9" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4dc61ab588" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m3939b8dfd9" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4dc61ab588" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m3939b8dfd9" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4dc61ab588" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m3939b8dfd9" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4dc61ab588" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m3939b8dfd9" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4dc61ab588" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m3939b8dfd9" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4dc61ab588" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m3939b8dfd9" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4dc61ab588" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="m3238c3ef8a" d="M 0 0 
+       <path id="m704c3b9abf" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m3238c3ef8a" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m704c3b9abf" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m3238c3ef8a" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m704c3b9abf" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m3238c3ef8a" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m704c3b9abf" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m3238c3ef8a" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m704c3b9abf" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m3238c3ef8a" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m704c3b9abf" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m3238c3ef8a" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m704c3b9abf" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m3238c3ef8a" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m704c3b9abf" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m3238c3ef8a" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m704c3b9abf" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -2092,18 +2092,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="imagedd6310b6c3" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
+iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="image0d3d3fe391" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="m6ffb84f4ab" d="M 0 0 
+       <path id="mb83de37498" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m6ffb84f4ab" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb83de37498" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
@@ -2129,7 +2129,7 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m6ffb84f4ab" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb83de37498" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
@@ -2146,7 +2146,7 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m6ffb84f4ab" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb83de37498" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
@@ -2163,7 +2163,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m6ffb84f4ab" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb83de37498" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
@@ -2180,7 +2180,7 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m6ffb84f4ab" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb83de37498" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_112">
@@ -2196,7 +2196,7 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m6ffb84f4ab" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb83de37498" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
@@ -2212,7 +2212,7 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m6ffb84f4ab" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb83de37498" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
@@ -2228,7 +2228,7 @@ z
     <g id="ytick_16">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#m6ffb84f4ab" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb83de37498" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_115">
@@ -2244,7 +2244,7 @@ z
     <g id="ytick_17">
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m6ffb84f4ab" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb83de37498" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_116">
@@ -2882,8 +2882,8 @@ z
    </g>
   </g>
   <g id="text_119">
-   <!-- 2026-07-06T07:54:18Z  ·  Linux chungus2 x86_64  ·  commit 38a6ad15  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(16.549375 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-06T10:45:22Z  ·  Linux chungus2 x86_64  ·  commit 8a6bc577  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(16.769766 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2952,14 +2952,14 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2999,109 +2999,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3260.400391 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3324.023438 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3385.302734 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3448.779297 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3512.402344 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3576.025391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3607.8125 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3639.599609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3671.386719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3703.173828 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3734.960938 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3762.744141 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3824.267578 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3885.546875 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3948.925781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4012.402344 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4051.265625 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4112.447266 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4171.626953 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4233.150391 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4274.263672 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4307.955078 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4335.738281 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4397.261719 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4458.541016 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4521.919922 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4585.542969 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4619.234375 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4678.414062 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4742.037109 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4773.824219 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4837.447266 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4901.070312 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4932.857422 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4996.480469 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5032.564453 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5071.427734 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5126.408203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5190.03125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5221.818359 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5253.605469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5285.392578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5317.179688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5348.966797 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5388.175781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5451.554688 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5490.417969 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5551.599609 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5614.978516 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5678.455078 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5741.833984 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5805.310547 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5868.689453 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5907.898438 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5939.685547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6023.474609 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6055.261719 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6152.673828 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6214.197266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6277.673828 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6305.457031 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6366.736328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6430.115234 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6461.902344 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6514.001953 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6577.380859 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6638.660156 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6702.136719 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6754.236328 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6817.615234 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6878.796875 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6918.005859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6951.697266 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6983.484375 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7024.597656 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7085.876953 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7125.085938 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7152.869141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7214.050781 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7245.837891 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7273.621094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7325.720703 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7357.507812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7420.984375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7482.507812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7521.716797 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7583.240234 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7622.603516 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7720.015625 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7747.798828 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7811.177734 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7838.960938 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7891.060547 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7930.269531 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7958.052734 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3196.777344 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3260.400391 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3323.876953 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3378.857422 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3442.480469 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3506.103516 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3569.726562 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3601.513672 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3633.300781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3665.087891 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3696.875 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3728.662109 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3756.445312 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3817.96875 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3879.248047 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3942.626953 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4006.103516 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4044.966797 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4106.148438 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4165.328125 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4226.851562 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4267.964844 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4301.65625 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4329.439453 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4390.962891 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4452.242188 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4515.621094 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4579.244141 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4612.935547 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4672.115234 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4735.738281 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4767.525391 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4831.148438 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4894.771484 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4926.558594 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4990.181641 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5026.265625 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5065.128906 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5120.109375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5183.732422 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5215.519531 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5247.306641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5279.09375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5310.880859 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5342.667969 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5381.876953 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5445.255859 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5484.119141 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5545.300781 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5608.679688 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5672.15625 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5735.535156 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5799.011719 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5862.390625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5901.599609 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5933.386719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6017.175781 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6048.962891 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6146.375 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6207.898438 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6271.375 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6299.158203 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6360.4375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6423.816406 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6455.603516 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6507.703125 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6571.082031 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6632.361328 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6695.837891 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6747.9375 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6811.316406 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6872.498047 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6911.707031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6945.398438 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6977.185547 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7018.298828 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7079.578125 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7118.787109 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7146.570312 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7207.751953 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7239.539062 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7267.322266 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7319.421875 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7351.208984 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7414.685547 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7476.208984 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7515.417969 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7576.941406 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7616.304688 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7713.716797 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7741.5 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7804.878906 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7832.662109 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7884.761719 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7923.970703 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7951.753906 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p7bf2830879">
+  <clipPath id="p8048062d4c">
    <rect x="95.67625" y="49.4355" width="416.571298" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_summary.svg
+++ b/bench/graphs/canterbury_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="575.30125pt" height="386.202469pt" viewBox="0 0 575.30125 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="574.860469pt" height="386.202469pt" viewBox="0 0 574.860469 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,232 +22,232 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 386.202469 
-L 575.30125 386.202469 
-L 575.30125 0 
+L 574.860469 386.202469 
+L 574.860469 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 189.775625 104.1264 
-L 294.400625 104.1264 
-L 294.400625 74.7432 
-L 189.775625 74.7432 
+    <path d="M 189.555234 104.1264 
+L 294.180234 104.1264 
+L 294.180234 74.7432 
+L 189.555234 74.7432 
 z
-" clip-path="url(#p2e5a5e918a)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9eeabc49f7)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 294.400625 104.1264 
-L 399.025625 104.1264 
-L 399.025625 74.7432 
-L 294.400625 74.7432 
+    <path d="M 294.180234 104.1264 
+L 398.805234 104.1264 
+L 398.805234 74.7432 
+L 294.180234 74.7432 
 z
-" clip-path="url(#p2e5a5e918a)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9eeabc49f7)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 399.025625 104.1264 
-L 503.650625 104.1264 
-L 503.650625 74.7432 
-L 399.025625 74.7432 
+    <path d="M 398.805234 104.1264 
+L 503.430234 104.1264 
+L 503.430234 74.7432 
+L 398.805234 74.7432 
 z
-" clip-path="url(#p2e5a5e918a)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9eeabc49f7)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 189.775625 133.5096 
-L 294.400625 133.5096 
-L 294.400625 104.1264 
-L 189.775625 104.1264 
+    <path d="M 189.555234 133.5096 
+L 294.180234 133.5096 
+L 294.180234 104.1264 
+L 189.555234 104.1264 
 z
-" clip-path="url(#p2e5a5e918a)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9eeabc49f7)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 294.400625 133.5096 
-L 399.025625 133.5096 
-L 399.025625 104.1264 
-L 294.400625 104.1264 
+    <path d="M 294.180234 133.5096 
+L 398.805234 133.5096 
+L 398.805234 104.1264 
+L 294.180234 104.1264 
 z
-" clip-path="url(#p2e5a5e918a)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9eeabc49f7)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 399.025625 133.5096 
-L 503.650625 133.5096 
-L 503.650625 104.1264 
-L 399.025625 104.1264 
+    <path d="M 398.805234 133.5096 
+L 503.430234 133.5096 
+L 503.430234 104.1264 
+L 398.805234 104.1264 
 z
-" clip-path="url(#p2e5a5e918a)" style="fill: #fdb768; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9eeabc49f7)" style="fill: #fdb768; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 189.775625 162.8928 
-L 294.400625 162.8928 
-L 294.400625 133.5096 
-L 189.775625 133.5096 
+    <path d="M 189.555234 162.8928 
+L 294.180234 162.8928 
+L 294.180234 133.5096 
+L 189.555234 133.5096 
 z
-" clip-path="url(#p2e5a5e918a)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9eeabc49f7)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 294.400625 162.8928 
-L 399.025625 162.8928 
-L 399.025625 133.5096 
-L 294.400625 133.5096 
+    <path d="M 294.180234 162.8928 
+L 398.805234 162.8928 
+L 398.805234 133.5096 
+L 294.180234 133.5096 
 z
-" clip-path="url(#p2e5a5e918a)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9eeabc49f7)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 399.025625 162.8928 
-L 503.650625 162.8928 
-L 503.650625 133.5096 
-L 399.025625 133.5096 
+    <path d="M 398.805234 162.8928 
+L 503.430234 162.8928 
+L 503.430234 133.5096 
+L 398.805234 133.5096 
 z
-" clip-path="url(#p2e5a5e918a)" style="fill: #bbe278; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9eeabc49f7)" style="fill: #bbe278; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 189.775625 192.276 
-L 294.400625 192.276 
-L 294.400625 162.8928 
-L 189.775625 162.8928 
+    <path d="M 189.555234 192.276 
+L 294.180234 192.276 
+L 294.180234 162.8928 
+L 189.555234 162.8928 
 z
-" clip-path="url(#p2e5a5e918a)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9eeabc49f7)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 294.400625 192.276 
-L 399.025625 192.276 
-L 399.025625 162.8928 
-L 294.400625 162.8928 
+    <path d="M 294.180234 192.276 
+L 398.805234 192.276 
+L 398.805234 162.8928 
+L 294.180234 162.8928 
 z
-" clip-path="url(#p2e5a5e918a)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9eeabc49f7)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 399.025625 192.276 
-L 503.650625 192.276 
-L 503.650625 162.8928 
-L 399.025625 162.8928 
+    <path d="M 398.805234 192.276 
+L 503.430234 192.276 
+L 503.430234 162.8928 
+L 398.805234 162.8928 
 z
-" clip-path="url(#p2e5a5e918a)" style="fill: #fdc776; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9eeabc49f7)" style="fill: #fdc776; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 189.775625 221.6592 
-L 294.400625 221.6592 
-L 294.400625 192.276 
-L 189.775625 192.276 
+    <path d="M 189.555234 221.6592 
+L 294.180234 221.6592 
+L 294.180234 192.276 
+L 189.555234 192.276 
 z
-" clip-path="url(#p2e5a5e918a)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9eeabc49f7)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 294.400625 221.6592 
-L 399.025625 221.6592 
-L 399.025625 192.276 
-L 294.400625 192.276 
+    <path d="M 294.180234 221.6592 
+L 398.805234 221.6592 
+L 398.805234 192.276 
+L 294.180234 192.276 
 z
-" clip-path="url(#p2e5a5e918a)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9eeabc49f7)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 399.025625 221.6592 
-L 503.650625 221.6592 
-L 503.650625 192.276 
-L 399.025625 192.276 
+    <path d="M 398.805234 221.6592 
+L 503.430234 221.6592 
+L 503.430234 192.276 
+L 398.805234 192.276 
 z
-" clip-path="url(#p2e5a5e918a)" style="fill: #addc6f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9eeabc49f7)" style="fill: #addc6f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 189.775625 251.0424 
-L 294.400625 251.0424 
-L 294.400625 221.6592 
-L 189.775625 221.6592 
+    <path d="M 189.555234 251.0424 
+L 294.180234 251.0424 
+L 294.180234 221.6592 
+L 189.555234 221.6592 
 z
-" clip-path="url(#p2e5a5e918a)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9eeabc49f7)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 294.400625 251.0424 
-L 399.025625 251.0424 
-L 399.025625 221.6592 
-L 294.400625 221.6592 
+    <path d="M 294.180234 251.0424 
+L 398.805234 251.0424 
+L 398.805234 221.6592 
+L 294.180234 221.6592 
 z
-" clip-path="url(#p2e5a5e918a)" style="fill: #fdbd6d; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9eeabc49f7)" style="fill: #fdbd6d; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 399.025625 251.0424 
-L 503.650625 251.0424 
-L 503.650625 221.6592 
-L 399.025625 221.6592 
+    <path d="M 398.805234 251.0424 
+L 503.430234 251.0424 
+L 503.430234 221.6592 
+L 398.805234 221.6592 
 z
-" clip-path="url(#p2e5a5e918a)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9eeabc49f7)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 189.775625 280.4256 
-L 294.400625 280.4256 
-L 294.400625 251.0424 
-L 189.775625 251.0424 
+    <path d="M 189.555234 280.4256 
+L 294.180234 280.4256 
+L 294.180234 251.0424 
+L 189.555234 251.0424 
 z
-" clip-path="url(#p2e5a5e918a)" style="fill: #ebf7a3; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9eeabc49f7)" style="fill: #ebf7a3; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 294.400625 280.4256 
-L 399.025625 280.4256 
-L 399.025625 251.0424 
-L 294.400625 251.0424 
+    <path d="M 294.180234 280.4256 
+L 398.805234 280.4256 
+L 398.805234 251.0424 
+L 294.180234 251.0424 
 z
-" clip-path="url(#p2e5a5e918a)" style="fill: #fb9d59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9eeabc49f7)" style="fill: #fa9b58; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 399.025625 280.4256 
-L 503.650625 280.4256 
-L 503.650625 251.0424 
-L 399.025625 251.0424 
+    <path d="M 398.805234 280.4256 
+L 503.430234 280.4256 
+L 503.430234 251.0424 
+L 398.805234 251.0424 
 z
-" clip-path="url(#p2e5a5e918a)" style="fill: #f36b42; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9eeabc49f7)" style="fill: #f99153; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 189.775625 309.8088 
-L 294.400625 309.8088 
-L 294.400625 280.4256 
-L 189.775625 280.4256 
+    <path d="M 189.555234 309.8088 
+L 294.180234 309.8088 
+L 294.180234 280.4256 
+L 189.555234 280.4256 
 z
-" clip-path="url(#p2e5a5e918a)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9eeabc49f7)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 294.400625 309.8088 
-L 399.025625 309.8088 
-L 399.025625 280.4256 
-L 294.400625 280.4256 
+    <path d="M 294.180234 309.8088 
+L 398.805234 309.8088 
+L 398.805234 280.4256 
+L 294.180234 280.4256 
 z
-" clip-path="url(#p2e5a5e918a)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9eeabc49f7)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 399.025625 309.8088 
-L 503.650625 309.8088 
-L 503.650625 280.4256 
-L 399.025625 280.4256 
+    <path d="M 398.805234 309.8088 
+L 503.430234 309.8088 
+L 503.430234 280.4256 
+L 398.805234 280.4256 
 z
-" clip-path="url(#p2e5a5e918a)" style="fill: #ee613e; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9eeabc49f7)" style="fill: #ee613e; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 189.775625 339.192 
-L 294.400625 339.192 
-L 294.400625 309.8088 
-L 189.775625 309.8088 
+    <path d="M 189.555234 339.192 
+L 294.180234 339.192 
+L 294.180234 309.8088 
+L 189.555234 309.8088 
 z
-" clip-path="url(#p2e5a5e918a)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9eeabc49f7)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 294.400625 339.192 
-L 399.025625 339.192 
-L 399.025625 309.8088 
-L 294.400625 309.8088 
+    <path d="M 294.180234 339.192 
+L 398.805234 339.192 
+L 398.805234 309.8088 
+L 294.180234 309.8088 
 z
-" clip-path="url(#p2e5a5e918a)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9eeabc49f7)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 399.025625 339.192 
-L 503.650625 339.192 
-L 503.650625 309.8088 
-L 399.025625 309.8088 
+    <path d="M 398.805234 339.192 
+L 503.430234 339.192 
+L 503.430234 309.8088 
+L 398.805234 309.8088 
 z
-" clip-path="url(#p2e5a5e918a)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9eeabc49f7)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(122.762891 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(122.5425 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(230.047109 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(229.826719 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(308.619219 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(308.398828 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(406.970937 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(406.750547 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(118.700625 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(118.480234 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.296 -->
-    <g transform="translate(230.636875 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(230.416484 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -946,7 +946,7 @@ z
    </g>
    <g id="text_7">
     <!-- 158 -->
-    <g transform="translate(339.078125 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(338.857734 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -1034,7 +1034,7 @@ z
    </g>
    <g id="text_8">
     <!-- 925 -->
-    <g transform="translate(443.703125 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(443.482734 91.6423) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-39"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
@@ -1042,7 +1042,7 @@ z
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(113.33875 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(113.118359 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1141,7 +1141,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.299 -->
-    <g transform="translate(230.636875 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(230.416484 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1151,7 +1151,7 @@ z
    </g>
    <g id="text_11">
     <!-- 73 -->
-    <g transform="translate(341.623125 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(341.402734 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -1202,7 +1202,7 @@ z
    </g>
    <g id="text_12">
     <!-- 283 -->
-    <g transform="translate(443.703125 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(443.482734 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(127.246094 0)"/>
@@ -1210,7 +1210,7 @@ z
    </g>
    <g id="text_13">
     <!-- zlib -->
-    <g transform="translate(130.601875 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(130.381484 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1234,7 +1234,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.299 -->
-    <g transform="translate(230.636875 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(230.416484 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1244,14 +1244,14 @@ z
    </g>
    <g id="text_15">
     <!-- 55 -->
-    <g transform="translate(341.623125 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(341.402734 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
     <!-- 692 -->
-    <g transform="translate(443.703125 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(443.482734 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-36"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
@@ -1259,7 +1259,7 @@ z
    </g>
    <g id="text_17">
     <!-- Go compress/flate -->
-    <g transform="translate(101.031875 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(100.811484 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -1430,7 +1430,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.299 -->
-    <g transform="translate(230.636875 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(230.416484 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1440,14 +1440,14 @@ z
    </g>
    <g id="text_19">
     <!-- 52 -->
-    <g transform="translate(341.623125 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(341.402734 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
     <!-- 323 -->
-    <g transform="translate(443.703125 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(443.482734 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(127.246094 0)"/>
@@ -1455,7 +1455,7 @@ z
    </g>
    <g id="text_21">
     <!-- miniz_oxide -->
-    <g transform="translate(113.908125 209.06385) scale(0.08 -0.08)">
+    <g transform="translate(113.687734 209.06385) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6e" d="M 3513 2113 
 L 3513 0 
@@ -1514,7 +1514,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.299 -->
-    <g transform="translate(230.636875 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(230.416484 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1524,14 +1524,14 @@ z
    </g>
    <g id="text_23">
     <!-- 51 -->
-    <g transform="translate(341.623125 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(341.402734 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_24">
     <!-- 729 -->
-    <g transform="translate(443.703125 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(443.482734 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-37"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(127.246094 0)"/>
@@ -1539,7 +1539,7 @@ z
    </g>
    <g id="text_25">
     <!-- JS fflate -->
-    <g transform="translate(122.064375 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(121.843984 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1599,7 +1599,7 @@ z
    </g>
    <g id="text_26">
     <!-- 0.307 -->
-    <g transform="translate(230.636875 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(230.416484 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1609,7 +1609,7 @@ z
    </g>
    <g id="text_27">
     <!-- 41 -->
-    <g transform="translate(341.623125 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(341.402734 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1637,14 +1637,14 @@ z
    </g>
    <g id="text_28">
     <!-- 80 -->
-    <g transform="translate(446.248125 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(446.027734 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-38"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_29">
     <!-- lean-zip (native) -->
-    <g transform="translate(100.41 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(100.189609 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1753,7 +1753,7 @@ z
    </g>
    <g id="text_30">
     <!-- 0.297 -->
-    <g transform="translate(229.43625 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(229.215859 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1855,7 +1855,7 @@ z
    </g>
    <g id="text_31">
     <!-- 28 -->
-    <g transform="translate(341.146875 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(340.926484 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-38" d="M 2228 2088 
 Q 1891 2088 1709 1903 
@@ -1902,64 +1902,16 @@ z
     </g>
    </g>
    <g id="text_32">
-    <!-- 139 -->
-    <g transform="translate(442.98875 267.9415) scale(0.08 -0.08)">
-     <defs>
-      <path id="DejaVuSans-Bold-31" d="M 750 831 
-L 1813 831 
-L 1813 3847 
-L 722 3622 
-L 722 4441 
-L 1806 4666 
-L 2950 4666 
-L 2950 831 
-L 4013 831 
-L 4013 0 
-L 750 0 
-L 750 831 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-33" d="M 2981 2516 
-Q 3453 2394 3698 2092 
-Q 3944 1791 3944 1325 
-Q 3944 631 3412 270 
-Q 2881 -91 1863 -91 
-Q 1503 -91 1142 -33 
-Q 781 25 428 141 
-L 428 1069 
-Q 766 900 1098 814 
-Q 1431 728 1753 728 
-Q 2231 728 2486 893 
-Q 2741 1059 2741 1369 
-Q 2741 1688 2480 1852 
-Q 2219 2016 1709 2016 
-L 1228 2016 
-L 1228 2791 
-L 1734 2791 
-Q 2188 2791 2409 2933 
-Q 2631 3075 2631 3366 
-Q 2631 3634 2415 3781 
-Q 2200 3928 1806 3928 
-Q 1516 3928 1219 3862 
-Q 922 3797 628 3669 
-L 628 4550 
-Q 984 4650 1334 4700 
-Q 1684 4750 2022 4750 
-Q 2931 4750 3382 4451 
-Q 3834 4153 3834 3553 
-Q 3834 3144 3618 2883 
-Q 3403 2622 2981 2516 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-Bold-31"/>
-     <use xlink:href="#DejaVuSans-Bold-33" transform="translate(69.580078 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-39" transform="translate(139.160156 0)"/>
+    <!-- 207 -->
+    <g transform="translate(442.768359 267.9415) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-Bold-32"/>
+     <use xlink:href="#DejaVuSans-Bold-30" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-37" transform="translate(139.160156 0)"/>
     </g>
    </g>
    <g id="text_33">
     <!-- OCaml decompress -->
-    <g transform="translate(98.525 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(98.304609 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -2024,7 +1976,7 @@ z
    </g>
    <g id="text_34">
     <!-- 0.321 -->
-    <g transform="translate(230.636875 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(230.416484 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -2034,14 +1986,14 @@ z
    </g>
    <g id="text_35">
     <!-- 23 -->
-    <g transform="translate(341.623125 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(341.402734 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_36">
     <!-- 117 -->
-    <g transform="translate(443.703125 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(443.482734 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
@@ -2049,7 +2001,7 @@ z
    </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(126.74625 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(126.525859 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -2060,7 +2012,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.279 -->
-    <g transform="translate(230.636875 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(230.416484 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -2070,13 +2022,13 @@ z
    </g>
    <g id="text_39">
     <!-- 0 -->
-    <g transform="translate(344.168125 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(343.947734 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(447.338125 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(447.117734 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2092,7 +2044,7 @@ z
   </g>
   <g id="text_41">
    <!-- canterbury — geomean over files, level 6 -->
-   <g transform="translate(137.159375 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(136.938984 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-62" d="M 2400 722 
 Q 2759 722 2948 984 
@@ -2305,7 +2257,7 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-07-06T07:54:18Z  ·  Linux chungus2 x86_64  ·  commit 38a6ad15  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-07-06T10:45:22Z  ·  Linux chungus2 x86_64  ·  commit 8a6bc577  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2446,14 +2398,14 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2493,110 +2445,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3260.400391 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3324.023438 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3385.302734 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3448.779297 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3512.402344 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3576.025391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3607.8125 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3639.599609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3671.386719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3703.173828 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3734.960938 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3762.744141 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3824.267578 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3885.546875 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3948.925781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4012.402344 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4051.265625 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4112.447266 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4171.626953 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4233.150391 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4274.263672 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4307.955078 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4335.738281 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4397.261719 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4458.541016 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4521.919922 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4585.542969 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4619.234375 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4678.414062 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4742.037109 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4773.824219 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4837.447266 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4901.070312 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4932.857422 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4996.480469 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5032.564453 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5071.427734 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5126.408203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5190.03125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5221.818359 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5253.605469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5285.392578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5317.179688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5348.966797 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5388.175781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5451.554688 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5490.417969 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5551.599609 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5614.978516 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5678.455078 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5741.833984 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5805.310547 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5868.689453 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5907.898438 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5939.685547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6023.474609 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6055.261719 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6152.673828 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6214.197266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6277.673828 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6305.457031 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6366.736328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6430.115234 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6461.902344 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6514.001953 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6577.380859 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6638.660156 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6702.136719 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6754.236328 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6817.615234 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6878.796875 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6918.005859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6951.697266 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6983.484375 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7024.597656 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7085.876953 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7125.085938 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7152.869141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7214.050781 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7245.837891 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7273.621094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7325.720703 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7357.507812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7420.984375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7482.507812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7521.716797 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7583.240234 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7622.603516 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7720.015625 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7747.798828 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7811.177734 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7838.960938 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7891.060547 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7930.269531 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7958.052734 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3196.777344 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3260.400391 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3323.876953 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3378.857422 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3442.480469 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3506.103516 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3569.726562 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3601.513672 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3633.300781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3665.087891 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3696.875 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3728.662109 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3756.445312 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3817.96875 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3879.248047 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3942.626953 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4006.103516 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4044.966797 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4106.148438 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4165.328125 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4226.851562 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4267.964844 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4301.65625 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4329.439453 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4390.962891 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4452.242188 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4515.621094 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4579.244141 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4612.935547 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4672.115234 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4735.738281 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4767.525391 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4831.148438 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4894.771484 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4926.558594 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4990.181641 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5026.265625 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5065.128906 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5120.109375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5183.732422 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5215.519531 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5247.306641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5279.09375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5310.880859 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5342.667969 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5381.876953 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5445.255859 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5484.119141 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5545.300781 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5608.679688 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5672.15625 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5735.535156 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5799.011719 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5862.390625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5901.599609 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5933.386719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6017.175781 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6048.962891 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6146.375 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6207.898438 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6271.375 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6299.158203 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6360.4375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6423.816406 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6455.603516 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6507.703125 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6571.082031 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6632.361328 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6695.837891 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6747.9375 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6811.316406 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6872.498047 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6911.707031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6945.398438 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6977.185547 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7018.298828 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7079.578125 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7118.787109 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7146.570312 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7207.751953 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7239.539062 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7267.322266 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7319.421875 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7351.208984 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7414.685547 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7476.208984 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7515.417969 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7576.941406 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7616.304688 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7713.716797 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7741.5 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7804.878906 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7832.662109 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7884.761719 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7923.970703 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7951.753906 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p2e5a5e918a">
-   <rect x="85.150625" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="p9eeabc49f7">
+   <rect x="84.930234" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/graphs/silesia_compress_heatmap.svg
+++ b/bench/graphs/silesia_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.34175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p1f0c6601ce)">
+   <g clip-path="url(#p842cdb10eb)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAqAAAAGaCAYAAADQNfGTAAAJ90lEQVR4nO3YP27lVx2H4di+djzDyMofsDIoDTQIUaAgRRHbYB1UtKyBDdBRsgAKGgoKpNCkjIREpCQgjYIYkWgyudg/2ywiOu93+Ol5VvC5Oj6+7z0n9//+3cNre3bzcnrBWien0wvWut+mF6y19/PbbqYXrPX4jekFa/33xfQCvo2zi+kFa+397/P8cnrBUjv/9gMA4FUjQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASB0+2j6b3rDUxflhesJSx+1mesJST6++Pz1hqU+/+nx6wlLbyd30hKV+/Oit6QlLba9fTk9Y6p8v/jE9YanrR9fTE5Y6XmzTE5Y6ee3l9ISlvIACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAACpw/Xj6+kNSz39zg+nJyz1xcvPpics9c5x37+Rrt7+6fSEpS7OLqcnLHV3v01PWGrv57f7z3e67893OH13esJSl8fj9ISl9v3tDgDAK0eAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQOrx+9nh6w1LPj8+mJyy19/O7e/Ot6QlLff6fj6YnLPXi9jg9Yan333x/esJSNw/b9ISlPv3qk+kJS/3k7Z9NT1jqw2d/mZ6w1Hvf2/f5eQEFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASJ3c/flXD9Mjlrq/n17At7H38zv1GxDG7P3++f/5/23bphcstfPTAwDgVSNAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBIHa4//Hh6w1JnF2fTE5b64uN/TU9Y6re/fG96wlK/+eu+z+/n715NT1jq93/6ZHrCUr/+xY+mJyz1h79/OT1hqR+88Wh6wlLPv7mdnrDUB08fT09YygsoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQOrm9++PD9IiVzm5vpiesdXYxvWCt7Ti9YK3D5fSCtc4O0wvWerifXrDW7c7v38nO32BO933/bk/2ff/Ot216wlI7v30AALxqBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAAKnDN9uL6Q1LPbnZpicsdf/kcnrCUqdfPp+esNaT704vWGs7Ti9Y6vb8YnrCUudf7/z+Xb0zvWCth/vpBUudP/vb9IS1rq6nFyzlBRQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAg9T/BOXzNdEWHCQAAAABJRU5ErkJggg==" id="imageaf5b2de82c" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="483.84" height="295.2"/>
+iVBORw0KGgoAAAANSUhEUgAAAqAAAAGaCAYAAADQNfGTAAAJ80lEQVR4nO3YPY5k1R2HYbqrpulpYMSH3PIgEkgsywEaSwixDdbhyClrYAPOHHoBDpw4cGAJEkKcGIkPCzTYYxgNQ9Nd3e1FoPP+x1fPs4Jf6dSp+9Y9uvnPH2+f27LLp9ML1jo6nl6w1s1hesFaWz+/w+X0grXOXp5esNZPT6YX8HPsTqYXrLX17+ed0+kFS2386QcAwLNGgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkNp/cvhiesNSJ3f20xOWujhcTk9Y6v6916cnLPX54y+nJyx1OLqenrDUr+++Oj1hqcPzp9MTlvrXk6+mJyx1fvd8esJSFyeH6QlLHT33dHrCUt6AAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAqf352fn0hqXuv/DW9ISlHj79YnrCUr+82PZ/pHuvvT09YamT3en0hKWubw7TE5ba+vlt/vMdb/vz7Y/fmJ6w1OnFxfSEpbb9dAcA4JkjQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASO2f351Nb1jq0cU30xOW2vr5Xb/y6vSEpb787pPpCUs9ubqYnrDUO6+8Mz1hqcvbw/SEpT5//Nn0hKV+89pvpycs9dE3f5+esNSDX2z7/LwBBQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgdXf/t97fTI5a6uZlewM+x9fM79h8Qxmz9/vn9/P92OEwvWGrjpwcAwLNGgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkNqff/Tp9Ialdie76QlLPfz02+kJS/3hdw+mJyz14cfbPr/33rg3PWGpP/31s+kJS33w/q+mJyz1539+Pz1hqTdfvjs9YalHP15NT1jq3ftn0xOW8gYUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBIHV1d/+V2esRKu6vL6Qlr7U6mF6x1uJhesNb+dHrBWrv99IK1bm+mF6x1tfH7d7TxdzDH275/V0fbvn93DofpCUtt/PYBAPCsEaAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKT2Px6eTG9Y6sWfLqcnrPXS+fSCtf777+kFa93b+PldPp1esNT16dn0hKV2PzyanrDW1n8/b2+mFyx15+t/TE9Ya+PfT29AAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFL/A3xse9URBqLaAAAAAElFTkSuQmCC" id="image1e922b2c1f" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="483.84" height="295.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m35bb9f9505" d="M 0 0 
+       <path id="m873a75b8fd" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m35bb9f9505" x="115.814949" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m873a75b8fd" x="115.814949" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m35bb9f9505" x="156.092348" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m873a75b8fd" x="156.092348" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m35bb9f9505" x="196.369746" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m873a75b8fd" x="196.369746" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m35bb9f9505" x="236.647145" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m873a75b8fd" x="236.647145" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m35bb9f9505" x="276.924544" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m873a75b8fd" x="276.924544" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m35bb9f9505" x="317.201942" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m873a75b8fd" x="317.201942" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m35bb9f9505" x="357.479341" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m873a75b8fd" x="357.479341" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m35bb9f9505" x="397.756739" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m873a75b8fd" x="397.756739" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m35bb9f9505" x="438.034138" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m873a75b8fd" x="438.034138" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m35bb9f9505" x="478.311536" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m873a75b8fd" x="478.311536" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m35bb9f9505" x="518.588935" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m873a75b8fd" x="518.588935" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m35bb9f9505" x="558.866334" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m873a75b8fd" x="558.866334" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="m75d2606e1b" d="M 0 0 
+       <path id="m47a365c4db" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m75d2606e1b" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m47a365c4db" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m75d2606e1b" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m47a365c4db" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m75d2606e1b" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m47a365c4db" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m75d2606e1b" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m47a365c4db" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -836,7 +836,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m75d2606e1b" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m47a365c4db" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -899,7 +899,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m75d2606e1b" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m47a365c4db" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -966,7 +966,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m75d2606e1b" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m47a365c4db" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1047,7 +1047,7 @@ z
     <g id="ytick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m75d2606e1b" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m47a365c4db" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -1138,7 +1138,7 @@ L 579.005033 49.34175
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_21">
-    <!-- +21 -->
+    <!-- +19 -->
     <g transform="translate(108.955926 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-2b" d="M 2944 4013 
@@ -1156,6 +1156,60 @@ L 2419 4013
 L 2944 4013 
 z
 " transform="scale(0.015625)"/>
+      <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_22">
+    <!-- -27 -->
+    <g transform="translate(150.784184 69.553235) scale(0.065 -0.065)">
+     <defs>
       <path id="DejaVuSans-32" d="M 1228 531 
 L 3431 531 
 L 3431 0 
@@ -1180,64 +1234,32 @@ Q 2828 2175 2409 1742
 Q 1991 1309 1228 531 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-31" d="M 794 531 
-L 1825 531 
-L 1825 4091 
-L 703 3866 
-L 703 4441 
-L 1819 4666 
-L 2450 4666 
-L 2450 531 
-L 3481 531 
-L 3481 0 
-L 794 0 
-L 794 531 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_22">
-    <!-- -25 -->
-    <g transform="translate(150.784184 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_23">
-    <!-- +3 -->
+    <!-- +1 -->
     <g transform="translate(191.578535 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_24">
+    <!-- -38 -->
+    <g transform="translate(231.338981 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
@@ -1271,83 +1293,6 @@ Q 3450 3153 3228 2886
 Q 3006 2619 2597 2516 
 z
 " transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_24">
-    <!-- -37 -->
-    <g transform="translate(231.338981 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_25">
-    <!-- -12 -->
-    <g transform="translate(271.616379 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_26">
-    <!-- -16 -->
-    <g transform="translate(311.893778 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-36" d="M 2113 2584 
-Q 1688 2584 1439 2293 
-Q 1191 2003 1191 1497 
-Q 1191 994 1439 701 
-Q 1688 409 2113 409 
-Q 2538 409 2786 701 
-Q 3034 994 3034 1497 
-Q 3034 2003 2786 2293 
-Q 2538 2584 2113 2584 
-z
-M 3366 4563 
-L 3366 3988 
-Q 3128 4100 2886 4159 
-Q 2644 4219 2406 4219 
-Q 1781 4219 1451 3797 
-Q 1122 3375 1075 2522 
-Q 1259 2794 1537 2939 
-Q 1816 3084 2150 3084 
-Q 2853 3084 3261 2657 
-Q 3669 2231 3669 1497 
-Q 3669 778 3244 343 
-Q 2819 -91 2113 -91 
-Q 1303 -91 875 529 
-Q 447 1150 447 2328 
-Q 447 3434 972 4092 
-Q 1497 4750 2381 4750 
-Q 2619 4750 2861 4703 
-Q 3103 4656 3366 4563 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_27">
-    <!-- +8 -->
-    <g transform="translate(352.68813 69.553235) scale(0.065 -0.065)">
-     <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
 Q 1069 1734 1069 1313 
@@ -1388,13 +1333,14 @@ Q 1172 3844 1172 3481
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
     </g>
    </g>
-   <g id="text_28">
-    <!-- -34 -->
-    <g transform="translate(392.448575 69.553235) scale(0.065 -0.065)">
+   <g id="text_25">
+    <!-- -14 -->
+    <g transform="translate(271.616379 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1417,30 +1363,80 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
     </g>
    </g>
-   <g id="text_29">
-    <!-- -5 -->
-    <g transform="translate(434.793786 69.553235) scale(0.065 -0.065)">
+   <g id="text_26">
+    <!-- -18 -->
+    <g transform="translate(311.893778 69.553235) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
     </g>
    </g>
-   <g id="text_30">
+   <g id="text_27">
+    <!-- +7 -->
+    <g transform="translate(352.68813 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_28">
+    <!-- -33 -->
+    <g transform="translate(392.448575 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_29">
     <!-- -7 -->
-    <g transform="translate(475.071185 69.553235) scale(0.065 -0.065)">
+    <g transform="translate(434.793786 69.553235) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
     </g>
    </g>
+   <g id="text_30">
+    <!-- -9 -->
+    <g transform="translate(475.071185 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
    <g id="text_31">
-    <!-- -53 -->
+    <!-- -55 -->
     <g transform="translate(513.280771 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_32">
@@ -1476,6 +1472,38 @@ z
    <g id="text_36">
     <!-- -16 -->
     <g transform="translate(231.338981 106.389018) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
@@ -1551,38 +1579,6 @@ z
    <g id="text_43">
     <!-- +9 -->
     <g transform="translate(513.797724 106.389018) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-39" d="M 703 97 
-L 703 672 
-Q 941 559 1184 500 
-Q 1428 441 1663 441 
-Q 2288 441 2617 861 
-Q 2947 1281 2994 2138 
-Q 2813 1869 2534 1725 
-Q 2256 1581 1919 1581 
-Q 1219 1581 811 2004 
-Q 403 2428 403 3163 
-Q 403 3881 828 4315 
-Q 1253 4750 1959 4750 
-Q 2769 4750 3195 4129 
-Q 3622 3509 3622 2328 
-Q 3622 1225 3098 567 
-Q 2575 -91 1691 -91 
-Q 1453 -91 1209 -44 
-Q 966 3 703 97 
-z
-M 1959 2075 
-Q 2384 2075 2632 2365 
-Q 2881 2656 2881 3163 
-Q 2881 3666 2632 3958 
-Q 2384 4250 1959 4250 
-Q 1534 4250 1286 3958 
-Q 1038 3666 1038 3163 
-Q 1038 2656 1286 2365 
-Q 1534 2075 1959 2075 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(83.789062 0)"/>
     </g>
@@ -2192,18 +2188,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB1ElEQVR4nO2b0a3DMAwD7cSzvM3fmI47gvpxCK6ENABhnkQ5aZH5P/7OAGpdFyEzBiQDnija2qSEghnZhIIZCa3NyWQkmZFOKJhRsDXsOopmJJwjaEPOmxHirE3MWjOqhSBr2EAGMyKtMVpc+ynYwe3viNQVbA0LrZDRFbxGbNbWyM3auG0RGbo1Qp0IZCSMiG2OgtNvbL+Oke6BvddIWaQ1qP3RjGSTLXypwdaIMP2ctWb0olAzKkr4LhLMCPvnOJiRbo6CrTWjF4WCGYHWJtU1TKgZvSZkfNAKZhRsDftFa96MkJCRrf29ausyWrOtWiMjmxDH6FAfDJzzIEKctQc60ToDEqJOBLbfZs04RxQjobWOSFXrjM0IdURqIaG1jkhVPmvGOUqOCPLJMdh+6kRk+zFGMtjKOdK13zbZ2EBGMxLOkSz90YygK9tozSbUa6Qu4RxtRifZ2np0jDY32YiOc44gIQo2aI1ZkB2Rb4SiIyJbtcr0Q0IPdCQyIpCQDnZHpC5uQ27uOtJFBBptH2zlHOnab+uaMSK29htXrW2NKK0hOtlrxLaPjIxys4a99x9dRKgTgUK69gsZ9RxVFWzNyIi6RZIZtbXfE+qI1BU8R5i1D2e5X2tFkZmlAAAAAElFTkSuQmCC" id="image8a485221c7" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-69.84" width="12.96" height="253.44"/>
+iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB1ElEQVR4nO2b0a3DMAwD7cSzvM3fmI47gvpxCK6ENABhnkQ5aZH5P/7OAGpdFyEzBiQDnija2qSEghnZhIIZCa3NyWQkmZFOKJhRsDXsOopmJJwjaEPOmxHirE3MWjOqhSBr2EAGMyKtMVpc+ynYwe3viNQVbA0LrZDRFbxGbNbWyM3auG0RGbo1Qp0IZCSMiG2OgtNvbL+Oke6BvddIWaQ1qP3RjGSTLXypwdaIMP2ctWb0olAzKkr4LhLMCPvnOJiRbo6CrTWjF4WCGYHWJtU1TKgZvSZkfNAKZhRsDftFa96MkJCRrf29ausyWrOtWiMjmxDH6FAfDJzzIEKctQc60ToDEqJOBLbfZs04RxQjobWOSFXrjM0IdURqIaG1jkhVPmvGOUqOCPLJMdh+6kRk+zFGMtjKOdK13zbZ2EBGMxLOkSz90YygK9tozSbUa6Qu4RxtRifZ2np0jDY32YiOc44gIQo2aI1ZkB2Rb4SiIyJbtcr0Q0IPdCQyIpCQDnZHpC5uQ27uOtJFBBptH2zlHOnab+uaMSK29htXrW2NKK0hOtlrxLaPjIxys4a99x9dRKgTgUK69gsZ9RxVFWzNyIi6RZIZtbXfE+qI1BU8R5i1D2e5X2tFkZmlAAAAAElFTkSuQmCC" id="imaged176b8bcee" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-69.84" width="12.96" height="253.44"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_21">
       <defs>
-       <path id="m7694cc3a98" d="M 0 0 
+       <path id="m749aa55aee" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m7694cc3a98" x="601.779688" y="322.507463" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m749aa55aee" x="601.779688" y="322.507463" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_117">
@@ -2226,7 +2222,7 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m7694cc3a98" x="601.779688" y="280.566603" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m749aa55aee" x="601.779688" y="280.566603" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_118">
@@ -2240,7 +2236,7 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m7694cc3a98" x="601.779688" y="238.625742" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m749aa55aee" x="601.779688" y="238.625742" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_119">
@@ -2254,7 +2250,7 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m7694cc3a98" x="601.779688" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m749aa55aee" x="601.779688" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_120">
@@ -2267,7 +2263,7 @@ z
     <g id="ytick_13">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m7694cc3a98" x="601.779688" y="154.74402" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m749aa55aee" x="601.779688" y="154.74402" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_121">
@@ -2280,7 +2276,7 @@ z
     <g id="ytick_14">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m7694cc3a98" x="601.779688" y="112.803159" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m749aa55aee" x="601.779688" y="112.803159" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_122">
@@ -2293,7 +2289,7 @@ z
     <g id="ytick_15">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#m7694cc3a98" x="601.779688" y="70.862298" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m749aa55aee" x="601.779688" y="70.862298" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_123">
@@ -2909,8 +2905,8 @@ z
    </g>
   </g>
   <g id="text_126">
-   <!-- 2026-07-06T07:54:18Z  ·  Linux chungus2 x86_64  ·  commit 38a6ad15  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(43.549375 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-06T10:45:22Z  ·  Linux chungus2 x86_64  ·  commit 8a6bc577  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(43.769766 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -3001,14 +2997,14 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3048,109 +3044,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3260.400391 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3324.023438 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3385.302734 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3448.779297 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3512.402344 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3576.025391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3607.8125 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3639.599609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3671.386719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3703.173828 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3734.960938 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3762.744141 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3824.267578 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3885.546875 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3948.925781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4012.402344 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4051.265625 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4112.447266 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4171.626953 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4233.150391 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4274.263672 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4307.955078 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4335.738281 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4397.261719 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4458.541016 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4521.919922 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4585.542969 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4619.234375 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4678.414062 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4742.037109 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4773.824219 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4837.447266 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4901.070312 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4932.857422 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4996.480469 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5032.564453 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5071.427734 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5126.408203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5190.03125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5221.818359 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5253.605469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5285.392578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5317.179688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5348.966797 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5388.175781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5451.554688 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5490.417969 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5551.599609 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5614.978516 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5678.455078 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5741.833984 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5805.310547 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5868.689453 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5907.898438 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5939.685547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6023.474609 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6055.261719 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6152.673828 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6214.197266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6277.673828 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6305.457031 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6366.736328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6430.115234 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6461.902344 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6514.001953 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6577.380859 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6638.660156 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6702.136719 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6754.236328 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6817.615234 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6878.796875 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6918.005859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6951.697266 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6983.484375 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7024.597656 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7085.876953 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7125.085938 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7152.869141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7214.050781 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7245.837891 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7273.621094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7325.720703 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7357.507812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7420.984375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7482.507812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7521.716797 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7583.240234 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7622.603516 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7720.015625 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7747.798828 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7811.177734 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7838.960938 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7891.060547 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7930.269531 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7958.052734 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3196.777344 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3260.400391 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3323.876953 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3378.857422 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3442.480469 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3506.103516 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3569.726562 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3601.513672 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3633.300781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3665.087891 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3696.875 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3728.662109 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3756.445312 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3817.96875 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3879.248047 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3942.626953 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4006.103516 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4044.966797 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4106.148438 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4165.328125 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4226.851562 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4267.964844 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4301.65625 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4329.439453 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4390.962891 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4452.242188 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4515.621094 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4579.244141 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4612.935547 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4672.115234 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4735.738281 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4767.525391 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4831.148438 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4894.771484 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4926.558594 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4990.181641 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5026.265625 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5065.128906 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5120.109375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5183.732422 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5215.519531 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5247.306641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5279.09375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5310.880859 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5342.667969 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5381.876953 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5445.255859 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5484.119141 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5545.300781 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5608.679688 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5672.15625 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5735.535156 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5799.011719 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5862.390625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5901.599609 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5933.386719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6017.175781 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6048.962891 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6146.375 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6207.898438 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6271.375 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6299.158203 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6360.4375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6423.816406 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6455.603516 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6507.703125 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6571.082031 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6632.361328 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6695.837891 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6747.9375 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6811.316406 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6872.498047 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6911.707031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6945.398438 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6977.185547 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7018.298828 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7079.578125 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7118.787109 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7146.570312 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7207.751953 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7239.539062 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7267.322266 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7319.421875 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7351.208984 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7414.685547 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7476.208984 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7515.417969 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7576.941406 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7616.304688 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7713.716797 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7741.5 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7804.878906 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7832.662109 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7884.761719 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7923.970703 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7951.753906 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p1f0c6601ce">
+  <clipPath id="p842cdb10eb">
    <rect x="95.67625" y="49.34175" width="483.328783" height="294.686261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_compress_pareto.svg
+++ b/bench/graphs/silesia_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 61.085542 412.80375 
 L 61.085542 48.323125 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="mc7636244b5" d="M 0 0 
+       <path id="m5055a65a9b" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mc7636244b5" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5055a65a9b" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -130,11 +130,11 @@ z
      <g id="line2d_3">
       <path d="M 145.270284 412.80375 
 L 145.270284 48.323125 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mc7636244b5" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5055a65a9b" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -177,11 +177,11 @@ z
      <g id="line2d_5">
       <path d="M 229.455026 412.80375 
 L 229.455026 48.323125 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#mc7636244b5" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5055a65a9b" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -219,11 +219,11 @@ z
      <g id="line2d_7">
       <path d="M 313.639768 412.80375 
 L 313.639768 48.323125 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#mc7636244b5" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5055a65a9b" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -272,11 +272,11 @@ z
      <g id="line2d_9">
       <path d="M 397.82451 412.80375 
 L 397.82451 48.323125 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#mc7636244b5" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5055a65a9b" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -334,11 +334,11 @@ z
      <g id="line2d_11">
       <path d="M 482.009253 412.80375 
 L 482.009253 48.323125 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#mc7636244b5" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5055a65a9b" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -355,11 +355,11 @@ L 482.009253 48.323125
      <g id="line2d_13">
       <path d="M 566.193995 412.80375 
 L 566.193995 48.323125 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mc7636244b5" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5055a65a9b" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -856,16 +856,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 368.08164 
 L 637.2 368.08164 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="m7c984bbdc1" d="M 0 0 
+       <path id="mea7b0022a8" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m7c984bbdc1" x="49.078125" y="368.08164" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mea7b0022a8" x="49.078125" y="368.08164" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -897,11 +897,11 @@ z
      <g id="line2d_17">
       <path d="M 49.078125 243.439835 
 L 637.2 243.439835 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m7c984bbdc1" x="49.078125" y="243.439835" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mea7b0022a8" x="49.078125" y="243.439835" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -917,11 +917,11 @@ L 637.2 243.439835
      <g id="line2d_19">
       <path d="M 49.078125 118.798029 
 L 637.2 118.798029 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m7c984bbdc1" x="49.078125" y="118.798029" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mea7b0022a8" x="49.078125" y="118.798029" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -937,16 +937,16 @@ L 637.2 118.798029
      <g id="line2d_21">
       <path d="M 49.078125 405.602562 
 L 637.2 405.602562 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="m4bc8eadb40" d="M 0 0 
+       <path id="mffd05be4c7" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m4bc8eadb40" x="49.078125" y="405.602562" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mffd05be4c7" x="49.078125" y="405.602562" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -954,11 +954,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 395.733268 
 L 637.2 395.733268 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m4bc8eadb40" x="49.078125" y="395.733268" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mffd05be4c7" x="49.078125" y="395.733268" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -966,11 +966,11 @@ L 637.2 395.733268
      <g id="line2d_25">
       <path d="M 49.078125 387.3889 
 L 637.2 387.3889 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m4bc8eadb40" x="49.078125" y="387.3889" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mffd05be4c7" x="49.078125" y="387.3889" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -978,11 +978,11 @@ L 637.2 387.3889
      <g id="line2d_27">
       <path d="M 49.078125 380.160679 
 L 637.2 380.160679 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m4bc8eadb40" x="49.078125" y="380.160679" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mffd05be4c7" x="49.078125" y="380.160679" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -990,11 +990,11 @@ L 637.2 380.160679
      <g id="line2d_29">
       <path d="M 49.078125 373.784936 
 L 637.2 373.784936 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m4bc8eadb40" x="49.078125" y="373.784936" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mffd05be4c7" x="49.078125" y="373.784936" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1002,11 +1002,11 @@ L 637.2 373.784936
      <g id="line2d_31">
       <path d="M 49.078125 330.560718 
 L 637.2 330.560718 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m4bc8eadb40" x="49.078125" y="330.560718" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mffd05be4c7" x="49.078125" y="330.560718" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1014,11 +1014,11 @@ L 637.2 330.560718
      <g id="line2d_33">
       <path d="M 49.078125 308.612385 
 L 637.2 308.612385 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m4bc8eadb40" x="49.078125" y="308.612385" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mffd05be4c7" x="49.078125" y="308.612385" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1026,11 +1026,11 @@ L 637.2 308.612385
      <g id="line2d_35">
       <path d="M 49.078125 293.039796 
 L 637.2 293.039796 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m4bc8eadb40" x="49.078125" y="293.039796" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mffd05be4c7" x="49.078125" y="293.039796" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1038,11 +1038,11 @@ L 637.2 293.039796
      <g id="line2d_37">
       <path d="M 49.078125 280.960757 
 L 637.2 280.960757 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m4bc8eadb40" x="49.078125" y="280.960757" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mffd05be4c7" x="49.078125" y="280.960757" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1050,11 +1050,11 @@ L 637.2 280.960757
      <g id="line2d_39">
       <path d="M 49.078125 271.091463 
 L 637.2 271.091463 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m4bc8eadb40" x="49.078125" y="271.091463" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mffd05be4c7" x="49.078125" y="271.091463" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1062,11 +1062,11 @@ L 637.2 271.091463
      <g id="line2d_41">
       <path d="M 49.078125 262.747094 
 L 637.2 262.747094 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m4bc8eadb40" x="49.078125" y="262.747094" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mffd05be4c7" x="49.078125" y="262.747094" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1074,11 +1074,11 @@ L 637.2 262.747094
      <g id="line2d_43">
       <path d="M 49.078125 255.518874 
 L 637.2 255.518874 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m4bc8eadb40" x="49.078125" y="255.518874" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mffd05be4c7" x="49.078125" y="255.518874" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1086,11 +1086,11 @@ L 637.2 255.518874
      <g id="line2d_45">
       <path d="M 49.078125 249.143131 
 L 637.2 249.143131 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m4bc8eadb40" x="49.078125" y="249.143131" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mffd05be4c7" x="49.078125" y="249.143131" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1098,11 +1098,11 @@ L 637.2 249.143131
      <g id="line2d_47">
       <path d="M 49.078125 205.918912 
 L 637.2 205.918912 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m4bc8eadb40" x="49.078125" y="205.918912" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mffd05be4c7" x="49.078125" y="205.918912" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1110,11 +1110,11 @@ L 637.2 205.918912
      <g id="line2d_49">
       <path d="M 49.078125 183.97058 
 L 637.2 183.97058 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m4bc8eadb40" x="49.078125" y="183.97058" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mffd05be4c7" x="49.078125" y="183.97058" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1122,11 +1122,11 @@ L 637.2 183.97058
      <g id="line2d_51">
       <path d="M 49.078125 168.39799 
 L 637.2 168.39799 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m4bc8eadb40" x="49.078125" y="168.39799" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mffd05be4c7" x="49.078125" y="168.39799" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1134,11 +1134,11 @@ L 637.2 168.39799
      <g id="line2d_53">
       <path d="M 49.078125 156.318951 
 L 637.2 156.318951 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#m4bc8eadb40" x="49.078125" y="156.318951" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mffd05be4c7" x="49.078125" y="156.318951" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1146,11 +1146,11 @@ L 637.2 156.318951
      <g id="line2d_55">
       <path d="M 49.078125 146.449658 
 L 637.2 146.449658 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#m4bc8eadb40" x="49.078125" y="146.449658" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mffd05be4c7" x="49.078125" y="146.449658" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1158,11 +1158,11 @@ L 637.2 146.449658
      <g id="line2d_57">
       <path d="M 49.078125 138.105289 
 L 637.2 138.105289 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#m4bc8eadb40" x="49.078125" y="138.105289" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mffd05be4c7" x="49.078125" y="138.105289" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1170,11 +1170,11 @@ L 637.2 138.105289
      <g id="line2d_59">
       <path d="M 49.078125 130.877068 
 L 637.2 130.877068 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#m4bc8eadb40" x="49.078125" y="130.877068" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mffd05be4c7" x="49.078125" y="130.877068" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1182,11 +1182,11 @@ L 637.2 130.877068
      <g id="line2d_61">
       <path d="M 49.078125 124.501326 
 L 637.2 124.501326 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#m4bc8eadb40" x="49.078125" y="124.501326" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mffd05be4c7" x="49.078125" y="124.501326" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1194,11 +1194,11 @@ L 637.2 124.501326
      <g id="line2d_63">
       <path d="M 49.078125 81.277107 
 L 637.2 81.277107 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#m4bc8eadb40" x="49.078125" y="81.277107" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mffd05be4c7" x="49.078125" y="81.277107" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1206,11 +1206,11 @@ L 637.2 81.277107
      <g id="line2d_65">
       <path d="M 49.078125 59.328775 
 L 637.2 59.328775 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#m4bc8eadb40" x="49.078125" y="59.328775" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mffd05be4c7" x="49.078125" y="59.328775" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1332,7 +1332,7 @@ L 637.2 48.323125
    </g>
    <g id="text_13">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(324.643112 122.805741) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(324.643112 122.648492) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1364,7 +1364,7 @@ z
    </g>
    <g id="text_14">
     <!-- L10 -->
-    <g style="fill: #d62728" transform="translate(102.799363 311.472287) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(102.799363 311.67736) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1686,23 +1686,23 @@ z
    </g>
    <g id="line2d_67">
     <defs>
-     <path id="md6dae34af6" d="M -2.5 2.5 
+     <path id="md787940e14" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pf7130b8580)">
-     <use xlink:href="#md6dae34af6" x="377.110281" y="104.685421" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md6dae34af6" x="323.801439" y="110.409833" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md6dae34af6" x="272.665744" y="126.308323" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md6dae34af6" x="235.168828" y="128.026741" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md6dae34af6" x="186.228265" y="149.377587" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md6dae34af6" x="158.303164" y="171.457731" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md6dae34af6" x="149.489547" y="182.192614" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md6dae34af6" x="140.563162" y="202.482797" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md6dae34af6" x="138.984853" y="209.328911" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#peaa930e7dd)">
+     <use xlink:href="#md787940e14" x="377.110281" y="104.685421" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md787940e14" x="323.801439" y="110.409833" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md787940e14" x="272.665744" y="126.308323" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md787940e14" x="235.168828" y="128.026741" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md787940e14" x="186.228265" y="149.377587" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md787940e14" x="158.303164" y="171.457731" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md787940e14" x="149.489547" y="182.192614" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md787940e14" x="140.563162" y="202.482797" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md787940e14" x="138.984853" y="209.328911" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_68">
@@ -1755,7 +1755,7 @@ L 327.133241 110.069256
 L 326.02264 110.18302 
 L 324.91204 110.296545 
 L 323.801439 110.409833 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_69">
     <path d="M 323.801439 110.409833 
@@ -1807,7 +1807,7 @@ L 275.861725 125.44037
 L 274.796398 125.731236 
 L 273.731071 126.020548 
 L 272.665744 126.308323 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_70">
     <path d="M 272.665744 126.308323 
@@ -1859,7 +1859,7 @@ L 237.512385 127.920923
 L 236.7312 127.956219 
 L 235.950014 127.991491 
 L 235.168828 128.026741 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_71">
     <path d="M 235.168828 128.026741 
@@ -1911,7 +1911,7 @@ L 189.28705 148.263499
 L 188.267455 148.637415 
 L 187.24786 149.008766 
 L 186.228265 149.377587 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_72">
     <path d="M 186.228265 149.377587 
@@ -1963,7 +1963,7 @@ L 160.048483 170.312481
 L 159.46671 170.696929 
 L 158.884937 171.078667 
 L 158.303164 171.457731 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_73">
     <path d="M 158.303164 171.457731 
@@ -2015,7 +2015,7 @@ L 150.040398 181.580576
 L 149.856781 181.785359 
 L 149.673164 181.989369 
 L 149.489547 182.192614 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_74">
     <path d="M 149.489547 182.192614 
@@ -2067,7 +2067,7 @@ L 141.121061 201.414753
 L 140.935095 201.773114 
 L 140.749129 202.129119 
 L 140.563162 202.482797 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_75">
     <path d="M 140.563162 202.482797 
@@ -2119,26 +2119,26 @@ L 139.083497 208.925481
 L 139.050616 209.060292 
 L 139.017734 209.194768 
 L 138.984853 209.328911 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_76">
     <defs>
-     <path id="m3bf5e9f3a7" d="M 0 -2.5 
+     <path id="m4e606e4963" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pf7130b8580)">
-     <use xlink:href="#m3bf5e9f3a7" x="610.467187" y="71.939349" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3bf5e9f3a7" x="319.880958" y="101.884157" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3bf5e9f3a7" x="210.281253" y="129.778154" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3bf5e9f3a7" x="196.287076" y="133.586625" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3bf5e9f3a7" x="176.054419" y="147.38645" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3bf5e9f3a7" x="152.161413" y="174.753272" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3bf5e9f3a7" x="146.720208" y="186.587648" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3bf5e9f3a7" x="143.994022" y="196.356323" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3bf5e9f3a7" x="142.666037" y="200.180971" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#peaa930e7dd)">
+     <use xlink:href="#m4e606e4963" x="610.467187" y="71.939349" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4e606e4963" x="319.880958" y="101.884157" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4e606e4963" x="210.281253" y="129.778154" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4e606e4963" x="196.287076" y="133.586625" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4e606e4963" x="176.054419" y="147.38645" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4e606e4963" x="152.161413" y="174.753272" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4e606e4963" x="146.720208" y="186.587648" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4e606e4963" x="143.994022" y="196.356323" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4e606e4963" x="142.666037" y="200.180971" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_77">
@@ -2191,7 +2191,7 @@ L 338.042598 100.427247
 L 331.988718 100.917253 
 L 325.934838 101.402864 
 L 319.880958 101.884157 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_78">
     <path d="M 319.880958 101.884157 
@@ -2243,7 +2243,7 @@ L 217.131235 128.398367
 L 214.847908 128.862215 
 L 212.564581 129.322122 
 L 210.281253 129.778154 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_79">
     <path d="M 210.281253 129.778154 
@@ -2295,7 +2295,7 @@ L 197.161712 133.356286
 L 196.870166 133.433175 
 L 196.578621 133.509954 
 L 196.287076 133.586625 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_80">
     <path d="M 196.287076 133.586625 
@@ -2347,7 +2347,7 @@ L 177.31896 146.619719
 L 176.897447 146.876504 
 L 176.475933 147.132078 
 L 176.054419 147.38645 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_81">
     <path d="M 176.054419 147.38645 
@@ -2399,7 +2399,7 @@ L 153.654726 173.393769
 L 153.156955 173.850741 
 L 152.659184 174.303887 
 L 152.161413 174.753272 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_82">
     <path d="M 152.161413 174.753272 
@@ -2451,7 +2451,7 @@ L 147.060283 185.919158
 L 146.946925 186.142906 
 L 146.833566 186.365734 
 L 146.720208 186.587648 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_83">
     <path d="M 146.720208 186.587648 
@@ -2503,7 +2503,7 @@ L 144.164409 195.794799
 L 144.107613 195.982622 
 L 144.050817 196.169795 
 L 143.994022 196.356323 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_84">
     <path d="M 143.994022 196.356323 
@@ -2555,30 +2555,30 @@ L 142.749036 199.949687
 L 142.72137 200.026891 
 L 142.693704 200.103986 
 L 142.666037 200.180971 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_85">
     <defs>
-     <path id="md6c60a8ac5" d="M -0 3.535534 
+     <path id="m5aab7942b7" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pf7130b8580)">
-     <use xlink:href="#md6c60a8ac5" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md6c60a8ac5" x="242.839153" y="80.778898" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md6c60a8ac5" x="218.251194" y="86.377096" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md6c60a8ac5" x="197.814984" y="90.309617" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md6c60a8ac5" x="166.378359" y="99.066934" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md6c60a8ac5" x="145.830392" y="110.431955" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md6c60a8ac5" x="134.598477" y="126.026287" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md6c60a8ac5" x="124.077268" y="149.033155" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md6c60a8ac5" x="122.462976" y="157.476606" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md6c60a8ac5" x="81.012077" y="220.06889" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md6c60a8ac5" x="77.44276" y="239.652656" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md6c60a8ac5" x="76.953425" y="252.706566" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#peaa930e7dd)">
+     <use xlink:href="#m5aab7942b7" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5aab7942b7" x="242.839153" y="80.778898" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5aab7942b7" x="218.251194" y="86.377096" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5aab7942b7" x="197.814984" y="90.309617" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5aab7942b7" x="166.378359" y="99.066934" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5aab7942b7" x="145.830392" y="110.431955" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5aab7942b7" x="134.598477" y="126.026287" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5aab7942b7" x="124.077268" y="149.033155" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5aab7942b7" x="122.462976" y="157.476606" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5aab7942b7" x="81.012077" y="220.06889" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5aab7942b7" x="77.44276" y="239.652656" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5aab7942b7" x="76.953425" y="252.706566" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_86">
@@ -2631,7 +2631,7 @@ L 245.91379 79.91142
 L 244.888911 80.202126 
 L 243.864032 80.49128 
 L 242.839153 80.778898 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_87">
     <path d="M 242.839153 80.778898 
@@ -2683,7 +2683,7 @@ L 219.787941 86.043669
 L 219.275692 86.155039 
 L 218.763443 86.266182 
 L 218.251194 86.377096 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_88">
     <path d="M 218.251194 86.377096 
@@ -2735,7 +2735,7 @@ L 199.092247 90.072029
 L 198.666492 90.151341 
 L 198.240738 90.230537 
 L 197.814984 90.309617 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_89">
     <path d="M 197.814984 90.309617 
@@ -2787,7 +2787,7 @@ L 168.343148 98.559208
 L 167.688219 98.72898 
 L 167.033289 98.898221 
 L 166.378359 99.066934 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_90">
     <path d="M 166.378359 99.066934 
@@ -2839,7 +2839,7 @@ L 147.11464 109.78743
 L 146.686557 110.003126 
 L 146.258475 110.217965 
 L 145.830392 110.431955 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_91">
     <path d="M 145.830392 110.431955 
@@ -2891,7 +2891,7 @@ L 135.300472 125.172774
 L 135.066474 125.458776 
 L 134.832476 125.743276 
 L 134.598477 126.026287 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_92">
     <path d="M 134.598477 126.026287 
@@ -2943,7 +2943,7 @@ L 124.734843 147.848882
 L 124.515652 148.246526 
 L 124.29646 148.641269 
 L 124.077268 149.033155 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_93">
     <path d="M 124.077268 149.033155 
@@ -2995,7 +2995,7 @@ L 122.56387 156.985769
 L 122.530239 157.149876 
 L 122.496607 157.313488 
 L 122.462976 157.476606 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_94">
     <path d="M 122.462976 157.476606 
@@ -3047,7 +3047,7 @@ L 83.602758 217.699074
 L 82.739198 218.500595 
 L 81.875637 219.290422 
 L 81.012077 220.06889 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_95">
     <path d="M 81.012077 220.06889 
@@ -3099,7 +3099,7 @@ L 77.665842 238.615761
 L 77.591481 238.963605 
 L 77.517121 239.309227 
 L 77.44276 239.652656 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_96">
     <path d="M 77.44276 239.652656 
@@ -3151,23 +3151,23 @@ L 76.984008 251.97672
 L 76.973814 252.221097 
 L 76.96362 252.464376 
 L 76.953425 252.706566 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_97">
     <defs>
-     <path id="m1a6b18cb05" d="M -0 2.5 
+     <path id="mf0aace66c0" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pf7130b8580)">
-     <use xlink:href="#m1a6b18cb05" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#peaa930e7dd)">
+     <use xlink:href="#mf0aace66c0" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_98">
     <defs>
-     <path id="mb9d09be06c" d="M -0.833333 2.5 
+     <path id="m62d0bf00d9" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -3182,16 +3182,16 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pf7130b8580)">
-     <use xlink:href="#mb9d09be06c" x="432.495268" y="96.067622" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb9d09be06c" x="300.62247" y="112.493412" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb9d09be06c" x="266.967623" y="120.8136" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb9d09be06c" x="226.040946" y="122.099593" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb9d09be06c" x="180.985721" y="141.85872" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb9d09be06c" x="164.441833" y="156.106179" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb9d09be06c" x="157.761315" y="165.23787" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb9d09be06c" x="151.269082" y="178.700983" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb9d09be06c" x="150.327087" y="185.23695" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#peaa930e7dd)">
+     <use xlink:href="#m62d0bf00d9" x="432.495268" y="96.067622" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m62d0bf00d9" x="300.62247" y="112.493412" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m62d0bf00d9" x="266.967623" y="120.8136" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m62d0bf00d9" x="226.040946" y="122.099593" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m62d0bf00d9" x="180.985721" y="141.85872" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m62d0bf00d9" x="164.441833" y="156.106179" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m62d0bf00d9" x="157.761315" y="165.23787" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m62d0bf00d9" x="151.269082" y="178.700983" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m62d0bf00d9" x="150.327087" y="185.23695" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_99">
@@ -3244,7 +3244,7 @@ L 308.86452 111.600609
 L 306.11717 111.899849 
 L 303.36982 112.197444 
 L 300.62247 112.493412 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_100">
     <path d="M 300.62247 112.493412 
@@ -3296,7 +3296,7 @@ L 269.071051 120.329422
 L 268.369908 120.491297 
 L 267.668766 120.652688 
 L 266.967623 120.8136 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_101">
     <path d="M 266.967623 120.8136 
@@ -3348,7 +3348,7 @@ L 228.598863 122.020108
 L 227.746224 122.046616 
 L 226.893585 122.073111 
 L 226.040946 122.099593 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_102">
     <path d="M 226.040946 122.099593 
@@ -3400,7 +3400,7 @@ L 183.801673 140.814056
 L 182.863022 141.164522 
 L 181.924372 141.512734 
 L 180.985721 141.85872 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_103">
     <path d="M 180.985721 141.85872 
@@ -3452,7 +3452,7 @@ L 165.475826 155.317544
 L 165.131161 155.581701 
 L 164.786497 155.844575 
 L 164.441833 156.106179 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_104">
     <path d="M 164.441833 156.106179 
@@ -3504,7 +3504,7 @@ L 158.178848 164.710119
 L 158.03967 164.886608 
 L 157.900493 165.062524 
 L 157.761315 165.23787 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_105">
     <path d="M 157.761315 165.23787 
@@ -3556,7 +3556,7 @@ L 151.674847 177.950842
 L 151.539592 178.202046 
 L 151.404337 178.452089 
 L 151.269082 178.700983 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_106">
     <path d="M 151.269082 178.700983 
@@ -3608,11 +3608,11 @@ L 150.385962 184.850776
 L 150.366337 184.979807 
 L 150.346712 185.108531 
 L 150.327087 185.23695 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_107">
     <defs>
-     <path id="m4585feaf44" d="M -1.25 2.5 
+     <path id="m07f2324acd" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -3627,16 +3627,16 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pf7130b8580)">
-     <use xlink:href="#m4585feaf44" x="345.030867" y="136.859359" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4585feaf44" x="273.364924" y="143.571257" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4585feaf44" x="240.719951" y="149.310846" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4585feaf44" x="221.353978" y="154.160538" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4585feaf44" x="207.129625" y="156.092215" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4585feaf44" x="181.064802" y="166.758473" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4585feaf44" x="179.282169" y="170.289343" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4585feaf44" x="177.719335" y="175.489948" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4585feaf44" x="177.643939" y="181.552088" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#peaa930e7dd)">
+     <use xlink:href="#m07f2324acd" x="345.030867" y="136.859359" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m07f2324acd" x="273.364924" y="143.571257" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m07f2324acd" x="240.719951" y="149.310846" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m07f2324acd" x="221.353978" y="154.160538" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m07f2324acd" x="207.129625" y="156.092215" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m07f2324acd" x="181.064802" y="166.758473" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m07f2324acd" x="179.282169" y="170.289343" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m07f2324acd" x="177.719335" y="175.489948" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m07f2324acd" x="177.643939" y="181.552088" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_108">
@@ -3689,7 +3689,7 @@ L 277.844045 143.175283
 L 276.351005 143.307597 
 L 274.857964 143.439587 
 L 273.364924 143.571257 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_109">
     <path d="M 273.364924 143.571257 
@@ -3741,7 +3741,7 @@ L 242.760262 148.96941
 L 242.080158 149.083462 
 L 241.400055 149.197273 
 L 240.719951 149.310846 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_110">
     <path d="M 240.719951 149.310846 
@@ -3793,7 +3793,7 @@ L 222.564351 153.869835
 L 222.160893 153.966909 
 L 221.757435 154.06381 
 L 221.353978 154.160538 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_111">
     <path d="M 221.353978 154.160538 
@@ -3845,7 +3845,7 @@ L 208.018647 155.973483
 L 207.722306 156.013089 
 L 207.425965 156.052666 
 L 207.129625 156.092215 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_112">
     <path d="M 207.129625 156.092215 
@@ -3897,7 +3897,7 @@ L 182.693853 166.149994
 L 182.150836 166.353581 
 L 181.607819 166.556405 
 L 181.064802 166.758473 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_113">
     <path d="M 181.064802 166.758473 
@@ -3949,7 +3949,7 @@ L 179.393584 170.075284
 L 179.356445 170.146731 
 L 179.319307 170.218084 
 L 179.282169 170.289343 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_114">
     <path d="M 179.282169 170.289343 
@@ -4001,7 +4001,7 @@ L 177.817012 175.179146
 L 177.784453 175.282945 
 L 177.751894 175.386546 
 L 177.719335 175.489948 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_115">
     <path d="M 177.719335 175.489948 
@@ -4053,11 +4053,11 @@ L 177.648651 181.192458
 L 177.64708 181.3126 
 L 177.645509 181.432477 
 L 177.643939 181.552088 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_116">
     <defs>
-     <path id="m9265bab173" d="M 0 -2.5 
+     <path id="m01cd396865" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -4070,16 +4070,16 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#pf7130b8580)">
-     <use xlink:href="#m9265bab173" x="226.871027" y="113.224491" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m9265bab173" x="226.871027" y="113.066324" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m9265bab173" x="226.871027" y="113.178221" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m9265bab173" x="226.871027" y="113.089884" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m9265bab173" x="177.768423" y="132.327899" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m9265bab173" x="160.37503" y="145.652356" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m9265bab173" x="153.995779" y="152.678629" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m9265bab173" x="147.106887" y="168.143801" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m9265bab173" x="145.871703" y="175.118358" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#peaa930e7dd)">
+     <use xlink:href="#m01cd396865" x="226.871027" y="113.224491" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m01cd396865" x="226.871027" y="113.066324" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m01cd396865" x="226.871027" y="113.178221" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m01cd396865" x="226.871027" y="113.089884" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m01cd396865" x="177.768423" y="132.327899" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m01cd396865" x="160.37503" y="145.652356" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m01cd396865" x="153.995779" y="152.678629" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m01cd396865" x="147.106887" y="168.143801" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m01cd396865" x="145.871703" y="175.118358" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_117">
@@ -4132,7 +4132,7 @@ L 226.871027 113.076223
 L 226.871027 113.072924 
 L 226.871027 113.069624 
 L 226.871027 113.066324 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_118">
     <path d="M 226.871027 113.066324 
@@ -4184,7 +4184,7 @@ L 226.871027 113.171234
 L 226.871027 113.173563 
 L 226.871027 113.175892 
 L 226.871027 113.178221 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_119">
     <path d="M 226.871027 113.178221 
@@ -4236,7 +4236,7 @@ L 226.871027 113.09541
 L 226.871027 113.093568 
 L 226.871027 113.091726 
 L 226.871027 113.089884 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_120">
     <path d="M 226.871027 113.089884 
@@ -4288,7 +4288,7 @@ L 180.837336 131.306392
 L 179.814365 131.649041 
 L 178.791394 131.989534 
 L 177.768423 132.327899 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_121">
     <path d="M 177.768423 132.327899 
@@ -4340,7 +4340,7 @@ L 161.462117 144.909076
 L 161.099755 145.157972 
 L 160.737393 145.405728 
 L 160.37503 145.652356 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_122">
     <path d="M 160.37503 145.652356 
@@ -4392,7 +4392,7 @@ L 154.394483 152.265218
 L 154.261581 152.403373 
 L 154.12868 152.541176 
 L 153.995779 152.678629 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_123">
     <path d="M 153.995779 152.678629 
@@ -4444,7 +4444,7 @@ L 147.537442 167.296442
 L 147.393924 167.580372 
 L 147.250405 167.862819 
 L 147.106887 168.143801 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_124">
     <path d="M 147.106887 168.143801 
@@ -4496,11 +4496,11 @@ L 145.948902 174.70781
 L 145.923169 174.845005 
 L 145.897436 174.981854 
 L 145.871703 175.118358 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_125">
     <defs>
-     <path id="m435ca23b53" d="M 0 -2.5 
+     <path id="mb562c0f6bb" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -4509,16 +4509,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pf7130b8580)">
-     <use xlink:href="#m435ca23b53" x="585.66883" y="173.051371" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m435ca23b53" x="527.144592" y="175.326465" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m435ca23b53" x="457.339427" y="183.688849" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m435ca23b53" x="292.124837" y="178.486631" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m435ca23b53" x="243.129344" y="190.369032" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m435ca23b53" x="213.541392" y="204.43395" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m435ca23b53" x="204.551957" y="212.140784" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m435ca23b53" x="195.860087" y="228.582256" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m435ca23b53" x="194.019853" y="234.294862" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#peaa930e7dd)">
+     <use xlink:href="#mb562c0f6bb" x="585.66883" y="173.051371" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb562c0f6bb" x="527.144592" y="175.326465" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb562c0f6bb" x="457.339427" y="183.688849" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb562c0f6bb" x="292.124837" y="178.486631" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb562c0f6bb" x="243.129344" y="190.369032" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb562c0f6bb" x="213.541392" y="204.43395" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb562c0f6bb" x="204.551957" y="212.140784" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb562c0f6bb" x="195.860087" y="228.582256" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb562c0f6bb" x="194.019853" y="234.294862" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_126">
@@ -4571,7 +4571,7 @@ L 530.802357 175.187039
 L 529.583102 175.233554 
 L 528.363847 175.28003 
 L 527.144592 175.326465 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_127">
     <path d="M 527.144592 175.326465 
@@ -4623,7 +4623,7 @@ L 461.70225 183.20239
 L 460.247976 183.36503 
 L 458.793701 183.527182 
 L 457.339427 183.688849 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_128">
     <path d="M 457.339427 183.688849 
@@ -4675,7 +4675,7 @@ L 302.450749 178.826834
 L 299.008779 178.713671 
 L 295.566808 178.60027 
 L 292.124837 178.486631 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_129">
     <path d="M 292.124837 178.486631 
@@ -4727,7 +4727,7 @@ L 246.191563 189.6981
 L 245.170823 189.922669 
 L 244.150084 190.146311 
 L 243.129344 190.369032 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_130">
     <path d="M 243.129344 190.369032 
@@ -4779,7 +4779,7 @@ L 215.390639 203.654226
 L 214.774224 203.915384 
 L 214.157808 204.175288 
 L 213.541392 204.43395 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_131">
     <path d="M 213.541392 204.43395 
@@ -4831,7 +4831,7 @@ L 205.113797 211.689953
 L 204.926517 211.840648 
 L 204.739237 211.990924 
 L 204.551957 212.140784 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_132">
     <path d="M 204.551957 212.140784 
@@ -4883,7 +4883,7 @@ L 196.403329 227.688717
 L 196.222248 227.988205 
 L 196.041168 228.286045 
 L 195.860087 228.582256 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_133">
     <path d="M 195.860087 228.582256 
@@ -4935,7 +4935,7 @@ L 194.134867 233.954953
 L 194.096529 234.068494 
 L 194.058191 234.181796 
 L 194.019853 234.294862 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="legend_1">
     <g id="patch_7">
@@ -4953,7 +4953,7 @@ z
     </g>
     <g id="line2d_134">
      <defs>
-      <path id="m64b2f8c67b" d="M 0 3.5 
+      <path id="ma4bd2f6945" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -4966,7 +4966,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m64b2f8c67b" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#ma4bd2f6945" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -5025,7 +5025,7 @@ z
     </g>
     <g id="line2d_135">
      <g>
-      <use xlink:href="#md6dae34af6" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#md787940e14" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -5039,7 +5039,7 @@ z
     </g>
     <g id="line2d_136">
      <g>
-      <use xlink:href="#m3bf5e9f3a7" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m4e606e4963" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -5084,7 +5084,7 @@ z
     </g>
     <g id="line2d_137">
      <g>
-      <use xlink:href="#md6c60a8ac5" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m5aab7942b7" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -5127,7 +5127,7 @@ z
     </g>
     <g id="line2d_138">
      <g>
-      <use xlink:href="#m1a6b18cb05" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mf0aace66c0" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -5143,7 +5143,7 @@ z
     </g>
     <g id="line2d_139">
      <g>
-      <use xlink:href="#mb9d09be06c" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m62d0bf00d9" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -5197,7 +5197,7 @@ z
     </g>
     <g id="line2d_140">
      <g>
-      <use xlink:href="#m4585feaf44" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m07f2324acd" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -5262,7 +5262,7 @@ z
     </g>
     <g id="line2d_141">
      <g>
-      <use xlink:href="#m9265bab173" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#m01cd396865" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -5300,7 +5300,7 @@ z
     </g>
     <g id="line2d_142">
      <g>
-      <use xlink:href="#m435ca23b53" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mb562c0f6bb" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -5370,486 +5370,486 @@ z
     </g>
    </g>
    <g id="line2d_143">
-    <g clip-path="url(#pf7130b8580)">
-     <use xlink:href="#m64b2f8c67b" x="319.643112" y="127.805741" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m64b2f8c67b" x="269.129958" y="143.474516" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m64b2f8c67b" x="247.452898" y="148.487078" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m64b2f8c67b" x="192.820547" y="161.324417" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m64b2f8c67b" x="180.389901" y="171.50672" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m64b2f8c67b" x="156.350594" y="182.172794" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m64b2f8c67b" x="147.843012" y="191.187666" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m64b2f8c67b" x="146.231533" y="194.941576" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m64b2f8c67b" x="119.590386" y="288.62936" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m64b2f8c67b" x="97.799363" y="316.472287" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <g clip-path="url(#peaa930e7dd)">
+     <use xlink:href="#ma4bd2f6945" x="319.643112" y="127.648492" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma4bd2f6945" x="269.129958" y="143.227987" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma4bd2f6945" x="247.452898" y="148.451845" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma4bd2f6945" x="193.126328" y="161.74155" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma4bd2f6945" x="180.705537" y="171.919174" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma4bd2f6945" x="156.608415" y="183.193711" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma4bd2f6945" x="148.121575" y="191.7487" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma4bd2f6945" x="146.442931" y="195.543648" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma4bd2f6945" x="119.590386" y="289.493136" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma4bd2f6945" x="97.799363" y="316.67736" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
    <g id="line2d_144">
-    <path d="M 319.643112 127.805741 
-L 318.590755 128.183009 
-L 317.538397 128.557666 
-L 316.48604 128.929747 
-L 315.433682 129.299288 
-L 314.381325 129.666324 
-L 313.328968 130.030888 
-L 312.27661 130.393013 
-L 311.224253 130.752731 
-L 310.171896 131.110075 
-L 309.119538 131.465075 
-L 308.067181 131.817762 
-L 307.014823 132.168166 
-L 305.962466 132.516317 
-L 304.910109 132.862243 
-L 303.857751 133.205972 
-L 302.805394 133.547532 
-L 301.753037 133.88695 
-L 300.700679 134.224254 
-L 299.648322 134.559469 
-L 298.595965 134.89262 
-L 297.543607 135.223734 
-L 296.49125 135.552835 
-L 295.438892 135.879947 
-L 294.386535 136.205094 
-L 293.334178 136.528299 
-L 292.28182 136.849587 
-L 291.229463 137.168979 
-L 290.177106 137.486497 
-L 289.124748 137.802163 
-L 288.072391 138.116 
-L 287.020033 138.428027 
-L 285.967676 138.738266 
-L 284.915319 139.046737 
-L 283.862961 139.353461 
-L 282.810604 139.658456 
-L 281.758247 139.961742 
-L 280.705889 140.263338 
-L 279.653532 140.563264 
-L 278.601175 140.861537 
-L 277.548817 141.158175 
-L 276.49646 141.453196 
-L 275.444102 141.746619 
-L 274.391745 142.038459 
-L 273.339388 142.328734 
-L 272.28703 142.617461 
-L 271.234673 142.904657 
-L 270.182316 143.190336 
-L 269.129958 143.474516 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 319.643112 127.648492 
+L 318.590755 128.023295 
+L 317.538397 128.39552 
+L 316.48604 128.765203 
+L 315.433682 129.132379 
+L 314.381325 129.497081 
+L 313.328968 129.859342 
+L 312.27661 130.219195 
+L 311.224253 130.576672 
+L 310.171896 130.931803 
+L 309.119538 131.28462 
+L 308.067181 131.635152 
+L 307.014823 131.983429 
+L 305.962466 132.329479 
+L 304.910109 132.673331 
+L 303.857751 133.015012 
+L 302.805394 133.354551 
+L 301.753037 133.691972 
+L 300.700679 134.027304 
+L 299.648322 134.360571 
+L 298.595965 134.691799 
+L 297.543607 135.021012 
+L 296.49125 135.348235 
+L 295.438892 135.673492 
+L 294.386535 135.996807 
+L 293.334178 136.318202 
+L 292.28182 136.637699 
+L 291.229463 136.955322 
+L 290.177106 137.271093 
+L 289.124748 137.585032 
+L 288.072391 137.89716 
+L 287.020033 138.207499 
+L 285.967676 138.51607 
+L 284.915319 138.822891 
+L 283.862961 139.127983 
+L 282.810604 139.431364 
+L 281.758247 139.733056 
+L 280.705889 140.033074 
+L 279.653532 140.33144 
+L 278.601175 140.62817 
+L 277.548817 140.923282 
+L 276.49646 141.216793 
+L 275.444102 141.508722 
+L 274.391745 141.799085 
+L 273.339388 142.087899 
+L 272.28703 142.37518 
+L 271.234673 142.660945 
+L 270.182316 142.945209 
+L 269.129958 143.227987 
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_145">
-    <path d="M 269.129958 143.474516 
-L 268.678353 143.583822 
-L 268.226747 143.692907 
-L 267.775142 143.801773 
-L 267.323537 143.910421 
-L 266.871931 144.018851 
-L 266.420326 144.127064 
-L 265.96872 144.235061 
-L 265.517115 144.342844 
-L 265.065509 144.450412 
-L 264.613904 144.557766 
-L 264.162299 144.664909 
-L 263.710693 144.771839 
-L 263.259088 144.878559 
-L 262.807482 144.985069 
-L 262.355877 145.091369 
-L 261.904271 145.197462 
-L 261.452666 145.303346 
-L 261.001061 145.409024 
-L 260.549455 145.514497 
-L 260.09785 145.619764 
-L 259.646244 145.724826 
-L 259.194639 145.829686 
-L 258.743034 145.934342 
-L 258.291428 146.038797 
-L 257.839823 146.14305 
-L 257.388217 146.247103 
-L 256.936612 146.350956 
-L 256.485006 146.454611 
-L 256.033401 146.558067 
-L 255.581796 146.661326 
-L 255.13019 146.764388 
-L 254.678585 146.867255 
-L 254.226979 146.969926 
-L 253.775374 147.072403 
-L 253.323769 147.174687 
-L 252.872163 147.276777 
-L 252.420558 147.378676 
-L 251.968952 147.480383 
-L 251.517347 147.581899 
-L 251.065741 147.683225 
-L 250.614136 147.784362 
-L 250.162531 147.88531 
-L 249.710925 147.98607 
-L 249.25932 148.086643 
-L 248.807714 148.18703 
-L 248.356109 148.287231 
-L 247.904503 148.387246 
-L 247.452898 148.487078 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 269.129958 143.227987 
+L 268.678353 143.342122 
+L 268.226747 143.456016 
+L 267.775142 143.569671 
+L 267.323537 143.683088 
+L 266.871931 143.796267 
+L 266.420326 143.909211 
+L 265.96872 144.021919 
+L 265.517115 144.134394 
+L 265.065509 144.246635 
+L 264.613904 144.358644 
+L 264.162299 144.470421 
+L 263.710693 144.581968 
+L 263.259088 144.693286 
+L 262.807482 144.804375 
+L 262.355877 144.915237 
+L 261.904271 145.025872 
+L 261.452666 145.136282 
+L 261.001061 145.246467 
+L 260.549455 145.356428 
+L 260.09785 145.466166 
+L 259.646244 145.575682 
+L 259.194639 145.684977 
+L 258.743034 145.794052 
+L 258.291428 145.902907 
+L 257.839823 146.011544 
+L 257.388217 146.119963 
+L 256.936612 146.228166 
+L 256.485006 146.336152 
+L 256.033401 146.443924 
+L 255.581796 146.551482 
+L 255.13019 146.658826 
+L 254.678585 146.765958 
+L 254.226979 146.872878 
+L 253.775374 146.979588 
+L 253.323769 147.086087 
+L 252.872163 147.192378 
+L 252.420558 147.29846 
+L 251.968952 147.404334 
+L 251.517347 147.510002 
+L 251.065741 147.615465 
+L 250.614136 147.720722 
+L 250.162531 147.825774 
+L 249.710925 147.930624 
+L 249.25932 148.03527 
+L 248.807714 148.139715 
+L 248.356109 148.243958 
+L 247.904503 148.348002 
+L 247.452898 148.451845 
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_146">
-    <path d="M 247.452898 148.487078 
-L 246.314724 148.788059 
-L 245.17655 149.087377 
-L 244.038376 149.385048 
-L 242.900202 149.681091 
-L 241.762028 149.975525 
-L 240.623854 150.268365 
-L 239.48568 150.55963 
-L 238.347506 150.849335 
-L 237.209332 151.137499 
-L 236.071158 151.424137 
-L 234.932984 151.709264 
-L 233.79481 151.992898 
-L 232.656636 152.275054 
-L 231.518462 152.555746 
-L 230.380288 152.83499 
-L 229.242114 153.112802 
-L 228.10394 153.389194 
-L 226.965766 153.664183 
-L 225.827592 153.937782 
-L 224.689418 154.210005 
-L 223.551244 154.480865 
-L 222.41307 154.750377 
-L 221.274896 155.018554 
-L 220.136722 155.285409 
-L 218.998548 155.550955 
-L 217.860374 155.815204 
-L 216.7222 156.07817 
-L 215.584026 156.339864 
-L 214.445852 156.6003 
-L 213.307678 156.859488 
-L 212.169505 157.117441 
-L 211.031331 157.374171 
-L 209.893157 157.629689 
-L 208.754983 157.884007 
-L 207.616809 158.137135 
-L 206.478635 158.389085 
-L 205.340461 158.639868 
-L 204.202287 158.889494 
-L 203.064113 159.137975 
-L 201.925939 159.38532 
-L 200.787765 159.63154 
-L 199.649591 159.876645 
-L 198.511417 160.120645 
-L 197.373243 160.363551 
-L 196.235069 160.605371 
-L 195.096895 160.846116 
-L 193.958721 161.085795 
-L 192.820547 161.324417 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 247.452898 148.451845 
+L 246.321094 148.764756 
+L 245.189291 149.075867 
+L 244.057487 149.385202 
+L 242.925684 149.692778 
+L 241.79388 149.998617 
+L 240.662077 150.302737 
+L 239.530273 150.605158 
+L 238.39847 150.9059 
+L 237.266666 151.204979 
+L 236.134863 151.502415 
+L 235.003059 151.798226 
+L 233.871256 152.092429 
+L 232.739452 152.385042 
+L 231.607648 152.676081 
+L 230.475845 152.965564 
+L 229.344041 153.253507 
+L 228.212238 153.539927 
+L 227.080434 153.824839 
+L 225.948631 154.108259 
+L 224.816827 154.390203 
+L 223.685024 154.670686 
+L 222.55322 154.949724 
+L 221.421417 155.22733 
+L 220.289613 155.50352 
+L 219.15781 155.778308 
+L 218.026006 156.051708 
+L 216.894202 156.323734 
+L 215.762399 156.5944 
+L 214.630595 156.863719 
+L 213.498792 157.131705 
+L 212.366988 157.398371 
+L 211.235185 157.663729 
+L 210.103381 157.927793 
+L 208.971578 158.190575 
+L 207.839774 158.452088 
+L 206.707971 158.712343 
+L 205.576167 158.971353 
+L 204.444364 159.22913 
+L 203.31256 159.485685 
+L 202.180756 159.741029 
+L 201.048953 159.995175 
+L 199.917149 160.248133 
+L 198.785346 160.499915 
+L 197.653542 160.750531 
+L 196.521739 160.999991 
+L 195.389935 161.248308 
+L 194.258132 161.495491 
+L 193.126328 161.74155 
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_147">
-    <path d="M 192.820547 161.324417 
-L 192.561575 161.55731 
-L 192.302603 161.789205 
-L 192.043631 162.020111 
-L 191.78466 162.250037 
-L 191.525688 162.47899 
-L 191.266716 162.706978 
-L 191.007744 162.934011 
-L 190.748773 163.160095 
-L 190.489801 163.385239 
-L 190.230829 163.60945 
-L 189.971857 163.832736 
-L 189.712885 164.055105 
-L 189.453914 164.276565 
-L 189.194942 164.497122 
-L 188.93597 164.716784 
-L 188.676998 164.935558 
-L 188.418027 165.153452 
-L 188.159055 165.370472 
-L 187.900083 165.586626 
-L 187.641111 165.801919 
-L 187.382139 166.01636 
-L 187.123168 166.229955 
-L 186.864196 166.44271 
-L 186.605224 166.654633 
-L 186.346252 166.865729 
-L 186.087281 167.076004 
-L 185.828309 167.285467 
-L 185.569337 167.494121 
-L 185.310365 167.701975 
-L 185.051393 167.909034 
-L 184.792422 168.115303 
-L 184.53345 168.32079 
-L 184.274478 168.525499 
-L 184.015506 168.729437 
-L 183.756535 168.93261 
-L 183.497563 169.135023 
-L 183.238591 169.336682 
-L 182.979619 169.537592 
-L 182.720647 169.73776 
-L 182.461676 169.93719 
-L 182.202704 170.135888 
-L 181.943732 170.333859 
-L 181.68476 170.531109 
-L 181.425789 170.727643 
-L 181.166817 170.923466 
-L 180.907845 171.118583 
-L 180.648873 171.312999 
-L 180.389901 171.50672 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 193.126328 161.74155 
+L 192.867562 161.974326 
+L 192.608795 162.206105 
+L 192.350029 162.436896 
+L 192.091262 162.666707 
+L 191.832496 162.895547 
+L 191.573729 163.123423 
+L 191.314963 163.350344 
+L 191.056196 163.576318 
+L 190.79743 163.801352 
+L 190.538663 164.025455 
+L 190.279897 164.248634 
+L 190.02113 164.470896 
+L 189.762364 164.69225 
+L 189.503597 164.912702 
+L 189.244831 165.13226 
+L 188.986064 165.35093 
+L 188.727298 165.568722 
+L 188.468531 165.78564 
+L 188.209765 166.001693 
+L 187.950998 166.216886 
+L 187.692232 166.431228 
+L 187.433465 166.644724 
+L 187.174699 166.857382 
+L 186.915932 167.069207 
+L 186.657166 167.280207 
+L 186.398399 167.490387 
+L 186.139633 167.699754 
+L 185.880866 167.908315 
+L 185.6221 168.116076 
+L 185.363333 168.323042 
+L 185.104567 168.529219 
+L 184.8458 168.734615 
+L 184.587034 168.939233 
+L 184.328268 169.143082 
+L 184.069501 169.346165 
+L 183.810735 169.54849 
+L 183.551968 169.750061 
+L 183.293202 169.950884 
+L 183.034435 170.150965 
+L 182.775669 170.35031 
+L 182.516902 170.548922 
+L 182.258136 170.746809 
+L 181.999369 170.943975 
+L 181.740603 171.140425 
+L 181.481836 171.336166 
+L 181.22307 171.5312 
+L 180.964303 171.725535 
+L 180.705537 171.919174 
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_148">
-    <path d="M 180.389901 171.50672 
-L 179.889083 171.751778 
-L 179.388264 171.995732 
-L 178.887445 172.238591 
-L 178.386626 172.480365 
-L 177.885807 172.721065 
-L 177.384988 172.960699 
-L 176.884169 173.199277 
-L 176.38335 173.436807 
-L 175.882531 173.673301 
-L 175.381713 173.908765 
-L 174.880894 174.14321 
-L 174.380075 174.376643 
-L 173.879256 174.609074 
-L 173.378437 174.840512 
-L 172.877618 175.070964 
-L 172.376799 175.300439 
-L 171.87598 175.528946 
-L 171.375161 175.756492 
-L 170.874342 175.983085 
-L 170.373524 176.208734 
-L 169.872705 176.433446 
-L 169.371886 176.65723 
-L 168.871067 176.880091 
-L 168.370248 177.10204 
-L 167.869429 177.323081 
-L 167.36861 177.543224 
-L 166.867791 177.762475 
-L 166.366972 177.980842 
-L 165.866154 178.198331 
-L 165.365335 178.41495 
-L 164.864516 178.630706 
-L 164.363697 178.845605 
-L 163.862878 179.059655 
-L 163.362059 179.272861 
-L 162.86124 179.485231 
-L 162.360421 179.69677 
-L 161.859602 179.907487 
-L 161.358783 180.117386 
-L 160.857965 180.326475 
-L 160.357146 180.534759 
-L 159.856327 180.742244 
-L 159.355508 180.948938 
-L 158.854689 181.154845 
-L 158.35387 181.359972 
-L 157.853051 181.564324 
-L 157.352232 181.767908 
-L 156.851413 181.97073 
-L 156.350594 182.172794 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 180.705537 171.919174 
+L 180.203513 172.179684 
+L 179.70149 172.438947 
+L 179.199467 172.696973 
+L 178.697443 172.953776 
+L 178.19542 173.209365 
+L 177.693396 173.463754 
+L 177.191373 173.716953 
+L 176.68935 173.968973 
+L 176.187326 174.219825 
+L 175.685303 174.46952 
+L 175.18328 174.718068 
+L 174.681256 174.965481 
+L 174.179233 175.211768 
+L 173.67721 175.456939 
+L 173.175186 175.701005 
+L 172.673163 175.943975 
+L 172.171139 176.18586 
+L 171.669116 176.426668 
+L 171.167093 176.666411 
+L 170.665069 176.905095 
+L 170.163046 177.142733 
+L 169.661023 177.379331 
+L 169.158999 177.6149 
+L 168.656976 177.849448 
+L 168.154953 178.082984 
+L 167.652929 178.315517 
+L 167.150906 178.547056 
+L 166.648882 178.777608 
+L 166.146859 179.007182 
+L 165.644836 179.235787 
+L 165.142812 179.463431 
+L 164.640789 179.690121 
+L 164.138766 179.915866 
+L 163.636742 180.140673 
+L 163.134719 180.364551 
+L 162.632696 180.587506 
+L 162.130672 180.809547 
+L 161.628649 181.030681 
+L 161.126625 181.250915 
+L 160.624602 181.470257 
+L 160.122579 181.688713 
+L 159.620555 181.906292 
+L 159.118532 182.122999 
+L 158.616509 182.338842 
+L 158.114485 182.553828 
+L 157.612462 182.767964 
+L 157.110439 182.981256 
+L 156.608415 183.193711 
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_149">
-    <path d="M 156.350594 182.172794 
-L 156.173353 182.376763 
-L 155.996112 182.579967 
-L 155.818871 182.78241 
-L 155.641629 182.9841 
-L 155.464388 183.18504 
-L 155.287147 183.385238 
-L 155.109905 183.584698 
-L 154.932664 183.783425 
-L 154.755423 183.981426 
-L 154.578182 184.178705 
-L 154.40094 184.375267 
-L 154.223699 184.571119 
-L 154.046458 184.766264 
-L 153.869216 184.960709 
-L 153.691975 185.154457 
-L 153.514734 185.347515 
-L 153.337492 185.539886 
-L 153.160251 185.731577 
-L 152.98301 185.92259 
-L 152.805769 186.112932 
-L 152.628527 186.302608 
-L 152.451286 186.49162 
-L 152.274045 186.679976 
-L 152.096803 186.867678 
-L 151.919562 187.054731 
-L 151.742321 187.24114 
-L 151.56508 187.42691 
-L 151.387838 187.612044 
-L 151.210597 187.796547 
-L 151.033356 187.980424 
-L 150.856114 188.163678 
-L 150.678873 188.346313 
-L 150.501632 188.528335 
-L 150.32439 188.709746 
-L 150.147149 188.890552 
-L 149.969908 189.070756 
-L 149.792667 189.250361 
-L 149.615425 189.429373 
-L 149.438184 189.607795 
-L 149.260943 189.78563 
-L 149.083701 189.962884 
-L 148.90646 190.139558 
-L 148.729219 190.315658 
-L 148.551977 190.491187 
-L 148.374736 190.666149 
-L 148.197495 190.840547 
-L 148.020254 191.014385 
-L 147.843012 191.187666 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 156.608415 183.193711 
+L 156.431606 183.386452 
+L 156.254797 183.57851 
+L 156.077988 183.769888 
+L 155.901179 183.960592 
+L 155.724369 184.150627 
+L 155.54756 184.339997 
+L 155.370751 184.528707 
+L 155.193942 184.716761 
+L 155.017133 184.904165 
+L 154.840323 185.090921 
+L 154.663514 185.277036 
+L 154.486705 185.462513 
+L 154.309896 185.647356 
+L 154.133087 185.83157 
+L 153.956278 186.01516 
+L 153.779468 186.198129 
+L 153.602659 186.380482 
+L 153.42585 186.562222 
+L 153.249041 186.743355 
+L 153.072232 186.923883 
+L 152.895423 187.103811 
+L 152.718613 187.283143 
+L 152.541804 187.461883 
+L 152.364995 187.640035 
+L 152.188186 187.817603 
+L 152.011377 187.994589 
+L 151.834567 188.170999 
+L 151.657758 188.346836 
+L 151.480949 188.522104 
+L 151.30414 188.696806 
+L 151.127331 188.870946 
+L 150.950522 189.044527 
+L 150.773712 189.217554 
+L 150.596903 189.390029 
+L 150.420094 189.561957 
+L 150.243285 189.73334 
+L 150.066476 189.904182 
+L 149.889667 190.074487 
+L 149.712857 190.244258 
+L 149.536048 190.413498 
+L 149.359239 190.58221 
+L 149.18243 190.750399 
+L 149.005621 190.918066 
+L 148.828811 191.085216 
+L 148.652002 191.251851 
+L 148.475193 191.417974 
+L 148.298384 191.58359 
+L 148.121575 191.7487 
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_150">
-    <path d="M 147.843012 191.187666 
-L 147.80944 191.268588 
-L 147.775867 191.349388 
-L 147.742295 191.430069 
-L 147.708722 191.510629 
-L 147.67515 191.591069 
-L 147.641577 191.67139 
-L 147.608005 191.751593 
-L 147.574432 191.831676 
-L 147.54086 191.911641 
-L 147.507287 191.991488 
-L 147.473715 192.071218 
-L 147.440142 192.15083 
-L 147.40657 192.230326 
-L 147.372997 192.309704 
-L 147.339425 192.388967 
-L 147.305852 192.468114 
-L 147.27228 192.547145 
-L 147.238707 192.626061 
-L 147.205135 192.704862 
-L 147.171562 192.783548 
-L 147.13799 192.862121 
-L 147.104417 192.940579 
-L 147.070845 193.018924 
-L 147.037273 193.097156 
-L 147.0037 193.175274 
-L 146.970128 193.253281 
-L 146.936555 193.331174 
-L 146.902983 193.408956 
-L 146.86941 193.486627 
-L 146.835838 193.564186 
-L 146.802265 193.641634 
-L 146.768693 193.718972 
-L 146.73512 193.796199 
-L 146.701548 193.873316 
-L 146.667975 193.950323 
-L 146.634403 194.027221 
-L 146.60083 194.10401 
-L 146.567258 194.18069 
-L 146.533685 194.257262 
-L 146.500113 194.333726 
-L 146.46654 194.410081 
-L 146.432968 194.486329 
-L 146.399395 194.56247 
-L 146.365823 194.638504 
-L 146.33225 194.714431 
-L 146.298678 194.790252 
-L 146.265105 194.865967 
-L 146.231533 194.941576 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 148.121575 191.7487 
+L 148.086603 191.830537 
+L 148.051631 191.91225 
+L 148.01666 191.99384 
+L 147.981688 192.075307 
+L 147.946716 192.156652 
+L 147.911744 192.237875 
+L 147.876773 192.318976 
+L 147.841801 192.399956 
+L 147.806829 192.480815 
+L 147.771857 192.561553 
+L 147.736886 192.642171 
+L 147.701914 192.722669 
+L 147.666942 192.803048 
+L 147.63197 192.883307 
+L 147.596999 192.963448 
+L 147.562027 193.04347 
+L 147.527055 193.123374 
+L 147.492083 193.20316 
+L 147.457112 193.282829 
+L 147.42214 193.362381 
+L 147.387168 193.441816 
+L 147.352197 193.521134 
+L 147.317225 193.600337 
+L 147.282253 193.679423 
+L 147.247281 193.758395 
+L 147.21231 193.837251 
+L 147.177338 193.915993 
+L 147.142366 193.99462 
+L 147.107394 194.073134 
+L 147.072423 194.151533 
+L 147.037451 194.229819 
+L 147.002479 194.307992 
+L 146.967507 194.386053 
+L 146.932536 194.464001 
+L 146.897564 194.541837 
+L 146.862592 194.619561 
+L 146.82762 194.697173 
+L 146.792649 194.774675 
+L 146.757677 194.852066 
+L 146.722705 194.929346 
+L 146.687733 195.006516 
+L 146.652762 195.083576 
+L 146.61779 195.160527 
+L 146.582818 195.237368 
+L 146.547847 195.314101 
+L 146.512875 195.390725 
+L 146.477903 195.467241 
+L 146.442931 195.543648 
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_151">
-    <path d="M 146.231533 194.941576 
-L 145.676509 199.94159 
-L 145.121485 204.518561 
-L 144.566461 208.738524 
-L 144.011437 212.653167 
-L 143.456413 216.303704 
-L 142.901389 219.723531 
-L 142.346365 222.940083 
-L 141.791342 225.976176 
-L 141.236318 228.850988 
-L 140.681294 231.580793 
-L 140.12627 234.179519 
-L 139.571246 236.65918 
-L 139.016222 239.030211 
-L 138.461198 241.301729 
-L 137.906174 243.481755 
-L 137.35115 245.577372 
-L 136.796126 247.594875 
-L 136.241103 249.539879 
-L 135.686079 251.417414 
-L 135.131055 253.232003 
-L 134.576031 254.987732 
-L 134.021007 256.688299 
-L 133.465983 258.337064 
-L 132.910959 259.937092 
-L 132.355935 261.49118 
-L 131.800911 263.001893 
-L 131.245887 264.471586 
-L 130.690864 265.902429 
-L 130.13584 267.296423 
-L 129.580816 268.655418 
-L 129.025792 269.981129 
-L 128.470768 271.275146 
-L 127.915744 272.538951 
-L 127.36072 273.773922 
-L 126.805696 274.981344 
-L 126.250672 276.162422 
-L 125.695648 277.318278 
-L 125.140625 278.44997 
-L 124.585601 279.558485 
-L 124.030577 280.644754 
-L 123.475553 281.709653 
-L 122.920529 282.754007 
-L 122.365505 283.778592 
-L 121.810481 284.784144 
-L 121.255457 285.771357 
-L 120.700433 286.740888 
-L 120.145409 287.693359 
-L 119.590386 288.62936 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 146.442931 195.543648 
+L 145.883503 200.571784 
+L 145.324075 205.172306 
+L 144.764647 209.412279 
+L 144.205219 213.344134 
+L 143.645791 217.009634 
+L 143.086363 220.442588 
+L 142.526935 223.670751 
+L 141.967507 226.717186 
+L 141.408079 229.601268 
+L 140.848651 232.339429 
+L 140.289223 234.945728 
+L 139.729795 237.432282 
+L 139.170367 239.809614 
+L 138.610939 242.086916 
+L 138.051511 244.272267 
+L 137.492083 246.372806 
+L 136.932655 248.394869 
+L 136.373227 250.344111 
+L 135.813799 252.225595 
+L 135.254371 254.043873 
+L 134.694943 255.803055 
+L 134.135514 257.50686 
+L 133.576086 259.15867 
+L 133.016658 260.761565 
+L 132.45723 262.318357 
+L 131.897802 263.831626 
+L 131.338374 265.303738 
+L 130.778946 266.736873 
+L 130.219518 268.133043 
+L 129.66009 269.494105 
+L 129.100662 270.821783 
+L 128.541234 272.117675 
+L 127.981806 273.383268 
+L 127.422378 274.619946 
+L 126.86295 275.829001 
+L 126.303522 277.011639 
+L 125.744094 278.168991 
+L 125.184666 279.302116 
+L 124.625238 280.412007 
+L 124.06581 281.499597 
+L 123.506382 282.565765 
+L 122.946954 283.611339 
+L 122.387526 284.637099 
+L 121.828098 285.643783 
+L 121.26867 286.632086 
+L 120.709242 287.602669 
+L 120.149814 288.556155 
+L 119.590386 289.493136 
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_152">
-    <path d="M 119.590386 288.62936 
-L 119.136406 289.382572 
-L 118.682426 290.125447 
-L 118.228447 290.858265 
-L 117.774467 291.581295 
-L 117.320487 292.294795 
-L 116.866508 292.999012 
-L 116.412528 293.694185 
-L 115.958549 294.380544 
-L 115.504569 295.058309 
-L 115.050589 295.727692 
-L 114.59661 296.388899 
-L 114.14263 297.042127 
-L 113.68865 297.687566 
-L 113.234671 298.325399 
-L 112.780691 298.955804 
-L 112.326712 299.578953 
-L 111.872732 300.195009 
-L 111.418752 300.804132 
-L 110.964773 301.406478 
-L 110.510793 302.002195 
-L 110.056813 302.591427 
-L 109.602834 303.174314 
-L 109.148854 303.750991 
-L 108.694874 304.32159 
-L 108.240895 304.886237 
-L 107.786915 305.445054 
-L 107.332936 305.998162 
-L 106.878956 306.545675 
-L 106.424976 307.087705 
-L 105.970997 307.624362 
-L 105.517017 308.155751 
-L 105.063037 308.681974 
-L 104.609058 309.20313 
-L 104.155078 309.719317 
-L 103.701099 310.230628 
-L 103.247119 310.737154 
-L 102.793139 311.238985 
-L 102.33916 311.736206 
-L 101.88518 312.228901 
-L 101.4312 312.717153 
-L 100.977221 313.201039 
-L 100.523241 313.680639 
-L 100.069262 314.156026 
-L 99.615282 314.627275 
-L 99.161302 315.094457 
-L 98.707323 315.557641 
-L 98.253343 316.016896 
-L 97.799363 316.472287 
-" clip-path="url(#pf7130b8580)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 119.590386 289.493136 
+L 119.136406 290.223845 
+L 118.682426 290.944822 
+L 118.228447 291.656322 
+L 117.774467 292.358592 
+L 117.320487 293.051867 
+L 116.866508 293.736375 
+L 116.412528 294.412335 
+L 115.958549 295.079959 
+L 115.504569 295.739448 
+L 115.050589 296.391 
+L 114.59661 297.034802 
+L 114.14263 297.671037 
+L 113.68865 298.299881 
+L 113.234671 298.921504 
+L 112.780691 299.536069 
+L 112.326712 300.143735 
+L 111.872732 300.744655 
+L 111.418752 301.338977 
+L 110.964773 301.926845 
+L 110.510793 302.508397 
+L 110.056813 303.083768 
+L 109.602834 303.653087 
+L 109.148854 304.21648 
+L 108.694874 304.774071 
+L 108.240895 305.325976 
+L 107.786915 305.872311 
+L 107.332936 306.413187 
+L 106.878956 306.948712 
+L 106.424976 307.478991 
+L 105.970997 308.004125 
+L 105.517017 308.524214 
+L 105.063037 309.039354 
+L 104.609058 309.549637 
+L 104.155078 310.055155 
+L 103.701099 310.555996 
+L 103.247119 311.052245 
+L 102.793139 311.543986 
+L 102.33916 312.0313 
+L 101.88518 312.514267 
+L 101.4312 312.992962 
+L 100.977221 313.467461 
+L 100.523241 313.937837 
+L 100.069262 314.404161 
+L 99.615282 314.866502 
+L 99.161302 315.324927 
+L 98.707323 315.779503 
+L 98.253343 316.230293 
+L 97.799363 316.67736 
+" clip-path="url(#peaa930e7dd)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
   </g>
   <g id="text_25">
@@ -6166,8 +6166,8 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-07-06T07:54:18Z  ·  Linux chungus2 x86_64  ·  commit 38a6ad15  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(43.549375 465.66) scale(0.07 -0.07)">
+   <!-- 2026-07-06T10:45:22Z  ·  Linux chungus2 x86_64  ·  commit 8a6bc577  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(43.769766 465.66) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -6325,14 +6325,14 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -6372,109 +6372,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3260.400391 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3324.023438 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3385.302734 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3448.779297 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3512.402344 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3576.025391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3607.8125 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3639.599609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3671.386719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3703.173828 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3734.960938 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3762.744141 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3824.267578 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3885.546875 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3948.925781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4012.402344 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4051.265625 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4112.447266 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4171.626953 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4233.150391 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4274.263672 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4307.955078 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4335.738281 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4397.261719 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4458.541016 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4521.919922 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4585.542969 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4619.234375 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4678.414062 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4742.037109 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4773.824219 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4837.447266 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4901.070312 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4932.857422 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4996.480469 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5032.564453 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5071.427734 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5126.408203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5190.03125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5221.818359 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5253.605469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5285.392578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5317.179688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5348.966797 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5388.175781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5451.554688 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5490.417969 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5551.599609 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5614.978516 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5678.455078 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5741.833984 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5805.310547 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5868.689453 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5907.898438 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5939.685547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6023.474609 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6055.261719 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6152.673828 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6214.197266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6277.673828 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6305.457031 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6366.736328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6430.115234 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6461.902344 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6514.001953 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6577.380859 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6638.660156 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6702.136719 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6754.236328 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6817.615234 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6878.796875 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6918.005859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6951.697266 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6983.484375 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7024.597656 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7085.876953 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7125.085938 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7152.869141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7214.050781 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7245.837891 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7273.621094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7325.720703 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7357.507812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7420.984375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7482.507812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7521.716797 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7583.240234 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7622.603516 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7720.015625 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7747.798828 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7811.177734 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7838.960938 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7891.060547 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7930.269531 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7958.052734 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3196.777344 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3260.400391 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3323.876953 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3378.857422 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3442.480469 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3506.103516 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3569.726562 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3601.513672 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3633.300781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3665.087891 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3696.875 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3728.662109 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3756.445312 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3817.96875 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3879.248047 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3942.626953 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4006.103516 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4044.966797 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4106.148438 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4165.328125 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4226.851562 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4267.964844 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4301.65625 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4329.439453 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4390.962891 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4452.242188 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4515.621094 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4579.244141 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4612.935547 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4672.115234 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4735.738281 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4767.525391 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4831.148438 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4894.771484 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4926.558594 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4990.181641 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5026.265625 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5065.128906 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5120.109375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5183.732422 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5215.519531 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5247.306641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5279.09375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5310.880859 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5342.667969 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5381.876953 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5445.255859 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5484.119141 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5545.300781 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5608.679688 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5672.15625 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5735.535156 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5799.011719 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5862.390625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5901.599609 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5933.386719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6017.175781 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6048.962891 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6146.375 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6207.898438 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6271.375 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6299.158203 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6360.4375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6423.816406 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6455.603516 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6507.703125 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6571.082031 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6632.361328 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6695.837891 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6747.9375 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6811.316406 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6872.498047 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6911.707031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6945.398438 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6977.185547 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7018.298828 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7079.578125 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7118.787109 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7146.570312 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7207.751953 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7239.539062 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7267.322266 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7319.421875 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7351.208984 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7414.685547 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7476.208984 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7515.417969 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7576.941406 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7616.304688 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7713.716797 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7741.5 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7804.878906 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7832.662109 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7884.761719 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7923.970703 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7951.753906 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pf7130b8580">
+  <clipPath id="peaa930e7dd">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_decode_density.svg
+++ b/bench/graphs/silesia_decode_density.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 82.373685 412.80375 
 L 82.373685 47.3475 
-" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p47995d47df)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="maa893f17ff" d="M 0 0 
+       <path id="m0b3ddcb083" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#maa893f17ff" x="82.373685" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0b3ddcb083" x="82.373685" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -111,11 +111,11 @@ z
      <g id="line2d_3">
       <path d="M 165.44644 412.80375 
 L 165.44644 47.3475 
-" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p47995d47df)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#maa893f17ff" x="165.44644" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0b3ddcb083" x="165.44644" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -157,11 +157,11 @@ z
      <g id="line2d_5">
       <path d="M 248.519195 412.80375 
 L 248.519195 47.3475 
-" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p47995d47df)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#maa893f17ff" x="248.519195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0b3ddcb083" x="248.519195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -211,11 +211,11 @@ z
      <g id="line2d_7">
       <path d="M 331.59195 412.80375 
 L 331.59195 47.3475 
-" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p47995d47df)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#maa893f17ff" x="331.59195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0b3ddcb083" x="331.59195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -252,11 +252,11 @@ z
      <g id="line2d_9">
       <path d="M 414.664704 412.80375 
 L 414.664704 47.3475 
-" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p47995d47df)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#maa893f17ff" x="414.664704" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0b3ddcb083" x="414.664704" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -299,11 +299,11 @@ z
      <g id="line2d_11">
       <path d="M 497.737459 412.80375 
 L 497.737459 47.3475 
-" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p47995d47df)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#maa893f17ff" x="497.737459" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0b3ddcb083" x="497.737459" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -351,11 +351,11 @@ z
      <g id="line2d_13">
       <path d="M 580.810214 412.80375 
 L 580.810214 47.3475 
-" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p47995d47df)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#maa893f17ff" x="580.810214" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0b3ddcb083" x="580.810214" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -897,16 +897,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 391.82245 
 L 637.2 391.82245 
-" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p47995d47df)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="m3291c2fef2" d="M 0 0 
+       <path id="m31e0e63d9c" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m3291c2fef2" x="49.078125" y="391.82245" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m31e0e63d9c" x="49.078125" y="391.82245" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -922,11 +922,11 @@ L -3.5 0
      <g id="line2d_17">
       <path d="M 49.078125 265.911133 
 L 637.2 265.911133 
-" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p47995d47df)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m3291c2fef2" x="49.078125" y="265.911133" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m31e0e63d9c" x="49.078125" y="265.911133" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -942,11 +942,11 @@ L 637.2 265.911133
      <g id="line2d_19">
       <path d="M 49.078125 139.999816 
 L 637.2 139.999816 
-" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p47995d47df)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m3291c2fef2" x="49.078125" y="139.999816" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m31e0e63d9c" x="49.078125" y="139.999816" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -962,16 +962,16 @@ L 637.2 139.999816
      <g id="line2d_21">
       <path d="M 49.078125 411.32636 
 L 637.2 411.32636 
-" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p47995d47df)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="md4fa40ca18" d="M 0 0 
+       <path id="macfb72a46a" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#md4fa40ca18" x="49.078125" y="411.32636" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#macfb72a46a" x="49.078125" y="411.32636" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -979,11 +979,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 404.024518 
 L 637.2 404.024518 
-" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p47995d47df)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#md4fa40ca18" x="49.078125" y="404.024518" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#macfb72a46a" x="49.078125" y="404.024518" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -991,11 +991,11 @@ L 637.2 404.024518
      <g id="line2d_25">
       <path d="M 49.078125 397.583836 
 L 637.2 397.583836 
-" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p47995d47df)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#md4fa40ca18" x="49.078125" y="397.583836" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#macfb72a46a" x="49.078125" y="397.583836" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1003,11 +1003,11 @@ L 637.2 397.583836
      <g id="line2d_27">
       <path d="M 49.078125 353.919367 
 L 637.2 353.919367 
-" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p47995d47df)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#md4fa40ca18" x="49.078125" y="353.919367" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#macfb72a46a" x="49.078125" y="353.919367" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1015,11 +1015,11 @@ L 637.2 353.919367
      <g id="line2d_29">
       <path d="M 49.078125 331.747485 
 L 637.2 331.747485 
-" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p47995d47df)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#md4fa40ca18" x="49.078125" y="331.747485" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#macfb72a46a" x="49.078125" y="331.747485" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1027,11 +1027,11 @@ L 637.2 331.747485
      <g id="line2d_31">
       <path d="M 49.078125 316.016284 
 L 637.2 316.016284 
-" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p47995d47df)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#md4fa40ca18" x="49.078125" y="316.016284" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#macfb72a46a" x="49.078125" y="316.016284" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1039,11 +1039,11 @@ L 637.2 316.016284
      <g id="line2d_33">
       <path d="M 49.078125 303.814216 
 L 637.2 303.814216 
-" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p47995d47df)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#md4fa40ca18" x="49.078125" y="303.814216" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#macfb72a46a" x="49.078125" y="303.814216" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1051,11 +1051,11 @@ L 637.2 303.814216
      <g id="line2d_35">
       <path d="M 49.078125 293.844402 
 L 637.2 293.844402 
-" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p47995d47df)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#md4fa40ca18" x="49.078125" y="293.844402" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#macfb72a46a" x="49.078125" y="293.844402" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1063,11 +1063,11 @@ L 637.2 293.844402
      <g id="line2d_37">
       <path d="M 49.078125 285.415043 
 L 637.2 285.415043 
-" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p47995d47df)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#md4fa40ca18" x="49.078125" y="285.415043" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#macfb72a46a" x="49.078125" y="285.415043" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1075,11 +1075,11 @@ L 637.2 285.415043
      <g id="line2d_39">
       <path d="M 49.078125 278.113201 
 L 637.2 278.113201 
-" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p47995d47df)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#md4fa40ca18" x="49.078125" y="278.113201" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#macfb72a46a" x="49.078125" y="278.113201" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1087,11 +1087,11 @@ L 637.2 278.113201
      <g id="line2d_41">
       <path d="M 49.078125 271.672519 
 L 637.2 271.672519 
-" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p47995d47df)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#md4fa40ca18" x="49.078125" y="271.672519" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#macfb72a46a" x="49.078125" y="271.672519" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1099,11 +1099,11 @@ L 637.2 271.672519
      <g id="line2d_43">
       <path d="M 49.078125 228.00805 
 L 637.2 228.00805 
-" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p47995d47df)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#md4fa40ca18" x="49.078125" y="228.00805" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#macfb72a46a" x="49.078125" y="228.00805" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1111,11 +1111,11 @@ L 637.2 228.00805
      <g id="line2d_45">
       <path d="M 49.078125 205.836168 
 L 637.2 205.836168 
-" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p47995d47df)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#md4fa40ca18" x="49.078125" y="205.836168" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#macfb72a46a" x="49.078125" y="205.836168" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1123,11 +1123,11 @@ L 637.2 205.836168
      <g id="line2d_47">
       <path d="M 49.078125 190.104967 
 L 637.2 190.104967 
-" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p47995d47df)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#md4fa40ca18" x="49.078125" y="190.104967" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#macfb72a46a" x="49.078125" y="190.104967" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1135,11 +1135,11 @@ L 637.2 190.104967
      <g id="line2d_49">
       <path d="M 49.078125 177.9029 
 L 637.2 177.9029 
-" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p47995d47df)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#md4fa40ca18" x="49.078125" y="177.9029" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#macfb72a46a" x="49.078125" y="177.9029" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1147,11 +1147,11 @@ L 637.2 177.9029
      <g id="line2d_51">
       <path d="M 49.078125 167.933085 
 L 637.2 167.933085 
-" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p47995d47df)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#md4fa40ca18" x="49.078125" y="167.933085" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#macfb72a46a" x="49.078125" y="167.933085" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1159,11 +1159,11 @@ L 637.2 167.933085
      <g id="line2d_53">
       <path d="M 49.078125 159.503726 
 L 637.2 159.503726 
-" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p47995d47df)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#md4fa40ca18" x="49.078125" y="159.503726" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#macfb72a46a" x="49.078125" y="159.503726" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1171,11 +1171,11 @@ L 637.2 159.503726
      <g id="line2d_55">
       <path d="M 49.078125 152.201884 
 L 637.2 152.201884 
-" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p47995d47df)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#md4fa40ca18" x="49.078125" y="152.201884" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#macfb72a46a" x="49.078125" y="152.201884" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1183,11 +1183,11 @@ L 637.2 152.201884
      <g id="line2d_57">
       <path d="M 49.078125 145.761202 
 L 637.2 145.761202 
-" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p47995d47df)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#md4fa40ca18" x="49.078125" y="145.761202" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#macfb72a46a" x="49.078125" y="145.761202" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1195,11 +1195,11 @@ L 637.2 145.761202
      <g id="line2d_59">
       <path d="M 49.078125 102.096733 
 L 637.2 102.096733 
-" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p47995d47df)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#md4fa40ca18" x="49.078125" y="102.096733" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#macfb72a46a" x="49.078125" y="102.096733" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1207,11 +1207,11 @@ L 637.2 102.096733
      <g id="line2d_61">
       <path d="M 49.078125 79.924851 
 L 637.2 79.924851 
-" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p47995d47df)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#md4fa40ca18" x="49.078125" y="79.924851" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#macfb72a46a" x="49.078125" y="79.924851" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1219,11 +1219,11 @@ L 637.2 79.924851
      <g id="line2d_63">
       <path d="M 49.078125 64.19365 
 L 637.2 64.19365 
-" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p47995d47df)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#md4fa40ca18" x="49.078125" y="64.19365" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#macfb72a46a" x="49.078125" y="64.19365" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1231,11 +1231,11 @@ L 637.2 64.19365
      <g id="line2d_65">
       <path d="M 49.078125 51.991583 
 L 637.2 51.991583 
-" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p47995d47df)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#md4fa40ca18" x="49.078125" y="51.991583" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#macfb72a46a" x="49.078125" y="51.991583" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1398,7 +1398,7 @@ z
    <g id="line2d_67">
     <path d="M 49.078125 63.959148 
 L 637.2 63.959148 
-" clip-path="url(#p1426252be7)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
+" clip-path="url(#p47995d47df)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
    </g>
    <g id="patch_3">
     <path d="M 49.078125 412.80375 
@@ -1762,78 +1762,78 @@ z
    </g>
    <g id="line2d_68">
     <defs>
-     <path id="m7bee23be3f" d="M -2.5 2.5 
+     <path id="med9cafb625" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p1426252be7)">
-     <use xlink:href="#m7bee23be3f" x="75.810937" y="263.216607" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7bee23be3f" x="105.634056" y="269.620798" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7bee23be3f" x="204.490635" y="301.215031" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7bee23be3f" x="234.479899" y="307.658059" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7bee23be3f" x="242.537956" y="315.917944" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7bee23be3f" x="300.771958" y="298.734802" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7bee23be3f" x="303.26414" y="310.074879" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7bee23be3f" x="304.261013" y="319.328576" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7bee23be3f" x="313.897453" y="319.101018" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7bee23be3f" x="414.166268" y="335.426532" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7bee23be3f" x="587.289889" y="328.826648" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7bee23be3f" x="610.467187" y="319.678275" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p47995d47df)">
+     <use xlink:href="#med9cafb625" x="75.810937" y="263.216607" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#med9cafb625" x="105.634056" y="269.620798" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#med9cafb625" x="204.490635" y="301.215031" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#med9cafb625" x="234.479899" y="307.658059" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#med9cafb625" x="242.537956" y="315.917944" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#med9cafb625" x="300.771958" y="298.734802" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#med9cafb625" x="303.26414" y="310.074879" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#med9cafb625" x="304.261013" y="319.328576" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#med9cafb625" x="313.897453" y="319.101018" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#med9cafb625" x="414.166268" y="335.426532" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#med9cafb625" x="587.289889" y="328.826648" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#med9cafb625" x="610.467187" y="319.678275" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_69">
     <defs>
-     <path id="md04406f221" d="M 0 -2.5 
+     <path id="mca6967c272" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p1426252be7)">
-     <use xlink:href="#md04406f221" x="75.810937" y="262.505003" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md04406f221" x="105.634056" y="256.516219" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md04406f221" x="204.490635" y="300.455891" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md04406f221" x="234.479899" y="298.72384" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md04406f221" x="242.537956" y="307.046683" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md04406f221" x="300.771958" y="287.726284" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md04406f221" x="303.26414" y="300.256724" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md04406f221" x="304.261013" y="315.235818" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md04406f221" x="313.897453" y="307.4765" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md04406f221" x="414.166268" y="326.223389" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md04406f221" x="587.289889" y="329.609806" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md04406f221" x="610.467187" y="318.379704" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p47995d47df)">
+     <use xlink:href="#mca6967c272" x="75.810937" y="262.505003" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mca6967c272" x="105.634056" y="256.516219" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mca6967c272" x="204.490635" y="300.455891" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mca6967c272" x="234.479899" y="298.72384" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mca6967c272" x="242.537956" y="307.046683" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mca6967c272" x="300.771958" y="287.726284" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mca6967c272" x="303.26414" y="300.256724" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mca6967c272" x="304.261013" y="315.235818" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mca6967c272" x="313.897453" y="307.4765" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mca6967c272" x="414.166268" y="326.223389" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mca6967c272" x="587.289889" y="329.609806" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mca6967c272" x="610.467187" y="318.379704" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_70">
     <defs>
-     <path id="m2e009cffac" d="M -0 3.535534 
+     <path id="m4955646a1b" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p1426252be7)">
-     <use xlink:href="#m2e009cffac" x="75.810937" y="231.044207" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2e009cffac" x="105.634056" y="233.464672" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2e009cffac" x="204.490635" y="259.725746" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2e009cffac" x="234.479899" y="262.023129" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2e009cffac" x="242.537956" y="273.368182" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2e009cffac" x="300.771958" y="259.408271" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2e009cffac" x="303.26414" y="270.926655" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2e009cffac" x="304.261013" y="281.595692" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2e009cffac" x="313.897453" y="277.309155" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2e009cffac" x="414.166268" y="296.377475" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2e009cffac" x="587.289889" y="301.735817" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2e009cffac" x="610.467187" y="297.040139" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p47995d47df)">
+     <use xlink:href="#m4955646a1b" x="75.810937" y="231.044207" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4955646a1b" x="105.634056" y="233.464672" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4955646a1b" x="204.490635" y="259.725746" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4955646a1b" x="234.479899" y="262.023129" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4955646a1b" x="242.537956" y="273.368182" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4955646a1b" x="300.771958" y="259.408271" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4955646a1b" x="303.26414" y="270.926655" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4955646a1b" x="304.261013" y="281.595692" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4955646a1b" x="313.897453" y="277.309155" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4955646a1b" x="414.166268" y="296.377475" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4955646a1b" x="587.289889" y="301.735817" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4955646a1b" x="610.467187" y="297.040139" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_71">
     <defs>
-     <path id="md03f756d09" d="M -0.833333 2.5 
+     <path id="m0b6e7ab615" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -1848,24 +1848,24 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p1426252be7)">
-     <use xlink:href="#md03f756d09" x="75.810937" y="286.910165" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md03f756d09" x="105.634056" y="294.974253" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md03f756d09" x="204.490635" y="327.107019" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md03f756d09" x="234.479899" y="335.778593" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md03f756d09" x="242.537956" y="341.647351" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md03f756d09" x="300.771958" y="337.663009" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md03f756d09" x="303.26414" y="345.502509" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md03f756d09" x="304.261013" y="345.645685" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md03f756d09" x="313.897453" y="351.930007" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md03f756d09" x="414.166268" y="363.456717" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md03f756d09" x="587.289889" y="368.243436" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md03f756d09" x="610.467187" y="356.848113" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p47995d47df)">
+     <use xlink:href="#m0b6e7ab615" x="75.810937" y="286.910165" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0b6e7ab615" x="105.634056" y="294.974253" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0b6e7ab615" x="204.490635" y="327.107019" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0b6e7ab615" x="234.479899" y="335.778593" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0b6e7ab615" x="242.537956" y="341.647351" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0b6e7ab615" x="300.771958" y="337.663009" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0b6e7ab615" x="303.26414" y="345.502509" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0b6e7ab615" x="304.261013" y="345.645685" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0b6e7ab615" x="313.897453" y="351.930007" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0b6e7ab615" x="414.166268" y="363.456717" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0b6e7ab615" x="587.289889" y="368.243436" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0b6e7ab615" x="610.467187" y="356.848113" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_72">
     <defs>
-     <path id="m1ed9c5d6df" d="M -1.25 2.5 
+     <path id="mf1f412a592" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -1880,24 +1880,24 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p1426252be7)">
-     <use xlink:href="#m1ed9c5d6df" x="75.810937" y="328.907922" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1ed9c5d6df" x="105.634056" y="342.121252" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1ed9c5d6df" x="204.490635" y="364.316276" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1ed9c5d6df" x="234.479899" y="371.357513" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1ed9c5d6df" x="242.537956" y="368.122771" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1ed9c5d6df" x="300.771958" y="365.072092" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1ed9c5d6df" x="303.26414" y="374.607784" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1ed9c5d6df" x="304.261013" y="366.131688" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1ed9c5d6df" x="313.897453" y="378.589014" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1ed9c5d6df" x="414.166268" y="386.15027" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1ed9c5d6df" x="587.289889" y="392.30027" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1ed9c5d6df" x="610.467187" y="391.11076" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p47995d47df)">
+     <use xlink:href="#mf1f412a592" x="75.810937" y="328.907922" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf1f412a592" x="105.634056" y="342.121252" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf1f412a592" x="204.490635" y="364.316276" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf1f412a592" x="234.479899" y="371.357513" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf1f412a592" x="242.537956" y="368.122771" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf1f412a592" x="300.771958" y="365.072092" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf1f412a592" x="303.26414" y="374.607784" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf1f412a592" x="304.261013" y="366.131688" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf1f412a592" x="313.897453" y="378.589014" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf1f412a592" x="414.166268" y="386.15027" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf1f412a592" x="587.289889" y="392.30027" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf1f412a592" x="610.467187" y="391.11076" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_73">
     <defs>
-     <path id="m8bc952b190" d="M 0 -2.5 
+     <path id="mcff6315b2f" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -1910,24 +1910,24 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p1426252be7)">
-     <use xlink:href="#m8bc952b190" x="75.810937" y="274.450514" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m8bc952b190" x="105.634056" y="287.578172" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m8bc952b190" x="204.490635" y="320.76932" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m8bc952b190" x="234.479899" y="321.538199" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m8bc952b190" x="242.537956" y="326.688339" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m8bc952b190" x="300.771958" y="333.426229" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m8bc952b190" x="303.26414" y="337.000867" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m8bc952b190" x="304.261013" y="346.386297" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m8bc952b190" x="313.897453" y="336.174424" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m8bc952b190" x="414.166268" y="357.767316" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m8bc952b190" x="587.289889" y="366.526213" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m8bc952b190" x="610.467187" y="361.324423" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p47995d47df)">
+     <use xlink:href="#mcff6315b2f" x="75.810937" y="274.450514" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mcff6315b2f" x="105.634056" y="287.578172" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mcff6315b2f" x="204.490635" y="320.76932" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mcff6315b2f" x="234.479899" y="321.538199" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mcff6315b2f" x="242.537956" y="326.688339" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mcff6315b2f" x="300.771958" y="333.426229" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mcff6315b2f" x="303.26414" y="337.000867" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mcff6315b2f" x="304.261013" y="346.386297" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mcff6315b2f" x="313.897453" y="336.174424" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mcff6315b2f" x="414.166268" y="357.767316" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mcff6315b2f" x="587.289889" y="366.526213" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mcff6315b2f" x="610.467187" y="361.324423" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_74">
     <defs>
-     <path id="mf1e8dc5d01" d="M 0 -2.5 
+     <path id="m698e3b0c42" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -1936,19 +1936,19 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p1426252be7)">
-     <use xlink:href="#mf1e8dc5d01" x="75.810937" y="345.30596" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf1e8dc5d01" x="105.634056" y="352.048776" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf1e8dc5d01" x="204.490635" y="367.386827" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf1e8dc5d01" x="234.479899" y="374.711659" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf1e8dc5d01" x="242.537956" y="380.187639" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf1e8dc5d01" x="300.771958" y="368.991079" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf1e8dc5d01" x="303.26414" y="375.43221" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf1e8dc5d01" x="304.261013" y="381.227374" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf1e8dc5d01" x="313.897453" y="385.221601" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf1e8dc5d01" x="414.166268" y="390.900659" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf1e8dc5d01" x="587.289889" y="396.192102" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf1e8dc5d01" x="610.467187" y="386.05669" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p47995d47df)">
+     <use xlink:href="#m698e3b0c42" x="75.810937" y="345.30596" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m698e3b0c42" x="105.634056" y="352.048776" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m698e3b0c42" x="204.490635" y="367.386827" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m698e3b0c42" x="234.479899" y="374.711659" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m698e3b0c42" x="242.537956" y="380.187639" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m698e3b0c42" x="300.771958" y="368.991079" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m698e3b0c42" x="303.26414" y="375.43221" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m698e3b0c42" x="304.261013" y="381.227374" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m698e3b0c42" x="313.897453" y="385.221601" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m698e3b0c42" x="414.166268" y="390.900659" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m698e3b0c42" x="587.289889" y="396.192102" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m698e3b0c42" x="610.467187" y="386.05669" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="legend_1">
@@ -1967,7 +1967,7 @@ z
     </g>
     <g id="line2d_75">
      <defs>
-      <path id="m1487120ad8" d="M 0 3.5 
+      <path id="m93e3aff8f1" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -1980,7 +1980,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m1487120ad8" x="434.04625" y="211.758125" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m93e3aff8f1" x="434.04625" y="211.758125" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_15">
@@ -2039,7 +2039,7 @@ z
     </g>
     <g id="line2d_76">
      <g>
-      <use xlink:href="#m7bee23be3f" x="434.04625" y="223.500625" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#med9cafb625" x="434.04625" y="223.500625" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_16">
@@ -2053,7 +2053,7 @@ z
     </g>
     <g id="line2d_77">
      <g>
-      <use xlink:href="#md04406f221" x="434.04625" y="235.243125" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mca6967c272" x="434.04625" y="235.243125" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -2098,7 +2098,7 @@ z
     </g>
     <g id="line2d_78">
      <g>
-      <use xlink:href="#m2e009cffac" x="434.04625" y="247.208125" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m4955646a1b" x="434.04625" y="247.208125" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -2118,7 +2118,7 @@ z
     </g>
     <g id="line2d_79">
      <g>
-      <use xlink:href="#md03f756d09" x="537.72375" y="211.758125" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m0b6e7ab615" x="537.72375" y="211.758125" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -2145,7 +2145,7 @@ z
     </g>
     <g id="line2d_80">
      <g>
-      <use xlink:href="#m1ed9c5d6df" x="537.72375" y="223.500625" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mf1f412a592" x="537.72375" y="223.500625" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -2210,7 +2210,7 @@ z
     </g>
     <g id="line2d_81">
      <g>
-      <use xlink:href="#m8bc952b190" x="537.72375" y="235.243125" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#mcff6315b2f" x="537.72375" y="235.243125" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_21">
@@ -2248,7 +2248,7 @@ z
     </g>
     <g id="line2d_82">
      <g>
-      <use xlink:href="#mf1e8dc5d01" x="537.72375" y="246.985625" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m698e3b0c42" x="537.72375" y="246.985625" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -2318,19 +2318,19 @@ z
     </g>
    </g>
    <g id="line2d_83">
-    <g clip-path="url(#p1426252be7)">
-     <use xlink:href="#m1487120ad8" x="75.810937" y="298.510024" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m1487120ad8" x="105.634056" y="315.672864" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m1487120ad8" x="204.490635" y="347.595466" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m1487120ad8" x="234.479899" y="355.186159" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m1487120ad8" x="242.537956" y="354.419257" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m1487120ad8" x="300.771958" y="342.079401" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m1487120ad8" x="303.26414" y="366.152202" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m1487120ad8" x="304.261013" y="375.092892" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m1487120ad8" x="313.897453" y="369.574066" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m1487120ad8" x="414.166268" y="382.204646" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m1487120ad8" x="587.289889" y="393.510593" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m1487120ad8" x="610.467187" y="371.196024" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <g clip-path="url(#p47995d47df)">
+     <use xlink:href="#m93e3aff8f1" x="75.810937" y="298.510024" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m93e3aff8f1" x="105.634056" y="315.672864" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m93e3aff8f1" x="204.490635" y="347.595466" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m93e3aff8f1" x="234.479899" y="355.186159" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m93e3aff8f1" x="242.537956" y="354.419257" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m93e3aff8f1" x="300.771958" y="342.079401" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m93e3aff8f1" x="303.26414" y="366.152202" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m93e3aff8f1" x="304.261013" y="375.092892" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m93e3aff8f1" x="313.897453" y="369.574066" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m93e3aff8f1" x="414.166268" y="382.204646" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m93e3aff8f1" x="587.289889" y="393.510593" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m93e3aff8f1" x="610.467187" y="371.196024" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
   </g>
@@ -3184,7 +3184,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p1426252be7">
+  <clipPath id="p47995d47df">
    <rect x="49.078125" y="47.3475" width="588.121875" height="365.45625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_decode_ranking.svg
+++ b/bench/graphs/silesia_decode_ranking.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 290.788615 308.04375 
 L 290.788615 56.7075 
-" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2370dab7a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m5c613c82e4" d="M 0 0 
+       <path id="m570d5ad2cd" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m5c613c82e4" x="290.788615" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m570d5ad2cd" x="290.788615" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -136,11 +136,11 @@ z
      <g id="line2d_3">
       <path d="M 447.590599 308.04375 
 L 447.590599 56.7075 
-" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2370dab7a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m5c613c82e4" x="447.590599" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m570d5ad2cd" x="447.590599" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -177,16 +177,16 @@ z
      <g id="line2d_5">
       <path d="M 181.188732 308.04375 
 L 181.188732 56.7075 
-" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2370dab7a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <defs>
-       <path id="m80769aa95f" d="M 0 0 
+       <path id="md430f0713d" d="M 0 0 
 L 0 2 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m80769aa95f" x="181.188732" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md430f0713d" x="181.188732" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -194,11 +194,11 @@ L 0 2
      <g id="line2d_7">
       <path d="M 208.800191 308.04375 
 L 208.800191 56.7075 
-" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2370dab7a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m80769aa95f" x="208.800191" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md430f0713d" x="208.800191" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -206,11 +206,11 @@ L 208.800191 56.7075
      <g id="line2d_9">
       <path d="M 228.390833 308.04375 
 L 228.390833 56.7075 
-" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2370dab7a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m80769aa95f" x="228.390833" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md430f0713d" x="228.390833" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -218,11 +218,11 @@ L 228.390833 56.7075
      <g id="line2d_11">
       <path d="M 243.586515 308.04375 
 L 243.586515 56.7075 
-" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2370dab7a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m80769aa95f" x="243.586515" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md430f0713d" x="243.586515" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -230,11 +230,11 @@ L 243.586515 56.7075
      <g id="line2d_13">
       <path d="M 256.002291 308.04375 
 L 256.002291 56.7075 
-" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2370dab7a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m80769aa95f" x="256.002291" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md430f0713d" x="256.002291" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -242,11 +242,11 @@ L 256.002291 56.7075
      <g id="line2d_15">
       <path d="M 266.499681 308.04375 
 L 266.499681 56.7075 
-" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2370dab7a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m80769aa95f" x="266.499681" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md430f0713d" x="266.499681" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -254,11 +254,11 @@ L 266.499681 56.7075
      <g id="line2d_17">
       <path d="M 275.592933 308.04375 
 L 275.592933 56.7075 
-" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2370dab7a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m80769aa95f" x="275.592933" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md430f0713d" x="275.592933" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -266,11 +266,11 @@ L 275.592933 56.7075
      <g id="line2d_19">
       <path d="M 283.61375 308.04375 
 L 283.61375 56.7075 
-" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2370dab7a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m80769aa95f" x="283.61375" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md430f0713d" x="283.61375" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -278,11 +278,11 @@ L 283.61375 56.7075
      <g id="line2d_21">
       <path d="M 337.990716 308.04375 
 L 337.990716 56.7075 
-" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2370dab7a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m80769aa95f" x="337.990716" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md430f0713d" x="337.990716" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -290,11 +290,11 @@ L 337.990716 56.7075
      <g id="line2d_23">
       <path d="M 365.602174 308.04375 
 L 365.602174 56.7075 
-" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2370dab7a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m80769aa95f" x="365.602174" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md430f0713d" x="365.602174" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -302,11 +302,11 @@ L 365.602174 56.7075
      <g id="line2d_25">
       <path d="M 385.192816 308.04375 
 L 385.192816 56.7075 
-" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2370dab7a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m80769aa95f" x="385.192816" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md430f0713d" x="385.192816" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -314,11 +314,11 @@ L 385.192816 56.7075
      <g id="line2d_27">
       <path d="M 400.388498 308.04375 
 L 400.388498 56.7075 
-" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2370dab7a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m80769aa95f" x="400.388498" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md430f0713d" x="400.388498" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -326,11 +326,11 @@ L 400.388498 56.7075
      <g id="line2d_29">
       <path d="M 412.804275 308.04375 
 L 412.804275 56.7075 
-" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2370dab7a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m80769aa95f" x="412.804275" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md430f0713d" x="412.804275" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -338,11 +338,11 @@ L 412.804275 56.7075
      <g id="line2d_31">
       <path d="M 423.301664 308.04375 
 L 423.301664 56.7075 
-" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2370dab7a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m80769aa95f" x="423.301664" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md430f0713d" x="423.301664" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -350,11 +350,11 @@ L 423.301664 56.7075
      <g id="line2d_33">
       <path d="M 432.394917 308.04375 
 L 432.394917 56.7075 
-" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2370dab7a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m80769aa95f" x="432.394917" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md430f0713d" x="432.394917" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -362,11 +362,11 @@ L 432.394917 56.7075
      <g id="line2d_35">
       <path d="M 440.415734 308.04375 
 L 440.415734 56.7075 
-" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2370dab7a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m80769aa95f" x="440.415734" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md430f0713d" x="440.415734" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -374,11 +374,11 @@ L 440.415734 56.7075
      <g id="line2d_37">
       <path d="M 494.792699 308.04375 
 L 494.792699 56.7075 
-" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2370dab7a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m80769aa95f" x="494.792699" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md430f0713d" x="494.792699" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -386,11 +386,11 @@ L 494.792699 56.7075
      <g id="line2d_39">
       <path d="M 522.404158 308.04375 
 L 522.404158 56.7075 
-" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2370dab7a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m80769aa95f" x="522.404158" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md430f0713d" x="522.404158" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -398,11 +398,11 @@ L 522.404158 56.7075
      <g id="line2d_41">
       <path d="M 541.9948 308.04375 
 L 541.9948 56.7075 
-" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2370dab7a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m80769aa95f" x="541.9948" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md430f0713d" x="541.9948" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -410,11 +410,11 @@ L 541.9948 56.7075
      <g id="line2d_43">
       <path d="M 557.190482 308.04375 
 L 557.190482 56.7075 
-" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2370dab7a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m80769aa95f" x="557.190482" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md430f0713d" x="557.190482" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -985,12 +985,12 @@ z
     <g id="ytick_1">
      <g id="line2d_45">
       <defs>
-       <path id="mdc77b50919" d="M 0 0 
+       <path id="m40ad88d346" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mdc77b50919" x="139.360469" y="296.619375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m40ad88d346" x="139.360469" y="296.619375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -1062,7 +1062,7 @@ z
     <g id="ytick_2">
      <g id="line2d_46">
       <g>
-       <use xlink:href="#mdc77b50919" x="139.360469" y="263.978304" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m40ad88d346" x="139.360469" y="263.978304" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -1129,7 +1129,7 @@ z
     <g id="ytick_3">
      <g id="line2d_47">
       <g>
-       <use xlink:href="#mdc77b50919" x="139.360469" y="231.337232" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m40ad88d346" x="139.360469" y="231.337232" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -1242,7 +1242,7 @@ z
     <g id="ytick_4">
      <g id="line2d_48">
       <g>
-       <use xlink:href="#mdc77b50919" x="139.360469" y="198.696161" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m40ad88d346" x="139.360469" y="198.696161" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -1298,7 +1298,7 @@ z
     <g id="ytick_5">
      <g id="line2d_49">
       <g>
-       <use xlink:href="#mdc77b50919" x="139.360469" y="166.055089" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m40ad88d346" x="139.360469" y="166.055089" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -1345,7 +1345,7 @@ z
     <g id="ytick_6">
      <g id="line2d_50">
       <g>
-       <use xlink:href="#mdc77b50919" x="139.360469" y="133.414018" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m40ad88d346" x="139.360469" y="133.414018" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -1361,7 +1361,7 @@ z
     <g id="ytick_7">
      <g id="line2d_51">
       <g>
-       <use xlink:href="#mdc77b50919" x="139.360469" y="100.772946" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m40ad88d346" x="139.360469" y="100.772946" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -1408,7 +1408,7 @@ z
     <g id="ytick_8">
      <g id="line2d_52">
       <g>
-       <use xlink:href="#mdc77b50919" x="139.360469" y="68.131875" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m40ad88d346" x="139.360469" y="68.131875" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -1431,47 +1431,47 @@ z
    <g id="LineCollection_1">
     <path d="M 139.360469 296.619375 
 L 154.556151 296.619375 
-" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #17becf; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p2370dab7a9)" style="fill: none; stroke: #17becf; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_2">
     <path d="M 139.360469 263.978304 
 L 162.32653 263.978304 
-" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p2370dab7a9)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_3">
     <path d="M 139.360469 231.337232 
 L 178.681331 231.337232 
-" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #d62728; stroke-opacity: 0.9; stroke-width: 2.4"/>
+" clip-path="url(#p2370dab7a9)" style="fill: none; stroke: #d62728; stroke-opacity: 0.9; stroke-width: 2.4"/>
    </g>
    <g id="LineCollection_4">
     <path d="M 139.360469 198.696161 
 L 201.044126 198.696161 
-" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p2370dab7a9)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_5">
     <path d="M 139.360469 166.055089 
 L 209.976983 166.055089 
-" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p2370dab7a9)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_6">
     <path d="M 139.360469 133.414018 
 L 239.121093 133.414018 
-" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p2370dab7a9)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_7">
     <path d="M 139.360469 100.772946 
 L 247.282543 100.772946 
-" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p2370dab7a9)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_8">
     <path d="M 139.360469 68.131875 
 L 285.279501 68.131875 
-" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p2370dab7a9)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="line2d_53">
     <path d="M 542.286834 308.04375 
 L 542.286834 56.7075 
-" clip-path="url(#p226beb7eef)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
+" clip-path="url(#p2370dab7a9)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
    </g>
    <g id="patch_3">
     <path d="M 139.360469 308.04375 
@@ -1875,7 +1875,7 @@ z
    </g>
    <g id="line2d_54">
     <defs>
-     <path id="ma411708496" d="M 0 3 
+     <path id="m5da3c845d0" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1887,13 +1887,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #17becf"/>
     </defs>
-    <g clip-path="url(#p226beb7eef)">
-     <use xlink:href="#ma411708496" x="154.556151" y="296.619375" style="fill: #17becf; stroke: #17becf"/>
+    <g clip-path="url(#p2370dab7a9)">
+     <use xlink:href="#m5da3c845d0" x="154.556151" y="296.619375" style="fill: #17becf; stroke: #17becf"/>
     </g>
    </g>
    <g id="line2d_55">
     <defs>
-     <path id="m1cf1554c37" d="M 0 3 
+     <path id="m113bac6fa5" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1905,13 +1905,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #e377c2"/>
     </defs>
-    <g clip-path="url(#p226beb7eef)">
-     <use xlink:href="#m1cf1554c37" x="162.32653" y="263.978304" style="fill: #e377c2; stroke: #e377c2"/>
+    <g clip-path="url(#p2370dab7a9)">
+     <use xlink:href="#m113bac6fa5" x="162.32653" y="263.978304" style="fill: #e377c2; stroke: #e377c2"/>
     </g>
    </g>
    <g id="line2d_56">
     <defs>
-     <path id="mfeefa3e48a" d="M 0 5 
+     <path id="m1e1966747a" d="M 0 5 
 C 1.326016 5 2.597899 4.473168 3.535534 3.535534 
 C 4.473168 2.597899 5 1.326016 5 0 
 C 5 -1.326016 4.473168 -2.597899 3.535534 -3.535534 
@@ -1923,13 +1923,13 @@ C -2.597899 4.473168 -1.326016 5 0 5
 z
 " style="stroke: #d62728"/>
     </defs>
-    <g clip-path="url(#p226beb7eef)">
-     <use xlink:href="#mfeefa3e48a" x="178.681331" y="231.337232" style="fill: #d62728; stroke: #d62728"/>
+    <g clip-path="url(#p2370dab7a9)">
+     <use xlink:href="#m1e1966747a" x="178.681331" y="231.337232" style="fill: #d62728; stroke: #d62728"/>
     </g>
    </g>
    <g id="line2d_57">
     <defs>
-     <path id="m998b032618" d="M 0 3 
+     <path id="md4598aa119" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1941,13 +1941,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #8c564b"/>
     </defs>
-    <g clip-path="url(#p226beb7eef)">
-     <use xlink:href="#m998b032618" x="201.044126" y="198.696161" style="fill: #8c564b; stroke: #8c564b"/>
+    <g clip-path="url(#p2370dab7a9)">
+     <use xlink:href="#md4598aa119" x="201.044126" y="198.696161" style="fill: #8c564b; stroke: #8c564b"/>
     </g>
    </g>
    <g id="line2d_58">
     <defs>
-     <path id="mc9c9953a71" d="M 0 3 
+     <path id="m1f243c6154" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1959,13 +1959,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #bcbd22"/>
     </defs>
-    <g clip-path="url(#p226beb7eef)">
-     <use xlink:href="#mc9c9953a71" x="209.976983" y="166.055089" style="fill: #bcbd22; stroke: #bcbd22"/>
+    <g clip-path="url(#p2370dab7a9)">
+     <use xlink:href="#m1f243c6154" x="209.976983" y="166.055089" style="fill: #bcbd22; stroke: #bcbd22"/>
     </g>
    </g>
    <g id="line2d_59">
     <defs>
-     <path id="mff19055156" d="M 0 3 
+     <path id="m93931b91e7" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1977,13 +1977,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #1f77b4"/>
     </defs>
-    <g clip-path="url(#p226beb7eef)">
-     <use xlink:href="#mff19055156" x="239.121093" y="133.414018" style="fill: #1f77b4; stroke: #1f77b4"/>
+    <g clip-path="url(#p2370dab7a9)">
+     <use xlink:href="#m93931b91e7" x="239.121093" y="133.414018" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_60">
     <defs>
-     <path id="m43c7729c95" d="M 0 3 
+     <path id="mf28c957615" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1995,13 +1995,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #2ca02c"/>
     </defs>
-    <g clip-path="url(#p226beb7eef)">
-     <use xlink:href="#m43c7729c95" x="247.282543" y="100.772946" style="fill: #2ca02c; stroke: #2ca02c"/>
+    <g clip-path="url(#p2370dab7a9)">
+     <use xlink:href="#mf28c957615" x="247.282543" y="100.772946" style="fill: #2ca02c; stroke: #2ca02c"/>
     </g>
    </g>
    <g id="line2d_61">
     <defs>
-     <path id="m94dbf7a018" d="M 0 3 
+     <path id="md1b8d884f0" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -2013,8 +2013,8 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #9467bd"/>
     </defs>
-    <g clip-path="url(#p226beb7eef)">
-     <use xlink:href="#m94dbf7a018" x="285.279501" y="68.131875" style="fill: #9467bd; stroke: #9467bd"/>
+    <g clip-path="url(#p2370dab7a9)">
+     <use xlink:href="#md1b8d884f0" x="285.279501" y="68.131875" style="fill: #9467bd; stroke: #9467bd"/>
     </g>
    </g>
   </g>
@@ -2869,7 +2869,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p226beb7eef">
+  <clipPath id="p2370dab7a9">
    <rect x="139.360469" y="56.7075" width="425.839531" height="251.33625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_ratio_heatmap.svg
+++ b/bench/graphs/silesia_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.34175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p173a80bbb2)">
+   <g clip-path="url(#p8ca21c546b)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAosAAAGaCAYAAABniAm0AAAJ/klEQVR4nO3Yu45eVx2H4ZnM+IDHmbEtSCLCQcJRQAqBEoWCKhWCgmvgCmioqBB3QMUN0KGI0k1KpACBEAogSkIQB1lDjB1jGXs8Mx9X8BYoWvqjT89zBT9pb6397rV7fvsnm50tdPLTW9MTlrjw6svTE5bZfebT0xOW2Lz1u+kJS+x+5aXpCUtsHt6fnrDM8fdfm56wxDM/+tb0hCV2bzw7PWGNk4fTC5Y5/+V2nvdPTQ8AAOD/l1gEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACDt/vvktc30iBUO/nU8PWGJDw+vTE9Y5j+nD6YnLPHZj06mJyzx0aeem56wxPnmfHrCMtf3b0xPWOPOB9MLlrh/fTuf19N//tP0hGU2L35tesISbhYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEj7B3duT29Y48q16QVLbDYn0xOW+czrv56esMar35xesMTRh/+YnrDG+en0gnUOtvT8uHR1esESh//czu/z3c/fnJ6wzPW/vj09YQk3iwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEDafXJ2azM9YoW94/enJyxx++mL0xOWefDk3vSEJW7+5d70hCVOv/z16QlLPDy9Pz1hmaO9a9MTlti896vpCUs8+sLL0xOWuPz2G9MTlnn81VemJyzhZhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIuz9/73ub6REr3Lh8MD1hiXfu3ZmesMx3f/yb6QlL/PaH356esMTRpaPpCUv84BdvTk9Y5hvPX56esMR3br4yPWGJ1//2xvSEJa5e2M73cGdnZ+dn796dnrCEm0UAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAg7T45u7WZHrHC3cfH0xOWONg/nJ6wzDv3fj89YYkXrr00PWGJzeZ8esISV0+39x/67+fbeS4+f/DC9IQlHp09nJ6wxLaeHTs7Ozt7T+1PT1hie09FAAA+NrEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAApP293f3pDUt8cu/G9IQ19i5OL1jm6NLR9IQlDvYPpycscbY5nZ6wxPmF7f2Hfm5zZXoC/4Nt/T6fbB5NT1jm/uPj6QlLbO+pCADAxyYWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBI+4/OHk5vWOLy7v70hCU+ePDH6QnLnJ6fTE9Y4/jd6QVL3D86nJ6wxOHFG9MTljk5ezQ9YYlP3H5/esISj5/93PSEJQ7+8Nb0hGUef/FL0xOWcLMIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAApP8Cc6OciHDVLsgAAAAASUVORK5CYII=" id="imagea92e907769" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="468.72" height="295.2"/>
+iVBORw0KGgoAAAANSUhEUgAAAosAAAGaCAYAAABniAm0AAAJ/klEQVR4nO3YzYqeZx3H8ZnO5MVMOpMEbYv1BUwRSq0upS5cdSW68Bg8AjeuXIln4MoTcCfFZTZdFupbtSJoaWvFF8LYmDSGmExm5vEIvgupF395+HyO4Af3zXV/72v3/PaPNztb6OQnt6YnLHHh1ZenJyyz+8ynpycssfnNb6cnLLH75ZemJyyxeXh/esIyx997bXrCEs/88JvTE5bYvfHs9IQ1Th5OL1jm/Ofbed4/NT0AAID/X2IRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIC0+6+T1zbTI1Y4+Ofx9IQlPjy8Mj1hmX+fPpiesMRnPzqZnrDER596bnrCEueb8+kJy1zfvzE9YY07H0wvWOL+9e18Xk//6Y/TE5bZfPGr0xOWcLMIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEDaP7hze3rDGleuTS9YYrM5mZ6wzGde/+X0hDVe/cb0giWOPvz79IQ1zk+nF6xzsKXnx6Wr0wuWOPzHdn6f737+5vSEZa7/5e3pCUu4WQQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAADS7pOzW5vpESvsHb8/PWGJ209fnJ6wzIMn96YnLHHzz/emJyxx+qWvTU9Y4uHp/ekJyxztXZuesMTmvV9MT1ji0Rdenp6wxOW335yesMzjr7wyPWEJN4sAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA2v3Ze9/dTI9Y4cblg+kJS7xz7870hGW+86NfT09Y4q0ffGt6whJHl46mJyzx/Td+NT1hma8/f3l6whLfvvnK9IQlXv/rm9MTlrh6YTvfw52dnZ2fvnt3esISbhYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAtPvk7NZmesQKdx8fT09Y4mD/cHrCMu/c+930hCVeuPbS9IQlNpvz6QlLXD3d3n/ov51v57n4/MEL0xOWeHT2cHrCEtt6duzs7OzsPbU/PWGJ7T0VAQD42MQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkPb3dvenNyzxyb0b0xPW2Ls4vWCZo0tH0xOWONg/nJ6wxNnmdHrCEucXtvcf+rnNlekJ/Be29ft8snk0PWGZ+4+Ppycssb2nIgAAH5tYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAg7T86ezi9YYnLW9rBHzz4w/SEZU7PT6YnrHH87vSCJe4fHU5PWOLw4o3pCcucnD2anrDEJ26/Pz1hicfPfm56whIHv39resIyj198cXrCEttZVAAA/E+IRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAA0n8AXmCchTrPEGEAAAAASUVORK5CYII=" id="imaged0cfba3e9c" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="468.72" height="295.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="me9a6f6a210" d="M 0 0 
+       <path id="m9d9b4c5d82" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#me9a6f6a210" x="115.182137" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9d9b4c5d82" x="115.182137" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#me9a6f6a210" x="154.193912" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9d9b4c5d82" x="154.193912" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#me9a6f6a210" x="193.205687" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9d9b4c5d82" x="193.205687" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#me9a6f6a210" x="232.217462" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9d9b4c5d82" x="232.217462" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#me9a6f6a210" x="271.229237" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9d9b4c5d82" x="271.229237" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#me9a6f6a210" x="310.241012" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9d9b4c5d82" x="310.241012" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#me9a6f6a210" x="349.252787" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9d9b4c5d82" x="349.252787" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#me9a6f6a210" x="388.264562" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9d9b4c5d82" x="388.264562" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#me9a6f6a210" x="427.276336" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9d9b4c5d82" x="427.276336" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#me9a6f6a210" x="466.288111" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9d9b4c5d82" x="466.288111" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#me9a6f6a210" x="505.299886" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9d9b4c5d82" x="505.299886" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#me9a6f6a210" x="544.311661" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9d9b4c5d82" x="544.311661" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="m0fb05e63ce" d="M 0 0 
+       <path id="mdfa59f3489" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m0fb05e63ce" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdfa59f3489" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m0fb05e63ce" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdfa59f3489" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m0fb05e63ce" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdfa59f3489" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m0fb05e63ce" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdfa59f3489" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -836,7 +836,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m0fb05e63ce" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdfa59f3489" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -899,7 +899,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m0fb05e63ce" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdfa59f3489" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -966,7 +966,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m0fb05e63ce" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdfa59f3489" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1047,7 +1047,7 @@ z
     <g id="ytick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m0fb05e63ce" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdfa59f3489" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -2060,18 +2060,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABEAAAFUCAYAAADCj9eRAAAB2ElEQVR4nO2aQY7EIAwEIeFP+6X9/33C3MPcKKSS1TygZRftNlLS2//fbJtn9KvvajAi17ZCM7Uzeg+TEyJhsh4TE8D25ZhYRMJkPSYmmZ0zIhfQEMPkJq74JpgQlUBMABkIrOV2KLMRItXMhrQjqcQUSszsbGuomFSbHULEAlblE0klor1zMaG0XwnDBDAsBVY0O4CIBizlE4ntEbCijK3mE8vKUPkEEIF8YslYje2RZFP5BJkdCxOonf1i6jEhRICOyjEBzFaPiWd2iChoYbKKhMkqgmSsh4kkHkU+6UyeACJEJaLZ6QQTzy7WtGPyicX2Kp/c+yKaATTliSWoTXsnPllEEtTLGX37f+7WRpuPQ4RhomlntCdMTohATIDbKceEaGfOD1BJZueIiImJZQBNTCxgw2Q91N7Zf7RBsxMmR0TqMdmvxPRmI0TmDJNVJExWkTBZRcJkFSnFZH6Q5aVhQrQzkYUOVEIxIXxSjAnRDjQ7mndsZud9VEwsPtFcsWjvaNZofHKoEpFPELCPJmORdqblMWxiYjEbw+QJk/dR+SQD+BbROFbEJAP4Q4RgQpiNCupKIhAT4gewakws7YTJIREoY4FPeNWYaNoJk18iQNqXY1LKJ1/07Ct/l+QCQgAAAABJRU5ErkJggg==" id="image371bbc38bf" transform="scale(1 -1) translate(0 -244.8)" x="573.84" y="-74.16" width="12.24" height="244.8"/>
+iVBORw0KGgoAAAANSUhEUgAAABEAAAFUCAYAAADCj9eRAAAB2ElEQVR4nO2aQY7EIAwEIeFP+6X9/33C3MPcKKSS1TygZRftNlLS2//fbJtn9KvvajAi17ZCM7Uzeg+TEyJhsh4TE8D25ZhYRMJkPSYmmZ0zIhfQEMPkJq74JpgQlUBMABkIrOV2KLMRItXMhrQjqcQUSszsbGuomFSbHULEAlblE0klor1zMaG0XwnDBDAsBVY0O4CIBizlE4ntEbCijK3mE8vKUPkEEIF8YslYje2RZFP5BJkdCxOonf1i6jEhRICOyjEBzFaPiWd2iChoYbKKhMkqgmSsh4kkHkU+6UyeACJEJaLZ6QQTzy7WtGPyicX2Kp/c+yKaATTliSWoTXsnPllEEtTLGX37f+7WRpuPQ4RhomlntCdMTohATIDbKceEaGfOD1BJZueIiImJZQBNTCxgw2Q91N7Zf7RBsxMmR0TqMdmvxPRmI0TmDJNVJExWkTBZRcJkFSnFZH6Q5aVhQrQzkYUOVEIxIXxSjAnRDjQ7mndsZud9VEwsPtFcsWjvaNZofHKoEpFPELCPJmORdqblMWxiYjEbw+QJk/dR+SQD+BbROFbEJAP4Q4RgQpiNCupKIhAT4gewakws7YTJIREoY4FPeNWYaNoJk18iQNqXY1LKJ1/07Ct/l+QCQgAAAABJRU5ErkJggg==" id="image2ae9d67e07" transform="scale(1 -1) translate(0 -244.8)" x="573.84" y="-74.16" width="12.24" height="244.8"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_21">
       <defs>
-       <path id="mec03fcd6eb" d="M 0 0 
+       <path id="me99b935294" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mec03fcd6eb" x="585.876562" y="282.022672" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me99b935294" x="585.876562" y="282.022672" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_117">
@@ -2097,7 +2097,7 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#mec03fcd6eb" x="585.876562" y="239.353777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me99b935294" x="585.876562" y="239.353777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_118">
@@ -2114,7 +2114,7 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#mec03fcd6eb" x="585.876562" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me99b935294" x="585.876562" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_119">
@@ -2130,7 +2130,7 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mec03fcd6eb" x="585.876562" y="154.015985" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me99b935294" x="585.876562" y="154.015985" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_120">
@@ -2146,7 +2146,7 @@ z
     <g id="ytick_13">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#mec03fcd6eb" x="585.876562" y="111.347089" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me99b935294" x="585.876562" y="111.347089" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_121">
@@ -2739,8 +2739,8 @@ z
    </g>
   </g>
   <g id="text_124">
-   <!-- 2026-07-06T07:54:18Z  ·  Linux chungus2 x86_64  ·  commit 38a6ad15  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(43.549375 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-06T10:45:22Z  ·  Linux chungus2 x86_64  ·  commit 8a6bc577  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(43.769766 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2764,6 +2764,44 @@ L 1409 3309
 L 1409 2516 
 L 750 2516 
 L 750 3309 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-b7" d="M 684 2619 
+L 1344 2619 
+L 1344 1825 
+L 684 1825 
+L 684 2619 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-4c" d="M 628 4666 
+L 1259 4666 
+L 1259 531 
+L 3531 531 
+L 3531 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-75" d="M 544 1381 
+L 544 3500 
+L 1119 3500 
+L 1119 1403 
+Q 1119 906 1312 657 
+Q 1506 409 1894 409 
+Q 2359 409 2629 706 
+Q 2900 1003 2900 1516 
+L 2900 3500 
+L 3475 3500 
+L 3475 0 
+L 2900 0 
+L 2900 538 
+Q 2691 219 2414 64 
+Q 2138 -91 1772 -91 
+Q 1169 -91 856 284 
+Q 544 659 544 1381 
+z
+M 1991 3584 
+L 1991 3584 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-38" d="M 2034 2216 
@@ -2805,44 +2843,6 @@ Q 1625 4250 1398 4047
 Q 1172 3844 1172 3481 
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-b7" d="M 684 2619 
-L 1344 2619 
-L 1344 1825 
-L 684 1825 
-L 684 2619 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-4c" d="M 628 4666 
-L 1259 4666 
-L 1259 531 
-L 3531 531 
-L 3531 0 
-L 628 0 
-L 628 4666 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-75" d="M 544 1381 
-L 544 3500 
-L 1119 3500 
-L 1119 1403 
-Q 1119 906 1312 657 
-Q 1506 409 1894 409 
-Q 2359 409 2629 706 
-Q 2900 1003 2900 1516 
-L 2900 3500 
-L 3475 3500 
-L 3475 0 
-L 2900 0 
-L 2900 538 
-Q 2691 219 2414 64 
-Q 2138 -91 1772 -91 
-Q 1169 -91 856 284 
-Q 544 659 544 1381 
-z
-M 1991 3584 
-L 1991 3584 
-z
-" transform="scale(0.015625)"/>
      <path id="DejaVuSans-3b" d="M 750 3309 
 L 1409 3309 
 L 1409 2516 
@@ -2870,14 +2870,14 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2917,109 +2917,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3260.400391 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3324.023438 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3385.302734 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3448.779297 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3512.402344 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3576.025391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3607.8125 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3639.599609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3671.386719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3703.173828 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3734.960938 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3762.744141 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3824.267578 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3885.546875 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3948.925781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4012.402344 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4051.265625 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4112.447266 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4171.626953 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4233.150391 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4274.263672 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4307.955078 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4335.738281 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4397.261719 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4458.541016 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4521.919922 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4585.542969 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4619.234375 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4678.414062 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4742.037109 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4773.824219 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4837.447266 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4901.070312 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4932.857422 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4996.480469 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5032.564453 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5071.427734 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5126.408203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5190.03125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5221.818359 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5253.605469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5285.392578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5317.179688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5348.966797 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5388.175781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5451.554688 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5490.417969 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5551.599609 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5614.978516 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5678.455078 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5741.833984 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5805.310547 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5868.689453 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5907.898438 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5939.685547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6023.474609 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6055.261719 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6152.673828 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6214.197266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6277.673828 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6305.457031 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6366.736328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6430.115234 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6461.902344 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6514.001953 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6577.380859 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6638.660156 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6702.136719 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6754.236328 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6817.615234 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6878.796875 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6918.005859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6951.697266 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6983.484375 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7024.597656 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7085.876953 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7125.085938 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7152.869141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7214.050781 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7245.837891 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7273.621094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7325.720703 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7357.507812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7420.984375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7482.507812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7521.716797 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7583.240234 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7622.603516 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7720.015625 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7747.798828 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7811.177734 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7838.960938 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7891.060547 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7930.269531 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7958.052734 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3196.777344 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3260.400391 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3323.876953 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3378.857422 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3442.480469 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3506.103516 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3569.726562 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3601.513672 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3633.300781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3665.087891 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3696.875 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3728.662109 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3756.445312 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3817.96875 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3879.248047 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3942.626953 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4006.103516 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4044.966797 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4106.148438 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4165.328125 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4226.851562 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4267.964844 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4301.65625 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4329.439453 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4390.962891 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4452.242188 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4515.621094 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4579.244141 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4612.935547 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4672.115234 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4735.738281 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4767.525391 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4831.148438 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4894.771484 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4926.558594 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4990.181641 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5026.265625 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5065.128906 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5120.109375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5183.732422 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5215.519531 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5247.306641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5279.09375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5310.880859 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5342.667969 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5381.876953 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5445.255859 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5484.119141 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5545.300781 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5608.679688 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5672.15625 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5735.535156 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5799.011719 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5862.390625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5901.599609 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5933.386719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6017.175781 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6048.962891 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6146.375 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6207.898438 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6271.375 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6299.158203 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6360.4375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6423.816406 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6455.603516 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6507.703125 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6571.082031 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6632.361328 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6695.837891 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6747.9375 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6811.316406 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6872.498047 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6911.707031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6945.398438 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6977.185547 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7018.298828 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7079.578125 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7118.787109 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7146.570312 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7207.751953 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7239.539062 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7267.322266 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7319.421875 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7351.208984 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7414.685547 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7476.208984 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7515.417969 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7576.941406 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7616.304688 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7713.716797 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7741.5 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7804.878906 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7832.662109 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7884.761719 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7923.970703 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7951.753906 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p173a80bbb2">
+  <clipPath id="p8ca21c546b">
    <rect x="95.67625" y="49.34175" width="468.141298" height="294.686261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_summary.svg
+++ b/bench/graphs/silesia_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="575.30125pt" height="386.202469pt" viewBox="0 0 575.30125 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="574.860469pt" height="386.202469pt" viewBox="0 0 574.860469 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,232 +22,232 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 386.202469 
-L 575.30125 386.202469 
-L 575.30125 0 
+L 574.860469 386.202469 
+L 574.860469 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 189.775625 104.1264 
-L 294.400625 104.1264 
-L 294.400625 74.7432 
-L 189.775625 74.7432 
+    <path d="M 189.555234 104.1264 
+L 294.180234 104.1264 
+L 294.180234 74.7432 
+L 189.555234 74.7432 
 z
-" clip-path="url(#p020d1abf7b)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8e65b59eac)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 294.400625 104.1264 
-L 399.025625 104.1264 
-L 399.025625 74.7432 
-L 294.400625 74.7432 
+    <path d="M 294.180234 104.1264 
+L 398.805234 104.1264 
+L 398.805234 74.7432 
+L 294.180234 74.7432 
 z
-" clip-path="url(#p020d1abf7b)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8e65b59eac)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 399.025625 104.1264 
-L 503.650625 104.1264 
-L 503.650625 74.7432 
-L 399.025625 74.7432 
+    <path d="M 398.805234 104.1264 
+L 503.430234 104.1264 
+L 503.430234 74.7432 
+L 398.805234 74.7432 
 z
-" clip-path="url(#p020d1abf7b)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8e65b59eac)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 189.775625 133.5096 
-L 294.400625 133.5096 
-L 294.400625 104.1264 
-L 189.775625 104.1264 
+    <path d="M 189.555234 133.5096 
+L 294.180234 133.5096 
+L 294.180234 104.1264 
+L 189.555234 104.1264 
 z
-" clip-path="url(#p020d1abf7b)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8e65b59eac)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 294.400625 133.5096 
-L 399.025625 133.5096 
-L 399.025625 104.1264 
-L 294.400625 104.1264 
+    <path d="M 294.180234 133.5096 
+L 398.805234 133.5096 
+L 398.805234 104.1264 
+L 294.180234 104.1264 
 z
-" clip-path="url(#p020d1abf7b)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8e65b59eac)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 399.025625 133.5096 
-L 503.650625 133.5096 
-L 503.650625 104.1264 
-L 399.025625 104.1264 
+    <path d="M 398.805234 133.5096 
+L 503.430234 133.5096 
+L 503.430234 104.1264 
+L 398.805234 104.1264 
 z
-" clip-path="url(#p020d1abf7b)" style="fill: #fece7c; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8e65b59eac)" style="fill: #fece7c; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 189.775625 162.8928 
-L 294.400625 162.8928 
-L 294.400625 133.5096 
-L 189.775625 133.5096 
+    <path d="M 189.555234 162.8928 
+L 294.180234 162.8928 
+L 294.180234 133.5096 
+L 189.555234 133.5096 
 z
-" clip-path="url(#p020d1abf7b)" style="fill: #fee08b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8e65b59eac)" style="fill: #fee08b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 294.400625 162.8928 
-L 399.025625 162.8928 
-L 399.025625 133.5096 
-L 294.400625 133.5096 
+    <path d="M 294.180234 162.8928 
+L 398.805234 162.8928 
+L 398.805234 133.5096 
+L 294.180234 133.5096 
 z
-" clip-path="url(#p020d1abf7b)" style="fill: #feefa3; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8e65b59eac)" style="fill: #feefa3; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 399.025625 162.8928 
-L 503.650625 162.8928 
-L 503.650625 133.5096 
-L 399.025625 133.5096 
+    <path d="M 398.805234 162.8928 
+L 503.430234 162.8928 
+L 503.430234 133.5096 
+L 398.805234 133.5096 
 z
-" clip-path="url(#p020d1abf7b)" style="fill: #fdbf6f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8e65b59eac)" style="fill: #fdbf6f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 189.775625 192.276 
-L 294.400625 192.276 
-L 294.400625 162.8928 
-L 189.775625 162.8928 
+    <path d="M 189.555234 192.276 
+L 294.180234 192.276 
+L 294.180234 162.8928 
+L 189.555234 162.8928 
 z
-" clip-path="url(#p020d1abf7b)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8e65b59eac)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 294.400625 192.276 
-L 399.025625 192.276 
-L 399.025625 162.8928 
-L 294.400625 162.8928 
+    <path d="M 294.180234 192.276 
+L 398.805234 192.276 
+L 398.805234 162.8928 
+L 294.180234 162.8928 
 z
-" clip-path="url(#p020d1abf7b)" style="fill: #fede89; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8e65b59eac)" style="fill: #fede89; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 399.025625 192.276 
-L 503.650625 192.276 
-L 503.650625 162.8928 
-L 399.025625 162.8928 
+    <path d="M 398.805234 192.276 
+L 503.430234 192.276 
+L 503.430234 162.8928 
+L 398.805234 162.8928 
 z
-" clip-path="url(#p020d1abf7b)" style="fill: #f7814c; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8e65b59eac)" style="fill: #f7814c; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 189.775625 221.6592 
-L 294.400625 221.6592 
-L 294.400625 192.276 
-L 189.775625 192.276 
+    <path d="M 189.555234 221.6592 
+L 294.180234 221.6592 
+L 294.180234 192.276 
+L 189.555234 192.276 
 z
-" clip-path="url(#p020d1abf7b)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8e65b59eac)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 294.400625 221.6592 
-L 399.025625 221.6592 
-L 399.025625 192.276 
-L 294.400625 192.276 
+    <path d="M 294.180234 221.6592 
+L 398.805234 221.6592 
+L 398.805234 192.276 
+L 294.180234 192.276 
 z
-" clip-path="url(#p020d1abf7b)" style="fill: #fed27f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8e65b59eac)" style="fill: #fed27f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 399.025625 221.6592 
-L 503.650625 221.6592 
-L 503.650625 192.276 
-L 399.025625 192.276 
+    <path d="M 398.805234 221.6592 
+L 503.430234 221.6592 
+L 503.430234 192.276 
+L 398.805234 192.276 
 z
-" clip-path="url(#p020d1abf7b)" style="fill: #fffcba; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8e65b59eac)" style="fill: #fffcba; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 189.775625 251.0424 
-L 294.400625 251.0424 
-L 294.400625 221.6592 
-L 189.775625 221.6592 
+    <path d="M 189.555234 251.0424 
+L 294.180234 251.0424 
+L 294.180234 221.6592 
+L 189.555234 221.6592 
 z
-" clip-path="url(#p020d1abf7b)" style="fill: #fff3ac; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8e65b59eac)" style="fill: #fff3ac; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 294.400625 251.0424 
-L 399.025625 251.0424 
-L 399.025625 221.6592 
-L 294.400625 221.6592 
+    <path d="M 294.180234 251.0424 
+L 398.805234 251.0424 
+L 398.805234 221.6592 
+L 294.180234 221.6592 
 z
-" clip-path="url(#p020d1abf7b)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8e65b59eac)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 399.025625 251.0424 
-L 503.650625 251.0424 
-L 503.650625 221.6592 
-L 399.025625 221.6592 
+    <path d="M 398.805234 251.0424 
+L 503.430234 251.0424 
+L 503.430234 221.6592 
+L 398.805234 221.6592 
 z
-" clip-path="url(#p020d1abf7b)" style="fill: #e8f59f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8e65b59eac)" style="fill: #e8f59f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 189.775625 280.4256 
-L 294.400625 280.4256 
-L 294.400625 251.0424 
-L 189.775625 251.0424 
+    <path d="M 189.555234 280.4256 
+L 294.180234 280.4256 
+L 294.180234 251.0424 
+L 189.555234 251.0424 
 z
-" clip-path="url(#p020d1abf7b)" style="fill: #feec9f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8e65b59eac)" style="fill: #feec9f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 294.400625 280.4256 
-L 399.025625 280.4256 
-L 399.025625 251.0424 
-L 294.400625 251.0424 
+    <path d="M 294.180234 280.4256 
+L 398.805234 280.4256 
+L 398.805234 251.0424 
+L 294.180234 251.0424 
 z
-" clip-path="url(#p020d1abf7b)" style="fill: #fdbf6f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8e65b59eac)" style="fill: #fdbd6d; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 399.025625 280.4256 
-L 503.650625 280.4256 
-L 503.650625 251.0424 
-L 399.025625 251.0424 
+    <path d="M 398.805234 280.4256 
+L 503.430234 280.4256 
+L 503.430234 251.0424 
+L 398.805234 251.0424 
 z
-" clip-path="url(#p020d1abf7b)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8e65b59eac)" style="fill: #fdb96a; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 189.775625 309.8088 
-L 294.400625 309.8088 
-L 294.400625 280.4256 
-L 189.775625 280.4256 
+    <path d="M 189.555234 309.8088 
+L 294.180234 309.8088 
+L 294.180234 280.4256 
+L 189.555234 280.4256 
 z
-" clip-path="url(#p020d1abf7b)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8e65b59eac)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 294.400625 309.8088 
-L 399.025625 309.8088 
-L 399.025625 280.4256 
-L 294.400625 280.4256 
+    <path d="M 294.180234 309.8088 
+L 398.805234 309.8088 
+L 398.805234 280.4256 
+L 294.180234 280.4256 
 z
-" clip-path="url(#p020d1abf7b)" style="fill: #fa9b58; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8e65b59eac)" style="fill: #fa9b58; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 399.025625 309.8088 
-L 503.650625 309.8088 
-L 503.650625 280.4256 
-L 399.025625 280.4256 
+    <path d="M 398.805234 309.8088 
+L 503.430234 309.8088 
+L 503.430234 280.4256 
+L 398.805234 280.4256 
 z
-" clip-path="url(#p020d1abf7b)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8e65b59eac)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 189.775625 339.192 
-L 294.400625 339.192 
-L 294.400625 309.8088 
-L 189.775625 309.8088 
+    <path d="M 189.555234 339.192 
+L 294.180234 339.192 
+L 294.180234 309.8088 
+L 189.555234 309.8088 
 z
-" clip-path="url(#p020d1abf7b)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8e65b59eac)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 294.400625 339.192 
-L 399.025625 339.192 
-L 399.025625 309.8088 
-L 294.400625 309.8088 
+    <path d="M 294.180234 339.192 
+L 398.805234 339.192 
+L 398.805234 309.8088 
+L 294.180234 309.8088 
 z
-" clip-path="url(#p020d1abf7b)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8e65b59eac)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 399.025625 339.192 
-L 503.650625 339.192 
-L 503.650625 309.8088 
-L 399.025625 309.8088 
+    <path d="M 398.805234 339.192 
+L 503.430234 339.192 
+L 503.430234 309.8088 
+L 398.805234 309.8088 
 z
-" clip-path="url(#p020d1abf7b)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8e65b59eac)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(122.762891 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(122.5425 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(230.047109 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(229.826719 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(308.619219 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(308.398828 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(406.970937 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(406.750547 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(118.700625 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(118.480234 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.320 -->
-    <g transform="translate(230.636875 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(230.416484 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -918,7 +918,7 @@ z
    </g>
    <g id="text_7">
     <!-- 117 -->
-    <g transform="translate(339.078125 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(338.857734 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -952,7 +952,7 @@ z
    </g>
    <g id="text_8">
     <!-- 852 -->
-    <g transform="translate(443.703125 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(443.482734 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -1026,7 +1026,7 @@ z
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(113.33875 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(113.118359 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1125,7 +1125,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.324 -->
-    <g transform="translate(230.636875 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(230.416484 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1156,7 +1156,7 @@ z
    </g>
    <g id="text_11">
     <!-- 61 -->
-    <g transform="translate(341.623125 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(341.402734 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -1195,7 +1195,7 @@ z
    </g>
    <g id="text_12">
     <!-- 312 -->
-    <g transform="translate(443.703125 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(443.482734 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
@@ -1203,7 +1203,7 @@ z
    </g>
    <g id="text_13">
     <!-- Go compress/flate -->
-    <g transform="translate(101.031875 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(100.811484 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -1374,7 +1374,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.325 -->
-    <g transform="translate(230.636875 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(230.416484 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1384,14 +1384,14 @@ z
    </g>
    <g id="text_15">
     <!-- 50 -->
-    <g transform="translate(341.623125 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(341.402734 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
     <!-- 275 -->
-    <g transform="translate(443.703125 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(443.482734 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
@@ -1399,7 +1399,7 @@ z
    </g>
    <g id="text_17">
     <!-- JS fflate -->
-    <g transform="translate(122.064375 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(121.843984 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1459,7 +1459,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.329 -->
-    <g transform="translate(230.636875 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(230.416484 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-39" d="M 703 97 
 L 703 672 
@@ -1501,14 +1501,14 @@ z
    </g>
    <g id="text_19">
     <!-- 41 -->
-    <g transform="translate(341.623125 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(341.402734 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
     <!-- 160 -->
-    <g transform="translate(443.703125 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(443.482734 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -1516,7 +1516,7 @@ z
    </g>
    <g id="text_21">
     <!-- zlib -->
-    <g transform="translate(130.601875 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(130.381484 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1540,7 +1540,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.323 -->
-    <g transform="translate(230.636875 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(230.416484 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1550,14 +1550,14 @@ z
    </g>
    <g id="text_23">
     <!-- 38 -->
-    <g transform="translate(341.623125 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(341.402734 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_24">
     <!-- 448 -->
-    <g transform="translate(443.703125 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(443.482734 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(127.246094 0)"/>
@@ -1565,7 +1565,7 @@ z
    </g>
    <g id="text_25">
     <!-- miniz_oxide -->
-    <g transform="translate(113.908125 238.44705) scale(0.08 -0.08)">
+    <g transform="translate(113.687734 238.44705) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6e" d="M 3513 2113 
 L 3513 0 
@@ -1624,7 +1624,7 @@ z
    </g>
    <g id="text_26">
     <!-- 0.322 -->
-    <g transform="translate(230.636875 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(230.416484 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1634,14 +1634,14 @@ z
    </g>
    <g id="text_27">
     <!-- 36 -->
-    <g transform="translate(341.623125 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(341.402734 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_28">
     <!-- 527 -->
-    <g transform="translate(443.703125 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(443.482734 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
@@ -1649,7 +1649,7 @@ z
    </g>
    <g id="text_29">
     <!-- lean-zip (native) -->
-    <g transform="translate(100.41 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(100.189609 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1758,7 +1758,7 @@ z
    </g>
    <g id="text_30">
     <!-- 0.323 -->
-    <g transform="translate(229.43625 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(229.215859 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1851,80 +1851,55 @@ z
     </g>
    </g>
    <g id="text_31">
-    <!-- 31 -->
-    <g transform="translate(341.146875 267.9415) scale(0.08 -0.08)">
-     <defs>
-      <path id="DejaVuSans-Bold-31" d="M 750 831 
-L 1813 831 
-L 1813 3847 
-L 722 3622 
-L 722 4441 
-L 1806 4666 
-L 2950 4666 
-L 2950 831 
-L 4013 831 
-L 4013 0 
-L 750 0 
-L 750 831 
-z
-" transform="scale(0.015625)"/>
-     </defs>
+    <!-- 30 -->
+    <g transform="translate(340.926484 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-Bold-33"/>
-     <use xlink:href="#DejaVuSans-Bold-31" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-30" transform="translate(69.580078 0)"/>
     </g>
    </g>
    <g id="text_32">
-    <!-- 183 -->
-    <g transform="translate(442.98875 267.9415) scale(0.08 -0.08)">
+    <!-- 263 -->
+    <g transform="translate(442.768359 267.9415) scale(0.08 -0.08)">
      <defs>
-      <path id="DejaVuSans-Bold-38" d="M 2228 2088 
-Q 1891 2088 1709 1903 
-Q 1528 1719 1528 1375 
-Q 1528 1031 1709 848 
-Q 1891 666 2228 666 
-Q 2563 666 2741 848 
-Q 2919 1031 2919 1375 
-Q 2919 1722 2741 1905 
-Q 2563 2088 2228 2088 
+      <path id="DejaVuSans-Bold-36" d="M 2316 2303 
+Q 2000 2303 1842 2098 
+Q 1684 1894 1684 1484 
+Q 1684 1075 1842 870 
+Q 2000 666 2316 666 
+Q 2634 666 2792 870 
+Q 2950 1075 2950 1484 
+Q 2950 1894 2792 2098 
+Q 2634 2303 2316 2303 
 z
-M 1350 2484 
-Q 925 2613 709 2878 
-Q 494 3144 494 3541 
-Q 494 4131 934 4440 
-Q 1375 4750 2228 4750 
-Q 3075 4750 3515 4442 
-Q 3956 4134 3956 3541 
-Q 3956 3144 3739 2878 
-Q 3522 2613 3097 2484 
-Q 3572 2353 3814 2058 
-Q 4056 1763 4056 1313 
-Q 4056 619 3595 264 
-Q 3134 -91 2228 -91 
-Q 1319 -91 855 264 
-Q 391 619 391 1313 
-Q 391 1763 633 2058 
-Q 875 2353 1350 2484 
-z
-M 1631 3419 
-Q 1631 3141 1786 2991 
-Q 1941 2841 2228 2841 
-Q 2509 2841 2662 2991 
-Q 2816 3141 2816 3419 
-Q 2816 3697 2662 3845 
-Q 2509 3994 2228 3994 
-Q 1941 3994 1786 3844 
-Q 1631 3694 1631 3419 
+M 3803 4544 
+L 3803 3681 
+Q 3506 3822 3243 3889 
+Q 2981 3956 2731 3956 
+Q 2194 3956 1894 3657 
+Q 1594 3359 1544 2772 
+Q 1750 2925 1990 3001 
+Q 2231 3078 2516 3078 
+Q 3231 3078 3670 2659 
+Q 4109 2241 4109 1563 
+Q 4109 813 3618 361 
+Q 3128 -91 2303 -91 
+Q 1394 -91 895 523 
+Q 397 1138 397 2266 
+Q 397 3422 980 4083 
+Q 1563 4744 2578 4744 
+Q 2900 4744 3203 4694 
+Q 3506 4644 3803 4544 
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-Bold-31"/>
-     <use xlink:href="#DejaVuSans-Bold-38" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-32"/>
+     <use xlink:href="#DejaVuSans-Bold-36" transform="translate(69.580078 0)"/>
      <use xlink:href="#DejaVuSans-Bold-33" transform="translate(139.160156 0)"/>
     </g>
    </g>
    <g id="text_33">
     <!-- OCaml decompress -->
-    <g transform="translate(98.525 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(98.304609 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -1989,7 +1964,7 @@ z
    </g>
    <g id="text_34">
     <!-- 0.336 -->
-    <g transform="translate(230.636875 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(230.416484 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1999,21 +1974,21 @@ z
    </g>
    <g id="text_35">
     <!-- 21 -->
-    <g transform="translate(341.623125 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(341.402734 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_36">
     <!-- 69 -->
-    <g transform="translate(446.248125 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(446.027734 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-36"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(126.74625 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(126.525859 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -2024,7 +1999,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.303 -->
-    <g transform="translate(230.636875 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(230.416484 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -2034,13 +2009,13 @@ z
    </g>
    <g id="text_39">
     <!-- 1 -->
-    <g transform="translate(344.168125 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(343.947734 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(447.338125 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(447.117734 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2056,7 +2031,7 @@ z
   </g>
   <g id="text_41">
    <!-- silesia — geomean over files, level 6 -->
-   <g transform="translate(154.252344 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(154.031953 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-2014" d="M 344 2156 
 L 6056 2156 
@@ -2129,36 +2104,6 @@ L 653 256
 L 653 1209 
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Bold-36" d="M 2316 2303 
-Q 2000 2303 1842 2098 
-Q 1684 1894 1684 1484 
-Q 1684 1075 1842 870 
-Q 2000 666 2316 666 
-Q 2634 666 2792 870 
-Q 2950 1075 2950 1484 
-Q 2950 1894 2792 2098 
-Q 2634 2303 2316 2303 
-z
-M 3803 4544 
-L 3803 3681 
-Q 3506 3822 3243 3889 
-Q 2981 3956 2731 3956 
-Q 2194 3956 1894 3657 
-Q 1594 3359 1544 2772 
-Q 1750 2925 1990 3001 
-Q 2231 3078 2516 3078 
-Q 3231 3078 3670 2659 
-Q 4109 2241 4109 1563 
-Q 4109 813 3618 361 
-Q 3128 -91 2303 -91 
-Q 1394 -91 895 523 
-Q 397 1138 397 2266 
-Q 397 3422 980 4083 
-Q 1563 4744 2578 4744 
-Q 2900 4744 3203 4694 
-Q 3506 4644 3803 4544 
-z
-" transform="scale(0.015625)"/>
     </defs>
     <use xlink:href="#DejaVuSans-Bold-73"/>
     <use xlink:href="#DejaVuSans-Bold-69" transform="translate(59.521484 0)"/>
@@ -2200,7 +2145,7 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-07-06T07:54:18Z  ·  Linux chungus2 x86_64  ·  commit 38a6ad15  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-07-06T10:45:22Z  ·  Linux chungus2 x86_64  ·  commit 8a6bc577  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2341,14 +2286,14 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2388,110 +2333,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3260.400391 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3324.023438 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3385.302734 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3448.779297 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3512.402344 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3576.025391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3607.8125 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3639.599609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3671.386719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3703.173828 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3734.960938 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3762.744141 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3824.267578 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3885.546875 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3948.925781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4012.402344 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4051.265625 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4112.447266 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4171.626953 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4233.150391 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4274.263672 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4307.955078 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4335.738281 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4397.261719 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4458.541016 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4521.919922 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4585.542969 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4619.234375 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4678.414062 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4742.037109 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4773.824219 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4837.447266 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4901.070312 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4932.857422 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4996.480469 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5032.564453 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5071.427734 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5126.408203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5190.03125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5221.818359 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5253.605469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5285.392578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5317.179688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5348.966797 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5388.175781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5451.554688 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5490.417969 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5551.599609 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5614.978516 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5678.455078 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5741.833984 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5805.310547 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5868.689453 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5907.898438 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5939.685547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6023.474609 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6055.261719 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6152.673828 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6214.197266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6277.673828 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6305.457031 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6366.736328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6430.115234 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6461.902344 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6514.001953 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6577.380859 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6638.660156 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6702.136719 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6754.236328 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6817.615234 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6878.796875 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6918.005859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6951.697266 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6983.484375 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7024.597656 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7085.876953 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7125.085938 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7152.869141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7214.050781 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7245.837891 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7273.621094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7325.720703 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7357.507812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7420.984375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7482.507812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7521.716797 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7583.240234 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7622.603516 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7720.015625 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7747.798828 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7811.177734 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7838.960938 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7891.060547 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7930.269531 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7958.052734 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3196.777344 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3260.400391 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3323.876953 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3378.857422 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3442.480469 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3506.103516 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3569.726562 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3601.513672 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3633.300781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3665.087891 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3696.875 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3728.662109 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3756.445312 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3817.96875 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3879.248047 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3942.626953 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4006.103516 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4044.966797 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4106.148438 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4165.328125 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4226.851562 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4267.964844 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4301.65625 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4329.439453 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4390.962891 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4452.242188 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4515.621094 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4579.244141 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4612.935547 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4672.115234 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4735.738281 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4767.525391 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4831.148438 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4894.771484 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4926.558594 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4990.181641 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5026.265625 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5065.128906 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5120.109375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5183.732422 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5215.519531 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5247.306641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5279.09375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5310.880859 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5342.667969 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5381.876953 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5445.255859 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5484.119141 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5545.300781 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5608.679688 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5672.15625 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5735.535156 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5799.011719 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5862.390625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5901.599609 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5933.386719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6017.175781 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6048.962891 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6146.375 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6207.898438 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6271.375 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6299.158203 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6360.4375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6423.816406 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6455.603516 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6507.703125 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6571.082031 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6632.361328 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6695.837891 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6747.9375 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6811.316406 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6872.498047 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6911.707031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6945.398438 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6977.185547 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7018.298828 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7079.578125 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7118.787109 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7146.570312 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7207.751953 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7239.539062 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7267.322266 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7319.421875 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7351.208984 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7414.685547 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7476.208984 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7515.417969 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7576.941406 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7616.304688 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7713.716797 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7741.5 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7804.878906 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7832.662109 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7884.761719 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7923.970703 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7951.753906 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p020d1abf7b">
-   <rect x="85.150625" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="p8e65b59eac">
+   <rect x="84.930234" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/lakefile.lean
+++ b/bench/lakefile.lean
@@ -335,6 +335,10 @@ lean_exe «mid-sweep» where
   root := `ZipMidSweep
 
 @[default_target]
+lean_exe «skip-spike» where
+  root := `ZipSkipSpike
+
+@[default_target]
 lean_exe «lazy2-sweep» where
   root := `ZipLazy2Sweep
 

--- a/bench/results/latest.json
+++ b/bench/results/latest.json
@@ -1,8 +1,8 @@
 {
  "meta": {
-  "date": "2026-07-06T07:54:18Z",
+  "date": "2026-07-06T10:45:22Z",
   "machine": "Linux chungus2 x86_64",
-  "git_commit": "38a6ad15",
+  "git_commit": "8a6bc577",
   "toolchain": "leanprover/lean4:v4.30.0-rc2",
   "note": "compress_mbps/decompress_mbps are a median-of-5 snapshot on the machine above; ratio is deterministic"
  },
@@ -14,8 +14,8 @@
    "level": 1,
    "out_size": 60455,
    "ratio": 0.3975,
-   "compress_mbps": 68.23,
-   "decompress_mbps": 114.19
+   "compress_mbps": 68.21,
+   "decompress_mbps": 190.04
   },
   {
    "compressor": "native",
@@ -24,8 +24,8 @@
    "level": 2,
    "out_size": 56316,
    "ratio": 0.3703,
-   "compress_mbps": 49.2,
-   "decompress_mbps": 126.63
+   "compress_mbps": 49.38,
+   "decompress_mbps": 216.69
   },
   {
    "compressor": "native",
@@ -34,8 +34,8 @@
    "level": 3,
    "out_size": 55646,
    "ratio": 0.3659,
-   "compress_mbps": 43.93,
-   "decompress_mbps": 138.07
+   "compress_mbps": 43.77,
+   "decompress_mbps": 235.85
   },
   {
    "compressor": "native",
@@ -44,8 +44,8 @@
    "level": 4,
    "out_size": 54357,
    "ratio": 0.3574,
-   "compress_mbps": 33.63,
-   "decompress_mbps": 141.71
+   "compress_mbps": 33.35,
+   "decompress_mbps": 237.06
   },
   {
    "compressor": "native",
@@ -54,8 +54,8 @@
    "level": 5,
    "out_size": 54078,
    "ratio": 0.3556,
-   "compress_mbps": 27.45,
-   "decompress_mbps": 148.74
+   "compress_mbps": 27.21,
+   "decompress_mbps": 240.25
   },
   {
    "compressor": "native",
@@ -64,8 +64,8 @@
    "level": 6,
    "out_size": 54013,
    "ratio": 0.3551,
-   "compress_mbps": 26.01,
-   "decompress_mbps": 152.87
+   "compress_mbps": 25.83,
+   "decompress_mbps": 246.64
   },
   {
    "compressor": "native",
@@ -74,8 +74,8 @@
    "level": 7,
    "out_size": 53772,
    "ratio": 0.3536,
-   "compress_mbps": 21.82,
-   "decompress_mbps": 154.07
+   "compress_mbps": 21.89,
+   "decompress_mbps": 247.21
   },
   {
    "compressor": "native",
@@ -84,8 +84,8 @@
    "level": 8,
    "out_size": 53753,
    "ratio": 0.3534,
-   "compress_mbps": 21.04,
-   "decompress_mbps": 154.59
+   "compress_mbps": 21.05,
+   "decompress_mbps": 248.18
   },
   {
    "compressor": "native",
@@ -94,8 +94,8 @@
    "level": 9,
    "out_size": 52732,
    "ratio": 0.3467,
-   "compress_mbps": 4.17,
-   "decompress_mbps": 154.24
+   "compress_mbps": 4.15,
+   "decompress_mbps": 247.34
   },
   {
    "compressor": "native",
@@ -104,7 +104,7 @@
    "level": 10,
    "out_size": 52078,
    "ratio": 0.3424,
-   "compress_mbps": 2.33,
+   "compress_mbps": 2.32,
    "decompress_mbps": null
   },
   {
@@ -114,8 +114,8 @@
    "level": 1,
    "out_size": 53135,
    "ratio": 0.4245,
-   "compress_mbps": 62.06,
-   "decompress_mbps": 107.14
+   "compress_mbps": 62.09,
+   "decompress_mbps": 181.62
   },
   {
    "compressor": "native",
@@ -124,8 +124,8 @@
    "level": 2,
    "out_size": 50187,
    "ratio": 0.4009,
-   "compress_mbps": 46.26,
-   "decompress_mbps": 115.51
+   "compress_mbps": 46.45,
+   "decompress_mbps": 196.78
   },
   {
    "compressor": "native",
@@ -134,8 +134,8 @@
    "level": 3,
    "out_size": 49810,
    "ratio": 0.3979,
-   "compress_mbps": 42.06,
-   "decompress_mbps": 125.16
+   "compress_mbps": 41.94,
+   "decompress_mbps": 215.01
   },
   {
    "compressor": "native",
@@ -144,8 +144,8 @@
    "level": 4,
    "out_size": 48687,
    "ratio": 0.3889,
-   "compress_mbps": 31.88,
-   "decompress_mbps": 129.98
+   "compress_mbps": 31.56,
+   "decompress_mbps": 219.22
   },
   {
    "compressor": "native",
@@ -154,8 +154,8 @@
    "level": 5,
    "out_size": 48586,
    "ratio": 0.3881,
-   "compress_mbps": 27.62,
-   "decompress_mbps": 135.51
+   "compress_mbps": 27.32,
+   "decompress_mbps": 220.39
   },
   {
    "compressor": "native",
@@ -164,8 +164,8 @@
    "level": 6,
    "out_size": 48373,
    "ratio": 0.3864,
-   "compress_mbps": 24.94,
-   "decompress_mbps": 138.64
+   "compress_mbps": 24.76,
+   "decompress_mbps": 224.67
   },
   {
    "compressor": "native",
@@ -174,8 +174,8 @@
    "level": 7,
    "out_size": 48288,
    "ratio": 0.3858,
-   "compress_mbps": 22.61,
-   "decompress_mbps": 138.9
+   "compress_mbps": 22.63,
+   "decompress_mbps": 224.76
   },
   {
    "compressor": "native",
@@ -184,8 +184,8 @@
    "level": 8,
    "out_size": 48284,
    "ratio": 0.3857,
-   "compress_mbps": 22.33,
-   "decompress_mbps": 139.03
+   "compress_mbps": 22.35,
+   "decompress_mbps": 224.99
   },
   {
    "compressor": "native",
@@ -194,8 +194,8 @@
    "level": 9,
    "out_size": 47430,
    "ratio": 0.3789,
-   "compress_mbps": 4.52,
-   "decompress_mbps": 139.2
+   "compress_mbps": 4.46,
+   "decompress_mbps": 225.55
   },
   {
    "compressor": "native",
@@ -204,7 +204,7 @@
    "level": 10,
    "out_size": 46865,
    "ratio": 0.3744,
-   "compress_mbps": 2.72,
+   "compress_mbps": 2.7,
    "decompress_mbps": null
   },
   {
@@ -214,8 +214,8 @@
    "level": 1,
    "out_size": 8476,
    "ratio": 0.3445,
-   "compress_mbps": 61.7,
-   "decompress_mbps": 126.92
+   "compress_mbps": 61.66,
+   "decompress_mbps": 218.18
   },
   {
    "compressor": "native",
@@ -224,8 +224,8 @@
    "level": 2,
    "out_size": 8271,
    "ratio": 0.3362,
-   "compress_mbps": 51.34,
-   "decompress_mbps": 131.04
+   "compress_mbps": 51.33,
+   "decompress_mbps": 223.69
   },
   {
    "compressor": "native",
@@ -234,8 +234,8 @@
    "level": 3,
    "out_size": 8158,
    "ratio": 0.3316,
-   "compress_mbps": 49.4,
-   "decompress_mbps": 134.03
+   "compress_mbps": 49.27,
+   "decompress_mbps": 229.88
   },
   {
    "compressor": "native",
@@ -244,8 +244,8 @@
    "level": 4,
    "out_size": 7948,
    "ratio": 0.3231,
-   "compress_mbps": 43.47,
-   "decompress_mbps": 139.9
+   "compress_mbps": 42.48,
+   "decompress_mbps": 237.06
   },
   {
    "compressor": "native",
@@ -254,8 +254,8 @@
    "level": 5,
    "out_size": 7899,
    "ratio": 0.3211,
-   "compress_mbps": 37.12,
-   "decompress_mbps": 144.09
+   "compress_mbps": 36.38,
+   "decompress_mbps": 244.75
   },
   {
    "compressor": "native",
@@ -264,8 +264,8 @@
    "level": 6,
    "out_size": 7912,
    "ratio": 0.3216,
-   "compress_mbps": 36.53,
-   "decompress_mbps": 145.8
+   "compress_mbps": 35.81,
+   "decompress_mbps": 245.14
   },
   {
    "compressor": "native",
@@ -274,8 +274,8 @@
    "level": 7,
    "out_size": 7897,
    "ratio": 0.321,
-   "compress_mbps": 33.23,
-   "decompress_mbps": 147.05
+   "compress_mbps": 32.72,
+   "decompress_mbps": 248.09
   },
   {
    "compressor": "native",
@@ -284,8 +284,8 @@
    "level": 8,
    "out_size": 7897,
    "ratio": 0.321,
-   "compress_mbps": 33.23,
-   "decompress_mbps": 147.39
+   "compress_mbps": 32.68,
+   "decompress_mbps": 248.39
   },
   {
    "compressor": "native",
@@ -294,8 +294,8 @@
    "level": 9,
    "out_size": 7803,
    "ratio": 0.3172,
-   "compress_mbps": 4.74,
-   "decompress_mbps": 147.06
+   "compress_mbps": 4.75,
+   "decompress_mbps": 249.53
   },
   {
    "compressor": "native",
@@ -304,7 +304,7 @@
    "level": 10,
    "out_size": 7737,
    "ratio": 0.3145,
-   "compress_mbps": 2.84,
+   "compress_mbps": 2.81,
    "decompress_mbps": null
   },
   {
@@ -314,8 +314,8 @@
    "level": 1,
    "out_size": 3509,
    "ratio": 0.3147,
-   "compress_mbps": 47.22,
-   "decompress_mbps": 101.17
+   "compress_mbps": 46.78,
+   "decompress_mbps": 150.39
   },
   {
    "compressor": "native",
@@ -324,8 +324,8 @@
    "level": 2,
    "out_size": 3269,
    "ratio": 0.2932,
-   "compress_mbps": 41.21,
-   "decompress_mbps": 105.15
+   "compress_mbps": 40.71,
+   "decompress_mbps": 152.65
   },
   {
    "compressor": "native",
@@ -334,8 +334,8 @@
    "level": 3,
    "out_size": 3208,
    "ratio": 0.2877,
-   "compress_mbps": 39.89,
-   "decompress_mbps": 108.37
+   "compress_mbps": 39.43,
+   "decompress_mbps": 155.6
   },
   {
    "compressor": "native",
@@ -344,8 +344,8 @@
    "level": 4,
    "out_size": 3128,
    "ratio": 0.2805,
-   "compress_mbps": 36.66,
-   "decompress_mbps": 110.99
+   "compress_mbps": 35.8,
+   "decompress_mbps": 158.2
   },
   {
    "compressor": "native",
@@ -354,8 +354,8 @@
    "level": 5,
    "out_size": 3111,
    "ratio": 0.279,
-   "compress_mbps": 32.9,
-   "decompress_mbps": 112.8
+   "compress_mbps": 32.0,
+   "decompress_mbps": 159.44
   },
   {
    "compressor": "native",
@@ -364,8 +364,8 @@
    "level": 6,
    "out_size": 3119,
    "ratio": 0.2797,
-   "compress_mbps": 33.02,
-   "decompress_mbps": 113.73
+   "compress_mbps": 32.23,
+   "decompress_mbps": 160.09
   },
   {
    "compressor": "native",
@@ -374,8 +374,8 @@
    "level": 7,
    "out_size": 3111,
    "ratio": 0.279,
-   "compress_mbps": 31.0,
-   "decompress_mbps": 114.24
+   "compress_mbps": 30.3,
+   "decompress_mbps": 160.61
   },
   {
    "compressor": "native",
@@ -384,8 +384,8 @@
    "level": 8,
    "out_size": 3111,
    "ratio": 0.279,
-   "compress_mbps": 30.88,
-   "decompress_mbps": 113.96
+   "compress_mbps": 30.25,
+   "decompress_mbps": 160.42
   },
   {
    "compressor": "native",
@@ -394,8 +394,8 @@
    "level": 9,
    "out_size": 3056,
    "ratio": 0.2741,
-   "compress_mbps": 5.31,
-   "decompress_mbps": 114.01
+   "compress_mbps": 5.25,
+   "decompress_mbps": 160.74
   },
   {
    "compressor": "native",
@@ -404,7 +404,7 @@
    "level": 10,
    "out_size": 3032,
    "ratio": 0.2719,
-   "compress_mbps": 2.97,
+   "compress_mbps": 2.96,
    "decompress_mbps": null
   },
   {
@@ -414,8 +414,8 @@
    "level": 1,
    "out_size": 1282,
    "ratio": 0.3445,
-   "compress_mbps": 24.79,
-   "decompress_mbps": 56.85
+   "compress_mbps": 22.03,
+   "decompress_mbps": 68.75
   },
   {
    "compressor": "native",
@@ -424,8 +424,8 @@
    "level": 2,
    "out_size": 1225,
    "ratio": 0.3292,
-   "compress_mbps": 23.38,
-   "decompress_mbps": 57.7
+   "compress_mbps": 20.81,
+   "decompress_mbps": 69.33
   },
   {
    "compressor": "native",
@@ -434,8 +434,8 @@
    "level": 3,
    "out_size": 1220,
    "ratio": 0.3279,
-   "compress_mbps": 23.26,
-   "decompress_mbps": 57.8
+   "compress_mbps": 20.61,
+   "decompress_mbps": 69.44
   },
   {
    "compressor": "native",
@@ -444,8 +444,8 @@
    "level": 4,
    "out_size": 1213,
    "ratio": 0.326,
-   "compress_mbps": 22.49,
-   "decompress_mbps": 58.75
+   "compress_mbps": 19.84,
+   "decompress_mbps": 69.9
   },
   {
    "compressor": "native",
@@ -454,8 +454,8 @@
    "level": 5,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 21.73,
-   "decompress_mbps": 59.43
+   "compress_mbps": 19.15,
+   "decompress_mbps": 69.97
   },
   {
    "compressor": "native",
@@ -464,8 +464,8 @@
    "level": 6,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 21.25,
-   "decompress_mbps": 59.36
+   "compress_mbps": 18.86,
+   "decompress_mbps": 70.23
   },
   {
    "compressor": "native",
@@ -474,8 +474,8 @@
    "level": 7,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 21.03,
-   "decompress_mbps": 59.44
+   "compress_mbps": 18.79,
+   "decompress_mbps": 70.07
   },
   {
    "compressor": "native",
@@ -484,8 +484,8 @@
    "level": 8,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 21.06,
-   "decompress_mbps": 59.35
+   "compress_mbps": 18.72,
+   "decompress_mbps": 70.26
   },
   {
    "compressor": "native",
@@ -494,8 +494,8 @@
    "level": 9,
    "out_size": 1205,
    "ratio": 0.3238,
-   "compress_mbps": 4.88,
-   "decompress_mbps": 59.26
+   "compress_mbps": 4.47,
+   "decompress_mbps": 70.22
   },
   {
    "compressor": "native",
@@ -504,7 +504,7 @@
    "level": 10,
    "out_size": 1191,
    "ratio": 0.3201,
-   "compress_mbps": 2.91,
+   "compress_mbps": 2.71,
    "decompress_mbps": null
   },
   {
@@ -514,8 +514,8 @@
    "level": 1,
    "out_size": 251793,
    "ratio": 0.2445,
-   "compress_mbps": 129.61,
-   "decompress_mbps": 210.08
+   "compress_mbps": 129.39,
+   "decompress_mbps": 343.03
   },
   {
    "compressor": "native",
@@ -524,8 +524,8 @@
    "level": 2,
    "out_size": 242565,
    "ratio": 0.2356,
-   "compress_mbps": 90.46,
-   "decompress_mbps": 225.33
+   "compress_mbps": 89.88,
+   "decompress_mbps": 373.37
   },
   {
    "compressor": "native",
@@ -534,8 +534,8 @@
    "level": 3,
    "out_size": 242532,
    "ratio": 0.2355,
-   "compress_mbps": 77.36,
-   "decompress_mbps": 234.74
+   "compress_mbps": 76.01,
+   "decompress_mbps": 394.87
   },
   {
    "compressor": "native",
@@ -544,8 +544,8 @@
    "level": 4,
    "out_size": 239953,
    "ratio": 0.233,
-   "compress_mbps": 72.69,
-   "decompress_mbps": 241.25
+   "compress_mbps": 70.37,
+   "decompress_mbps": 416.01
   },
   {
    "compressor": "native",
@@ -554,8 +554,8 @@
    "level": 5,
    "out_size": 218565,
    "ratio": 0.2123,
-   "compress_mbps": 48.88,
-   "decompress_mbps": 237.4
+   "compress_mbps": 48.66,
+   "decompress_mbps": 401.04
   },
   {
    "compressor": "native",
@@ -564,8 +564,8 @@
    "level": 6,
    "out_size": 202676,
    "ratio": 0.1968,
-   "compress_mbps": 37.38,
-   "decompress_mbps": 245.27
+   "compress_mbps": 36.96,
+   "decompress_mbps": 415.47
   },
   {
    "compressor": "native",
@@ -574,8 +574,8 @@
    "level": 7,
    "out_size": 201403,
    "ratio": 0.1956,
-   "compress_mbps": 27.54,
-   "decompress_mbps": 248.75
+   "compress_mbps": 27.29,
+   "decompress_mbps": 418.52
   },
   {
    "compressor": "native",
@@ -584,8 +584,8 @@
    "level": 8,
    "out_size": 200798,
    "ratio": 0.195,
-   "compress_mbps": 21.02,
-   "decompress_mbps": 252.69
+   "compress_mbps": 20.87,
+   "decompress_mbps": 426.41
   },
   {
    "compressor": "native",
@@ -594,8 +594,8 @@
    "level": 9,
    "out_size": 182508,
    "ratio": 0.1772,
-   "compress_mbps": 3.37,
-   "decompress_mbps": 253.59
+   "compress_mbps": 3.44,
+   "decompress_mbps": 426.34
   },
   {
    "compressor": "native",
@@ -604,7 +604,7 @@
    "level": 10,
    "out_size": 178067,
    "ratio": 0.1729,
-   "compress_mbps": 1.41,
+   "compress_mbps": 1.44,
    "decompress_mbps": null
   },
   {
@@ -614,8 +614,8 @@
    "level": 1,
    "out_size": 160674,
    "ratio": 0.3765,
-   "compress_mbps": 74.22,
-   "decompress_mbps": 122.07
+   "compress_mbps": 74.26,
+   "decompress_mbps": 199.31
   },
   {
    "compressor": "native",
@@ -625,7 +625,7 @@
    "out_size": 149787,
    "ratio": 0.351,
    "compress_mbps": 52.95,
-   "decompress_mbps": 131.58
+   "decompress_mbps": 214.58
   },
   {
    "compressor": "native",
@@ -634,8 +634,8 @@
    "level": 3,
    "out_size": 148055,
    "ratio": 0.3469,
-   "compress_mbps": 46.62,
-   "decompress_mbps": 144.93
+   "compress_mbps": 46.96,
+   "decompress_mbps": 239.18
   },
   {
    "compressor": "native",
@@ -644,8 +644,8 @@
    "level": 4,
    "out_size": 144750,
    "ratio": 0.3392,
-   "compress_mbps": 36.02,
-   "decompress_mbps": 149.28
+   "compress_mbps": 35.82,
+   "decompress_mbps": 243.37
   },
   {
    "compressor": "native",
@@ -654,8 +654,8 @@
    "level": 5,
    "out_size": 144408,
    "ratio": 0.3384,
-   "compress_mbps": 29.36,
-   "decompress_mbps": 156.55
+   "compress_mbps": 29.25,
+   "decompress_mbps": 246.3
   },
   {
    "compressor": "native",
@@ -664,8 +664,8 @@
    "level": 6,
    "out_size": 144070,
    "ratio": 0.3376,
-   "compress_mbps": 27.4,
-   "decompress_mbps": 160.67
+   "compress_mbps": 27.49,
+   "decompress_mbps": 251.63
   },
   {
    "compressor": "native",
@@ -674,8 +674,8 @@
    "level": 7,
    "out_size": 143628,
    "ratio": 0.3366,
-   "compress_mbps": 23.68,
-   "decompress_mbps": 161.61
+   "compress_mbps": 23.58,
+   "decompress_mbps": 252.68
   },
   {
    "compressor": "native",
@@ -684,8 +684,8 @@
    "level": 8,
    "out_size": 143569,
    "ratio": 0.3364,
-   "compress_mbps": 22.97,
-   "decompress_mbps": 161.61
+   "compress_mbps": 22.72,
+   "decompress_mbps": 252.89
   },
   {
    "compressor": "native",
@@ -694,8 +694,8 @@
    "level": 9,
    "out_size": 140322,
    "ratio": 0.3288,
-   "compress_mbps": 4.11,
-   "decompress_mbps": 162.29
+   "compress_mbps": 4.1,
+   "decompress_mbps": 252.69
   },
   {
    "compressor": "native",
@@ -714,8 +714,8 @@
    "level": 1,
    "out_size": 212588,
    "ratio": 0.4412,
-   "compress_mbps": 62.58,
-   "decompress_mbps": 102.07
+   "compress_mbps": 62.85,
+   "decompress_mbps": 172.17
   },
   {
    "compressor": "native",
@@ -724,8 +724,8 @@
    "level": 2,
    "out_size": 199981,
    "ratio": 0.415,
-   "compress_mbps": 44.94,
-   "decompress_mbps": 111.14
+   "compress_mbps": 45.26,
+   "decompress_mbps": 191.67
   },
   {
    "compressor": "native",
@@ -734,8 +734,8 @@
    "level": 3,
    "out_size": 198551,
    "ratio": 0.4121,
-   "compress_mbps": 39.91,
-   "decompress_mbps": 121.45
+   "compress_mbps": 40.02,
+   "decompress_mbps": 211.05
   },
   {
    "compressor": "native",
@@ -744,8 +744,8 @@
    "level": 4,
    "out_size": 193783,
    "ratio": 0.4022,
-   "compress_mbps": 28.81,
-   "decompress_mbps": 125.0
+   "compress_mbps": 28.51,
+   "decompress_mbps": 213.91
   },
   {
    "compressor": "native",
@@ -754,8 +754,8 @@
    "level": 5,
    "out_size": 193223,
    "ratio": 0.401,
-   "compress_mbps": 24.28,
-   "decompress_mbps": 131.96
+   "compress_mbps": 24.02,
+   "decompress_mbps": 212.94
   },
   {
    "compressor": "native",
@@ -764,8 +764,8 @@
    "level": 6,
    "out_size": 193416,
    "ratio": 0.4014,
-   "compress_mbps": 23.72,
-   "decompress_mbps": 135.59
+   "compress_mbps": 23.74,
+   "decompress_mbps": 217.16
   },
   {
    "compressor": "native",
@@ -774,8 +774,8 @@
    "level": 7,
    "out_size": 192664,
    "ratio": 0.3998,
-   "compress_mbps": 20.16,
-   "decompress_mbps": 135.69
+   "compress_mbps": 19.91,
+   "decompress_mbps": 216.97
   },
   {
    "compressor": "native",
@@ -784,8 +784,8 @@
    "level": 8,
    "out_size": 192638,
    "ratio": 0.3998,
-   "compress_mbps": 19.54,
-   "decompress_mbps": 134.78
+   "compress_mbps": 19.38,
+   "decompress_mbps": 217.61
   },
   {
    "compressor": "native",
@@ -794,8 +794,8 @@
    "level": 9,
    "out_size": 189365,
    "ratio": 0.393,
-   "compress_mbps": 3.95,
-   "decompress_mbps": 135.72
+   "compress_mbps": 3.92,
+   "decompress_mbps": 218.0
   },
   {
    "compressor": "native",
@@ -804,7 +804,7 @@
    "level": 10,
    "out_size": 186147,
    "ratio": 0.3863,
-   "compress_mbps": 2.37,
+   "compress_mbps": 2.35,
    "decompress_mbps": null
   },
   {
@@ -814,8 +814,8 @@
    "level": 1,
    "out_size": 60161,
    "ratio": 0.1172,
-   "compress_mbps": 208.98,
-   "decompress_mbps": 346.6
+   "compress_mbps": 208.07,
+   "decompress_mbps": 468.99
   },
   {
    "compressor": "native",
@@ -824,8 +824,8 @@
    "level": 2,
    "out_size": 58873,
    "ratio": 0.1147,
-   "compress_mbps": 154.58,
-   "decompress_mbps": 362.83
+   "compress_mbps": 153.83,
+   "decompress_mbps": 495.69
   },
   {
    "compressor": "native",
@@ -834,8 +834,8 @@
    "level": 3,
    "out_size": 58327,
    "ratio": 0.1137,
-   "compress_mbps": 133.69,
-   "decompress_mbps": 387.14
+   "compress_mbps": 133.39,
+   "decompress_mbps": 536.87
   },
   {
    "compressor": "native",
@@ -844,8 +844,8 @@
    "level": 4,
    "out_size": 55588,
    "ratio": 0.1083,
-   "compress_mbps": 91.04,
-   "decompress_mbps": 359.2
+   "compress_mbps": 89.95,
+   "decompress_mbps": 460.31
   },
   {
    "compressor": "native",
@@ -854,8 +854,8 @@
    "level": 5,
    "out_size": 55097,
    "ratio": 0.1074,
-   "compress_mbps": 68.9,
-   "decompress_mbps": 381.72
+   "compress_mbps": 68.34,
+   "decompress_mbps": 487.01
   },
   {
    "compressor": "native",
@@ -864,8 +864,8 @@
    "level": 6,
    "out_size": 55195,
    "ratio": 0.1075,
-   "compress_mbps": 56.09,
-   "decompress_mbps": 412.47
+   "compress_mbps": 54.99,
+   "decompress_mbps": 530.63
   },
   {
    "compressor": "native",
@@ -874,8 +874,8 @@
    "level": 7,
    "out_size": 54316,
    "ratio": 0.1058,
-   "compress_mbps": 43.78,
-   "decompress_mbps": 434.77
+   "compress_mbps": 43.24,
+   "decompress_mbps": 567.77
   },
   {
    "compressor": "native",
@@ -884,8 +884,8 @@
    "level": 8,
    "out_size": 53091,
    "ratio": 0.1034,
-   "compress_mbps": 35.13,
-   "decompress_mbps": 462.84
+   "compress_mbps": 34.89,
+   "decompress_mbps": 607.53
   },
   {
    "compressor": "native",
@@ -894,8 +894,8 @@
    "level": 9,
    "out_size": 52605,
    "ratio": 0.1025,
-   "compress_mbps": 5.44,
-   "decompress_mbps": 476.99
+   "compress_mbps": 5.53,
+   "decompress_mbps": 621.52
   },
   {
    "compressor": "native",
@@ -904,7 +904,7 @@
    "level": 10,
    "out_size": 52234,
    "ratio": 0.1018,
-   "compress_mbps": 3.56,
+   "compress_mbps": 3.65,
    "decompress_mbps": null
   },
   {
@@ -914,8 +914,8 @@
    "level": 1,
    "out_size": 14249,
    "ratio": 0.3726,
-   "compress_mbps": 51.79,
-   "decompress_mbps": 116.01
+   "compress_mbps": 51.35,
+   "decompress_mbps": 184.88
   },
   {
    "compressor": "native",
@@ -924,8 +924,8 @@
    "level": 2,
    "out_size": 13825,
    "ratio": 0.3615,
-   "compress_mbps": 45.11,
-   "decompress_mbps": 118.34
+   "compress_mbps": 44.68,
+   "decompress_mbps": 189.1
   },
   {
    "compressor": "native",
@@ -934,8 +934,8 @@
    "level": 3,
    "out_size": 13751,
    "ratio": 0.3596,
-   "compress_mbps": 43.29,
-   "decompress_mbps": 120.26
+   "compress_mbps": 42.93,
+   "decompress_mbps": 192.61
   },
   {
    "compressor": "native",
@@ -944,8 +944,8 @@
    "level": 4,
    "out_size": 13287,
    "ratio": 0.3475,
-   "compress_mbps": 38.35,
-   "decompress_mbps": 126.21
+   "compress_mbps": 37.36,
+   "decompress_mbps": 200.51
   },
   {
    "compressor": "native",
@@ -954,8 +954,8 @@
    "level": 5,
    "out_size": 13240,
    "ratio": 0.3462,
-   "compress_mbps": 34.14,
-   "decompress_mbps": 132.78
+   "compress_mbps": 33.28,
+   "decompress_mbps": 208.53
   },
   {
    "compressor": "native",
@@ -964,8 +964,8 @@
    "level": 6,
    "out_size": 12944,
    "ratio": 0.3385,
-   "compress_mbps": 18.75,
-   "decompress_mbps": 135.39
+   "compress_mbps": 18.07,
+   "decompress_mbps": 212.37
   },
   {
    "compressor": "native",
@@ -974,8 +974,8 @@
    "level": 7,
    "out_size": 12929,
    "ratio": 0.3381,
-   "compress_mbps": 17.26,
-   "decompress_mbps": 135.81
+   "compress_mbps": 16.79,
+   "decompress_mbps": 214.17
   },
   {
    "compressor": "native",
@@ -984,8 +984,8 @@
    "level": 8,
    "out_size": 12921,
    "ratio": 0.3379,
-   "compress_mbps": 16.06,
-   "decompress_mbps": 137.89
+   "compress_mbps": 15.66,
+   "decompress_mbps": 217.22
   },
   {
    "compressor": "native",
@@ -994,8 +994,8 @@
    "level": 9,
    "out_size": 12427,
    "ratio": 0.325,
-   "compress_mbps": 5.21,
-   "decompress_mbps": 139.45
+   "compress_mbps": 5.14,
+   "decompress_mbps": 218.41
   },
   {
    "compressor": "native",
@@ -1004,7 +1004,7 @@
    "level": 10,
    "out_size": 12274,
    "ratio": 0.321,
-   "compress_mbps": 2.97,
+   "compress_mbps": 2.98,
    "decompress_mbps": null
   },
   {
@@ -1014,8 +1014,8 @@
    "level": 1,
    "out_size": 1800,
    "ratio": 0.4258,
-   "compress_mbps": 26.11,
-   "decompress_mbps": 58.97
+   "compress_mbps": 25.14,
+   "decompress_mbps": 76.93
   },
   {
    "compressor": "native",
@@ -1024,8 +1024,8 @@
    "level": 2,
    "out_size": 1750,
    "ratio": 0.414,
-   "compress_mbps": 24.54,
-   "decompress_mbps": 59.08
+   "compress_mbps": 23.76,
+   "decompress_mbps": 77.03
   },
   {
    "compressor": "native",
@@ -1034,8 +1034,8 @@
    "level": 3,
    "out_size": 1742,
    "ratio": 0.4121,
-   "compress_mbps": 24.43,
-   "decompress_mbps": 59.58
+   "compress_mbps": 23.73,
+   "decompress_mbps": 77.01
   },
   {
    "compressor": "native",
@@ -1044,8 +1044,8 @@
    "level": 4,
    "out_size": 1726,
    "ratio": 0.4083,
-   "compress_mbps": 23.72,
-   "decompress_mbps": 61.07
+   "compress_mbps": 22.65,
+   "decompress_mbps": 77.78
   },
   {
    "compressor": "native",
@@ -1054,8 +1054,8 @@
    "level": 5,
    "out_size": 1722,
    "ratio": 0.4074,
-   "compress_mbps": 23.28,
-   "decompress_mbps": 61.09
+   "compress_mbps": 22.31,
+   "decompress_mbps": 77.68
   },
   {
    "compressor": "native",
@@ -1064,8 +1064,8 @@
    "level": 6,
    "out_size": 1722,
    "ratio": 0.4074,
-   "compress_mbps": 22.27,
-   "decompress_mbps": 61.3
+   "compress_mbps": 21.37,
+   "decompress_mbps": 77.63
   },
   {
    "compressor": "native",
@@ -1074,8 +1074,8 @@
    "level": 7,
    "out_size": 1722,
    "ratio": 0.4074,
-   "compress_mbps": 22.34,
-   "decompress_mbps": 61.25
+   "compress_mbps": 21.35,
+   "decompress_mbps": 77.68
   },
   {
    "compressor": "native",
@@ -1084,8 +1084,8 @@
    "level": 8,
    "out_size": 1722,
    "ratio": 0.4074,
-   "compress_mbps": 22.34,
-   "decompress_mbps": 61.39
+   "compress_mbps": 21.39,
+   "decompress_mbps": 77.73
   },
   {
    "compressor": "native",
@@ -1094,8 +1094,8 @@
    "level": 9,
    "out_size": 1708,
    "ratio": 0.4041,
-   "compress_mbps": 5.33,
-   "decompress_mbps": 61.51
+   "compress_mbps": 5.18,
+   "decompress_mbps": 77.7
   },
   {
    "compressor": "native",
@@ -1104,7 +1104,7 @@
    "level": 10,
    "out_size": 1693,
    "ratio": 0.4005,
-   "compress_mbps": 3.22,
+   "compress_mbps": 3.13,
    "decompress_mbps": null
   },
   {
@@ -4414,8 +4414,8 @@
    "level": 1,
    "out_size": 4259644,
    "ratio": 0.4179,
-   "compress_mbps": 65.73,
-   "decompress_mbps": 107.54
+   "compress_mbps": 65.32,
+   "decompress_mbps": 177.18
   },
   {
    "compressor": "native",
@@ -4424,8 +4424,8 @@
    "level": 2,
    "out_size": 3977395,
    "ratio": 0.3902,
-   "compress_mbps": 46.67,
-   "decompress_mbps": 116.09
+   "compress_mbps": 47.04,
+   "decompress_mbps": 193.58
   },
   {
    "compressor": "native",
@@ -4434,8 +4434,8 @@
    "level": 3,
    "out_size": 3945296,
    "ratio": 0.3871,
-   "compress_mbps": 41.45,
-   "decompress_mbps": 127.28
+   "compress_mbps": 41.74,
+   "decompress_mbps": 213.68
   },
   {
    "compressor": "native",
@@ -4444,8 +4444,8 @@
    "level": 4,
    "out_size": 3851998,
    "ratio": 0.3779,
-   "compress_mbps": 30.98,
-   "decompress_mbps": 130.09
+   "compress_mbps": 30.45,
+   "decompress_mbps": 214.33
   },
   {
    "compressor": "native",
@@ -4454,8 +4454,8 @@
    "level": 5,
    "out_size": 3840481,
    "ratio": 0.3768,
-   "compress_mbps": 26.02,
-   "decompress_mbps": 135.8
+   "compress_mbps": 25.7,
+   "decompress_mbps": 213.86
   },
   {
    "compressor": "native",
@@ -4464,8 +4464,8 @@
    "level": 6,
    "out_size": 3847941,
    "ratio": 0.3775,
-   "compress_mbps": 25.55,
-   "decompress_mbps": 140.6
+   "compress_mbps": 25.23,
+   "decompress_mbps": 221.03
   },
   {
    "compressor": "native",
@@ -4474,8 +4474,8 @@
    "level": 7,
    "out_size": 3834802,
    "ratio": 0.3762,
-   "compress_mbps": 21.52,
-   "decompress_mbps": 140.92
+   "compress_mbps": 21.39,
+   "decompress_mbps": 219.03
   },
   {
    "compressor": "native",
@@ -4484,8 +4484,8 @@
    "level": 8,
    "out_size": 3833946,
    "ratio": 0.3762,
-   "compress_mbps": 20.95,
-   "decompress_mbps": 141.74
+   "compress_mbps": 20.75,
+   "decompress_mbps": 221.16
   },
   {
    "compressor": "native",
@@ -4494,8 +4494,8 @@
    "level": 9,
    "out_size": 3766584,
    "ratio": 0.3695,
-   "compress_mbps": 4.06,
-   "decompress_mbps": 144.99
+   "compress_mbps": 3.99,
+   "decompress_mbps": 230.18
   },
   {
    "compressor": "native",
@@ -4504,7 +4504,7 @@
    "level": 10,
    "out_size": 3711172,
    "ratio": 0.3641,
-   "compress_mbps": 2.38,
+   "compress_mbps": 2.36,
    "decompress_mbps": null
   },
   {
@@ -4514,8 +4514,8 @@
    "level": 1,
    "out_size": 21267086,
    "ratio": 0.4152,
-   "compress_mbps": 80.38,
-   "decompress_mbps": 135.47
+   "compress_mbps": 80.43,
+   "decompress_mbps": 190.58
   },
   {
    "compressor": "native",
@@ -4524,8 +4524,8 @@
    "level": 2,
    "out_size": 20802983,
    "ratio": 0.4061,
-   "compress_mbps": 63.32,
-   "decompress_mbps": 142.45
+   "compress_mbps": 63.45,
+   "decompress_mbps": 200.95
   },
   {
    "compressor": "native",
@@ -4534,58 +4534,58 @@
    "level": 3,
    "out_size": 20665485,
    "ratio": 0.4035,
-   "compress_mbps": 59.14,
-   "decompress_mbps": 146.48
+   "compress_mbps": 59.41,
+   "decompress_mbps": 204.21
   },
   {
    "compressor": "native",
    "pattern": "silesia/mozilla",
    "size": 51220480,
    "level": 4,
-   "out_size": 20356893,
-   "ratio": 0.3974,
-   "compress_mbps": 48.18,
-   "decompress_mbps": 151.15
+   "out_size": 20367639,
+   "ratio": 0.3976,
+   "compress_mbps": 49.33,
+   "decompress_mbps": 206.73
   },
   {
    "compressor": "native",
    "pattern": "silesia/mozilla",
    "size": 51220480,
    "level": 5,
-   "out_size": 20209289,
-   "ratio": 0.3946,
-   "compress_mbps": 38.38,
-   "decompress_mbps": 159.0
+   "out_size": 20220490,
+   "ratio": 0.3948,
+   "compress_mbps": 38.73,
+   "decompress_mbps": 219.4
   },
   {
    "compressor": "native",
    "pattern": "silesia/mozilla",
    "size": 51220480,
    "level": 6,
-   "out_size": 19174181,
-   "ratio": 0.3743,
-   "compress_mbps": 25.63,
-   "decompress_mbps": 165.27
+   "out_size": 19183133,
+   "ratio": 0.3745,
+   "compress_mbps": 25.21,
+   "decompress_mbps": 225.05
   },
   {
    "compressor": "native",
    "pattern": "silesia/mozilla",
    "size": 51220480,
    "level": 7,
-   "out_size": 19127630,
-   "ratio": 0.3734,
-   "compress_mbps": 21.26,
-   "decompress_mbps": 165.51
+   "out_size": 19136744,
+   "ratio": 0.3736,
+   "compress_mbps": 21.13,
+   "decompress_mbps": 224.39
   },
   {
    "compressor": "native",
    "pattern": "silesia/mozilla",
    "size": 51220480,
    "level": 8,
-   "out_size": 19117840,
-   "ratio": 0.3732,
-   "compress_mbps": 18.37,
-   "decompress_mbps": 166.63
+   "out_size": 19126715,
+   "ratio": 0.3734,
+   "compress_mbps": 18.42,
+   "decompress_mbps": 226.53
   },
   {
    "compressor": "native",
@@ -4594,8 +4594,8 @@
    "level": 9,
    "out_size": 18686872,
    "ratio": 0.3648,
-   "compress_mbps": 4.25,
-   "decompress_mbps": 161.25
+   "compress_mbps": 4.15,
+   "decompress_mbps": 221.76
   },
   {
    "compressor": "native",
@@ -4604,7 +4604,7 @@
    "level": 10,
    "out_size": 18539905,
    "ratio": 0.362,
-   "compress_mbps": 2.26,
+   "compress_mbps": 2.28,
    "decompress_mbps": null
   },
   {
@@ -4614,8 +4614,8 @@
    "level": 1,
    "out_size": 3864163,
    "ratio": 0.3876,
-   "compress_mbps": 79.76,
-   "decompress_mbps": 124.13
+   "compress_mbps": 79.71,
+   "decompress_mbps": 203.05
   },
   {
    "compressor": "native",
@@ -4624,8 +4624,8 @@
    "level": 2,
    "out_size": 3734957,
    "ratio": 0.3746,
-   "compress_mbps": 61.5,
-   "decompress_mbps": 131.08
+   "compress_mbps": 61.48,
+   "decompress_mbps": 217.94
   },
   {
    "compressor": "native",
@@ -4634,58 +4634,58 @@
    "level": 3,
    "out_size": 3708443,
    "ratio": 0.3719,
-   "compress_mbps": 52.34,
-   "decompress_mbps": 140.16
+   "compress_mbps": 53.09,
+   "decompress_mbps": 236.68
   },
   {
    "compressor": "native",
    "pattern": "silesia/mr",
    "size": 9970564,
    "level": 4,
-   "out_size": 3683603,
-   "ratio": 0.3694,
-   "compress_mbps": 36.72,
-   "decompress_mbps": 134.43
+   "out_size": 3683727,
+   "ratio": 0.3695,
+   "compress_mbps": 36.4,
+   "decompress_mbps": 210.56
   },
   {
    "compressor": "native",
    "pattern": "silesia/mr",
    "size": 9970564,
    "level": 5,
-   "out_size": 3677014,
+   "out_size": 3677138,
    "ratio": 0.3688,
-   "compress_mbps": 29.81,
-   "decompress_mbps": 140.38
+   "compress_mbps": 29.77,
+   "decompress_mbps": 206.12
   },
   {
    "compressor": "native",
    "pattern": "silesia/mr",
    "size": 9970564,
    "level": 6,
-   "out_size": 3588221,
+   "out_size": 3588298,
    "ratio": 0.3599,
-   "compress_mbps": 27.0,
-   "decompress_mbps": 146.58
+   "compress_mbps": 26.4,
+   "decompress_mbps": 214.05
   },
   {
    "compressor": "native",
    "pattern": "silesia/mr",
    "size": 9970564,
    "level": 7,
-   "out_size": 3581006,
+   "out_size": 3581864,
    "ratio": 0.3592,
-   "compress_mbps": 21.8,
-   "decompress_mbps": 147.02
+   "compress_mbps": 21.66,
+   "decompress_mbps": 212.36
   },
   {
    "compressor": "native",
    "pattern": "silesia/mr",
    "size": 9970564,
    "level": 8,
-   "out_size": 3580944,
+   "out_size": 3581236,
    "ratio": 0.3592,
-   "compress_mbps": 19.91,
-   "decompress_mbps": 150.08
+   "compress_mbps": 19.75,
+   "decompress_mbps": 220.97
   },
   {
    "compressor": "native",
@@ -4694,8 +4694,8 @@
    "level": 9,
    "out_size": 3581441,
    "ratio": 0.3592,
-   "compress_mbps": 4.55,
-   "decompress_mbps": 154.65
+   "compress_mbps": 4.48,
+   "decompress_mbps": 228.66
   },
   {
    "compressor": "native",
@@ -4704,7 +4704,7 @@
    "level": 10,
    "out_size": 3512886,
    "ratio": 0.3523,
-   "compress_mbps": 2.78,
+   "compress_mbps": 2.77,
    "decompress_mbps": null
   },
   {
@@ -4714,8 +4714,8 @@
    "level": 1,
    "out_size": 3785443,
    "ratio": 0.1128,
-   "compress_mbps": 234.11,
-   "decompress_mbps": 372.04
+   "compress_mbps": 234.01,
+   "decompress_mbps": 604.69
   },
   {
    "compressor": "native",
@@ -4724,8 +4724,8 @@
    "level": 2,
    "out_size": 3761560,
    "ratio": 0.1121,
-   "compress_mbps": 146.21,
-   "decompress_mbps": 410.98
+   "compress_mbps": 148.63,
+   "decompress_mbps": 677.76
   },
   {
    "compressor": "native",
@@ -4734,8 +4734,8 @@
    "level": 3,
    "out_size": 3606997,
    "ratio": 0.1075,
-   "compress_mbps": 124.66,
-   "decompress_mbps": 465.52
+   "compress_mbps": 126.84,
+   "decompress_mbps": 751.41
   },
   {
    "compressor": "native",
@@ -4744,8 +4744,8 @@
    "level": 4,
    "out_size": 3201209,
    "ratio": 0.0954,
-   "compress_mbps": 96.66,
-   "decompress_mbps": 475.53
+   "compress_mbps": 96.74,
+   "decompress_mbps": 743.78
   },
   {
    "compressor": "native",
@@ -4754,8 +4754,8 @@
    "level": 5,
    "out_size": 3091564,
    "ratio": 0.0921,
-   "compress_mbps": 73.61,
-   "decompress_mbps": 540.1
+   "compress_mbps": 73.37,
+   "decompress_mbps": 832.59
   },
   {
    "compressor": "native",
@@ -4764,8 +4764,8 @@
    "level": 6,
    "out_size": 3112756,
    "ratio": 0.0928,
-   "compress_mbps": 71.65,
-   "decompress_mbps": 578.84
+   "compress_mbps": 70.26,
+   "decompress_mbps": 887.68
   },
   {
    "compressor": "native",
@@ -4774,8 +4774,8 @@
    "level": 7,
    "out_size": 3062314,
    "ratio": 0.0913,
-   "compress_mbps": 55.14,
-   "decompress_mbps": 592.23
+   "compress_mbps": 54.53,
+   "decompress_mbps": 894.31
   },
   {
    "compressor": "native",
@@ -4784,8 +4784,8 @@
    "level": 8,
    "out_size": 3045348,
    "ratio": 0.0908,
-   "compress_mbps": 46.42,
-   "decompress_mbps": 614.04
+   "compress_mbps": 46.1,
+   "decompress_mbps": 903.68
   },
   {
    "compressor": "native",
@@ -4794,8 +4794,8 @@
    "level": 9,
    "out_size": 3031645,
    "ratio": 0.0904,
-   "compress_mbps": 3.21,
-   "decompress_mbps": 605.23
+   "compress_mbps": 3.24,
+   "decompress_mbps": 912.26
   },
   {
    "compressor": "native",
@@ -4814,8 +4814,8 @@
    "level": 1,
    "out_size": 3357083,
    "ratio": 0.5457,
-   "compress_mbps": 56.4,
-   "decompress_mbps": 93.49
+   "compress_mbps": 56.95,
+   "decompress_mbps": 129.96
   },
   {
    "compressor": "native",
@@ -4824,8 +4824,8 @@
    "level": 2,
    "out_size": 3285077,
    "ratio": 0.534,
-   "compress_mbps": 46.56,
-   "decompress_mbps": 94.83
+   "compress_mbps": 46.72,
+   "decompress_mbps": 136.01
   },
   {
    "compressor": "native",
@@ -4834,58 +4834,58 @@
    "level": 3,
    "out_size": 3272746,
    "ratio": 0.532,
-   "compress_mbps": 44.71,
-   "decompress_mbps": 98.56
+   "compress_mbps": 44.34,
+   "decompress_mbps": 136.9
   },
   {
    "compressor": "native",
    "pattern": "silesia/ooffice",
    "size": 6152192,
    "level": 4,
-   "out_size": 3228052,
-   "ratio": 0.5247,
-   "compress_mbps": 37.15,
-   "decompress_mbps": 108.17
+   "out_size": 3228689,
+   "ratio": 0.5248,
+   "compress_mbps": 36.43,
+   "decompress_mbps": 144.84
   },
   {
    "compressor": "native",
    "pattern": "silesia/ooffice",
    "size": 6152192,
    "level": 5,
-   "out_size": 3223415,
-   "ratio": 0.5239,
-   "compress_mbps": 33.83,
-   "decompress_mbps": 110.86
+   "out_size": 3224055,
+   "ratio": 0.524,
+   "compress_mbps": 33.07,
+   "decompress_mbps": 154.84
   },
   {
    "compressor": "native",
    "pattern": "silesia/ooffice",
    "size": 6152192,
    "level": 6,
-   "out_size": 3159522,
+   "out_size": 3159810,
    "ratio": 0.5136,
-   "compress_mbps": 23.21,
-   "decompress_mbps": 112.09
+   "compress_mbps": 22.78,
+   "decompress_mbps": 152.39
   },
   {
    "compressor": "native",
    "pattern": "silesia/ooffice",
    "size": 6152192,
    "level": 7,
-   "out_size": 3156358,
-   "ratio": 0.513,
-   "compress_mbps": 21.57,
-   "decompress_mbps": 111.99
+   "out_size": 3156775,
+   "ratio": 0.5131,
+   "compress_mbps": 21.2,
+   "decompress_mbps": 153.11
   },
   {
    "compressor": "native",
    "pattern": "silesia/ooffice",
    "size": 6152192,
    "level": 8,
-   "out_size": 3155368,
+   "out_size": 3155625,
    "ratio": 0.5129,
-   "compress_mbps": 20.8,
-   "decompress_mbps": 113.28
+   "compress_mbps": 20.52,
+   "decompress_mbps": 154.51
   },
   {
    "compressor": "native",
@@ -4894,8 +4894,8 @@
    "level": 9,
    "out_size": 3048772,
    "ratio": 0.4956,
-   "compress_mbps": 4.98,
-   "decompress_mbps": 115.07
+   "compress_mbps": 4.95,
+   "decompress_mbps": 158.06
   },
   {
    "compressor": "native",
@@ -4904,7 +4904,7 @@
    "level": 10,
    "out_size": 3021986,
    "ratio": 0.4912,
-   "compress_mbps": 3.09,
+   "compress_mbps": 3.05,
    "decompress_mbps": null
   },
   {
@@ -4914,8 +4914,8 @@
    "level": 1,
    "out_size": 3838828,
    "ratio": 0.3806,
-   "compress_mbps": 88.47,
-   "decompress_mbps": 160.86
+   "compress_mbps": 90.15,
+   "decompress_mbps": 230.98
   },
   {
    "compressor": "native",
@@ -4924,8 +4924,8 @@
    "level": 2,
    "out_size": 3792520,
    "ratio": 0.376,
-   "compress_mbps": 66.75,
-   "decompress_mbps": 166.63
+   "compress_mbps": 66.3,
+   "decompress_mbps": 238.76
   },
   {
    "compressor": "native",
@@ -4934,8 +4934,8 @@
    "level": 3,
    "out_size": 3783171,
    "ratio": 0.3751,
-   "compress_mbps": 63.96,
-   "decompress_mbps": 170.67
+   "compress_mbps": 63.8,
+   "decompress_mbps": 232.5
   },
   {
    "compressor": "native",
@@ -4944,58 +4944,58 @@
    "level": 4,
    "out_size": 3648458,
    "ratio": 0.3617,
-   "compress_mbps": 56.97,
-   "decompress_mbps": 182.82
+   "compress_mbps": 55.64,
+   "decompress_mbps": 255.29
   },
   {
    "compressor": "native",
    "pattern": "silesia/osdb",
    "size": 10085684,
    "level": 5,
-   "out_size": 3648472,
+   "out_size": 3648473,
    "ratio": 0.3617,
-   "compress_mbps": 52.59,
-   "decompress_mbps": 189.69
+   "compress_mbps": 52.04,
+   "decompress_mbps": 245.95
   },
   {
    "compressor": "native",
    "pattern": "silesia/osdb",
    "size": 10085684,
    "level": 6,
-   "out_size": 3648595,
+   "out_size": 3648596,
    "ratio": 0.3618,
-   "compress_mbps": 41.82,
-   "decompress_mbps": 199.79
+   "compress_mbps": 40.67,
+   "decompress_mbps": 255.39
   },
   {
    "compressor": "native",
    "pattern": "silesia/osdb",
    "size": 10085684,
    "level": 7,
-   "out_size": 3648160,
+   "out_size": 3648161,
    "ratio": 0.3617,
-   "compress_mbps": 41.43,
-   "decompress_mbps": 201.85
+   "compress_mbps": 40.98,
+   "decompress_mbps": 258.89
   },
   {
    "compressor": "native",
    "pattern": "silesia/osdb",
    "size": 10085684,
    "level": 8,
-   "out_size": 3648156,
+   "out_size": 3648157,
    "ratio": 0.3617,
-   "compress_mbps": 41.62,
-   "decompress_mbps": 200.56
+   "compress_mbps": 41.01,
+   "decompress_mbps": 259.78
   },
   {
    "compressor": "native",
    "pattern": "silesia/osdb",
    "size": 10085684,
    "level": 9,
-   "out_size": 3648156,
+   "out_size": 3648157,
    "ratio": 0.3617,
-   "compress_mbps": 5.79,
-   "decompress_mbps": 198.5
+   "compress_mbps": 5.6,
+   "decompress_mbps": 268.53
   },
   {
    "compressor": "native",
@@ -5004,7 +5004,7 @@
    "level": 10,
    "out_size": 3647321,
    "ratio": 0.3616,
-   "compress_mbps": 3.29,
+   "compress_mbps": 3.27,
    "decompress_mbps": null
   },
   {
@@ -5014,8 +5014,8 @@
    "level": 1,
    "out_size": 2254442,
    "ratio": 0.3402,
-   "compress_mbps": 82.84,
-   "decompress_mbps": 130.08
+   "compress_mbps": 84.04,
+   "decompress_mbps": 224.32
   },
   {
    "compressor": "native",
@@ -5024,8 +5024,8 @@
    "level": 2,
    "out_size": 2044843,
    "ratio": 0.3086,
-   "compress_mbps": 55.83,
-   "decompress_mbps": 145.2
+   "compress_mbps": 56.5,
+   "decompress_mbps": 236.84
   },
   {
    "compressor": "native",
@@ -5034,58 +5034,58 @@
    "level": 3,
    "out_size": 1992105,
    "ratio": 0.3006,
-   "compress_mbps": 46.14,
-   "decompress_mbps": 158.84
+   "compress_mbps": 45.88,
+   "decompress_mbps": 257.65
   },
   {
    "compressor": "native",
    "pattern": "silesia/reymont",
    "size": 6627202,
    "level": 4,
-   "out_size": 1890729,
+   "out_size": 1890828,
    "ratio": 0.2853,
-   "compress_mbps": 31.46,
-   "decompress_mbps": 162.57
+   "compress_mbps": 31.52,
+   "decompress_mbps": 265.04
   },
   {
    "compressor": "native",
    "pattern": "silesia/reymont",
    "size": 6627202,
    "level": 5,
-   "out_size": 1858234,
+   "out_size": 1858300,
    "ratio": 0.2804,
-   "compress_mbps": 20.67,
-   "decompress_mbps": 172.3
+   "compress_mbps": 20.83,
+   "decompress_mbps": 265.07
   },
   {
    "compressor": "native",
    "pattern": "silesia/reymont",
    "size": 6627202,
    "level": 6,
-   "out_size": 1856235,
+   "out_size": 1856302,
    "ratio": 0.2801,
-   "compress_mbps": 24.67,
-   "decompress_mbps": 186.06
+   "compress_mbps": 24.42,
+   "decompress_mbps": 279.98
   },
   {
    "compressor": "native",
    "pattern": "silesia/reymont",
    "size": 6627202,
    "level": 7,
-   "out_size": 1823963,
+   "out_size": 1824003,
    "ratio": 0.2752,
-   "compress_mbps": 16.04,
-   "decompress_mbps": 189.33
+   "compress_mbps": 15.97,
+   "decompress_mbps": 282.75
   },
   {
    "compressor": "native",
    "pattern": "silesia/reymont",
    "size": 6627202,
    "level": 8,
-   "out_size": 1820112,
+   "out_size": 1820159,
    "ratio": 0.2746,
-   "compress_mbps": 14.03,
-   "decompress_mbps": 190.34
+   "compress_mbps": 13.98,
+   "decompress_mbps": 283.21
   },
   {
    "compressor": "native",
@@ -5094,8 +5094,8 @@
    "level": 9,
    "out_size": 1773447,
    "ratio": 0.2676,
-   "compress_mbps": 2.86,
-   "decompress_mbps": 197.31
+   "compress_mbps": 2.81,
+   "decompress_mbps": 297.31
   },
   {
    "compressor": "native",
@@ -5104,7 +5104,7 @@
    "level": 10,
    "out_size": 1718500,
    "ratio": 0.2593,
-   "compress_mbps": 1.55,
+   "compress_mbps": 1.53,
    "decompress_mbps": null
   },
   {
@@ -5114,8 +5114,8 @@
    "level": 1,
    "out_size": 6406301,
    "ratio": 0.2965,
-   "compress_mbps": 110.39,
-   "decompress_mbps": 200.51
+   "compress_mbps": 111.1,
+   "decompress_mbps": 296.83
   },
   {
    "compressor": "native",
@@ -5124,8 +5124,8 @@
    "level": 2,
    "out_size": 6102377,
    "ratio": 0.2824,
-   "compress_mbps": 81.39,
-   "decompress_mbps": 212.19
+   "compress_mbps": 81.06,
+   "decompress_mbps": 315.34
   },
   {
    "compressor": "native",
@@ -5134,58 +5134,58 @@
    "level": 3,
    "out_size": 6022184,
    "ratio": 0.2787,
-   "compress_mbps": 73.12,
-   "decompress_mbps": 222.28
+   "compress_mbps": 73.42,
+   "decompress_mbps": 326.93
   },
   {
    "compressor": "native",
    "pattern": "silesia/samba",
    "size": 21606400,
    "level": 4,
-   "out_size": 5880892,
-   "ratio": 0.2722,
-   "compress_mbps": 57.01,
-   "decompress_mbps": 231.19
+   "out_size": 5886335,
+   "ratio": 0.2724,
+   "compress_mbps": 59.61,
+   "decompress_mbps": 336.97
   },
   {
    "compressor": "native",
    "pattern": "silesia/samba",
    "size": 21606400,
    "level": 5,
-   "out_size": 5834363,
-   "ratio": 0.27,
-   "compress_mbps": 45.09,
-   "decompress_mbps": 242.83
+   "out_size": 5839584,
+   "ratio": 0.2703,
+   "compress_mbps": 46.13,
+   "decompress_mbps": 344.78
   },
   {
    "compressor": "native",
    "pattern": "silesia/samba",
    "size": 21606400,
    "level": 6,
-   "out_size": 5409792,
-   "ratio": 0.2504,
-   "compress_mbps": 37.4,
-   "decompress_mbps": 248.71
+   "out_size": 5413769,
+   "ratio": 0.2506,
+   "compress_mbps": 37.76,
+   "decompress_mbps": 351.91
   },
   {
    "compressor": "native",
    "pattern": "silesia/samba",
    "size": 21606400,
    "level": 7,
-   "out_size": 5393735,
-   "ratio": 0.2496,
-   "compress_mbps": 31.81,
-   "decompress_mbps": 250.51
+   "out_size": 5397319,
+   "ratio": 0.2498,
+   "compress_mbps": 32.55,
+   "decompress_mbps": 354.85
   },
   {
    "compressor": "native",
    "pattern": "silesia/samba",
    "size": 21606400,
    "level": 8,
-   "out_size": 5389952,
-   "ratio": 0.2495,
-   "compress_mbps": 30.01,
-   "decompress_mbps": 253.09
+   "out_size": 5393817,
+   "ratio": 0.2496,
+   "compress_mbps": 30.32,
+   "decompress_mbps": 357.83
   },
   {
    "compressor": "native",
@@ -5194,8 +5194,8 @@
    "level": 9,
    "out_size": 5235865,
    "ratio": 0.2423,
-   "compress_mbps": 4.6,
-   "decompress_mbps": 252.44
+   "compress_mbps": 4.57,
+   "decompress_mbps": 358.15
   },
   {
    "compressor": "native",
@@ -5204,7 +5204,7 @@
    "level": 10,
    "out_size": 5177560,
    "ratio": 0.2396,
-   "compress_mbps": 2.49,
+   "compress_mbps": 2.5,
    "decompress_mbps": null
   },
   {
@@ -5214,8 +5214,8 @@
    "level": 1,
    "out_size": 5612204,
    "ratio": 0.7739,
-   "compress_mbps": 47.33,
-   "decompress_mbps": 94.3
+   "compress_mbps": 46.69,
+   "decompress_mbps": 129.04
   },
   {
    "compressor": "native",
@@ -5224,8 +5224,8 @@
    "level": 2,
    "out_size": 5533875,
    "ratio": 0.7631,
-   "compress_mbps": 39.46,
-   "decompress_mbps": 96.77
+   "compress_mbps": 39.57,
+   "decompress_mbps": 132.53
   },
   {
    "compressor": "native",
@@ -5234,8 +5234,8 @@
    "level": 3,
    "out_size": 5522436,
    "ratio": 0.7615,
-   "compress_mbps": 37.4,
-   "decompress_mbps": 99.69
+   "compress_mbps": 36.55,
+   "decompress_mbps": 135.43
   },
   {
    "compressor": "native",
@@ -5244,8 +5244,8 @@
    "level": 4,
    "out_size": 5494383,
    "ratio": 0.7576,
-   "compress_mbps": 31.44,
-   "decompress_mbps": 102.46
+   "compress_mbps": 30.14,
+   "decompress_mbps": 139.21
   },
   {
    "compressor": "native",
@@ -5254,8 +5254,8 @@
    "level": 5,
    "out_size": 5489807,
    "ratio": 0.757,
-   "compress_mbps": 29.54,
-   "decompress_mbps": 103.94
+   "compress_mbps": 28.67,
+   "decompress_mbps": 138.41
   },
   {
    "compressor": "native",
@@ -5264,8 +5264,8 @@
    "level": 6,
    "out_size": 5470520,
    "ratio": 0.7544,
-   "compress_mbps": 21.92,
-   "decompress_mbps": 106.37
+   "compress_mbps": 21.36,
+   "decompress_mbps": 137.96
   },
   {
    "compressor": "native",
@@ -5274,8 +5274,8 @@
    "level": 7,
    "out_size": 5463682,
    "ratio": 0.7534,
-   "compress_mbps": 20.89,
-   "decompress_mbps": 107.97
+   "compress_mbps": 20.41,
+   "decompress_mbps": 138.14
   },
   {
    "compressor": "native",
@@ -5284,8 +5284,8 @@
    "level": 8,
    "out_size": 5463761,
    "ratio": 0.7534,
-   "compress_mbps": 20.65,
-   "decompress_mbps": 107.41
+   "compress_mbps": 20.34,
+   "decompress_mbps": 139.21
   },
   {
    "compressor": "native",
@@ -5294,8 +5294,8 @@
    "level": 9,
    "out_size": 5284536,
    "ratio": 0.7287,
-   "compress_mbps": 4.87,
-   "decompress_mbps": 106.54
+   "compress_mbps": 4.79,
+   "decompress_mbps": 141.66
   },
   {
    "compressor": "native",
@@ -5304,7 +5304,7 @@
    "level": 10,
    "out_size": 5262319,
    "ratio": 0.7256,
-   "compress_mbps": 3.49,
+   "compress_mbps": 3.47,
    "decompress_mbps": null
   },
   {
@@ -5314,8 +5314,8 @@
    "level": 1,
    "out_size": 13727247,
    "ratio": 0.3311,
-   "compress_mbps": 83.39,
-   "decompress_mbps": 141.17
+   "compress_mbps": 83.51,
+   "decompress_mbps": 225.94
   },
   {
    "compressor": "native",
@@ -5324,8 +5324,8 @@
    "level": 2,
    "out_size": 12940398,
    "ratio": 0.3121,
-   "compress_mbps": 61.28,
-   "decompress_mbps": 152.55
+   "compress_mbps": 61.43,
+   "decompress_mbps": 236.52
   },
   {
    "compressor": "native",
@@ -5334,58 +5334,58 @@
    "level": 3,
    "out_size": 12703756,
    "ratio": 0.3064,
-   "compress_mbps": 56.17,
-   "decompress_mbps": 163.9
+   "compress_mbps": 55.92,
+   "decompress_mbps": 263.52
   },
   {
    "compressor": "native",
    "pattern": "silesia/webster",
    "size": 41458703,
    "level": 4,
-   "out_size": 12177338,
+   "out_size": 12177346,
    "ratio": 0.2937,
-   "compress_mbps": 42.5,
-   "decompress_mbps": 170.57
+   "compress_mbps": 42.34,
+   "decompress_mbps": 268.82
   },
   {
    "compressor": "native",
    "pattern": "silesia/webster",
    "size": 41458703,
    "level": 5,
-   "out_size": 12051075,
+   "out_size": 12051082,
    "ratio": 0.2907,
-   "compress_mbps": 33.08,
-   "decompress_mbps": 179.94
+   "compress_mbps": 32.81,
+   "decompress_mbps": 273.27
   },
   {
    "compressor": "native",
    "pattern": "silesia/webster",
    "size": 41458703,
    "level": 6,
-   "out_size": 12103573,
+   "out_size": 12103580,
    "ratio": 0.2919,
-   "compress_mbps": 33.64,
-   "decompress_mbps": 184.45
+   "compress_mbps": 33.07,
+   "decompress_mbps": 280.14
   },
   {
    "compressor": "native",
    "pattern": "silesia/webster",
    "size": 41458703,
    "level": 7,
-   "out_size": 12027976,
+   "out_size": 12027983,
    "ratio": 0.2901,
-   "compress_mbps": 26.81,
-   "decompress_mbps": 186.11
+   "compress_mbps": 26.68,
+   "decompress_mbps": 280.29
   },
   {
    "compressor": "native",
    "pattern": "silesia/webster",
    "size": 41458703,
    "level": 8,
-   "out_size": 12019953,
+   "out_size": 12019961,
    "ratio": 0.2899,
-   "compress_mbps": 25.6,
-   "decompress_mbps": 187.69
+   "compress_mbps": 25.29,
+   "decompress_mbps": 281.92
   },
   {
    "compressor": "native",
@@ -5394,8 +5394,8 @@
    "level": 9,
    "out_size": 11806466,
    "ratio": 0.2848,
-   "compress_mbps": 3.78,
-   "decompress_mbps": 187.17
+   "compress_mbps": 3.69,
+   "decompress_mbps": 281.68
   },
   {
    "compressor": "native",
@@ -5414,8 +5414,8 @@
    "level": 1,
    "out_size": 6438176,
    "ratio": 0.7597,
-   "compress_mbps": 43.32,
-   "decompress_mbps": 79.16
+   "compress_mbps": 43.14,
+   "decompress_mbps": 125.24
   },
   {
    "compressor": "native",
@@ -5424,8 +5424,8 @@
    "level": 2,
    "out_size": 6392101,
    "ratio": 0.7543,
-   "compress_mbps": 41.08,
-   "decompress_mbps": 79.98
+   "compress_mbps": 41.56,
+   "decompress_mbps": 126.89
   },
   {
    "compressor": "native",
@@ -5434,58 +5434,58 @@
    "level": 3,
    "out_size": 6392124,
    "ratio": 0.7543,
-   "compress_mbps": 41.34,
-   "decompress_mbps": 81.63
+   "compress_mbps": 41.48,
+   "decompress_mbps": 128.13
   },
   {
    "compressor": "native",
    "pattern": "silesia/x-ray",
    "size": 8474240,
    "level": 4,
-   "out_size": 6360604,
-   "ratio": 0.7506,
-   "compress_mbps": 38.63,
-   "decompress_mbps": 81.26
+   "out_size": 6366768,
+   "ratio": 0.7513,
+   "compress_mbps": 36.97,
+   "decompress_mbps": 115.37
   },
   {
    "compressor": "native",
    "pattern": "silesia/x-ray",
    "size": 8474240,
    "level": 5,
-   "out_size": 6360567,
-   "ratio": 0.7506,
-   "compress_mbps": 38.55,
-   "decompress_mbps": 83.83
+   "out_size": 6366731,
+   "ratio": 0.7513,
+   "compress_mbps": 37.21,
+   "decompress_mbps": 118.15
   },
   {
    "compressor": "native",
    "pattern": "silesia/x-ray",
    "size": 8474240,
    "level": 6,
-   "out_size": 6271453,
-   "ratio": 0.7401,
-   "compress_mbps": 16.44,
-   "decompress_mbps": 84.5
+   "out_size": 6277685,
+   "ratio": 0.7408,
+   "compress_mbps": 15.59,
+   "decompress_mbps": 119.42
   },
   {
    "compressor": "native",
    "pattern": "silesia/x-ray",
    "size": 8474240,
    "level": 7,
-   "out_size": 6271447,
-   "ratio": 0.7401,
-   "compress_mbps": 16.34,
-   "decompress_mbps": 84.67
+   "out_size": 6277678,
+   "ratio": 0.7408,
+   "compress_mbps": 15.63,
+   "decompress_mbps": 118.89
   },
   {
    "compressor": "native",
    "pattern": "silesia/x-ray",
    "size": 8474240,
    "level": 8,
-   "out_size": 6271447,
-   "ratio": 0.7401,
-   "compress_mbps": 16.36,
-   "decompress_mbps": 84.23
+   "out_size": 6277678,
+   "ratio": 0.7408,
+   "compress_mbps": 15.53,
+   "decompress_mbps": 118.63
   },
   {
    "compressor": "native",
@@ -5494,8 +5494,8 @@
    "level": 9,
    "out_size": 5952505,
    "ratio": 0.7024,
-   "compress_mbps": 5.88,
-   "decompress_mbps": 84.62
+   "compress_mbps": 5.69,
+   "decompress_mbps": 120.51
   },
   {
    "compressor": "native",
@@ -5504,7 +5504,7 @@
    "level": 10,
    "out_size": 5848663,
    "ratio": 0.6902,
-   "compress_mbps": 4.26,
+   "compress_mbps": 4.21,
    "decompress_mbps": null
   },
   {
@@ -5514,8 +5514,8 @@
    "level": 1,
    "out_size": 858525,
    "ratio": 0.1606,
-   "compress_mbps": 176.39,
-   "decompress_mbps": 275.45
+   "compress_mbps": 177.91,
+   "decompress_mbps": 425.73
   },
   {
    "compressor": "native",
@@ -5524,8 +5524,8 @@
    "level": 2,
    "out_size": 846807,
    "ratio": 0.1584,
-   "compress_mbps": 112.93,
-   "decompress_mbps": 310.55
+   "compress_mbps": 113.75,
+   "decompress_mbps": 508.73
   },
   {
    "compressor": "native",
@@ -5534,58 +5534,58 @@
    "level": 3,
    "out_size": 806798,
    "ratio": 0.1509,
-   "compress_mbps": 103.4,
-   "decompress_mbps": 362.94
+   "compress_mbps": 103.52,
+   "decompress_mbps": 567.04
   },
   {
    "compressor": "native",
    "pattern": "silesia/xml",
    "size": 5345280,
    "level": 4,
-   "out_size": 717301,
+   "out_size": 717298,
    "ratio": 0.1342,
-   "compress_mbps": 77.54,
-   "decompress_mbps": 343.54
+   "compress_mbps": 77.21,
+   "decompress_mbps": 556.91
   },
   {
    "compressor": "native",
    "pattern": "silesia/xml",
    "size": 5345280,
    "level": 5,
-   "out_size": 701552,
+   "out_size": 701558,
    "ratio": 0.1312,
-   "compress_mbps": 61.53,
-   "decompress_mbps": 399.92
+   "compress_mbps": 61.08,
+   "decompress_mbps": 606.62
   },
   {
    "compressor": "native",
    "pattern": "silesia/xml",
    "size": 5345280,
    "level": 6,
-   "out_size": 678544,
+   "out_size": 678541,
    "ratio": 0.1269,
-   "compress_mbps": 57.56,
-   "decompress_mbps": 415.92
+   "compress_mbps": 56.88,
+   "decompress_mbps": 652.72
   },
   {
    "compressor": "native",
    "pattern": "silesia/xml",
    "size": 5345280,
    "level": 7,
-   "out_size": 663716,
+   "out_size": 663771,
    "ratio": 0.1242,
-   "compress_mbps": 46.76,
-   "decompress_mbps": 444.35
+   "compress_mbps": 46.18,
+   "decompress_mbps": 666.42
   },
   {
    "compressor": "native",
    "pattern": "silesia/xml",
    "size": 5345280,
    "level": 8,
-   "out_size": 660481,
+   "out_size": 660479,
    "ratio": 0.1236,
-   "compress_mbps": 41.64,
-   "decompress_mbps": 431.85
+   "compress_mbps": 41.2,
+   "decompress_mbps": 669.51
   },
   {
    "compressor": "native",
@@ -5594,8 +5594,8 @@
    "level": 9,
    "out_size": 659417,
    "ratio": 0.1234,
-   "compress_mbps": 4.31,
-   "decompress_mbps": 444.62
+   "compress_mbps": 4.28,
+   "decompress_mbps": 661.23
   },
   {
    "compressor": "native",
@@ -5604,7 +5604,7 @@
    "level": 10,
    "out_size": 643093,
    "ratio": 0.1203,
-   "compress_mbps": 2.91,
+   "compress_mbps": 2.92,
    "decompress_mbps": null
   },
   {


### PR DESCRIPTION
This PR adds an LZ4/zstd-style skip-ahead to the lazy hash-chain matcher: after a run of positions with no match, the matcher advances by a growing `stride = 1 + (missStreak >>> skipShift)` instead of one byte, emitting the skipped bytes as literals and resetting the miss streak on every match. On the incompressible binary members (mozilla, x-ray) this cuts the per-position chain-walk cost the matcher otherwise pays on regions that just demonstrated they have no matches; on text and dense-match data (sao) the miss threshold rarely triggers, so their ratio is untouched. The shipped ladder enables `skipShift = 7` for the lazy tier (levels ≥ 4) and disables it below; `skipShift = 63` (the default) keeps `stride` at 1 and reproduces the pre-skip output exactly.

The stride is a pure heuristic — skipped positions are re-findable at the next searched position and every emitted reference is re-verified at emission — so it never enters the correctness proof: the encoder contracts (`ValidDecomp` → `resolveLZ77`, encodability, empty) hold for *any* `skipShift`. `skipShift` and a `missStreak` accumulator thread through all three lazy-matcher twins (`lz77ChainLazy` / `lz77ChainLazyIter` / `lz77ChainLazyIterP`, proven mutually equal). The proofs gain three bridging lemmas — `litRun_valid` (a skip-ahead literal run extends a valid decomposition, mirroring `trailing_valid` but bounded) and `pushLits_eq` / `pushLitsP_eq` (the boxed and packed accumulator push forms equal `litRun`) — plus one mirrored branch in each twin-equality and encodability proof.

Measured with the shipped matcher (`bench/skip-spike`, pinned core), single-block compression over the Silesia binary members at chain 64 (L6), size delta vs. skip-ahead off:

| member | shift 7 speed | shift 7 size | shift 6 | shift 5 | shift 4 |
|--------|--------------:|-------------:|--------:|--------:|--------:|
| mozilla (51 MB) | — | +0.055% | +0.093% | +0.186% | +0.469% |
| x-ray (8 MB) | — | +0.097% | +0.362% | +1.036% | +2.274% |
| sao (7 MB) | — | 0% | 0% | +0.001% | +0.096% |
| text (alice/lcet) | — | 0% | 0% | <0.01% | <0.03% |
| 3-member speed | **+4.3%** | | +4.9% | +8.0% | +10.8% |

At chain 256 (L7) the win is larger where the chain walk dominates more (x-ray+sao: shift 5 +11%, shift 4 +20%). `sao` barely triggers (frequent short matches keep the streak short), so it correctly self-disables. The conservative `skipShift = 7` keeps the corpus geomean ratio cost in the noise while capturing the binary-member speedup; the exact per-level ladder is open for tuning via `bench/skip-spike` and the graphs.

Tests cover the twin equalities at `skipShift ∈ {4, 6, 7, 63}` (including `prng`, where skip-ahead is active), the `skipShift = 63` identity to the default matcher, and end-to-end roundtrip of the skip-ahead token stream through native inflate.

Closes #2766

🤖 Prepared with Claude Code