### PR TITLE
perf: windowed optimal parse keeps the L9/L10 crown past the 64 MiB gate

### DIFF
--- a/Zip/Native/DeflateDynamic.lean
+++ b/Zip/Native/DeflateDynamic.lean
@@ -1529,6 +1529,28 @@ def deflateDynamicBlocksOptimalFast (data : ByteArray) (tokChunk : Nat) : ByteAr
   else
     (emitSharedBlocks data (lz77OptimalFastIter data) tokChunk 0 BitWriter.empty).flush
 
+/-- Windowed twin of `deflateDynamicBlocksOptimal` (#2787): identical block
+    stream, but the exact-DP tokens come from `lz77OptimalWindowedIter`, whose
+    live choice storage is capped to one region — so the exact crown runs in
+    bounded memory past the `optimalMaxSize` gate. -/
+def deflateDynamicBlocksOptimalWindowed (data : ByteArray) (tokChunk : Nat) : ByteArray :=
+  if data.size == 0 then
+    let f := tokenFreqs #[]
+    (emitDynBlock BitWriter.empty data #[] (dynamicCodeLengths f.1 f.2).1 (dynamicCodeLengths f.1 f.2).2
+      (dynamicCodeLengths_length f.1 f.2).1 (dynamicCodeLengths_length f.1 f.2).2 true).flush
+  else
+    (emitSharedBlocks data (lz77OptimalWindowedIter data) tokChunk 0 BitWriter.empty).flush
+
+/-- Windowed twin of `deflateDynamicBlocksOptimalFast` (#2787): the region-capped
+    L9-fast parse (`lz77OptimalWindowedFastIter`). -/
+def deflateDynamicBlocksOptimalWindowedFast (data : ByteArray) (tokChunk : Nat) : ByteArray :=
+  if data.size == 0 then
+    let f := tokenFreqs #[]
+    (emitDynBlock BitWriter.empty data #[] (dynamicCodeLengths f.1 f.2).1 (dynamicCodeLengths f.1 f.2).2
+      (dynamicCodeLengths_length f.1 f.2).1 (dynamicCodeLengths_length f.1 f.2).2 true).flush
+  else
+    (emitSharedBlocks data (lz77OptimalWindowedFastIter data) tokChunk 0 BitWriter.empty).flush
+
 /-! ## Incompressible pre-scan
 
 `deflateRaw` already falls back to a stored block whenever every compressed
@@ -1785,23 +1807,35 @@ def deflateRaw (data : ByteArray) (level : UInt8 := 6) : ByteArray :=
     -- Both candidates consume the packed words end-to-end (freqs *and* emit):
     -- no branch materializes boxed tokens.
     let ptokens := lzMatchP data level
-    if level == 9 ∧ data.size ≤ optimalMaxSize then
+    if level == 9 then
       -- Level 9 (#2638): the cheaper **L9-fast** approximate-optimal parse — near
       -- the crown's ratio at ~2× its speed, measured ~20% outside the L8↔L9
       -- mixing frontier on Silesia (a genuine new Pareto point). As with the
       -- exact candidate below, the split candidates are dropped on measured
       -- evidence; keep `base` (reuses `ptokens`, ~free) as the safety floor and
-      -- emit `pickSmaller(base, fast-optimal)`.
-      pickSmaller (deflateRawBaseP data ptokens)
-        (deflateDynamicBlocksOptimalFast data sharedTokChunk)
-    else if 10 ≤ level ∧ data.size ≤ optimalMaxSize then
+      -- emit `pickSmaller(base, fast-optimal)`. Above the `optimalMaxSize` memory
+      -- gate the same parse runs *windowed* (#2787): region-capped choice storage
+      -- gives byte-identical tokens in bounded memory, so the crown survives on
+      -- streams larger than 64 MiB instead of collapsing to the split ratio.
+      if data.size ≤ optimalMaxSize then
+        pickSmaller (deflateRawBaseP data ptokens)
+          (deflateDynamicBlocksOptimalFast data sharedTokChunk)
+      else
+        pickSmaller (deflateRawBaseP data ptokens)
+          (deflateDynamicBlocksOptimalWindowedFast data sharedTokChunk)
+    else if 10 ≤ level then
       -- Level ≥ 10: the exact backward-DP crown (the former level-9 behaviour,
       -- #2640) — the max-ratio ceiling, kept reachable per the #2638 directive.
       -- The fixed-cadence optimal candidate measured strictly smallest on every
       -- Canterbury and Silesia file, so the split candidates are dropped here;
-      -- `pickSmaller(base, optimal)` is never worse than the lazy baseline.
-      pickSmaller (deflateRawBaseP data ptokens)
-        (deflateDynamicBlocksOptimal data sharedTokChunk)
+      -- `pickSmaller(base, optimal)` is never worse than the lazy baseline. As at
+      -- level 9, above the memory gate the exact parse runs windowed (#2787).
+      if data.size ≤ optimalMaxSize then
+        pickSmaller (deflateRawBaseP data ptokens)
+          (deflateDynamicBlocksOptimal data sharedTokChunk)
+      else
+        pickSmaller (deflateRawBaseP data ptokens)
+          (deflateDynamicBlocksOptimalWindowed data sharedTokChunk)
     else
       -- Levels 6–8 (and level 9/10 above the memory gate): base vs cross-block
       -- shared-window split at the observation-divergence boundaries (#2737),

--- a/Zip/Native/DeflateDynamic.lean
+++ b/Zip/Native/DeflateDynamic.lean
@@ -1837,8 +1837,8 @@ def deflateRaw (data : ByteArray) (level : UInt8 := 6) : ByteArray :=
         pickSmaller (deflateRawBaseP data ptokens)
           (deflateDynamicBlocksOptimalWindowed data sharedTokChunk)
     else
-      -- Levels 6–8 (and level 9/10 above the memory gate): base vs cross-block
-      -- shared-window split at the observation-divergence boundaries (#2737),
+      -- Levels 6–8: base vs cross-block shared-window split at the
+      -- observation-divergence boundaries (#2737),
       -- **size-arbitrated** (#2753). Both candidates are *prepared* — sized to
       -- their flushed byte count with per-block trees captured
       -- (`deflateRawBasePPrep` for the base, `deflateDynamicBlocksSharedAtSizedP`

--- a/Zip/Native/DeflateParse.lean
+++ b/Zip/Native/DeflateParse.lean
@@ -1025,4 +1025,257 @@ def lz77OptimalFastIter (data : ByteArray) : Array LZ77Token :=
   let (chLen, chDist) := computeChoicesFast data
   optimalEmitIter data chLen chDist 0 #[]
 
+/-! ## Windowed parse (#2787): bounded live DP state past the 64 MiB gate
+
+`computeChoices`/`computeChoicesFast` allocate two `data.size`-sized `Array Nat`
+choice arrays (the exact-DP peak's dominant cost — ≈2/3 of the resident set at
+64 MiB, so ≈16 B of the ≈27 B/byte marginal, which is what forces the
+`optimalMaxSize` gate). This windowed twin caps that live state to **one region**
+at a time: it fills a region's choices into *region-local* buffers (relative
+index), emits that region's tokens immediately, and discards the buffers before
+the next region. The hash-chain finder state (`hashTable`/`prev`/`h3tab`, itself
+already bounded to the 32 KiB window) is threaded across regions exactly as
+`computeChoicesLoop` threads it, so cross-region matches survive and the choices
+— hence the token stream — are those of the global parse. Only the choice
+storage is bounded; the token array itself is still materialized (inherent to
+`emitSharedBlocks`), so the residual marginal is the ≈10 B/byte token stream.
+
+Everything here is heuristic — opaque to correctness, like the rest of this file.
+The region-local fills use panic-checked (`[..]!`) data/cost reads (they never
+fire: every access is in range by construction), which keeps the fills free of
+proof obligations so they compose as a plain `fillFn` the shared emitter calls. -/
+
+set_option maxRecDepth 4096 in
+/-- Relative-index twin of `fillRegion`: identical backward DP, but the chosen
+    length/distance are recorded at the *region-local* index `idx` (into a
+    region-sized buffer) rather than the absolute position `base + idx`, and the
+    data/cost reads are panic-checked (heuristic). The cache-slot reads stay
+    proven in range (`hcl`/`hcd`/`hir`), exactly as in `fillRegion`. -/
+def fillRegionWin (data : ByteArray) (base r slots : Nat)
+    (cacheLens cacheDists litCost lenCost distCost : Array Nat)
+    (i : Nat) (cost chLen chDist : Array Nat) (hir : i ≤ r)
+    (hcl : slots * r ≤ cacheLens.size) (hcd : slots * r ≤ cacheDists.size) :
+    Array Nat × Array Nat :=
+  if h0 : i = 0 then (chLen, chDist)
+  else
+    let idx := i - 1
+    let pos := base + idx
+    let byte := data[pos]!
+    let lit := litCost[byte.toNat]! + cost[idx + 1]!
+    have hidx : idx + 1 ≤ r := by omega
+    have hm := Nat.mul_le_mul (Nat.le_refl slots) hidx
+    have heq : slots * (idx + 1) = slots * idx + slots := Nat.mul_succ slots idx
+    let (bc, bl, bd) := scanCands cacheLens cacheDists lenCost distCost cost
+      (slots * idx) idx slots 0 0 lit 1 0 (by omega) (by omega)
+    let chLen := chLen.set! idx bl
+    let chDist := chDist.set! idx bd
+    fillRegionWin data base r slots cacheLens cacheDists litCost lenCost distCost
+      idx (cost.set! idx bc) chLen chDist (by omega) hcl hcd
+termination_by i
+decreasing_by omega
+
+/-- Relative-index twin of `fillRegionFast` (bounds-free `scanCandsFast`, no
+    cache-size hypotheses): records the choice at region-local index `idx`. -/
+def fillRegionFastWin (data : ByteArray) (base r slots : Nat)
+    (cacheLens cacheDists litCost lenCost distCost : Array Nat)
+    (i : Nat) (cost chLen chDist : Array Nat) (hir : i ≤ r) :
+    Array Nat × Array Nat :=
+  if h0 : i = 0 then (chLen, chDist)
+  else
+    let idx := i - 1
+    let pos := base + idx
+    let byte := data[pos]!
+    let lit := litCost[byte.toNat]! + cost[idx + 1]!
+    let (bc, bl, bd) := scanCandsFast cacheLens cacheDists lenCost distCost cost
+      (slots * idx) idx slots 0 lit 1 0
+    let chLen := chLen.set! idx bl
+    let chDist := chDist.set! idx bd
+    fillRegionFastWin data base r slots cacheLens cacheDists litCost lenCost distCost
+      idx (cost.set! idx bc) chLen chDist (by omega)
+termination_by i
+decreasing_by omega
+
+/-- Relative-index twin of `collectRegionTokens` (round-2 refit input): walks the
+    region-local choice buffers `[0, r)`, reading the data at the absolute
+    position `base + pos` so the fitted literal frequencies match the global
+    parse. Panic-checked (heuristic). -/
+def collectRegionTokensWin (data : ByteArray) (base : Nat) (chLen chDist : Array Nat)
+    (r pos : Nat) (acc : Array LZ77Token) : Array LZ77Token :=
+  if h : pos < r ∧ base + pos < data.size then
+    let len := chLen[pos]!
+    if 3 ≤ len then
+      collectRegionTokensWin data base chLen chDist r (pos + len)
+        (acc.push (.reference len (chDist[pos]!)))
+    else
+      collectRegionTokensWin data base chLen chDist r (pos + 1)
+        (acc.push (.literal (data[base + pos]'(by omega))))
+  else acc
+termination_by r - pos
+decreasing_by all_goals omega
+
+/-- Region-local twin of `fillRegionRounds` (exact two-round DP): returns the
+    threaded chain state and the region-sized choice buffers. Total — no `hr`/
+    `hslit` obligations (the internal reads are panic-checked), so it composes as
+    a plain `fillFn` for `windowedEmit`. -/
+def fillRegionRoundsWin (data : ByteArray) (depth slots niceSkip base r : Nat)
+    (slit slen sdist : Array Nat) (hashTable prev h3tab : Array Nat) :
+    Array Nat × Array Nat × Array Nat × Array Nat × Array Nat :=
+  let cache := buildCache data hashTable prev h3tab
+    depth slots niceSkip base r 0 (Array.replicate (slots * r) 0) (Array.replicate (slots * r) 0)
+  let cacheLens := cache.1
+  let cacheDists := cache.2.1
+  have hcl : slots * r ≤ cacheLens.size := by
+    have : cacheLens.size = slots * r := by
+      show (buildCache data hashTable prev h3tab depth slots niceSkip base r 0
+        (Array.replicate (slots * r) 0) (Array.replicate (slots * r) 0)).1.size = slots * r
+      rw [buildCache_fst_size, Array.size_replicate]
+    omega
+  have hcd : slots * r ≤ cacheDists.size := by
+    have : cacheDists.size = slots * r := by
+      show (buildCache data hashTable prev h3tab depth slots niceSkip base r 0
+        (Array.replicate (slots * r) 0) (Array.replicate (slots * r) 0)).2.1.size = slots * r
+      rw [buildCache_snd_fst_size, Array.size_replicate]
+    omega
+  let hashTable := cache.2.2.1
+  let prev := cache.2.2.2.1
+  let h3tab := cache.2.2.2.2
+  let cost := seedTailCosts (Array.replicate (r + 259) 0) r (avgLitBits slit) 0
+  let res1 := fillRegionWin data base r slots cacheLens cacheDists
+    slit slen sdist r cost (Array.replicate r 1) (Array.replicate r 0) (Nat.le_refl r) hcl hcd
+  let toks := collectRegionTokensWin data base res1.1 res1.2 r 0 #[]
+  let fitted := fittedCostTables toks
+  let cost2 := seedTailCosts (Array.replicate (r + 259) 0) r (avgLitBits fitted.1) 0
+  let res2 := fillRegionWin data base r slots cacheLens cacheDists
+    fitted.1 fitted.2.1 fitted.2.2 r cost2 res1.1 res1.2 (Nat.le_refl r) hcl hcd
+  (hashTable, prev, h3tab, res2.1, res2.2)
+
+/-- Region-local twin of `fillRegionFastRound` (single-round L9-fast DP). -/
+def fillRegionFastRoundWin (data : ByteArray) (depth slots niceSkip base r : Nat)
+    (slit slen sdist : Array Nat) (hashTable prev h3tab : Array Nat) :
+    Array Nat × Array Nat × Array Nat × Array Nat × Array Nat :=
+  let cache := buildCache data hashTable prev h3tab
+    depth slots niceSkip base r 0 (Array.replicate (slots * r) 0) (Array.replicate (slots * r) 0)
+  let cacheLens := cache.1
+  let cacheDists := cache.2.1
+  let hashTable := cache.2.2.1
+  let prev := cache.2.2.2.1
+  let h3tab := cache.2.2.2.2
+  let cost := seedTailCosts (Array.replicate (r + 259) 0) r (avgLitBits slit) 0
+  let res := fillRegionFastWin data base r slots cacheLens cacheDists
+    slit slen sdist r cost (Array.replicate r 1) (Array.replicate r 0) (Nat.le_refl r)
+  (hashTable, prev, h3tab, res.1, res.2)
+
+/-- The region-fill closure the windowed emitter calls to (re)fill each window:
+    `fill base r hashTable prev h3tab` returns the updated finder state and the
+    region-local choice buffers for `[base, base + r)`. `fillRegionRoundsWin`
+    (exact) and `fillRegionFastRoundWin` (L9-fast) are the two instances. -/
+abbrev WindowFill : Type :=
+  Nat → Nat → Array Nat → Array Nat → Array Nat →
+    Array Nat × Array Nat × Array Nat × Array Nat × Array Nat
+
+/-- Interleaved windowed emitter (list-cons version, the proofs' subject). Emits
+    `data[pos ..]` re-verifying every match exactly as `optimalEmit`, but reading
+    the choice at the *region-local* index `pos - base` from the current window's
+    buffers `cLen`/`cDist`; when `pos` runs off the window (`pos ≥ base + r`) it
+    refills the next window `[base + r, ..)` via `fill` (threading the finder
+    state) and continues. `fill`'s output is never inspected by the correctness
+    proofs — validity comes solely from the re-verification, as for `optimalEmit`. -/
+def windowedEmit (data : ByteArray) (fill : WindowFill) (regionSize : Nat)
+    (base : Nat) (cLen cDist : Array Nat) (hashTable prev h3tab : Array Nat)
+    (r pos : Nat) (hrs : 1 ≤ regionSize) (hr1 : 1 ≤ r) : List LZ77Token :=
+  if hpos : pos < data.size then
+    if hpr : pos < base + r then
+      let len := cLen[pos - base]!
+      let dist := cDist[pos - base]!
+      if hg : 3 ≤ len ∧ len ≤ 258 ∧ pos + len ≤ data.size ∧
+          1 ≤ dist ∧ dist ≤ pos ∧ dist ≤ 32768 then
+        have h1 : (pos - dist) + len ≤ data.size := by omega
+        if hml : lz77Greedy.countMatch data (pos - dist) pos len h1 hg.2.2.1 = len then
+          .reference len dist :: windowedEmit data fill regionSize base cLen cDist
+            hashTable prev h3tab r (pos + len) hrs hr1
+        else
+          .literal (data[pos]'hpos) :: windowedEmit data fill regionSize base cLen cDist
+            hashTable prev h3tab r (pos + 1) hrs hr1
+      else
+        .literal (data[pos]'hpos) :: windowedEmit data fill regionSize base cLen cDist
+          hashTable prev h3tab r (pos + 1) hrs hr1
+    else
+      let base' := base + r
+      let r' := min regionSize (data.size - base')
+      have hr1' : 1 ≤ r' := by omega
+      let res := fill base' r' hashTable prev h3tab
+      windowedEmit data fill regionSize base' res.2.2.2.1 res.2.2.2.2
+        res.1 res.2.1 res.2.2.1 r' pos hrs hr1'
+  else []
+termination_by 2 * (data.size - pos) + (data.size - base)
+decreasing_by all_goals omega
+
+/-- Iterative (`Array`-accumulating) twin of `windowedEmit`; the runtime entry
+    point (proven equal to `windowedEmit` in `LZ77OptimalCorrect`). -/
+def windowedEmitIter (data : ByteArray) (fill : WindowFill) (regionSize : Nat)
+    (base : Nat) (cLen cDist : Array Nat) (hashTable prev h3tab : Array Nat)
+    (r pos : Nat) (acc : Array LZ77Token) (hrs : 1 ≤ regionSize) (hr1 : 1 ≤ r) :
+    Array LZ77Token :=
+  if hpos : pos < data.size then
+    if hpr : pos < base + r then
+      let len := cLen[pos - base]!
+      let dist := cDist[pos - base]!
+      if hg : 3 ≤ len ∧ len ≤ 258 ∧ pos + len ≤ data.size ∧
+          1 ≤ dist ∧ dist ≤ pos ∧ dist ≤ 32768 then
+        have h1 : (pos - dist) + len ≤ data.size := by omega
+        if hml : lz77Greedy.countMatch data (pos - dist) pos len h1 hg.2.2.1 = len then
+          windowedEmitIter data fill regionSize base cLen cDist hashTable prev h3tab
+            r (pos + len) (acc.push (.reference len dist)) hrs hr1
+        else
+          windowedEmitIter data fill regionSize base cLen cDist hashTable prev h3tab
+            r (pos + 1) (acc.push (.literal (data[pos]'hpos))) hrs hr1
+      else
+        windowedEmitIter data fill regionSize base cLen cDist hashTable prev h3tab
+          r (pos + 1) (acc.push (.literal (data[pos]'hpos))) hrs hr1
+    else
+      let base' := base + r
+      let r' := min regionSize (data.size - base')
+      have hr1' : 1 ≤ r' := by omega
+      let res := fill base' r' hashTable prev h3tab
+      windowedEmitIter data fill regionSize base' res.2.2.2.1 res.2.2.2.2
+        res.1 res.2.1 res.2.2.1 r' pos acc hrs hr1'
+  else acc
+termination_by 2 * (data.size - pos) + (data.size - base)
+decreasing_by all_goals omega
+
+/-- Shared driver for both windowed parsers: set up the first window and run the
+    interleaved emitter with the given region-fill closure. -/
+def lz77OptimalWindowedWith (data : ByteArray) (fill : WindowFill) : Array LZ77Token :=
+  if h : data.size = 0 then #[]
+  else
+    let r0 := min optRegionSize data.size
+    have hr0 : 1 ≤ r0 := by
+      have h2 : 1 ≤ optRegionSize := by decide
+      omega
+    let ht0 := Array.replicate 65536 data.size
+    let prev0 := Array.replicate (min chainWinSize data.size) data.size
+    let h3tab0 := Array.replicate 32768 data.size
+    let init := fill 0 r0 ht0 prev0 h3tab0
+    windowedEmitIter data fill optRegionSize 0 init.2.2.2.1 init.2.2.2.2
+      init.1 init.2.1 init.2.2.1 r0 0 #[] (by decide) hr0
+
+/-- Windowed exact-DP parse (#2787): bit-for-bit the tokens of `lz77OptimalIter`,
+    but with the choice storage capped to one region. Deployed at level ≥ 10
+    above the memory gate. -/
+def lz77OptimalWindowedIter (data : ByteArray) : Array LZ77Token :=
+  let st := staticCostTables
+  lz77OptimalWindowedWith data
+    (fun base r ht prev h3 =>
+      fillRegionRoundsWin data optChainDepth optCacheSlots optNiceSkip base r
+        st.1 st.2.1 st.2.2 ht prev h3)
+
+/-- Windowed L9-fast parse (#2787): the region-capped twin of
+    `lz77OptimalFastIter`. Deployed at level 9 above the memory gate. -/
+def lz77OptimalWindowedFastIter (data : ByteArray) : Array LZ77Token :=
+  let st := staticCostTables
+  lz77OptimalWindowedWith data
+    (fun base r ht prev h3 =>
+      fillRegionFastRoundWin data fastChainDepth optCacheSlots fastNiceSkip base r
+        st.1 st.2.1 st.2.2 ht prev h3)
+
 end Zip.Native.Deflate

--- a/Zip/Spec/DeflateBlockSplit.lean
+++ b/Zip/Spec/DeflateBlockSplit.lean
@@ -1556,6 +1556,329 @@ theorem deflateDynamicBlocksOptimalFast_pad (data : ByteArray) (tokChunk : Nat) 
         data.data.toList BitWriter.empty (by omega) htokpos BitWriter.empty_wf hres0
     exact ⟨_, _, flush_toBits_aligned _ hwf, by simp only [List.length_replicate]; omega⟩
 
+/-! ## Cross-block split over the windowed parses (`deflateDynamicBlocksOptimalWindowed`/`Fast`, #2787)
+
+Byte-for-byte twins of the two quadruples above with the parser contracts
+replaced by the windowed parsers' (`lz77OptimalWindowedIter_*` /
+`lz77OptimalWindowedFastIter_*`); the shared-window fold is generic over the
+token array, so the proofs are identical modulo that substitution. -/
+
+private theorem deflateDynamicBlocksOptimalWindowed_facts (data : ByteArray)
+    (hpos : 0 < data.size) :
+    (∀ t ∈ (lz77OptimalWindowedIter data).toList,
+        match t with
+        | .literal _ => True
+        | .reference len dist => 3 ≤ len ∧ len ≤ 258 ∧ 1 ≤ dist ∧ dist ≤ 32768) ∧
+      0 < (lz77OptimalWindowedIter data).size ∧
+      Deflate.Spec.resolveLZ77
+        (((lz77OptimalWindowedIter data).toList.map
+          LZ77Token.toLZ77Symbol).drop 0) [] = some data.data.toList := by
+  have henc := lz77OptimalWindowedIter_encodable data
+  have hwhole := lz77OptimalWindowedIter_resolves data
+  have hMfree := mem_map_toLZ77Symbol_ne_endOfBlock
+    (lz77OptimalWindowedIter data).toList
+  have hM : Deflate.Spec.resolveLZ77
+      ((lz77OptimalWindowedIter data).toList.map
+        LZ77Token.toLZ77Symbol) [] = some data.data.toList := by
+    simp only [tokensToSymbols] at hwhole
+    rwa [Deflate.Spec.resolveLZ77_eobFree_eob _ [] hMfree] at hwhole
+  refine ⟨henc, ?_, ?_⟩
+  · rcases Nat.eq_zero_or_pos (lz77OptimalWindowedIter data).size with h0 | h0
+    · exfalso
+      have hnil : (lz77OptimalWindowedIter data).toList = [] :=
+        List.eq_nil_of_length_eq_zero (by rw [Array.length_toList]; omega)
+      rw [hnil, List.map_nil, Deflate.Spec.resolveLZ77_nil, Option.some.injEq] at hM
+      have hl := congrArg List.length hM
+      simp only [List.length_nil, Array.length_toList, ByteArray.size_data] at hl
+      omega
+    · exact h0
+  · rw [List.drop_zero]; exact hM
+
+/-- Near-optimal cross-block roundtrip: decoding the block stream over the
+    DP parse reproduces the input. -/
+theorem decode_deflateDynamicBlocksOptimalWindowed (data : ByteArray) (tokChunk : Nat) :
+    Deflate.Spec.decode
+      (Deflate.Spec.bytesToBits (deflateDynamicBlocksOptimalWindowed data tokChunk)) =
+      some data.data.toList := by
+  unfold deflateDynamicBlocksOptimalWindowed
+  split
+  · -- data.size = 0: one final block over the empty token list (as in SC).
+    rename_i hz
+    rw [beq_iff_eq] at hz
+    obtain ⟨litLens, distLens, headerBits, symBits, _, _, hlv, hdv,
+        hge1, hle1, hge2, hle2, hb1, hb2, htrees, hsyms, htoBits, hwf⟩ :=
+      emitDynBlock_spec BitWriter.empty BitWriter.empty_wf data #[] (by simp) (fun _ => rfl) true
+    rw [BitWriter.empty_toBits, List.nil_append] at htoBits
+    rw [flush_toBits_aligned _ hwf, htoBits]
+    have hheader := Deflate.Spec.encodeDynamicTrees_decodeDynamicTables litLens distLens headerBits
+      (symBits ++ List.replicate
+        ((8 - ([true, false, true] ++ headerBits ++ symBits).length % 8) % 8) false)
+      hb1 hb2 ⟨hge1, hle1⟩ ⟨hge2, hle2⟩ hlv hdv htrees
+    rw [← List.append_assoc] at hheader
+    have hres : Deflate.Spec.resolveLZ77 (tokensToSymbols #[]) [] = some data.data.toList := by
+      have he : data.data.toList = [] :=
+        List.eq_nil_of_length_eq_zero (by simp only [Array.length_toList, ByteArray.size_data, hz])
+      rw [he]; rfl
+    exact Deflate.Spec.encodeDynamic_decode_append (tokensToSymbols #[]) data.data.toList
+      litLens distLens headerBits symBits _ hlv hdv hheader hsyms hres
+      (tokensToSymbols_validSymbolList _)
+  · -- data.size > 0: the shared-window fold over the optimal tokens.
+    rename_i hz
+    have hpos : 0 < data.size := by
+      rcases Nat.eq_zero_or_pos data.size with h | h
+      · rw [h] at hz; simp at hz
+      · exact h
+    obtain ⟨henc, htokpos, hres0⟩ := deflateDynamicBlocksOptimalWindowed_facts data hpos
+    obtain ⟨B, htoBits, hwf, hdec⟩ :=
+      emitSharedBlocks_decode data (lz77OptimalWindowedIter data)
+        tokChunk (by omega) henc
+        (lz77OptimalWindowedIter data).size 0 []
+        data.data.toList BitWriter.empty (by omega) htokpos BitWriter.empty_wf hres0
+    rw [BitWriter.empty_toBits, List.nil_append] at htoBits
+    rw [flush_toBits_aligned _ hwf, htoBits]
+    exact hdec (List.replicate ((8 - B.length % 8) % 8) false)
+
+/-- Near-optimal cross-block roundtrip: inflating `deflateDynamicBlocksOptimalWindowed`
+    recovers the input, for any `maxOutputSize` large enough to hold it. -/
+theorem inflate_deflateDynamicBlocksOptimalWindowed (data : ByteArray) (tokChunk : Nat)
+    (maxOutputSize : Nat) (hsize : data.size ≤ maxOutputSize) :
+    Zip.Native.Inflate.inflateReference (deflateDynamicBlocksOptimalWindowed data tokChunk) maxOutputSize =
+      .ok data := by
+  have hlen : data.data.toList.length ≤ maxOutputSize := by
+    simp only [Array.length_toList, ByteArray.size_data]; omega
+  rw [← show ByteArray.mk ⟨data.data.toList⟩ = data from by simp only [Array.toArray_toList]]
+  exact inflate_complete (deflateDynamicBlocksOptimalWindowed data tokChunk) data.data.toList
+    maxOutputSize hlen (decode_deflateDynamicBlocksOptimalWindowed data tokChunk)
+
+/-- The `decode.goR` of `deflateDynamicBlocksOptimalWindowed` returns the input and
+    short (< 8-bit) trailing padding. -/
+theorem deflateDynamicBlocksOptimalWindowed_goR_pad (data : ByteArray) (tokChunk : Nat) :
+    ∃ remaining,
+      Deflate.Spec.decode.goR
+          (Deflate.Spec.bytesToBits (deflateDynamicBlocksOptimalWindowed data tokChunk)) []
+        = some (data.data.toList, remaining) ∧ remaining.length < 8 := by
+  unfold deflateDynamicBlocksOptimalWindowed
+  split
+  · -- data.size = 0
+    rename_i hz
+    rw [beq_iff_eq] at hz
+    obtain ⟨litLens, distLens, headerBits, symBits, _, _, hlv, hdv,
+        hge1, hle1, hge2, hle2, hb1, hb2, htrees, hsyms, htoBits, hwf⟩ :=
+      emitDynBlock_spec BitWriter.empty BitWriter.empty_wf data #[] (by simp) (fun _ => rfl) true
+    rw [BitWriter.empty_toBits, List.nil_append] at htoBits
+    rw [flush_toBits_aligned _ hwf, htoBits]
+    refine ⟨List.replicate
+      ((8 - ([true, false, true] ++ headerBits ++ symBits).length % 8) % 8) false, ?_, ?_⟩
+    · have hheader := Deflate.Spec.encodeDynamicTrees_decodeDynamicTables litLens distLens headerBits
+        (symBits ++ List.replicate
+          ((8 - ([true, false, true] ++ headerBits ++ symBits).length % 8) % 8) false)
+        hb1 hb2 ⟨hge1, hle1⟩ ⟨hge2, hle2⟩ hlv hdv htrees
+      rw [← List.append_assoc] at hheader
+      have hres : Deflate.Spec.resolveLZ77 (tokensToSymbols #[]) [] = some data.data.toList := by
+        have he : data.data.toList = [] :=
+          List.eq_nil_of_length_eq_zero (by simp only [Array.length_toList, ByteArray.size_data, hz])
+        rw [he]; rfl
+      exact Deflate.Spec.encodeDynamic_goR_rest (tokensToSymbols #[]) data.data.toList
+        litLens distLens headerBits symBits _ hlv hdv hheader hsyms hres
+        (tokensToSymbols_validSymbolList _)
+    · simp only [List.length_replicate]; omega
+  · -- data.size > 0
+    rename_i hz
+    have hpos : 0 < data.size := by
+      rcases Nat.eq_zero_or_pos data.size with h | h
+      · rw [h] at hz; simp at hz
+      · exact h
+    obtain ⟨henc, htokpos, hres0⟩ := deflateDynamicBlocksOptimalWindowed_facts data hpos
+    obtain ⟨B, htoBits, hwf, hdec⟩ :=
+      emitSharedBlocks_decodeR data (lz77OptimalWindowedIter data)
+        tokChunk (by omega) henc
+        (lz77OptimalWindowedIter data).size 0 []
+        data.data.toList BitWriter.empty (by omega) htokpos BitWriter.empty_wf hres0
+    rw [BitWriter.empty_toBits, List.nil_append] at htoBits
+    rw [flush_toBits_aligned _ hwf, htoBits]
+    refine ⟨List.replicate ((8 - B.length % 8) % 8) false, hdec _, ?_⟩
+    simp only [List.length_replicate]; omega
+
+/-- The output of `deflateDynamicBlocksOptimalWindowed` decomposes into content bits
+    plus short (< 8-bit) padding. -/
+theorem deflateDynamicBlocksOptimalWindowed_pad (data : ByteArray) (tokChunk : Nat) :
+    ∃ (contentBits padding : List Bool),
+      Deflate.Spec.bytesToBits (deflateDynamicBlocksOptimalWindowed data tokChunk) =
+        contentBits ++ padding ∧ padding.length < 8 := by
+  unfold deflateDynamicBlocksOptimalWindowed
+  split
+  · obtain ⟨_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, hwf⟩ :=
+      emitDynBlock_spec BitWriter.empty BitWriter.empty_wf data #[] (by simp) (fun _ => rfl) true
+    exact ⟨_, _, flush_toBits_aligned _ hwf, by simp only [List.length_replicate]; omega⟩
+  · rename_i hz
+    have hpos : 0 < data.size := by
+      rcases Nat.eq_zero_or_pos data.size with h | h
+      · rw [h] at hz; simp at hz
+      · exact h
+    obtain ⟨henc, htokpos, hres0⟩ := deflateDynamicBlocksOptimalWindowed_facts data hpos
+    obtain ⟨B, _, hwf, _⟩ :=
+      emitSharedBlocks_decode data (lz77OptimalWindowedIter data)
+        tokChunk (by omega) henc
+        (lz77OptimalWindowedIter data).size 0 []
+        data.data.toList BitWriter.empty (by omega) htokpos BitWriter.empty_wf hres0
+    exact ⟨_, _, flush_toBits_aligned _ hwf, by simp only [List.length_replicate]; omega⟩
+
+private theorem deflateDynamicBlocksOptimalWindowedFast_facts (data : ByteArray)
+    (hpos : 0 < data.size) :
+    (∀ t ∈ (lz77OptimalWindowedFastIter data).toList,
+        match t with
+        | .literal _ => True
+        | .reference len dist => 3 ≤ len ∧ len ≤ 258 ∧ 1 ≤ dist ∧ dist ≤ 32768) ∧
+      0 < (lz77OptimalWindowedFastIter data).size ∧
+      Deflate.Spec.resolveLZ77
+        (((lz77OptimalWindowedFastIter data).toList.map
+          LZ77Token.toLZ77Symbol).drop 0) [] = some data.data.toList := by
+  have henc := lz77OptimalWindowedFastIter_encodable data
+  have hwhole := lz77OptimalWindowedFastIter_resolves data
+  have hMfree := mem_map_toLZ77Symbol_ne_endOfBlock
+    (lz77OptimalWindowedFastIter data).toList
+  have hM : Deflate.Spec.resolveLZ77
+      ((lz77OptimalWindowedFastIter data).toList.map
+        LZ77Token.toLZ77Symbol) [] = some data.data.toList := by
+    simp only [tokensToSymbols] at hwhole
+    rwa [Deflate.Spec.resolveLZ77_eobFree_eob _ [] hMfree] at hwhole
+  refine ⟨henc, ?_, ?_⟩
+  · rcases Nat.eq_zero_or_pos (lz77OptimalWindowedFastIter data).size with h0 | h0
+    · exfalso
+      have hnil : (lz77OptimalWindowedFastIter data).toList = [] :=
+        List.eq_nil_of_length_eq_zero (by rw [Array.length_toList]; omega)
+      rw [hnil, List.map_nil, Deflate.Spec.resolveLZ77_nil, Option.some.injEq] at hM
+      have hl := congrArg List.length hM
+      simp only [List.length_nil, Array.length_toList, ByteArray.size_data] at hl
+      omega
+    · exact h0
+  · rw [List.drop_zero]; exact hM
+
+/-- L9-fast cross-block roundtrip: decoding the block stream over the L9-fast
+    parse reproduces the input. -/
+theorem decode_deflateDynamicBlocksOptimalWindowedFast (data : ByteArray) (tokChunk : Nat) :
+    Deflate.Spec.decode
+      (Deflate.Spec.bytesToBits (deflateDynamicBlocksOptimalWindowedFast data tokChunk)) =
+      some data.data.toList := by
+  unfold deflateDynamicBlocksOptimalWindowedFast
+  split
+  · rename_i hz
+    rw [beq_iff_eq] at hz
+    obtain ⟨litLens, distLens, headerBits, symBits, _, _, hlv, hdv,
+        hge1, hle1, hge2, hle2, hb1, hb2, htrees, hsyms, htoBits, hwf⟩ :=
+      emitDynBlock_spec BitWriter.empty BitWriter.empty_wf data #[] (by simp) (fun _ => rfl) true
+    rw [BitWriter.empty_toBits, List.nil_append] at htoBits
+    rw [flush_toBits_aligned _ hwf, htoBits]
+    have hheader := Deflate.Spec.encodeDynamicTrees_decodeDynamicTables litLens distLens headerBits
+      (symBits ++ List.replicate
+        ((8 - ([true, false, true] ++ headerBits ++ symBits).length % 8) % 8) false)
+      hb1 hb2 ⟨hge1, hle1⟩ ⟨hge2, hle2⟩ hlv hdv htrees
+    rw [← List.append_assoc] at hheader
+    have hres : Deflate.Spec.resolveLZ77 (tokensToSymbols #[]) [] = some data.data.toList := by
+      have he : data.data.toList = [] :=
+        List.eq_nil_of_length_eq_zero (by simp only [Array.length_toList, ByteArray.size_data, hz])
+      rw [he]; rfl
+    exact Deflate.Spec.encodeDynamic_decode_append (tokensToSymbols #[]) data.data.toList
+      litLens distLens headerBits symBits _ hlv hdv hheader hsyms hres
+      (tokensToSymbols_validSymbolList _)
+  · rename_i hz
+    have hpos : 0 < data.size := by
+      rcases Nat.eq_zero_or_pos data.size with h | h
+      · rw [h] at hz; simp at hz
+      · exact h
+    obtain ⟨henc, htokpos, hres0⟩ := deflateDynamicBlocksOptimalWindowedFast_facts data hpos
+    obtain ⟨B, htoBits, hwf, hdec⟩ :=
+      emitSharedBlocks_decode data (lz77OptimalWindowedFastIter data)
+        tokChunk (by omega) henc
+        (lz77OptimalWindowedFastIter data).size 0 []
+        data.data.toList BitWriter.empty (by omega) htokpos BitWriter.empty_wf hres0
+    rw [BitWriter.empty_toBits, List.nil_append] at htoBits
+    rw [flush_toBits_aligned _ hwf, htoBits]
+    exact hdec (List.replicate ((8 - B.length % 8) % 8) false)
+
+/-- L9-fast cross-block roundtrip: inflating `deflateDynamicBlocksOptimalWindowedFast`
+    recovers the input, for any `maxOutputSize` large enough to hold it. -/
+theorem inflate_deflateDynamicBlocksOptimalWindowedFast (data : ByteArray) (tokChunk : Nat)
+    (maxOutputSize : Nat) (hsize : data.size ≤ maxOutputSize) :
+    Zip.Native.Inflate.inflateReference (deflateDynamicBlocksOptimalWindowedFast data tokChunk) maxOutputSize =
+      .ok data := by
+  have hlen : data.data.toList.length ≤ maxOutputSize := by
+    simp only [Array.length_toList, ByteArray.size_data]; omega
+  rw [← show ByteArray.mk ⟨data.data.toList⟩ = data from by simp only [Array.toArray_toList]]
+  exact inflate_complete (deflateDynamicBlocksOptimalWindowedFast data tokChunk) data.data.toList
+    maxOutputSize hlen (decode_deflateDynamicBlocksOptimalWindowedFast data tokChunk)
+
+/-- The `decode.goR` of `deflateDynamicBlocksOptimalWindowedFast` returns the input and
+    short (< 8-bit) trailing padding. -/
+theorem deflateDynamicBlocksOptimalWindowedFast_goR_pad (data : ByteArray) (tokChunk : Nat) :
+    ∃ remaining,
+      Deflate.Spec.decode.goR
+          (Deflate.Spec.bytesToBits (deflateDynamicBlocksOptimalWindowedFast data tokChunk)) []
+        = some (data.data.toList, remaining) ∧ remaining.length < 8 := by
+  unfold deflateDynamicBlocksOptimalWindowedFast
+  split
+  · rename_i hz
+    rw [beq_iff_eq] at hz
+    obtain ⟨litLens, distLens, headerBits, symBits, _, _, hlv, hdv,
+        hge1, hle1, hge2, hle2, hb1, hb2, htrees, hsyms, htoBits, hwf⟩ :=
+      emitDynBlock_spec BitWriter.empty BitWriter.empty_wf data #[] (by simp) (fun _ => rfl) true
+    rw [BitWriter.empty_toBits, List.nil_append] at htoBits
+    rw [flush_toBits_aligned _ hwf, htoBits]
+    refine ⟨List.replicate
+      ((8 - ([true, false, true] ++ headerBits ++ symBits).length % 8) % 8) false, ?_, ?_⟩
+    · have hheader := Deflate.Spec.encodeDynamicTrees_decodeDynamicTables litLens distLens headerBits
+        (symBits ++ List.replicate
+          ((8 - ([true, false, true] ++ headerBits ++ symBits).length % 8) % 8) false)
+        hb1 hb2 ⟨hge1, hle1⟩ ⟨hge2, hle2⟩ hlv hdv htrees
+      rw [← List.append_assoc] at hheader
+      have hres : Deflate.Spec.resolveLZ77 (tokensToSymbols #[]) [] = some data.data.toList := by
+        have he : data.data.toList = [] :=
+          List.eq_nil_of_length_eq_zero (by simp only [Array.length_toList, ByteArray.size_data, hz])
+        rw [he]; rfl
+      exact Deflate.Spec.encodeDynamic_goR_rest (tokensToSymbols #[]) data.data.toList
+        litLens distLens headerBits symBits _ hlv hdv hheader hsyms hres
+        (tokensToSymbols_validSymbolList _)
+    · simp only [List.length_replicate]; omega
+  · rename_i hz
+    have hpos : 0 < data.size := by
+      rcases Nat.eq_zero_or_pos data.size with h | h
+      · rw [h] at hz; simp at hz
+      · exact h
+    obtain ⟨henc, htokpos, hres0⟩ := deflateDynamicBlocksOptimalWindowedFast_facts data hpos
+    obtain ⟨B, htoBits, hwf, hdec⟩ :=
+      emitSharedBlocks_decodeR data (lz77OptimalWindowedFastIter data)
+        tokChunk (by omega) henc
+        (lz77OptimalWindowedFastIter data).size 0 []
+        data.data.toList BitWriter.empty (by omega) htokpos BitWriter.empty_wf hres0
+    rw [BitWriter.empty_toBits, List.nil_append] at htoBits
+    rw [flush_toBits_aligned _ hwf, htoBits]
+    refine ⟨List.replicate ((8 - B.length % 8) % 8) false, hdec _, ?_⟩
+    simp only [List.length_replicate]; omega
+
+/-- The output of `deflateDynamicBlocksOptimalWindowedFast` decomposes into content bits
+    plus short (< 8-bit) padding. -/
+theorem deflateDynamicBlocksOptimalWindowedFast_pad (data : ByteArray) (tokChunk : Nat) :
+    ∃ (contentBits padding : List Bool),
+      Deflate.Spec.bytesToBits (deflateDynamicBlocksOptimalWindowedFast data tokChunk) =
+        contentBits ++ padding ∧ padding.length < 8 := by
+  unfold deflateDynamicBlocksOptimalWindowedFast
+  split
+  · obtain ⟨_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, hwf⟩ :=
+      emitDynBlock_spec BitWriter.empty BitWriter.empty_wf data #[] (by simp) (fun _ => rfl) true
+    exact ⟨_, _, flush_toBits_aligned _ hwf, by simp only [List.length_replicate]; omega⟩
+  · rename_i hz
+    have hpos : 0 < data.size := by
+      rcases Nat.eq_zero_or_pos data.size with h | h
+      · rw [h] at hz; simp at hz
+      · exact h
+    obtain ⟨henc, htokpos, hres0⟩ := deflateDynamicBlocksOptimalWindowedFast_facts data hpos
+    obtain ⟨B, _, hwf, _⟩ :=
+      emitSharedBlocks_decode data (lz77OptimalWindowedFastIter data)
+        tokChunk (by omega) henc
+        (lz77OptimalWindowedFastIter data).size 0 []
+        data.data.toList BitWriter.empty (by omega) htokpos BitWriter.empty_wf hres0
+    exact ⟨_, _, flush_toBits_aligned _ hwf, by simp only [List.length_replicate]; omega⟩
+
 /-! ## Sized-tree emitter equality (Wave 5, #2552)
 
 `deflateDynamicBlocksSharedSized` reuses the per-block Huffman trees the

--- a/Zip/Spec/DeflateRoundtrip.lean
+++ b/Zip/Spec/DeflateRoundtrip.lean
@@ -176,17 +176,28 @@ theorem inflate_deflateRaw (data : ByteArray) (level : UInt8)
     · exact inflate_deflateStoredPure data _ (by omega)
     · split
       · split
-        · -- level 9: L9-fast (#2638)
-          exact inflate_pickSmaller _ _ data maxOutputSize
-            (inflate_deflateRawBase data level _ hsize)
-            (inflate_deflateDynamicBlocksOptimalFast data sharedTokChunk _ hsize)
-        · split
-          · -- level ≥ 10: exact-DP crown
+        · -- level 9 (L9-fast, #2638)
+          split
+          · -- ≤ gate: the standard L9-fast parse
             exact inflate_pickSmaller _ _ data maxOutputSize
               (inflate_deflateRawBase data level _ hsize)
-              (inflate_deflateDynamicBlocksOptimal data sharedTokChunk _ hsize)
-          · -- levels 6–8 (and 9/10 above the optimal-size gate): one obs-split
-            -- candidate per tier, so `hwithObs` covers all three
+              (inflate_deflateDynamicBlocksOptimalFast data sharedTokChunk _ hsize)
+          · -- above gate: the windowed L9-fast parse (#2787)
+            exact inflate_pickSmaller _ _ data maxOutputSize
+              (inflate_deflateRawBase data level _ hsize)
+              (inflate_deflateDynamicBlocksOptimalWindowedFast data sharedTokChunk _ hsize)
+        · split
+          · -- level ≥ 10: exact-DP crown
+            split
+            · -- ≤ gate: the standard exact parse
+              exact inflate_pickSmaller _ _ data maxOutputSize
+                (inflate_deflateRawBase data level _ hsize)
+                (inflate_deflateDynamicBlocksOptimal data sharedTokChunk _ hsize)
+            · -- above gate: the windowed exact parse (#2787)
+              exact inflate_pickSmaller _ _ data maxOutputSize
+                (inflate_deflateRawBase data level _ hsize)
+                (inflate_deflateDynamicBlocksOptimalWindowed data sharedTokChunk _ hsize)
+          · -- levels 6–8: obs-split candidate, `hwithObs`
             exact hwithObs _ rfl
       · exact inflate_deflateRawBase data level _ hsize
 
@@ -306,20 +317,34 @@ theorem deflateRaw_pad (data : ByteArray) (level : UInt8) :
     · exact hstored
     · split
       · split
-        · -- level 9: L9-fast (#2638)
-          exact pickSmaller_bytesToBits
-            (P := fun bits => ∃ (contentBits padding : List Bool),
-              bits = contentBits ++ padding ∧ padding.length < 8)
-            _ _ (deflateRawBase_pad data level)
-            (deflateDynamicBlocksOptimalFast_pad data sharedTokChunk)
-        · split
-          · -- level ≥ 10: exact-DP crown
+        · -- level 9 (L9-fast, #2638)
+          split
+          · exact pickSmaller_bytesToBits
+              (P := fun bits => ∃ (contentBits padding : List Bool),
+                bits = contentBits ++ padding ∧ padding.length < 8)
+              _ _ (deflateRawBase_pad data level)
+              (deflateDynamicBlocksOptimalFast_pad data sharedTokChunk)
+          · -- above gate: windowed L9-fast (#2787)
             exact pickSmaller_bytesToBits
               (P := fun bits => ∃ (contentBits padding : List Bool),
                 bits = contentBits ++ padding ∧ padding.length < 8)
               _ _ (deflateRawBase_pad data level)
-              (deflateDynamicBlocksOptimal_pad data sharedTokChunk)
-          · -- levels 6–8 (and 9/10 above the optimal-size gate)
+              (deflateDynamicBlocksOptimalWindowedFast_pad data sharedTokChunk)
+        · split
+          · -- level ≥ 10: exact-DP crown
+            split
+            · exact pickSmaller_bytesToBits
+                (P := fun bits => ∃ (contentBits padding : List Bool),
+                  bits = contentBits ++ padding ∧ padding.length < 8)
+                _ _ (deflateRawBase_pad data level)
+                (deflateDynamicBlocksOptimal_pad data sharedTokChunk)
+            · -- above gate: windowed exact (#2787)
+              exact pickSmaller_bytesToBits
+                (P := fun bits => ∃ (contentBits padding : List Bool),
+                  bits = contentBits ++ padding ∧ padding.length < 8)
+                _ _ (deflateRawBase_pad data level)
+                (deflateDynamicBlocksOptimalWindowed_pad data sharedTokChunk)
+          · -- levels 6–8
             exact hwithObs _ rfl
       · exact deflateRawBase_pad data level
 
@@ -514,22 +539,38 @@ theorem deflateRaw_goR_pad (data : ByteArray) (level : UInt8) :
     · exact hstored
     · split
       · split
-        · -- level 9: L9-fast (#2638)
-          exact pickSmaller_bytesToBits
-            (P := fun bits => ∃ remaining,
-              Deflate.Spec.decode.goR bits [] = some (data.data.toList, remaining) ∧
-                remaining.length < 8)
-            _ _ (deflateRawBase_goR_pad data level)
-            (deflateDynamicBlocksOptimalFast_goR_pad data sharedTokChunk)
-        · split
-          · -- level ≥ 10: exact-DP crown
+        · -- level 9 (L9-fast, #2638)
+          split
+          · exact pickSmaller_bytesToBits
+              (P := fun bits => ∃ remaining,
+                Deflate.Spec.decode.goR bits [] = some (data.data.toList, remaining) ∧
+                  remaining.length < 8)
+              _ _ (deflateRawBase_goR_pad data level)
+              (deflateDynamicBlocksOptimalFast_goR_pad data sharedTokChunk)
+          · -- above gate: windowed L9-fast (#2787)
             exact pickSmaller_bytesToBits
               (P := fun bits => ∃ remaining,
                 Deflate.Spec.decode.goR bits [] = some (data.data.toList, remaining) ∧
                   remaining.length < 8)
               _ _ (deflateRawBase_goR_pad data level)
-              (deflateDynamicBlocksOptimal_goR_pad data sharedTokChunk)
-          · -- levels 6–8 (and 9/10 above the optimal-size gate)
+              (deflateDynamicBlocksOptimalWindowedFast_goR_pad data sharedTokChunk)
+        · split
+          · -- level ≥ 10: exact-DP crown
+            split
+            · exact pickSmaller_bytesToBits
+                (P := fun bits => ∃ remaining,
+                  Deflate.Spec.decode.goR bits [] = some (data.data.toList, remaining) ∧
+                    remaining.length < 8)
+                _ _ (deflateRawBase_goR_pad data level)
+                (deflateDynamicBlocksOptimal_goR_pad data sharedTokChunk)
+            · -- above gate: windowed exact (#2787)
+              exact pickSmaller_bytesToBits
+                (P := fun bits => ∃ remaining,
+                  Deflate.Spec.decode.goR bits [] = some (data.data.toList, remaining) ∧
+                    remaining.length < 8)
+                _ _ (deflateRawBase_goR_pad data level)
+                (deflateDynamicBlocksOptimalWindowed_goR_pad data sharedTokChunk)
+          · -- levels 6–8
             exact hwithObs _ rfl
       · exact deflateRawBase_goR_pad data level
 

--- a/Zip/Spec/LZ77OptimalCorrect.lean
+++ b/Zip/Spec/LZ77OptimalCorrect.lean
@@ -231,4 +231,200 @@ theorem lz77OptimalFastIter_empty (data : ByteArray) (hzero : data.size = 0) :
     lz77OptimalFastIter data = #[] := by
   rw [lz77OptimalFastIter_eq_lz77OptimalFast]; exact lz77OptimalFast_empty data hzero
 
+/-! ## Windowed parser contracts (#2787)
+
+The windowed emitter (`windowedEmit`) re-verifies every match exactly as
+`optimalEmit` does — the same emission guard plus a fresh `countMatch` — so its
+validity and encodability proofs are the same argument, extended by the one new
+(non-emitting) *refill* branch, which the induction hypothesis discharges
+directly. The region-fill closure `fill`'s output is never inspected: as with
+the rest of the DP, the windowed parse is opaque to correctness. -/
+
+/-- `windowedEmit` produces a valid decomposition from `pos`, for an arbitrary
+    region-fill closure and window state: identical to `optimalEmit_valid` on the
+    emit branches, with the refill branch handled by the recursion. -/
+theorem windowedEmit_valid (data : ByteArray) (fill : WindowFill) (regionSize base : Nat)
+    (cLen cDist ht prev h3tab : Array Nat) (r pos : Nat) (hrs : 1 ≤ regionSize) (hr1 : 1 ≤ r) :
+    ValidDecomp data pos
+      (windowedEmit data fill regionSize base cLen cDist ht prev h3tab r pos hrs hr1) := by
+  unfold windowedEmit
+  split
+  · rename_i hpos
+    split
+    · rename_i hpr
+      dsimp only
+      have hlit : ValidDecomp data pos (.literal (data[pos]'hpos) ::
+          windowedEmit data fill regionSize base cLen cDist ht prev h3tab r (pos + 1) hrs hr1) :=
+        .literal hpos (getElem!_pos data pos hpos)
+          (windowedEmit_valid data fill regionSize base cLen cDist ht prev h3tab r (pos + 1) hrs hr1)
+      split
+      · rename_i hg
+        split
+        · rename_i hml
+          refine ValidDecomp.reference hg.1 hg.2.2.2.1 hg.2.2.2.2.1 hg.2.2.1 ?_ ?_
+          · intro i hi
+            have hcm := lz77Greedy.countMatch_matches data (pos - cDist[pos - base]!) pos
+              cLen[pos - base]! (by omega) hg.2.2.1
+            exact (hcm.1 i (by omega)).symm
+          · exact windowedEmit_valid data fill regionSize base cLen cDist ht prev h3tab r
+              (pos + cLen[pos - base]!) hrs hr1
+        · exact hlit
+      · exact hlit
+    · rename_i hpr
+      dsimp only
+      exact windowedEmit_valid data fill regionSize (base + r) _ _ _ _ _
+        (min regionSize (data.size - (base + r))) pos hrs (by omega)
+  · exact .done (by omega)
+termination_by 2 * (data.size - pos) + (data.size - base)
+decreasing_by all_goals omega
+
+/-- Every token `windowedEmit` emits satisfies the encoder bounds. -/
+theorem windowedEmit_encodable (data : ByteArray) (fill : WindowFill) (regionSize base : Nat)
+    (cLen cDist ht prev h3tab : Array Nat) (r pos : Nat) (hrs : 1 ≤ regionSize) (hr1 : 1 ≤ r) :
+    ∀ t ∈ windowedEmit data fill regionSize base cLen cDist ht prev h3tab r pos hrs hr1,
+      match t with
+      | .literal _ => True
+      | .reference len dist => 3 ≤ len ∧ len ≤ 258 ∧ 1 ≤ dist ∧ dist ≤ 32768 := by
+  unfold windowedEmit
+  split
+  · rename_i hpos
+    split
+    · rename_i hpr
+      dsimp only
+      split
+      · rename_i hg
+        split
+        · exact List.forall_mem_cons.2 ⟨⟨hg.1, hg.2.1, hg.2.2.2.1, hg.2.2.2.2.2⟩,
+            windowedEmit_encodable data fill regionSize base cLen cDist ht prev h3tab r _ hrs hr1⟩
+        · exact List.forall_mem_cons.2 ⟨trivial,
+            windowedEmit_encodable data fill regionSize base cLen cDist ht prev h3tab r _ hrs hr1⟩
+      · exact List.forall_mem_cons.2 ⟨trivial,
+          windowedEmit_encodable data fill regionSize base cLen cDist ht prev h3tab r _ hrs hr1⟩
+    · rename_i hpr
+      dsimp only
+      exact windowedEmit_encodable data fill regionSize (base + r) _ _ _ _ _
+        (min regionSize (data.size - (base + r))) pos hrs (by omega)
+  · intro t ht; cases ht
+termination_by 2 * (data.size - pos) + (data.size - base)
+decreasing_by all_goals omega
+
+/-- The iterative windowed emitter is the accumulator form of the recursive one. -/
+theorem windowedEmitIter_eq (data : ByteArray) (fill : WindowFill) (regionSize base : Nat)
+    (cLen cDist ht prev h3tab : Array Nat) (r pos : Nat) (acc : Array LZ77Token)
+    (hrs : 1 ≤ regionSize) (hr1 : 1 ≤ r) :
+    windowedEmitIter data fill regionSize base cLen cDist ht prev h3tab r pos acc hrs hr1 =
+      acc ++ (windowedEmit data fill regionSize base cLen cDist ht prev h3tab r pos hrs hr1).toArray := by
+  unfold windowedEmitIter windowedEmit
+  split
+  · rename_i hpos
+    split
+    · rename_i hpr
+      dsimp only
+      split
+      · rename_i hg
+        split
+        · rw [windowedEmitIter_eq data fill regionSize base cLen cDist ht prev h3tab r _ _ hrs hr1,
+            List.toArray_cons, ← Array.append_assoc, Array.push_eq_append]
+        · rw [windowedEmitIter_eq data fill regionSize base cLen cDist ht prev h3tab r _ _ hrs hr1,
+            List.toArray_cons, ← Array.append_assoc, Array.push_eq_append]
+      · rw [windowedEmitIter_eq data fill regionSize base cLen cDist ht prev h3tab r _ _ hrs hr1,
+          List.toArray_cons, ← Array.append_assoc, Array.push_eq_append]
+    · rename_i hpr
+      dsimp only
+      rw [windowedEmitIter_eq data fill regionSize (base + r) _ _ _ _ _
+        (min regionSize (data.size - (base + r))) pos acc hrs (by omega)]
+  · simp
+termination_by 2 * (data.size - pos) + (data.size - base)
+decreasing_by all_goals omega
+
+/-! ### Contracts for the two windowed entry points
+
+`lz77OptimalWindowedIter` and `lz77OptimalWindowedFastIter` differ only in the
+`fill` closure passed to `lz77OptimalWindowedWith`; every contract is proved once
+against the shared driver and specializes to both. -/
+
+/-- The shared windowed driver produces a valid decomposition of the whole
+    input, for any region-fill closure. -/
+theorem lz77OptimalWindowedWith_valid (data : ByteArray) (fill : WindowFill) :
+    ValidDecomp data 0 (lz77OptimalWindowedWith data fill).toList := by
+  unfold lz77OptimalWindowedWith
+  split
+  · rename_i hz
+    simp only [Array.toList_empty]
+    exact .done (by omega)
+  · rename_i hz
+    dsimp only
+    rw [windowedEmitIter_eq]
+    simp only [Array.empty_append, List.toList_toArray]
+    exact windowedEmit_valid data fill optRegionSize 0 _ _ _ _ _ _ 0 _ _
+
+/-- Resolving the windowed driver's tokens recovers the data. -/
+theorem lz77OptimalWindowedWith_resolves (data : ByteArray) (fill : WindowFill) :
+    Deflate.Spec.resolveLZ77 (tokensToSymbols (lz77OptimalWindowedWith data fill)) [] =
+      some data.data.toList :=
+  validDecomp_resolves data _ (lz77OptimalWindowedWith_valid data fill)
+
+/-- Every token the windowed driver emits satisfies the encoder bounds. -/
+theorem lz77OptimalWindowedWith_encodable (data : ByteArray) (fill : WindowFill) :
+    ∀ t ∈ (lz77OptimalWindowedWith data fill).toList,
+      match t with
+      | .literal _ => True
+      | .reference len dist => 3 ≤ len ∧ len ≤ 258 ∧ 1 ≤ dist ∧ dist ≤ 32768 := by
+  unfold lz77OptimalWindowedWith
+  split
+  · rename_i hz
+    simp only [Array.toList_empty]
+    intro t ht; cases ht
+  · rename_i hz
+    dsimp only
+    rw [windowedEmitIter_eq]
+    simp only [Array.empty_append, List.toList_toArray]
+    exact windowedEmit_encodable data fill optRegionSize 0 _ _ _ _ _ _ 0 _ _
+
+/-- The windowed driver emits no tokens on empty input. -/
+theorem lz77OptimalWindowedWith_empty (data : ByteArray) (fill : WindowFill)
+    (hzero : data.size = 0) : lz77OptimalWindowedWith data fill = #[] := by
+  unfold lz77OptimalWindowedWith
+  simp only [hzero, ↓reduceDIte]
+
+theorem lz77OptimalWindowedIter_valid (data : ByteArray) :
+    ValidDecomp data 0 (lz77OptimalWindowedIter data).toList :=
+  lz77OptimalWindowedWith_valid data _
+
+theorem lz77OptimalWindowedIter_resolves (data : ByteArray) :
+    Deflate.Spec.resolveLZ77 (tokensToSymbols (lz77OptimalWindowedIter data)) [] =
+      some data.data.toList :=
+  lz77OptimalWindowedWith_resolves data _
+
+theorem lz77OptimalWindowedIter_encodable (data : ByteArray) :
+    ∀ t ∈ (lz77OptimalWindowedIter data).toList,
+      match t with
+      | .literal _ => True
+      | .reference len dist => 3 ≤ len ∧ len ≤ 258 ∧ 1 ≤ dist ∧ dist ≤ 32768 :=
+  lz77OptimalWindowedWith_encodable data _
+
+theorem lz77OptimalWindowedIter_empty (data : ByteArray) (hzero : data.size = 0) :
+    lz77OptimalWindowedIter data = #[] :=
+  lz77OptimalWindowedWith_empty data _ hzero
+
+theorem lz77OptimalWindowedFastIter_valid (data : ByteArray) :
+    ValidDecomp data 0 (lz77OptimalWindowedFastIter data).toList :=
+  lz77OptimalWindowedWith_valid data _
+
+theorem lz77OptimalWindowedFastIter_resolves (data : ByteArray) :
+    Deflate.Spec.resolveLZ77 (tokensToSymbols (lz77OptimalWindowedFastIter data)) [] =
+      some data.data.toList :=
+  lz77OptimalWindowedWith_resolves data _
+
+theorem lz77OptimalWindowedFastIter_encodable (data : ByteArray) :
+    ∀ t ∈ (lz77OptimalWindowedFastIter data).toList,
+      match t with
+      | .literal _ => True
+      | .reference len dist => 3 ≤ len ∧ len ≤ 258 ∧ 1 ≤ dist ∧ dist ≤ 32768 :=
+  lz77OptimalWindowedWith_encodable data _
+
+theorem lz77OptimalWindowedFastIter_empty (data : ByteArray) (hzero : data.size = 0) :
+    lz77OptimalWindowedFastIter data = #[] :=
+  lz77OptimalWindowedWith_empty data _ hzero
+
 end Zip.Native.Deflate

--- a/ZipTest/OptimalParse.lean
+++ b/ZipTest/OptimalParse.lean
@@ -70,7 +70,8 @@ private def resolveTokens (label : String) (tokens : Array LZ77Token) :
     each token stream resolves back to the data, and a dynamic Huffman block
     built from it inflates back to the data (native verified decoder). -/
 private def checkParse (label : String) (data : ByteArray) : IO Unit := do
-  for (pname, toks) in [("exact", lz77OptimalIter data), ("fast", lz77OptimalFastIter data)] do
+  for (pname, toks) in [("exact", lz77OptimalIter data), ("fast", lz77OptimalFastIter data),
+      ("wexact", lz77OptimalWindowedIter data), ("wfast", lz77OptimalWindowedFastIter data)] do
     let back ← resolveTokens s!"{label}-{pname}" toks
     unless back == data do
       throw (IO.userError s!"{label}-{pname}: token resolution mismatch ({back.size} vs {data.size})")
@@ -80,6 +81,13 @@ private def checkParse (label : String) (data : ByteArray) : IO Unit := do
       unless r == data do
         throw (IO.userError s!"{label}-{pname}: dynamic block roundtrip mismatch")
     | .error e => throw (IO.userError s!"{label}-{pname}: inflate failed: {e}")
+  -- Windowed parsers (#2787) cap live choice storage to one region but thread the
+  -- hash-chain state across regions, so they must produce byte-identical tokens
+  -- to the global parsers (only the ratio-neutral memory shape changes).
+  unless lz77OptimalWindowedIter data == lz77OptimalIter data do
+    throw (IO.userError s!"{label}: windowed exact tokens differ from global")
+  unless lz77OptimalWindowedFastIter data == lz77OptimalFastIter data do
+    throw (IO.userError s!"{label}: windowed L9-fast tokens differ from global")
 
 def tests : IO Unit := do
   IO.println "  OptimalParse tests..."
@@ -203,8 +211,10 @@ def tests : IO Unit := do
   let prng := mkPrngData 65536
   unless (deflateRaw prng 9).size ≤ prng.size + 600 do
     throw (IO.userError "deflateRaw-9: incompressible input expanded past stored bound")
-  -- Inputs above the memory gate skip the optimal candidate but roundtrip
-  -- (both level 9 and level 10 fall through to the split path there).
+  -- Inputs above the memory gate now run the *windowed* optimal candidate
+  -- (#2787): region-capped choice storage, byte-identical tokens, so the crown
+  -- survives past 64 MiB instead of collapsing to the split ratio. Verify both
+  -- tiers roundtrip through the whole `deflateRaw` dispatch above the gate.
   let big := mkConstantData (optimalMaxSize + 1)
   for lvl in [(9 : UInt8), 10] do
     match Zip.Native.Inflate.inflate (deflateRaw big lvl) (big.size + 1) with

--- a/bench/graphs/canterbury_compress_heatmap.svg
+++ b/bench/graphs/canterbury_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#pa3e89175f0)">
+   <g clip-path="url(#pd6d8e8b52b)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJBklEQVR4nO3YvYpdVQCG4TmZM5qYUQbBGBIIgoKNYKWN9vZeiFdg4zV4ByLYi2BhbWMpNgqCRAmIIdH8zEwm58dCsBfexTKb57mCb7NY+7xnr3Z/fbE/4Nly/mj2gnGeLPPZ9hfnsycMs3rp2uwJYzz/wuwF46wuzV4wxtPl3rOlntn+3m+zJwyzzBMDAJhIYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxNa3V/dmbxjiYns+e8Iw109emz1hmOPdtdkThlidPZg9YZhvz36cPWGIG8+9MnvCMNvdZvaEIR5uTmdPGGaz386eMMQ7L96cPWEYX7AAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgtj4+Opm9YYjdejd7wjDHB5dnTxjnz9uzFwyxP3swe8Iw7956b/aEIU43yz2zxwt9tjeO35o9YZiL1Wb2hCH2v3w/e8IwvmABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBAbH3l8Hj2hiHOt6ezJ4yzWnAXX35p9oIhVgs+s6PNZvaEIZZ8ZlfXy7xnv1/cmT1hmM3uYvaEIW5ePZk9YZjlvkEAACYRWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABBbbX/4ZD97BPxrt5u9AP5xyf/PZ473B/8j3iAAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQW3/0x+3ZG4Z48GQ7e8Iw3915OHvCMF99+P7sCUO8euXW7AnDvP3Z57MnDPHB6y/PnjDMz/fPZk8Y4sr6cPaEYb78+qfZE4Y4/fTj2ROG8QULACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYqvN7pv97BEjbHeb2ROGubRabhcfnp/OnjDG4Xr2gnEe35u9YIjtyfXZE4bZ7XezJwxxtFruPXu6X+Zv2tFmmc91cOALFgBATmABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMTWlxbaWNvZAwY6vH9n9oRxHt2dvWCI/cXT2ROGWd14c/YE/qMn29PZE4Y4Wu41Ozi6WOaZ7e/+OnvCMMusKwCAiQQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEDsb9P6geX4D1cUAAAAAElFTkSuQmCC" id="image82b341bd8c" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJD0lEQVR4nO3Yv6plZx3H4dlz9tEZcwyDkDEkEAIGbIRUptHe3gvJFdh4Dd6BBNKHgIW1jaWkiSDIEAdCdJJMkjNnzuw/KQR74fPySxbPcwXfxcta+7Pf3enL9893+H65+Xp6wTrPt/ls59ub6QnL7F5+OD1hjR/+aHrBOru70wvWeLHd92yrZ3Z+8sn0hGW2eWIAAIMEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBAbP9o92R6wxK3x5vpCcu8+uDN6QnLXJ0eTk9YYvfs6fSEZf7y7OPpCUu89oNXpicsczwdpics8dXhenrCMofzcXrCEr/88evTE5ZxgwUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAACx/dXlg+kNS5z2p+kJy1zduTc9YZ0vHk0vWOL87On0hGXeeeNX0xOWuD5s98y+2eizvXX1i+kJy9zuDtMTljj/82/TE5ZxgwUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAACx/f2Lq+kNS9wcr6cnrLPbcBffe3l6wRK7DZ/Z5eEwPWGJLZ/ZS/ttvmef3j6enrDM4XQ7PWGJ1196MD1hme1+QQAAhggsAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiO2OH/3+PD0C/ud0ml4A/3XX/8/vHd8PvkN8QQAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACC2f/ezR9Mblnj6/Dg9YZm/Pv5qesIyH/7219MTlvjp/TemJyzz9h/fm56wxG9+9pPpCcv84/Nn0xOWuL+/mJ6wzAd/+vv0hCWu//C76QnLuMECAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACA2O5w+vN5esQKx9NhesIyd3fb7eKLm+vpCWtc7KcXrPPNk+kFSxwfvDo9YZnT+TQ9YYnL3Xbfsxfnbf6mXR62+Vx37rjBAgDICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgNj+7kYb6zg9YKGLzx9PT1jn639PL1jifPtiesIyu9d+Pj2B/9Pt6WZ6whKXzw/TE5a5vL2enrDE+T//mp6wzDbrCgBgkMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIh9C2+nguZFZfrYAAAAAElFTkSuQmCC" id="image4eea8528b2" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m7633cf6bf2" d="M 0 0 
+       <path id="m00bb4f7fd2" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m7633cf6bf2" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m00bb4f7fd2" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m7633cf6bf2" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m00bb4f7fd2" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m7633cf6bf2" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m00bb4f7fd2" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m7633cf6bf2" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m00bb4f7fd2" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m7633cf6bf2" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m00bb4f7fd2" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m7633cf6bf2" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m00bb4f7fd2" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m7633cf6bf2" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m00bb4f7fd2" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m7633cf6bf2" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m00bb4f7fd2" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m7633cf6bf2" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m00bb4f7fd2" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m7633cf6bf2" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m00bb4f7fd2" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m7633cf6bf2" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m00bb4f7fd2" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="mc72cc03656" d="M 0 0 
+       <path id="m24fedad417" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mc72cc03656" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m24fedad417" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#mc72cc03656" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m24fedad417" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mc72cc03656" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m24fedad417" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#mc72cc03656" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m24fedad417" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#mc72cc03656" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m24fedad417" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#mc72cc03656" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m24fedad417" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mc72cc03656" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m24fedad417" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#mc72cc03656" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m24fedad417" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1359,11 +1359,11 @@ z
     </g>
    </g>
    <g id="text_21">
-    <!-- +11 -->
+    <!-- +10 -->
     <g transform="translate(147.693424 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_22">
@@ -1406,16 +1406,8 @@ z
     </g>
    </g>
    <g id="text_23">
-    <!-- -79 -->
+    <!-- -78 -->
     <g transform="translate(227.74588 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_24">
-    <!-- -88 -->
-    <g transform="translate(266.996679 68.904519) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -1458,47 +1450,87 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_24">
+    <!-- -88 -->
+    <g transform="translate(266.996679 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_25">
-    <!-- -25 -->
+    <!-- -26 -->
     <g transform="translate(306.247477 68.904519) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_26">
-    <!-- +7 -->
+    <!-- +6 -->
     <g transform="translate(346.015229 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_27">
-    <!-- +25 -->
+    <!-- +24 -->
     <g transform="translate(383.198215 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_28">
-    <!-- -27 -->
+    <!-- -29 -->
     <g transform="translate(423.999873 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_29">
-    <!-- -43 -->
+    <!-- -45 -->
     <g transform="translate(463.250671 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_30">
@@ -1631,38 +1663,6 @@ z
    <g id="text_46">
     <!-- +26 -->
     <g transform="translate(265.44582 139.606222) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-36" d="M 2113 2584 
-Q 1688 2584 1439 2293 
-Q 1191 2003 1191 1497 
-Q 1191 994 1439 701 
-Q 1688 409 2113 409 
-Q 2538 409 2786 701 
-Q 3034 994 3034 1497 
-Q 3034 2003 2786 2293 
-Q 2538 2584 2113 2584 
-z
-M 3366 4563 
-L 3366 3988 
-Q 3128 4100 2886 4159 
-Q 2644 4219 2406 4219 
-Q 1781 4219 1451 3797 
-Q 1122 3375 1075 2522 
-Q 1259 2794 1537 2939 
-Q 1816 3084 2150 3084 
-Q 2853 3084 3261 2657 
-Q 3669 2231 3669 1497 
-Q 3669 778 3244 343 
-Q 2819 -91 2113 -91 
-Q 1303 -91 875 529 
-Q 447 1150 447 2328 
-Q 447 3434 972 4092 
-Q 1497 4750 2381 4750 
-Q 2619 4750 2861 4703 
-Q 3103 4656 3366 4563 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
@@ -2177,18 +2177,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="imageec22a055fa" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
+iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="image1783b24fb6" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="m244bd5621d" d="M 0 0 
+       <path id="mf5ffc6765f" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m244bd5621d" x="547.779688" y="276.293905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf5ffc6765f" x="547.779688" y="276.293905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
@@ -2211,7 +2211,7 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m244bd5621d" x="547.779688" y="247.808905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf5ffc6765f" x="547.779688" y="247.808905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
@@ -2225,7 +2225,7 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m244bd5621d" x="547.779688" y="219.323905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf5ffc6765f" x="547.779688" y="219.323905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
@@ -2239,7 +2239,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m244bd5621d" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf5ffc6765f" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
@@ -2252,7 +2252,7 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m244bd5621d" x="547.779688" y="162.353904" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf5ffc6765f" x="547.779688" y="162.353904" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_112">
@@ -2265,7 +2265,7 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m244bd5621d" x="547.779688" y="133.868904" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf5ffc6765f" x="547.779688" y="133.868904" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
@@ -2278,7 +2278,7 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m244bd5621d" x="547.779688" y="105.383904" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf5ffc6765f" x="547.779688" y="105.383904" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
@@ -2939,8 +2939,8 @@ z
    </g>
   </g>
   <g id="text_117">
-   <!-- 2026-07-06T22:02:31Z  ·  Linux chungus2 x86_64  ·  commit ac74ebaf  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(17.919844 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-07T02:05:28Z  ·  Linux chungus2 x86_64  ·  commit 1a899305  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(16.462422 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -3007,16 +3007,16 @@ z
     <use xlink:href="#DejaVuSans-37" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3056,109 +3056,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3133.154297 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3188.134766 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3251.757812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3315.380859 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3376.904297 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3440.380859 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3501.660156 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3536.865234 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3568.652344 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3600.439453 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3632.226562 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3664.013672 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3695.800781 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3723.583984 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3785.107422 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3846.386719 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3909.765625 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3973.242188 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4012.105469 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4073.287109 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4132.466797 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4193.990234 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4235.103516 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4268.794922 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4296.578125 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4358.101562 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4419.380859 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4482.759766 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4546.382812 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4580.074219 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4639.253906 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4702.876953 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4734.664062 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4798.287109 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4861.910156 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4893.697266 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4957.320312 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4993.404297 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5032.267578 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5087.248047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5150.871094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5182.658203 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5214.445312 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5246.232422 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5278.019531 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5309.806641 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5349.015625 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5412.394531 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5451.257812 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5512.439453 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5575.818359 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5639.294922 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5702.673828 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5766.150391 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5829.529297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5868.738281 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5900.525391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5984.314453 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6016.101562 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6113.513672 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6175.037109 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6238.513672 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6266.296875 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6327.576172 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6390.955078 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6422.742188 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6474.841797 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6538.220703 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6599.5 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6662.976562 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6715.076172 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6778.455078 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6839.636719 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6878.845703 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6912.537109 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6944.324219 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6985.4375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7046.716797 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7085.925781 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7113.708984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7174.890625 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7206.677734 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7234.460938 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7286.560547 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7318.347656 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7381.824219 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7443.347656 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7482.556641 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7544.080078 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7583.443359 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7680.855469 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7708.638672 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7772.017578 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7799.800781 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7851.900391 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7891.109375 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7918.892578 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3196.777344 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3260.400391 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3324.023438 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3387.646484 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3451.269531 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3514.892578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3578.515625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3610.302734 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3642.089844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3673.876953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3705.664062 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3737.451172 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3765.234375 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3826.757812 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3888.037109 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3951.416016 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4014.892578 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4053.755859 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4114.9375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4174.117188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4235.640625 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4276.753906 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4310.445312 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4338.228516 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4399.751953 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4461.03125 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4524.410156 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4588.033203 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4621.724609 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4680.904297 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4744.527344 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4776.314453 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4839.9375 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4903.560547 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4935.347656 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4998.970703 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5035.054688 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5073.917969 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5128.898438 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5192.521484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5224.308594 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5256.095703 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5287.882812 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5319.669922 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5351.457031 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5390.666016 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5454.044922 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5492.908203 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5554.089844 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5617.46875 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5680.945312 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5744.324219 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5807.800781 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5871.179688 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5910.388672 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5942.175781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6025.964844 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6057.751953 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6155.164062 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6216.6875 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6280.164062 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6307.947266 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6369.226562 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6432.605469 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6464.392578 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6516.492188 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6579.871094 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6641.150391 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6704.626953 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6756.726562 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6820.105469 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6881.287109 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6920.496094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6954.1875 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6985.974609 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7027.087891 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7088.367188 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7127.576172 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7155.359375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7216.541016 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7248.328125 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7276.111328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7328.210938 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7359.998047 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7423.474609 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7484.998047 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7524.207031 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7585.730469 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7625.09375 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7722.505859 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7750.289062 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7813.667969 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7841.451172 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7893.550781 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7932.759766 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7960.542969 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pa3e89175f0">
+  <clipPath id="pd6d8e8b52b">
    <rect x="95.67625" y="49.4355" width="431.758783" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_compress_pareto.svg
+++ b/bench/graphs/canterbury_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 79.118387 412.80375 
 L 79.118387 48.323125 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m210e7502e8" d="M 0 0 
+       <path id="mb8ecdc507c" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m210e7502e8" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb8ecdc507c" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -161,11 +161,11 @@ z
      <g id="line2d_3">
       <path d="M 166.481434 412.80375 
 L 166.481434 48.323125 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m210e7502e8" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb8ecdc507c" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -216,11 +216,11 @@ z
      <g id="line2d_5">
       <path d="M 253.844481 412.80375 
 L 253.844481 48.323125 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m210e7502e8" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb8ecdc507c" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -237,11 +237,11 @@ L 253.844481 48.323125
      <g id="line2d_7">
       <path d="M 341.207528 412.80375 
 L 341.207528 48.323125 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m210e7502e8" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb8ecdc507c" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -279,11 +279,11 @@ z
      <g id="line2d_9">
       <path d="M 428.570575 412.80375 
 L 428.570575 48.323125 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m210e7502e8" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb8ecdc507c" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -332,11 +332,11 @@ z
      <g id="line2d_11">
       <path d="M 515.933622 412.80375 
 L 515.933622 48.323125 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m210e7502e8" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb8ecdc507c" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -353,11 +353,11 @@ L 515.933622 48.323125
      <g id="line2d_13">
       <path d="M 603.296669 412.80375 
 L 603.296669 48.323125 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m210e7502e8" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb8ecdc507c" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -854,16 +854,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 347.786382 
 L 637.2 347.786382 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="m325db555d2" d="M 0 0 
+       <path id="m10a4cb6b4c" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m325db555d2" x="49.078125" y="347.786382" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m10a4cb6b4c" x="49.078125" y="347.786382" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -895,11 +895,11 @@ z
      <g id="line2d_17">
       <path d="M 49.078125 238.646289 
 L 637.2 238.646289 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m325db555d2" x="49.078125" y="238.646289" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m10a4cb6b4c" x="49.078125" y="238.646289" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -915,11 +915,11 @@ L 637.2 238.646289
      <g id="line2d_19">
       <path d="M 49.078125 129.506196 
 L 637.2 129.506196 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m325db555d2" x="49.078125" y="129.506196" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m10a4cb6b4c" x="49.078125" y="129.506196" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -935,16 +935,16 @@ L 637.2 129.506196
      <g id="line2d_21">
       <path d="M 49.078125 404.853417 
 L 637.2 404.853417 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="md13d29b70a" d="M 0 0 
+       <path id="mafee7c4355" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#md13d29b70a" x="49.078125" y="404.853417" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mafee7c4355" x="49.078125" y="404.853417" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -952,11 +952,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 391.217592 
 L 637.2 391.217592 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#md13d29b70a" x="49.078125" y="391.217592" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mafee7c4355" x="49.078125" y="391.217592" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -964,11 +964,11 @@ L 637.2 391.217592
      <g id="line2d_25">
       <path d="M 49.078125 380.640824 
 L 637.2 380.640824 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#md13d29b70a" x="49.078125" y="380.640824" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mafee7c4355" x="49.078125" y="380.640824" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -976,11 +976,11 @@ L 637.2 380.640824
      <g id="line2d_27">
       <path d="M 49.078125 371.998975 
 L 637.2 371.998975 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#md13d29b70a" x="49.078125" y="371.998975" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mafee7c4355" x="49.078125" y="371.998975" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -988,11 +988,11 @@ L 637.2 371.998975
      <g id="line2d_29">
       <path d="M 49.078125 364.692396 
 L 637.2 364.692396 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#md13d29b70a" x="49.078125" y="364.692396" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mafee7c4355" x="49.078125" y="364.692396" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1000,11 +1000,11 @@ L 637.2 364.692396
      <g id="line2d_31">
       <path d="M 49.078125 358.36315 
 L 637.2 358.36315 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#md13d29b70a" x="49.078125" y="358.36315" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mafee7c4355" x="49.078125" y="358.36315" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1012,11 +1012,11 @@ L 637.2 358.36315
      <g id="line2d_33">
       <path d="M 49.078125 352.780359 
 L 637.2 352.780359 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#md13d29b70a" x="49.078125" y="352.780359" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mafee7c4355" x="49.078125" y="352.780359" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1024,11 +1024,11 @@ L 637.2 352.780359
      <g id="line2d_35">
       <path d="M 49.078125 314.93194 
 L 637.2 314.93194 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#md13d29b70a" x="49.078125" y="314.93194" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mafee7c4355" x="49.078125" y="314.93194" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1036,11 +1036,11 @@ L 637.2 314.93194
      <g id="line2d_37">
       <path d="M 49.078125 295.713324 
 L 637.2 295.713324 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#md13d29b70a" x="49.078125" y="295.713324" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mafee7c4355" x="49.078125" y="295.713324" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1048,11 +1048,11 @@ L 637.2 295.713324
      <g id="line2d_39">
       <path d="M 49.078125 282.077499 
 L 637.2 282.077499 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#md13d29b70a" x="49.078125" y="282.077499" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mafee7c4355" x="49.078125" y="282.077499" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1060,11 +1060,11 @@ L 637.2 282.077499
      <g id="line2d_41">
       <path d="M 49.078125 271.500731 
 L 637.2 271.500731 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#md13d29b70a" x="49.078125" y="271.500731" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mafee7c4355" x="49.078125" y="271.500731" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1072,11 +1072,11 @@ L 637.2 271.500731
      <g id="line2d_43">
       <path d="M 49.078125 262.858882 
 L 637.2 262.858882 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#md13d29b70a" x="49.078125" y="262.858882" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mafee7c4355" x="49.078125" y="262.858882" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1084,11 +1084,11 @@ L 637.2 262.858882
      <g id="line2d_45">
       <path d="M 49.078125 255.552304 
 L 637.2 255.552304 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#md13d29b70a" x="49.078125" y="255.552304" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mafee7c4355" x="49.078125" y="255.552304" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1096,11 +1096,11 @@ L 637.2 255.552304
      <g id="line2d_47">
       <path d="M 49.078125 249.223057 
 L 637.2 249.223057 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#md13d29b70a" x="49.078125" y="249.223057" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mafee7c4355" x="49.078125" y="249.223057" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1108,11 +1108,11 @@ L 637.2 249.223057
      <g id="line2d_49">
       <path d="M 49.078125 243.640266 
 L 637.2 243.640266 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#md13d29b70a" x="49.078125" y="243.640266" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mafee7c4355" x="49.078125" y="243.640266" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1120,11 +1120,11 @@ L 637.2 243.640266
      <g id="line2d_51">
       <path d="M 49.078125 205.791848 
 L 637.2 205.791848 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#md13d29b70a" x="49.078125" y="205.791848" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mafee7c4355" x="49.078125" y="205.791848" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1132,11 +1132,11 @@ L 637.2 205.791848
      <g id="line2d_53">
       <path d="M 49.078125 186.573231 
 L 637.2 186.573231 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#md13d29b70a" x="49.078125" y="186.573231" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mafee7c4355" x="49.078125" y="186.573231" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1144,11 +1144,11 @@ L 637.2 186.573231
      <g id="line2d_55">
       <path d="M 49.078125 172.937406 
 L 637.2 172.937406 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#md13d29b70a" x="49.078125" y="172.937406" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mafee7c4355" x="49.078125" y="172.937406" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1156,11 +1156,11 @@ L 637.2 172.937406
      <g id="line2d_57">
       <path d="M 49.078125 162.360638 
 L 637.2 162.360638 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#md13d29b70a" x="49.078125" y="162.360638" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mafee7c4355" x="49.078125" y="162.360638" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1168,11 +1168,11 @@ L 637.2 162.360638
      <g id="line2d_59">
       <path d="M 49.078125 153.71879 
 L 637.2 153.71879 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#md13d29b70a" x="49.078125" y="153.71879" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mafee7c4355" x="49.078125" y="153.71879" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1180,11 +1180,11 @@ L 637.2 153.71879
      <g id="line2d_61">
       <path d="M 49.078125 146.412211 
 L 637.2 146.412211 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#md13d29b70a" x="49.078125" y="146.412211" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mafee7c4355" x="49.078125" y="146.412211" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1192,11 +1192,11 @@ L 637.2 146.412211
      <g id="line2d_63">
       <path d="M 49.078125 140.082964 
 L 637.2 140.082964 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#md13d29b70a" x="49.078125" y="140.082964" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mafee7c4355" x="49.078125" y="140.082964" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1204,11 +1204,11 @@ L 637.2 140.082964
      <g id="line2d_65">
       <path d="M 49.078125 134.500173 
 L 637.2 134.500173 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#md13d29b70a" x="49.078125" y="134.500173" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mafee7c4355" x="49.078125" y="134.500173" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1216,11 +1216,11 @@ L 637.2 134.500173
      <g id="line2d_67">
       <path d="M 49.078125 96.651755 
 L 637.2 96.651755 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_68">
       <g>
-       <use xlink:href="#md13d29b70a" x="49.078125" y="96.651755" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mafee7c4355" x="49.078125" y="96.651755" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1228,11 +1228,11 @@ L 637.2 96.651755
      <g id="line2d_69">
       <path d="M 49.078125 77.433138 
 L 637.2 77.433138 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_70">
       <g>
-       <use xlink:href="#md13d29b70a" x="49.078125" y="77.433138" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mafee7c4355" x="49.078125" y="77.433138" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1240,11 +1240,11 @@ L 637.2 77.433138
      <g id="line2d_71">
       <path d="M 49.078125 63.797313 
 L 637.2 63.797313 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_72">
       <g>
-       <use xlink:href="#md13d29b70a" x="49.078125" y="63.797313" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mafee7c4355" x="49.078125" y="63.797313" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1252,11 +1252,11 @@ L 637.2 63.797313
      <g id="line2d_73">
       <path d="M 49.078125 53.220545 
 L 637.2 53.220545 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_74">
       <g>
-       <use xlink:href="#md13d29b70a" x="49.078125" y="53.220545" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mafee7c4355" x="49.078125" y="53.220545" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1378,7 +1378,7 @@ L 637.2 48.323125
    </g>
    <g id="text_13">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(294.669676 147.431777) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(294.669676 147.67497) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1410,7 +1410,7 @@ z
    </g>
    <g id="text_14">
     <!-- L10 -->
-    <g style="fill: #d62728" transform="translate(104.852312 297.196684) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(104.852312 297.661232) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1732,23 +1732,23 @@ z
    </g>
    <g id="line2d_75">
     <defs>
-     <path id="m6b02c34937" d="M -2.5 2.5 
+     <path id="m47be5a6fa4" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p21d19557b9)">
-     <use xlink:href="#m6b02c34937" x="355.479835" y="95.382063" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6b02c34937" x="308.273931" y="102.754513" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6b02c34937" x="271.230161" y="116.528062" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6b02c34937" x="217.83458" y="120.013651" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6b02c34937" x="177.077692" y="138.43462" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6b02c34937" x="162.880539" y="157.778627" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6b02c34937" x="160.741445" y="165.196647" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6b02c34937" x="153.966678" y="183.405761" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6b02c34937" x="151.589614" y="194.488118" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p3308c85399)">
+     <use xlink:href="#m47be5a6fa4" x="355.479835" y="95.382063" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m47be5a6fa4" x="308.273931" y="102.754513" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m47be5a6fa4" x="271.230161" y="116.528062" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m47be5a6fa4" x="217.83458" y="120.013651" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m47be5a6fa4" x="177.077692" y="138.43462" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m47be5a6fa4" x="162.880539" y="157.778627" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m47be5a6fa4" x="160.741445" y="165.196647" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m47be5a6fa4" x="153.966678" y="183.405761" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m47be5a6fa4" x="151.589614" y="194.488118" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_76">
@@ -1801,7 +1801,7 @@ L 311.2243 102.325849
 L 310.240844 102.469168 
 L 309.257387 102.612055 
 L 308.273931 102.754513 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_77">
     <path d="M 308.273931 102.754513 
@@ -1853,7 +1853,7 @@ L 273.545396 115.775058
 L 272.773651 116.027391 
 L 272.001906 116.278388 
 L 271.230161 116.528062 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_78">
     <path d="M 271.230161 116.528062 
@@ -1905,7 +1905,7 @@ L 221.171803 119.803152
 L 220.059395 119.873422 
 L 218.946988 119.943588 
 L 217.83458 120.013651 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_79">
     <path d="M 217.83458 120.013651 
@@ -1957,7 +1957,7 @@ L 179.624997 137.470928
 L 178.775895 137.79434 
 L 177.926794 138.115561 
 L 177.077692 138.43462 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_80">
     <path d="M 177.077692 138.43462 
@@ -2009,7 +2009,7 @@ L 163.767861 156.775388
 L 163.472087 157.112166 
 L 163.176313 157.446568 
 L 162.880539 157.778627 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_81">
     <path d="M 162.880539 157.778627 
@@ -2061,7 +2061,7 @@ L 160.875139 164.765525
 L 160.830574 164.909668 
 L 160.78601 165.053375 
 L 160.741445 165.196647 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_82">
     <path d="M 160.741445 165.196647 
@@ -2113,7 +2113,7 @@ L 154.390101 182.45125
 L 154.24896 182.771561 
 L 154.107819 183.089721 
 L 153.966678 183.405761 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_83">
     <path d="M 153.966678 183.405761 
@@ -2165,26 +2165,26 @@ L 151.73818 193.866427
 L 151.688658 194.074564 
 L 151.639136 194.281792 
 L 151.589614 194.488118 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_84">
     <defs>
-     <path id="mbcc6f76d87" d="M 0 -2.5 
+     <path id="md8a37bdf59" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p21d19557b9)">
-     <use xlink:href="#mbcc6f76d87" x="531.649087" y="75.963093" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbcc6f76d87" x="283.721324" y="99.020035" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbcc6f76d87" x="218.882044" y="121.069315" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbcc6f76d87" x="187.447228" y="127.10685" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbcc6f76d87" x="176.342474" y="138.36311" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbcc6f76d87" x="163.054314" y="161.312135" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbcc6f76d87" x="162.210539" y="168.753955" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbcc6f76d87" x="159.303811" y="175.753345" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbcc6f76d87" x="157.793928" y="179.494802" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p3308c85399)">
+     <use xlink:href="#md8a37bdf59" x="531.649087" y="75.963093" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md8a37bdf59" x="283.721324" y="99.020035" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md8a37bdf59" x="218.882044" y="121.069315" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md8a37bdf59" x="187.447228" y="127.10685" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md8a37bdf59" x="176.342474" y="138.36311" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md8a37bdf59" x="163.054314" y="161.312135" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md8a37bdf59" x="162.210539" y="168.753955" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md8a37bdf59" x="159.303811" y="175.753345" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md8a37bdf59" x="157.793928" y="179.494802" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_85">
@@ -2237,7 +2237,7 @@ L 299.21681 97.864971
 L 294.051648 98.253128 
 L 288.886486 98.638133 
 L 283.721324 99.020035 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_86">
     <path d="M 283.721324 99.020035 
@@ -2289,7 +2289,7 @@ L 222.934499 119.954333
 L 221.583681 120.328916 
 L 220.232863 120.700561 
 L 218.882044 121.069315 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_87">
     <path d="M 218.882044 121.069315 
@@ -2341,7 +2341,7 @@ L 189.411904 126.751217
 L 188.757012 126.870058 
 L 188.10212 126.988602 
 L 187.447228 127.10685 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_88">
     <path d="M 187.447228 127.10685 
@@ -2393,7 +2393,7 @@ L 177.036521 137.732718
 L 176.805172 137.943781 
 L 176.573823 138.153909 
 L 176.342474 138.36311 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_89">
     <path d="M 176.342474 138.36311 
@@ -2445,7 +2445,7 @@ L 163.884824 160.161325
 L 163.607987 160.548041 
 L 163.33115 160.931628 
 L 163.054314 161.312135 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_90">
     <path d="M 163.054314 161.312135 
@@ -2497,7 +2497,7 @@ L 162.263275 168.321549
 L 162.245696 168.466124 
 L 162.228118 168.610258 
 L 162.210539 168.753955 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_91">
     <path d="M 162.210539 168.753955 
@@ -2549,7 +2549,7 @@ L 159.485481 175.344896
 L 159.424925 175.481437 
 L 159.364368 175.617586 
 L 159.303811 175.753345 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_92">
     <path d="M 159.303811 175.753345 
@@ -2601,30 +2601,30 @@ L 157.888296 179.269417
 L 157.85684 179.344665 
 L 157.825384 179.419793 
 L 157.793928 179.494802 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_93">
     <defs>
-     <path id="m29b2d47246" d="M -0 3.535534 
+     <path id="mcb3e6705c5" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p21d19557b9)">
-     <use xlink:href="#m29b2d47246" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m29b2d47246" x="203.775848" y="81.750179" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m29b2d47246" x="186.982691" y="88.344921" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m29b2d47246" x="179.779306" y="91.045312" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m29b2d47246" x="157.610419" y="99.395085" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m29b2d47246" x="148.722526" y="107.864022" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m29b2d47246" x="144.388162" y="121.237794" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m29b2d47246" x="127.071247" y="144.560664" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m29b2d47246" x="124.491988" y="152.083585" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m29b2d47246" x="92.613662" y="207.637263" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m29b2d47246" x="87.348715" y="225.457654" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m29b2d47246" x="86.053433" y="242.017529" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p3308c85399)">
+     <use xlink:href="#mcb3e6705c5" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcb3e6705c5" x="203.775848" y="81.750179" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcb3e6705c5" x="186.982691" y="88.344921" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcb3e6705c5" x="179.779306" y="91.045312" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcb3e6705c5" x="157.610419" y="99.395085" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcb3e6705c5" x="148.722526" y="107.864022" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcb3e6705c5" x="144.388162" y="121.237794" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcb3e6705c5" x="127.071247" y="144.560664" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcb3e6705c5" x="124.491988" y="152.083585" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcb3e6705c5" x="92.613662" y="207.637263" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcb3e6705c5" x="87.348715" y="225.457654" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcb3e6705c5" x="86.053433" y="242.017529" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_94">
@@ -2677,7 +2677,7 @@ L 206.762331 80.855075
 L 205.766837 81.155325 
 L 204.771342 81.453685 
 L 203.775848 81.750179 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_95">
     <path d="M 203.775848 81.750179 
@@ -2729,7 +2729,7 @@ L 188.032264 87.958568
 L 187.682406 88.087703 
 L 187.332549 88.216487 
 L 186.982691 88.344921 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_96">
     <path d="M 186.982691 88.344921 
@@ -2781,7 +2781,7 @@ L 180.229518 90.88097
 L 180.079447 90.935814 
 L 179.929376 90.990595 
 L 179.779306 91.045312 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_97">
     <path d="M 179.779306 91.045312 
@@ -2833,7 +2833,7 @@ L 158.995974 98.914174
 L 158.534122 99.075021 
 L 158.07227 99.235323 
 L 157.610419 99.395085 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_98">
     <path d="M 157.610419 99.395085 
@@ -2885,7 +2885,7 @@ L 149.27802 107.37681
 L 149.092855 107.539771 
 L 148.907691 107.702174 
 L 148.722526 107.864022 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_99">
     <path d="M 148.722526 107.864022 
@@ -2937,7 +2937,7 @@ L 144.65906 120.50385
 L 144.568761 120.749763 
 L 144.478462 120.994407 
 L 144.388162 121.237794 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_100">
     <path d="M 144.388162 121.237794 
@@ -2989,7 +2989,7 @@ L 128.153555 143.395158
 L 127.792786 143.786853 
 L 127.432016 144.175338 
 L 127.071247 144.560664 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_101">
     <path d="M 127.071247 144.560664 
@@ -3041,7 +3041,7 @@ L 124.653192 151.646811
 L 124.599457 151.79285 
 L 124.545723 151.93844 
 L 124.491988 152.083585 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_102">
     <path d="M 124.491988 152.083585 
@@ -3093,7 +3093,7 @@ L 94.606058 205.546972
 L 93.941926 206.254028 
 L 93.277794 206.950691 
 L 92.613662 207.637263 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_103">
     <path d="M 92.613662 207.637263 
@@ -3145,7 +3145,7 @@ L 87.677774 224.520091
 L 87.568088 224.834677 
 L 87.458402 225.147189 
 L 87.348715 225.457654 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_104">
     <path d="M 87.348715 225.457654 
@@ -3197,23 +3197,23 @@ L 86.134388 241.135848
 L 86.107403 241.431568 
 L 86.080418 241.725454 
 L 86.053433 242.017529 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_105">
     <defs>
-     <path id="mfee8c7a340" d="M -0 2.5 
+     <path id="m9c59e62ab2" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p21d19557b9)">
-     <use xlink:href="#mfee8c7a340" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p3308c85399)">
+     <use xlink:href="#m9c59e62ab2" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_106">
     <defs>
-     <path id="m3299bba3b9" d="M -0.833333 2.5 
+     <path id="m81e9189b04" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -3228,16 +3228,16 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p21d19557b9)">
-     <use xlink:href="#m3299bba3b9" x="362.865999" y="115.428618" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3299bba3b9" x="278.798176" y="122.858526" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3299bba3b9" x="251.17632" y="128.261574" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3299bba3b9" x="200.806828" y="131.522849" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3299bba3b9" x="169.803221" y="147.931404" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3299bba3b9" x="161.916638" y="160.718659" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3299bba3b9" x="158.697104" y="167.705569" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3299bba3b9" x="154.26679" y="181.026105" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3299bba3b9" x="153.096464" y="191.924265" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p3308c85399)">
+     <use xlink:href="#m81e9189b04" x="362.865999" y="115.428618" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m81e9189b04" x="278.798176" y="122.858526" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m81e9189b04" x="251.17632" y="128.261574" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m81e9189b04" x="200.806828" y="131.522849" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m81e9189b04" x="169.803221" y="147.931404" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m81e9189b04" x="161.916638" y="160.718659" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m81e9189b04" x="158.697104" y="167.705569" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m81e9189b04" x="154.26679" y="181.026105" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m81e9189b04" x="153.096464" y="191.924265" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_107">
@@ -3290,7 +3290,7 @@ L 284.052415 122.426763
 L 282.301002 122.571121 
 L 280.549589 122.715042 
 L 278.798176 122.858526 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_108">
     <path d="M 278.798176 122.858526 
@@ -3342,7 +3342,7 @@ L 252.902686 127.94134
 L 252.327231 128.048325 
 L 251.751776 128.155069 
 L 251.17632 128.261574 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_109">
     <path d="M 251.17632 128.261574 
@@ -3394,7 +3394,7 @@ L 203.954921 131.325463
 L 202.905557 131.39135 
 L 201.856192 131.457145 
 L 200.806828 131.522849 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_110">
     <path d="M 200.806828 131.522849 
@@ -3446,7 +3446,7 @@ L 171.740947 147.056528
 L 171.095038 147.349951 
 L 170.44913 147.64157 
 L 169.803221 147.931404 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_111">
     <path d="M 169.803221 147.931404 
@@ -3498,7 +3498,7 @@ L 162.409549 160.012958
 L 162.245246 160.249361 
 L 162.080942 160.484591 
 L 161.916638 160.718659 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_112">
     <path d="M 161.916638 160.718659 
@@ -3550,7 +3550,7 @@ L 158.898325 167.297798
 L 158.831251 167.434112 
 L 158.764178 167.570034 
 L 158.697104 167.705569 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_113">
     <path d="M 158.697104 167.705569 
@@ -3602,7 +3602,7 @@ L 154.543684 180.294711
 L 154.451386 180.539765 
 L 154.359088 180.783558 
 L 154.26679 181.026105 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_114">
     <path d="M 154.26679 181.026105 
@@ -3654,11 +3654,11 @@ L 153.16961 191.311823
 L 153.145228 191.516851 
 L 153.120846 191.720996 
 L 153.096464 191.924265 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_115">
     <defs>
-     <path id="mde0fa2b1a6" d="M -1.25 2.5 
+     <path id="m0e3d3f430a" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -3673,16 +3673,16 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p21d19557b9)">
-     <use xlink:href="#mde0fa2b1a6" x="301.619021" y="150.561849" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mde0fa2b1a6" x="250.236474" y="156.671134" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mde0fa2b1a6" x="225.418659" y="160.842551" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mde0fa2b1a6" x="212.328936" y="161.382211" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mde0fa2b1a6" x="209.030149" y="166.25091" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mde0fa2b1a6" x="197.547749" y="171.432451" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mde0fa2b1a6" x="194.819287" y="175.129495" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mde0fa2b1a6" x="193.12279" y="181.606362" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mde0fa2b1a6" x="192.79794" y="189.451167" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p3308c85399)">
+     <use xlink:href="#m0e3d3f430a" x="301.619021" y="150.561849" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0e3d3f430a" x="250.236474" y="156.671134" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0e3d3f430a" x="225.418659" y="160.842551" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0e3d3f430a" x="212.328936" y="161.382211" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0e3d3f430a" x="209.030149" y="166.25091" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0e3d3f430a" x="197.547749" y="171.432451" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0e3d3f430a" x="194.819287" y="175.129495" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0e3d3f430a" x="193.12279" y="181.606362" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0e3d3f430a" x="192.79794" y="189.451167" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_116">
@@ -3735,7 +3735,7 @@ L 253.447883 156.311526
 L 252.377414 156.431699 
 L 251.306944 156.551567 
 L 250.236474 156.671134 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_117">
     <path d="M 250.236474 156.671134 
@@ -3787,7 +3787,7 @@ L 226.969772 160.592321
 L 226.452735 160.675878 
 L 225.935697 160.759287 
 L 225.418659 160.842551 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_118">
     <path d="M 225.418659 160.842551 
@@ -3839,7 +3839,7 @@ L 213.147044 161.348661
 L 212.874341 161.359847 
 L 212.601639 161.37103 
 L 212.328936 161.382211 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_119">
     <path d="M 212.328936 161.382211 
@@ -3891,7 +3891,7 @@ L 209.236323 165.960837
 L 209.167599 166.057725 
 L 209.098874 166.154416 
 L 209.030149 166.25091 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_120">
     <path d="M 209.030149 166.25091 
@@ -3943,7 +3943,7 @@ L 198.265399 171.124681
 L 198.026182 171.227493 
 L 197.786966 171.330083 
 L 197.547749 171.432451 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_121">
     <path d="M 197.547749 171.432451 
@@ -3995,7 +3995,7 @@ L 194.989815 174.906688
 L 194.932972 174.981074 
 L 194.876129 175.055342 
 L 194.819287 175.129495 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_122">
     <path d="M 194.819287 175.129495 
@@ -4047,7 +4047,7 @@ L 193.228821 181.226479
 L 193.193478 181.353445 
 L 193.158134 181.480072 
 L 193.12279 181.606362 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_123">
     <path d="M 193.12279 181.606362 
@@ -4099,11 +4099,11 @@ L 192.818243 188.997124
 L 192.811475 189.148955 
 L 192.804707 189.300302 
 L 192.79794 189.451167 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_124">
     <defs>
-     <path id="m21c72632c1" d="M 0 -2.5 
+     <path id="meb0b141d91" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -4116,16 +4116,16 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p21d19557b9)">
-     <use xlink:href="#m21c72632c1" x="206.45578" y="118.584066" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m21c72632c1" x="206.45578" y="118.258949" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m21c72632c1" x="206.45578" y="118.759361" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m21c72632c1" x="206.45578" y="118.234957" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m21c72632c1" x="171.767499" y="134.097889" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m21c72632c1" x="163.54283" y="144.663903" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m21c72632c1" x="160.174881" y="151.505345" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m21c72632c1" x="154.179217" y="169.303726" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m21c72632c1" x="152.4406" y="178.584542" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p3308c85399)">
+     <use xlink:href="#meb0b141d91" x="206.45578" y="118.584066" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#meb0b141d91" x="206.45578" y="118.258949" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#meb0b141d91" x="206.45578" y="118.759361" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#meb0b141d91" x="206.45578" y="118.234957" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#meb0b141d91" x="171.767499" y="134.097889" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#meb0b141d91" x="163.54283" y="144.663903" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#meb0b141d91" x="160.174881" y="151.505345" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#meb0b141d91" x="154.179217" y="169.303726" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#meb0b141d91" x="152.4406" y="178.584542" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_125">
@@ -4178,7 +4178,7 @@ L 206.45578 118.279335
 L 206.45578 118.27254 
 L 206.45578 118.265745 
 L 206.45578 118.258949 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_126">
     <path d="M 206.45578 118.258949 
@@ -4230,7 +4230,7 @@ L 206.45578 118.728239
 L 206.45578 118.738615 
 L 206.45578 118.748989 
 L 206.45578 118.759361 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_127">
     <path d="M 206.45578 118.759361 
@@ -4282,7 +4282,7 @@ L 206.45578 118.267903
 L 206.45578 118.256924 
 L 206.45578 118.245942 
 L 206.45578 118.234957 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_128">
     <path d="M 206.45578 118.234957 
@@ -4334,7 +4334,7 @@ L 173.935517 133.247721
 L 173.212844 133.532808 
 L 172.490172 133.816191 
 L 171.767499 134.097889 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_129">
     <path d="M 171.767499 134.097889 
@@ -4386,7 +4386,7 @@ L 164.056872 144.068227
 L 163.885524 144.267619 
 L 163.714177 144.466175 
 L 163.54283 144.663903 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_130">
     <path d="M 163.54283 144.663903 
@@ -4438,7 +4438,7 @@ L 160.385378 151.105499
 L 160.315212 151.239156 
 L 160.245047 151.372438 
 L 160.174881 151.505345 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_131">
     <path d="M 160.174881 151.505345 
@@ -4490,7 +4490,7 @@ L 154.553946 168.367127
 L 154.429036 168.681387 
 L 154.304126 168.993578 
 L 154.179217 169.303726 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_132">
     <path d="M 154.179217 169.303726 
@@ -4542,11 +4542,11 @@ L 152.549264 178.054798
 L 152.513043 178.232038 
 L 152.476822 178.408618 
 L 152.4406 178.584542 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_133">
     <defs>
-     <path id="mf6aea0349f" d="M 0 -2.5 
+     <path id="md4d65a6349" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -4555,16 +4555,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p21d19557b9)">
-     <use xlink:href="#mf6aea0349f" x="610.467188" y="172.829682" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf6aea0349f" x="592.067397" y="173.763838" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf6aea0349f" x="534.807821" y="180.385179" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf6aea0349f" x="327.802209" y="176.172104" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf6aea0349f" x="275.83761" y="186.734601" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf6aea0349f" x="258.25125" y="198.783148" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf6aea0349f" x="256.777056" y="203.737732" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf6aea0349f" x="248.769854" y="217.74136" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf6aea0349f" x="246.264594" y="227.740017" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p3308c85399)">
+     <use xlink:href="#md4d65a6349" x="610.467188" y="172.829682" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md4d65a6349" x="592.067397" y="173.763838" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md4d65a6349" x="534.807821" y="180.385179" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md4d65a6349" x="327.802209" y="176.172104" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md4d65a6349" x="275.83761" y="186.734601" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md4d65a6349" x="258.25125" y="198.783148" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md4d65a6349" x="256.777056" y="203.737732" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md4d65a6349" x="248.769854" y="217.74136" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md4d65a6349" x="246.264594" y="227.740017" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_134">
@@ -4617,7 +4617,7 @@ L 593.217384 173.705989
 L 592.834055 173.72528 
 L 592.450726 173.744563 
 L 592.067397 173.763838 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_135">
     <path d="M 592.067397 173.763838 
@@ -4669,7 +4669,7 @@ L 538.386544 179.997367
 L 537.193636 180.126991 
 L 536.000728 180.25626 
 L 534.807821 180.385179 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_136">
     <path d="M 534.807821 180.385179 
@@ -4721,7 +4721,7 @@ L 340.74006 176.446681
 L 336.427443 176.355332 
 L 332.114826 176.263806 
 L 327.802209 176.172104 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_137">
     <path d="M 327.802209 176.172104 
@@ -4773,7 +4773,7 @@ L 279.085397 186.139102
 L 278.002801 186.338434 
 L 276.920205 186.536931 
 L 275.83761 186.734601 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_138">
     <path d="M 275.83761 186.734601 
@@ -4825,7 +4825,7 @@ L 259.350398 198.113494
 L 258.984015 198.337765 
 L 258.617633 198.560979 
 L 258.25125 198.783148 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_139">
     <path d="M 258.25125 198.783148 
@@ -4877,7 +4877,7 @@ L 256.869193 203.442789
 L 256.838481 203.541307 
 L 256.807768 203.639621 
 L 256.777056 203.737732 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_140">
     <path d="M 256.777056 203.737732 
@@ -4929,7 +4929,7 @@ L 249.270304 216.977455
 L 249.103487 217.23346 
 L 248.93667 217.48809 
 L 248.769854 217.74136 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_141">
     <path d="M 248.769854 217.74136 
@@ -4981,7 +4981,7 @@ L 246.421172 227.173237
 L 246.368979 227.362918 
 L 246.316786 227.551842 
 L 246.264594 227.740017 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="legend_1">
     <g id="patch_7">
@@ -4999,7 +4999,7 @@ z
     </g>
     <g id="line2d_142">
      <defs>
-      <path id="m925272ffd3" d="M 0 3.5 
+      <path id="me555399f59" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -5012,7 +5012,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m925272ffd3" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#me555399f59" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -5071,7 +5071,7 @@ z
     </g>
     <g id="line2d_143">
      <g>
-      <use xlink:href="#m6b02c34937" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m47be5a6fa4" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -5085,7 +5085,7 @@ z
     </g>
     <g id="line2d_144">
      <g>
-      <use xlink:href="#mbcc6f76d87" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#md8a37bdf59" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -5130,7 +5130,7 @@ z
     </g>
     <g id="line2d_145">
      <g>
-      <use xlink:href="#m29b2d47246" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mcb3e6705c5" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -5173,7 +5173,7 @@ z
     </g>
     <g id="line2d_146">
      <g>
-      <use xlink:href="#mfee8c7a340" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m9c59e62ab2" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -5189,7 +5189,7 @@ z
     </g>
     <g id="line2d_147">
      <g>
-      <use xlink:href="#m3299bba3b9" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m81e9189b04" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -5243,7 +5243,7 @@ z
     </g>
     <g id="line2d_148">
      <g>
-      <use xlink:href="#mde0fa2b1a6" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m0e3d3f430a" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -5308,7 +5308,7 @@ z
     </g>
     <g id="line2d_149">
      <g>
-      <use xlink:href="#m21c72632c1" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#meb0b141d91" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -5346,7 +5346,7 @@ z
     </g>
     <g id="line2d_150">
      <g>
-      <use xlink:href="#mf6aea0349f" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#md4d65a6349" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -5416,486 +5416,486 @@ z
     </g>
    </g>
    <g id="line2d_151">
-    <g clip-path="url(#p21d19557b9)">
-     <use xlink:href="#m925272ffd3" x="289.669676" y="152.431777" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m925272ffd3" x="223.847406" y="163.243625" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m925272ffd3" x="212.215046" y="167.121198" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m925272ffd3" x="181.367844" y="174.805292" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m925272ffd3" x="165.231972" y="182.936697" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m925272ffd3" x="153.327587" y="188.955115" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m925272ffd3" x="148.576453" y="194.878579" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m925272ffd3" x="145.287154" y="197.823569" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m925272ffd3" x="115.00257" y="275.770824" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m925272ffd3" x="99.852312" y="302.196684" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <g clip-path="url(#p3308c85399)">
+     <use xlink:href="#me555399f59" x="289.669676" y="152.67497" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#me555399f59" x="223.847406" y="163.966652" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#me555399f59" x="212.215046" y="167.815997" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#me555399f59" x="181.367844" y="175.139341" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#me555399f59" x="165.231972" y="183.139877" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#me555399f59" x="153.327587" y="189.404203" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#me555399f59" x="148.576453" y="195.302106" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#me555399f59" x="145.287154" y="198.19502" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#me555399f59" x="115.00257" y="276.305881" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#me555399f59" x="99.852312" y="302.661232" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
    <g id="line2d_152">
-    <path d="M 289.669676 152.431777 
-L 288.298379 152.684111 
-L 286.927082 152.935108 
-L 285.555784 153.184784 
-L 284.184487 153.433151 
-L 282.81319 153.680223 
-L 281.441892 153.926014 
-L 280.070595 154.170538 
-L 278.699298 154.413806 
-L 277.328 154.655832 
-L 275.956703 154.896628 
-L 274.585406 155.136208 
-L 273.214109 155.374582 
-L 271.842811 155.611764 
-L 270.471514 155.847765 
-L 269.100217 156.082596 
-L 267.728919 156.31627 
-L 266.357622 156.548798 
-L 264.986325 156.78019 
-L 263.615028 157.010458 
-L 262.24373 157.239613 
-L 260.872433 157.467665 
-L 259.501136 157.694626 
-L 258.129838 157.920505 
-L 256.758541 158.145312 
-L 255.387244 158.369058 
-L 254.015947 158.591753 
-L 252.644649 158.813407 
-L 251.273352 159.034029 
-L 249.902055 159.253629 
-L 248.530757 159.472216 
-L 247.15946 159.6898 
-L 245.788163 159.906389 
-L 244.416866 160.121993 
-L 243.045568 160.336621 
-L 241.674271 160.550282 
-L 240.302974 160.762983 
-L 238.931676 160.974735 
-L 237.560379 161.185544 
-L 236.189082 161.395421 
-L 234.817784 161.604372 
-L 233.446487 161.812406 
-L 232.07519 162.01953 
-L 230.703893 162.225754 
-L 229.332595 162.431084 
-L 227.961298 162.635529 
-L 226.590001 162.839096 
-L 225.218703 163.041792 
-L 223.847406 163.243625 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 289.669676 152.67497 
+L 288.298379 152.939856 
+L 286.927082 153.203271 
+L 285.555784 153.46523 
+L 284.184487 153.725748 
+L 282.81319 153.984843 
+L 281.441892 154.24253 
+L 280.070595 154.498823 
+L 278.699298 154.753737 
+L 277.328 155.007288 
+L 275.956703 155.25949 
+L 274.585406 155.510357 
+L 273.214109 155.759903 
+L 271.842811 156.008142 
+L 270.471514 156.255088 
+L 269.100217 156.500755 
+L 267.728919 156.745154 
+L 266.357622 156.9883 
+L 264.986325 157.230204 
+L 263.615028 157.470881 
+L 262.24373 157.710341 
+L 260.872433 157.948598 
+L 259.501136 158.185663 
+L 258.129838 158.421549 
+L 256.758541 158.656266 
+L 255.387244 158.889827 
+L 254.015947 159.122242 
+L 252.644649 159.353524 
+L 251.273352 159.583682 
+L 249.902055 159.812728 
+L 248.530757 160.040673 
+L 247.15946 160.267527 
+L 245.788163 160.4933 
+L 244.416866 160.718003 
+L 243.045568 160.941645 
+L 241.674271 161.164238 
+L 240.302974 161.38579 
+L 238.931676 161.606311 
+L 237.560379 161.825811 
+L 236.189082 162.044299 
+L 234.817784 162.261785 
+L 233.446487 162.478277 
+L 232.07519 162.693785 
+L 230.703893 162.908317 
+L 229.332595 163.121883 
+L 227.961298 163.334491 
+L 226.590001 163.54615 
+L 225.218703 163.756867 
+L 223.847406 163.966652 
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_153">
-    <path d="M 223.847406 163.243625 
-L 223.605065 163.327729 
-L 223.362724 163.411685 
-L 223.120384 163.495492 
-L 222.878043 163.579151 
-L 222.635702 163.662662 
-L 222.393361 163.746027 
-L 222.15102 163.829246 
-L 221.908679 163.912318 
-L 221.666339 163.995246 
-L 221.423998 164.078028 
-L 221.181657 164.160666 
-L 220.939316 164.24316 
-L 220.696975 164.325511 
-L 220.454635 164.407719 
-L 220.212294 164.489785 
-L 219.969953 164.571709 
-L 219.727612 164.653492 
-L 219.485271 164.735133 
-L 219.24293 164.816635 
-L 219.00059 164.897996 
-L 218.758249 164.979218 
-L 218.515908 165.060301 
-L 218.273567 165.141246 
-L 218.031226 165.222052 
-L 217.788885 165.302721 
-L 217.546545 165.383253 
-L 217.304204 165.463649 
-L 217.061863 165.543908 
-L 216.819522 165.624032 
-L 216.577181 165.70402 
-L 216.33484 165.783874 
-L 216.0925 165.863593 
-L 215.850159 165.943179 
-L 215.607818 166.022631 
-L 215.365477 166.10195 
-L 215.123136 166.181136 
-L 214.880795 166.260191 
-L 214.638455 166.339114 
-L 214.396114 166.417906 
-L 214.153773 166.496567 
-L 213.911432 166.575097 
-L 213.669091 166.653498 
-L 213.42675 166.731769 
-L 213.18441 166.809911 
-L 212.942069 166.887925 
-L 212.699728 166.965811 
-L 212.457387 167.043568 
-L 212.215046 167.121198 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 223.847406 163.966652 
+L 223.605065 164.05012 
+L 223.362724 164.133441 
+L 223.120384 164.216615 
+L 222.878043 164.299644 
+L 222.635702 164.382528 
+L 222.393361 164.465267 
+L 222.15102 164.547861 
+L 221.908679 164.630313 
+L 221.666339 164.712621 
+L 221.423998 164.794786 
+L 221.181657 164.876809 
+L 220.939316 164.95869 
+L 220.696975 165.040431 
+L 220.454635 165.12203 
+L 220.212294 165.203489 
+L 219.969953 165.284809 
+L 219.727612 165.365989 
+L 219.485271 165.44703 
+L 219.24293 165.527933 
+L 219.00059 165.608699 
+L 218.758249 165.689326 
+L 218.515908 165.769817 
+L 218.273567 165.850172 
+L 218.031226 165.93039 
+L 217.788885 166.010473 
+L 217.546545 166.090421 
+L 217.304204 166.170234 
+L 217.061863 166.249913 
+L 216.819522 166.329459 
+L 216.577181 166.408871 
+L 216.33484 166.48815 
+L 216.0925 166.567297 
+L 215.850159 166.646312 
+L 215.607818 166.725195 
+L 215.365477 166.803948 
+L 215.123136 166.88257 
+L 214.880795 166.961061 
+L 214.638455 167.039423 
+L 214.396114 167.117655 
+L 214.153773 167.195759 
+L 213.911432 167.273734 
+L 213.669091 167.351581 
+L 213.42675 167.4293 
+L 213.18441 167.506892 
+L 212.942069 167.584358 
+L 212.699728 167.661697 
+L 212.457387 167.73891 
+L 212.215046 167.815997 
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_154">
-    <path d="M 212.215046 167.121198 
-L 211.572396 167.294673 
-L 210.929746 167.467514 
-L 210.287096 167.639728 
-L 209.644446 167.811318 
-L 209.001796 167.982289 
-L 208.359146 168.152646 
-L 207.716496 168.322393 
-L 207.073846 168.491534 
-L 206.431196 168.660073 
-L 205.788546 168.828015 
-L 205.145896 168.995365 
-L 204.503246 169.162125 
-L 203.860596 169.328301 
-L 203.217946 169.493897 
-L 202.575296 169.658916 
-L 201.932645 169.823362 
-L 201.289995 169.98724 
-L 200.647345 170.150553 
-L 200.004695 170.313305 
-L 199.362045 170.475501 
-L 198.719395 170.637143 
-L 198.076745 170.798236 
-L 197.434095 170.958783 
-L 196.791445 171.118789 
-L 196.148795 171.278256 
-L 195.506145 171.437188 
-L 194.863495 171.595589 
-L 194.220845 171.753463 
-L 193.578195 171.910813 
-L 192.935545 172.067641 
-L 192.292895 172.223953 
-L 191.650245 172.379751 
-L 191.007595 172.535039 
-L 190.364945 172.689819 
-L 189.722294 172.844096 
-L 189.079644 172.997872 
-L 188.436994 173.151151 
-L 187.794344 173.303935 
-L 187.151694 173.456229 
-L 186.509044 173.608035 
-L 185.866394 173.759357 
-L 185.223744 173.910197 
-L 184.581094 174.060558 
-L 183.938444 174.210444 
-L 183.295794 174.359857 
-L 182.653144 174.508801 
-L 182.010494 174.657279 
-L 181.367844 174.805292 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 212.215046 167.815997 
+L 211.572396 167.980698 
+L 210.929746 168.144828 
+L 210.287096 168.308392 
+L 209.644446 168.471394 
+L 209.001796 168.633837 
+L 208.359146 168.795725 
+L 207.716496 168.957062 
+L 207.073846 169.117852 
+L 206.431196 169.278098 
+L 205.788546 169.437804 
+L 205.145896 169.596974 
+L 204.503246 169.755611 
+L 203.860596 169.913719 
+L 203.217946 170.071301 
+L 202.575296 170.228362 
+L 201.932645 170.384903 
+L 201.289995 170.540929 
+L 200.647345 170.696444 
+L 200.004695 170.851449 
+L 199.362045 171.00595 
+L 198.719395 171.159948 
+L 198.076745 171.313448 
+L 197.434095 171.466453 
+L 196.791445 171.618965 
+L 196.148795 171.770987 
+L 195.506145 171.922524 
+L 194.863495 172.073578 
+L 194.220845 172.224152 
+L 193.578195 172.374249 
+L 192.935545 172.523873 
+L 192.292895 172.673025 
+L 191.650245 172.82171 
+L 191.007595 172.96993 
+L 190.364945 173.117687 
+L 189.722294 173.264986 
+L 189.079644 173.411828 
+L 188.436994 173.558217 
+L 187.794344 173.704155 
+L 187.151694 173.849645 
+L 186.509044 173.994689 
+L 185.866394 174.139292 
+L 185.223744 174.283454 
+L 184.581094 174.42718 
+L 183.938444 174.57047 
+L 183.295794 174.713329 
+L 182.653144 174.855759 
+L 182.010494 174.997762 
+L 181.367844 175.139341 
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_155">
-    <path d="M 181.367844 174.805292 
-L 181.03168 174.989736 
-L 180.695516 175.173465 
-L 180.359352 175.356484 
-L 180.023188 175.538799 
-L 179.687024 175.720416 
-L 179.35086 175.901339 
-L 179.014696 176.081575 
-L 178.678532 176.261128 
-L 178.342368 176.440003 
-L 178.006204 176.618205 
-L 177.67004 176.795741 
-L 177.333876 176.972613 
-L 176.997712 177.148828 
-L 176.661548 177.324391 
-L 176.325384 177.499305 
-L 175.98922 177.673577 
-L 175.653056 177.84721 
-L 175.316892 178.020209 
-L 174.980728 178.192579 
-L 174.644564 178.364325 
-L 174.3084 178.535451 
-L 173.972236 178.705961 
-L 173.636072 178.875859 
-L 173.299908 179.045151 
-L 172.963744 179.213841 
-L 172.62758 179.381932 
-L 172.291416 179.549429 
-L 171.955252 179.716337 
-L 171.619088 179.882659 
-L 171.282924 180.048399 
-L 170.94676 180.213561 
-L 170.610596 180.378151 
-L 170.274432 180.54217 
-L 169.938268 180.705624 
-L 169.602104 180.868516 
-L 169.26594 181.030851 
-L 168.929776 181.192631 
-L 168.593612 181.353861 
-L 168.257448 181.514544 
-L 167.921284 181.674685 
-L 167.58512 181.834286 
-L 167.248956 181.993352 
-L 166.912792 182.151886 
-L 166.576628 182.309891 
-L 166.240464 182.467371 
-L 165.9043 182.62433 
-L 165.568136 182.780771 
-L 165.231972 182.936697 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 181.367844 175.139341 
+L 181.03168 175.320565 
+L 180.695516 175.501098 
+L 180.359352 175.680947 
+L 180.023188 175.860116 
+L 179.687024 176.03861 
+L 179.35086 176.216434 
+L 179.014696 176.393594 
+L 178.678532 176.570094 
+L 178.342368 176.745939 
+L 178.006204 176.921135 
+L 177.67004 177.095685 
+L 177.333876 177.269595 
+L 176.997712 177.442869 
+L 176.661548 177.615511 
+L 176.325384 177.787528 
+L 175.98922 177.958922 
+L 175.653056 178.129699 
+L 175.316892 178.299862 
+L 174.980728 178.469417 
+L 174.644564 178.638368 
+L 174.3084 178.806718 
+L 173.972236 178.974473 
+L 173.636072 179.141636 
+L 173.299908 179.308212 
+L 172.963744 179.474204 
+L 172.62758 179.639617 
+L 172.291416 179.804455 
+L 171.955252 179.968721 
+L 171.619088 180.13242 
+L 171.282924 180.295556 
+L 170.94676 180.458132 
+L 170.610596 180.620153 
+L 170.274432 180.781621 
+L 169.938268 180.942541 
+L 169.602104 181.102917 
+L 169.26594 181.262752 
+L 168.929776 181.42205 
+L 168.593612 181.580814 
+L 168.257448 181.739049 
+L 167.921284 181.896756 
+L 167.58512 182.053941 
+L 167.248956 182.210606 
+L 166.912792 182.366756 
+L 166.576628 182.522392 
+L 166.240464 182.677519 
+L 165.9043 182.83214 
+L 165.568136 182.986258 
+L 165.231972 183.139877 
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_156">
-    <path d="M 165.231972 182.936697 
-L 164.983964 183.0702 
-L 164.735956 183.203329 
-L 164.487948 183.336085 
-L 164.23994 183.46847 
-L 163.991932 183.600486 
-L 163.743924 183.732136 
-L 163.495916 183.863421 
-L 163.247908 183.994343 
-L 162.9999 184.124905 
-L 162.751892 184.255108 
-L 162.503884 184.384954 
-L 162.255876 184.514446 
-L 162.007868 184.643584 
-L 161.75986 184.772372 
-L 161.511852 184.900811 
-L 161.263844 185.028903 
-L 161.015836 185.15665 
-L 160.767828 185.284053 
-L 160.51982 185.411115 
-L 160.271812 185.537837 
-L 160.023804 185.664221 
-L 159.775796 185.790269 
-L 159.527788 185.915983 
-L 159.27978 186.041364 
-L 159.031772 186.166415 
-L 158.783764 186.291136 
-L 158.535756 186.41553 
-L 158.287748 186.539598 
-L 158.03974 186.663343 
-L 157.791732 186.786765 
-L 157.543724 186.909867 
-L 157.295716 187.03265 
-L 157.047708 187.155116 
-L 156.7997 187.277266 
-L 156.551691 187.399102 
-L 156.303683 187.520625 
-L 156.055675 187.641838 
-L 155.807667 187.762742 
-L 155.559659 187.883338 
-L 155.311651 188.003628 
-L 155.063643 188.123614 
-L 154.815635 188.243296 
-L 154.567627 188.362678 
-L 154.319619 188.481759 
-L 154.071611 188.600542 
-L 153.823603 188.719028 
-L 153.575595 188.837218 
-L 153.327587 188.955115 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 165.231972 183.139877 
+L 164.983964 183.279196 
+L 164.735956 183.418106 
+L 164.487948 183.556611 
+L 164.23994 183.694712 
+L 163.991932 183.832411 
+L 163.743924 183.969712 
+L 163.495916 184.106616 
+L 163.247908 184.243126 
+L 162.9999 184.379244 
+L 162.751892 184.514972 
+L 162.503884 184.650313 
+L 162.255876 184.785268 
+L 162.007868 184.91984 
+L 161.75986 185.054032 
+L 161.511852 185.187844 
+L 161.263844 185.32128 
+L 161.015836 185.454341 
+L 160.767828 185.587029 
+L 160.51982 185.719347 
+L 160.271812 185.851297 
+L 160.023804 185.98288 
+L 159.775796 186.1141 
+L 159.527788 186.244956 
+L 159.27978 186.375453 
+L 159.031772 186.505591 
+L 158.783764 186.635373 
+L 158.535756 186.764801 
+L 158.287748 186.893876 
+L 158.03974 187.022601 
+L 157.791732 187.150977 
+L 157.543724 187.279006 
+L 157.295716 187.406691 
+L 157.047708 187.534032 
+L 156.7997 187.661032 
+L 156.551691 187.787693 
+L 156.303683 187.914016 
+L 156.055675 188.040003 
+L 155.807667 188.165657 
+L 155.559659 188.290978 
+L 155.311651 188.415969 
+L 155.063643 188.540631 
+L 154.815635 188.664966 
+L 154.567627 188.788975 
+L 154.319619 188.912662 
+L 154.071611 189.036026 
+L 153.823603 189.15907 
+L 153.575595 189.281795 
+L 153.327587 189.404203 
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_157">
-    <path d="M 153.327587 188.955115 
-L 153.228605 189.086381 
-L 153.129623 189.217284 
-L 153.030641 189.347827 
-L 152.931659 189.478012 
-L 152.832678 189.60784 
-L 152.733696 189.737313 
-L 152.634714 189.866434 
-L 152.535732 189.995203 
-L 152.43675 190.123624 
-L 152.337768 190.251698 
-L 152.238786 190.379427 
-L 152.139804 190.506813 
-L 152.040822 190.633857 
-L 151.94184 190.760561 
-L 151.842858 190.886928 
-L 151.743876 191.012958 
-L 151.644894 191.138655 
-L 151.545912 191.264019 
-L 151.44693 191.389052 
-L 151.347948 191.513757 
-L 151.248966 191.638134 
-L 151.149984 191.762185 
-L 151.051002 191.885913 
-L 150.95202 192.009319 
-L 150.853038 192.132404 
-L 150.754056 192.25517 
-L 150.655074 192.37762 
-L 150.556093 192.499753 
-L 150.457111 192.621573 
-L 150.358129 192.743081 
-L 150.259147 192.864277 
-L 150.160165 192.985165 
-L 150.061183 193.105745 
-L 149.962201 193.22602 
-L 149.863219 193.34599 
-L 149.764237 193.465656 
-L 149.665255 193.585022 
-L 149.566273 193.704088 
-L 149.467291 193.822855 
-L 149.368309 193.941326 
-L 149.269327 194.059501 
-L 149.170345 194.177382 
-L 149.071363 194.294971 
-L 148.972381 194.412269 
-L 148.873399 194.529277 
-L 148.774417 194.645997 
-L 148.675435 194.762431 
-L 148.576453 194.878579 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 153.327587 189.404203 
+L 153.228605 189.534868 
+L 153.129623 189.665173 
+L 153.030641 189.795121 
+L 152.931659 189.924714 
+L 152.832678 190.053953 
+L 152.733696 190.182841 
+L 152.634714 190.31138 
+L 152.535732 190.439571 
+L 152.43675 190.567416 
+L 152.337768 190.694917 
+L 152.238786 190.822076 
+L 152.139804 190.948895 
+L 152.040822 191.075375 
+L 151.94184 191.201519 
+L 151.842858 191.327328 
+L 151.743876 191.452804 
+L 151.644894 191.577949 
+L 151.545912 191.702764 
+L 151.44693 191.827252 
+L 151.347948 191.951413 
+L 151.248966 192.07525 
+L 151.149984 192.198764 
+L 151.051002 192.321957 
+L 150.95202 192.444831 
+L 150.853038 192.567387 
+L 150.754056 192.689627 
+L 150.655074 192.811553 
+L 150.556093 192.933165 
+L 150.457111 193.054467 
+L 150.358129 193.175459 
+L 150.259147 193.296143 
+L 150.160165 193.41652 
+L 150.061183 193.536592 
+L 149.962201 193.656361 
+L 149.863219 193.775828 
+L 149.764237 193.894995 
+L 149.665255 194.013863 
+L 149.566273 194.132434 
+L 149.467291 194.250708 
+L 149.368309 194.368689 
+L 149.269327 194.486376 
+L 149.170345 194.603772 
+L 149.071363 194.720878 
+L 148.972381 194.837695 
+L 148.873399 194.954225 
+L 148.774417 195.070469 
+L 148.675435 195.186429 
+L 148.576453 195.302106 
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_158">
-    <path d="M 148.576453 194.878579 
-L 148.507926 194.941837 
-L 148.439399 195.00501 
-L 148.370872 195.0681 
-L 148.302345 195.131105 
-L 148.233818 195.194027 
-L 148.165291 195.256866 
-L 148.096764 195.319621 
-L 148.028237 195.382293 
-L 147.95971 195.444883 
-L 147.891183 195.50739 
-L 147.822656 195.569815 
-L 147.754129 195.632158 
-L 147.685602 195.694418 
-L 147.617074 195.756597 
-L 147.548547 195.818695 
-L 147.48002 195.880711 
-L 147.411493 195.942647 
-L 147.342966 196.004501 
-L 147.274439 196.066275 
-L 147.205912 196.127969 
-L 147.137385 196.189582 
-L 147.068858 196.251115 
-L 147.000331 196.312569 
-L 146.931804 196.373943 
-L 146.863277 196.435237 
-L 146.79475 196.496453 
-L 146.726223 196.557589 
-L 146.657696 196.618647 
-L 146.589169 196.679626 
-L 146.520641 196.740527 
-L 146.452114 196.80135 
-L 146.383587 196.862094 
-L 146.31506 196.922761 
-L 146.246533 196.983351 
-L 146.178006 197.043863 
-L 146.109479 197.104298 
-L 146.040952 197.164656 
-L 145.972425 197.224937 
-L 145.903898 197.285141 
-L 145.835371 197.34527 
-L 145.766844 197.405322 
-L 145.698317 197.465298 
-L 145.62979 197.525198 
-L 145.561263 197.585023 
-L 145.492735 197.644772 
-L 145.424208 197.704446 
-L 145.355681 197.764045 
-L 145.287154 197.823569 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 148.576453 195.302106 
+L 148.507926 195.364211 
+L 148.439399 195.426236 
+L 148.370872 195.488179 
+L 148.302345 195.550041 
+L 148.233818 195.611823 
+L 148.165291 195.673524 
+L 148.096764 195.735145 
+L 148.028237 195.796687 
+L 147.95971 195.858148 
+L 147.891183 195.91953 
+L 147.822656 195.980832 
+L 147.754129 196.042055 
+L 147.685602 196.103199 
+L 147.617074 196.164264 
+L 147.548547 196.225251 
+L 147.48002 196.28616 
+L 147.411493 196.34699 
+L 147.342966 196.407742 
+L 147.274439 196.468417 
+L 147.205912 196.529014 
+L 147.137385 196.589533 
+L 147.068858 196.649976 
+L 147.000331 196.710341 
+L 146.931804 196.77063 
+L 146.863277 196.830842 
+L 146.79475 196.890978 
+L 146.726223 196.951037 
+L 146.657696 197.011021 
+L 146.589169 197.070928 
+L 146.520641 197.13076 
+L 146.452114 197.190517 
+L 146.383587 197.250198 
+L 146.31506 197.309805 
+L 146.246533 197.369336 
+L 146.178006 197.428793 
+L 146.109479 197.488175 
+L 146.040952 197.547483 
+L 145.972425 197.606717 
+L 145.903898 197.665877 
+L 145.835371 197.724963 
+L 145.766844 197.783976 
+L 145.698317 197.842915 
+L 145.62979 197.901781 
+L 145.561263 197.960574 
+L 145.492735 198.019294 
+L 145.424208 198.077942 
+L 145.355681 198.136517 
+L 145.287154 198.19502 
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_159">
-    <path d="M 145.287154 197.823569 
-L 144.656225 201.779834 
-L 144.025297 205.431167 
-L 143.394368 208.821231 
-L 142.763439 211.98493 
-L 142.13251 214.950613 
-L 141.501581 217.741613 
-L 140.870652 220.377369 
-L 140.239723 222.874245 
-L 139.608795 225.246147 
-L 138.977866 227.504991 
-L 138.346937 229.661066 
-L 137.716008 231.723319 
-L 137.085079 233.699575 
-L 136.45415 235.59672 
-L 135.823222 237.420845 
-L 135.192293 239.177363 
-L 134.561364 240.871108 
-L 133.930435 242.50641 
-L 133.299506 244.08717 
-L 132.668577 245.616909 
-L 132.037648 247.098817 
-L 131.40672 248.535794 
-L 130.775791 249.930486 
-L 130.144862 251.285311 
-L 129.513933 252.602483 
-L 128.883004 253.88404 
-L 128.252075 255.131857 
-L 127.621147 256.347665 
-L 126.990218 257.533065 
-L 126.359289 258.689542 
-L 125.72836 259.818472 
-L 125.097431 260.921138 
-L 124.466502 261.998735 
-L 123.835573 263.052377 
-L 123.204645 264.083105 
-L 122.573716 265.091895 
-L 121.942787 266.079662 
-L 121.311858 267.047264 
-L 120.680929 267.995508 
-L 120.05 268.925154 
-L 119.419071 269.836916 
-L 118.788143 270.73147 
-L 118.157214 271.609453 
-L 117.526285 272.471469 
-L 116.895356 273.318087 
-L 116.264427 274.149848 
-L 115.633498 274.967265 
-L 115.00257 275.770824 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 145.287154 198.19502 
+L 144.656225 202.167546 
+L 144.025297 205.832726 
+L 143.394368 209.234722 
+L 142.763439 212.408809 
+L 142.13251 215.383618 
+L 141.501581 218.1827 
+L 140.870652 220.825662 
+L 140.239723 223.329003 
+L 139.608795 225.706738 
+L 138.977866 227.970872 
+L 138.346937 230.131767 
+L 137.716008 232.198428 
+L 137.085079 234.178731 
+L 136.45415 236.079606 
+L 135.823222 237.907179 
+L 135.192293 239.666894 
+L 134.561364 241.363611 
+L 133.930435 243.001684 
+L 133.299506 244.585032 
+L 132.668577 246.117195 
+L 132.037648 247.601377 
+L 131.40672 249.040494 
+L 130.775791 250.4372 
+L 130.144862 251.793926 
+L 129.513933 253.112895 
+L 128.883004 254.396153 
+L 128.252075 255.645582 
+L 127.621147 256.862921 
+L 126.990218 258.049776 
+L 126.359289 259.207637 
+L 125.72836 260.337887 
+L 125.097431 261.441812 
+L 124.466502 262.520611 
+L 123.835573 263.575402 
+L 123.204645 264.60723 
+L 122.573716 265.617074 
+L 121.942787 266.605851 
+L 121.311858 267.574422 
+L 120.680929 268.523597 
+L 120.05 269.454137 
+L 119.419071 270.36676 
+L 118.788143 271.262142 
+L 118.157214 272.140923 
+L 117.526285 273.003708 
+L 116.895356 273.851068 
+L 116.264427 274.683546 
+L 115.633498 275.501654 
+L 115.00257 276.305881 
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_160">
-    <path d="M 115.00257 275.770824 
-L 114.686939 276.502144 
-L 114.371309 277.222351 
-L 114.055678 277.931779 
-L 113.740048 278.630745 
-L 113.424418 279.319553 
-L 113.108787 279.998495 
-L 112.793157 280.667849 
-L 112.477527 281.327882 
-L 112.161896 281.978849 
-L 111.846266 282.620998 
-L 111.530636 283.254563 
-L 111.215005 283.879771 
-L 110.899375 284.49684 
-L 110.583745 285.105978 
-L 110.268114 285.707387 
-L 109.952484 286.301261 
-L 109.636853 286.887787 
-L 109.321223 287.467143 
-L 109.005593 288.039503 
-L 108.689962 288.605033 
-L 108.374332 289.163896 
-L 108.058702 289.716247 
-L 107.743071 290.262234 
-L 107.427441 290.802004 
-L 107.111811 291.335697 
-L 106.79618 291.863447 
-L 106.48055 292.385385 
-L 106.16492 292.901639 
-L 105.849289 293.41233 
-L 105.533659 293.917578 
-L 105.218028 294.417497 
-L 104.902398 294.912198 
-L 104.586768 295.401789 
-L 104.271137 295.886375 
-L 103.955507 296.366056 
-L 103.639877 296.840932 
-L 103.324246 297.311098 
-L 103.008616 297.776645 
-L 102.692986 298.237664 
-L 102.377355 298.694243 
-L 102.061725 299.146465 
-L 101.746095 299.594413 
-L 101.430464 300.038168 
-L 101.114834 300.477807 
-L 100.799203 300.913405 
-L 100.483573 301.345037 
-L 100.167943 301.772773 
-L 99.852312 302.196684 
-" clip-path="url(#p21d19557b9)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 115.00257 276.305881 
+L 114.686939 277.034677 
+L 114.371309 277.752436 
+L 114.055678 278.459488 
+L 113.740048 279.156148 
+L 113.424418 279.842717 
+L 113.108787 280.519482 
+L 112.793157 281.186721 
+L 112.477527 281.844697 
+L 112.161896 282.493664 
+L 111.846266 283.133866 
+L 111.530636 283.765536 
+L 111.215005 284.388898 
+L 110.899375 285.004168 
+L 110.583745 285.611554 
+L 110.268114 286.211256 
+L 109.952484 286.803464 
+L 109.636853 287.388365 
+L 109.321223 287.966135 
+L 109.005593 288.536948 
+L 108.689962 289.100968 
+L 108.374332 289.658356 
+L 108.058702 290.209265 
+L 107.743071 290.753845 
+L 107.427441 291.292238 
+L 107.111811 291.824585 
+L 106.79618 292.351019 
+L 106.48055 292.871671 
+L 106.16492 293.386666 
+L 105.849289 293.896125 
+L 105.533659 294.400166 
+L 105.218028 294.898904 
+L 104.902398 295.392449 
+L 104.586768 295.880908 
+L 104.271137 296.364384 
+L 103.955507 296.842978 
+L 103.639877 297.316789 
+L 103.324246 297.785909 
+L 103.008616 298.250433 
+L 102.692986 298.710447 
+L 102.377355 299.166041 
+L 102.061725 299.617296 
+L 101.746095 300.064297 
+L 101.430464 300.507121 
+L 101.114834 300.945846 
+L 100.799203 301.380548 
+L 100.483573 301.811299 
+L 100.167943 302.23817 
+L 99.852312 302.661232 
+" clip-path="url(#p3308c85399)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
   </g>
   <g id="text_25">
@@ -6254,8 +6254,8 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-07-06T22:02:31Z  ·  Linux chungus2 x86_64  ·  commit ac74ebaf  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(44.919844 465.66) scale(0.07 -0.07)">
+   <!-- 2026-07-07T02:05:28Z  ·  Linux chungus2 x86_64  ·  commit 1a899305  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(43.462422 465.66) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -6289,6 +6289,31 @@ L 1409 3309
 L 1409 2516 
 L 750 2516 
 L 750 3309 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-b7" d="M 684 2619 
@@ -6348,6 +6373,36 @@ Q 2894 3584 3203 3211
 Q 3513 2838 3513 2113 
 z
 " transform="scale(0.015625)"/>
+     <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
      <path id="DejaVuSans-3d" d="M 678 2906 
 L 4684 2906 
 L 4684 2381 
@@ -6386,16 +6441,16 @@ z
     <use xlink:href="#DejaVuSans-37" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -6435,109 +6490,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3133.154297 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3188.134766 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3251.757812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3315.380859 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3376.904297 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3440.380859 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3501.660156 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3536.865234 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3568.652344 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3600.439453 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3632.226562 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3664.013672 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3695.800781 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3723.583984 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3785.107422 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3846.386719 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3909.765625 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3973.242188 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4012.105469 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4073.287109 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4132.466797 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4193.990234 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4235.103516 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4268.794922 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4296.578125 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4358.101562 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4419.380859 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4482.759766 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4546.382812 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4580.074219 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4639.253906 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4702.876953 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4734.664062 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4798.287109 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4861.910156 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4893.697266 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4957.320312 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4993.404297 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5032.267578 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5087.248047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5150.871094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5182.658203 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5214.445312 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5246.232422 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5278.019531 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5309.806641 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5349.015625 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5412.394531 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5451.257812 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5512.439453 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5575.818359 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5639.294922 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5702.673828 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5766.150391 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5829.529297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5868.738281 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5900.525391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5984.314453 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6016.101562 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6113.513672 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6175.037109 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6238.513672 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6266.296875 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6327.576172 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6390.955078 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6422.742188 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6474.841797 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6538.220703 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6599.5 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6662.976562 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6715.076172 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6778.455078 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6839.636719 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6878.845703 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6912.537109 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6944.324219 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6985.4375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7046.716797 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7085.925781 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7113.708984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7174.890625 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7206.677734 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7234.460938 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7286.560547 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7318.347656 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7381.824219 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7443.347656 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7482.556641 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7544.080078 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7583.443359 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7680.855469 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7708.638672 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7772.017578 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7799.800781 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7851.900391 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7891.109375 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7918.892578 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3196.777344 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3260.400391 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3324.023438 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3387.646484 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3451.269531 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3514.892578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3578.515625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3610.302734 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3642.089844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3673.876953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3705.664062 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3737.451172 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3765.234375 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3826.757812 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3888.037109 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3951.416016 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4014.892578 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4053.755859 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4114.9375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4174.117188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4235.640625 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4276.753906 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4310.445312 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4338.228516 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4399.751953 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4461.03125 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4524.410156 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4588.033203 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4621.724609 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4680.904297 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4744.527344 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4776.314453 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4839.9375 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4903.560547 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4935.347656 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4998.970703 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5035.054688 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5073.917969 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5128.898438 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5192.521484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5224.308594 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5256.095703 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5287.882812 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5319.669922 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5351.457031 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5390.666016 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5454.044922 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5492.908203 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5554.089844 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5617.46875 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5680.945312 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5744.324219 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5807.800781 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5871.179688 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5910.388672 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5942.175781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6025.964844 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6057.751953 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6155.164062 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6216.6875 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6280.164062 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6307.947266 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6369.226562 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6432.605469 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6464.392578 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6516.492188 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6579.871094 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6641.150391 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6704.626953 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6756.726562 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6820.105469 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6881.287109 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6920.496094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6954.1875 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6985.974609 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7027.087891 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7088.367188 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7127.576172 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7155.359375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7216.541016 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7248.328125 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7276.111328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7328.210938 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7359.998047 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7423.474609 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7484.998047 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7524.207031 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7585.730469 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7625.09375 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7722.505859 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7750.289062 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7813.667969 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7841.451172 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7893.550781 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7932.759766 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7960.542969 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p21d19557b9">
+  <clipPath id="p3308c85399">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_ratio_heatmap.svg
+++ b/bench/graphs/canterbury_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#pc002732282)">
+   <g clip-path="url(#pd225242cc5)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAI/UlEQVR4nO3YwYqkVx2H4aqe7qYn4oAyashScCfBhRtn49o7yRW4DNl7HcYbEEQk2Yjixo24E3ciISRjnMyE7p7q78sljMKRv9T7PFfwO3zUqZdz3P71y/1wbl5+Nr1gqf3z8zrP4XA4/OPnv56esNTf//JqesJyP/3wZ9MTljv+6MfTE9Y6XkwvWO/FJ9ML1rt5Mr1gqV997xfTE5Y7w18SAMB/TgwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKQd706/2adHrLYftukJSx3PsFmvLq6nJyx1v91OT1ju6q9/mp6w3OmHz6YnLHXa7qcnLPfq9GJ6wnJPz+x6eP3k6fSE5c7vXxYA4L8ghgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0i6vXn0xvWG9u6+mF6y1b9ML1nv8ZHrBUtfTA/4H9hevpicsd/Xl8+kJS11tp+kJyz0+x/vu9uX0gqWuLs/vxvMyBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgLTjafvdPj1itX3fpicstZ3ZeQ6Hw+Hq4np6wlIP+2l6wnKPXj6fnrDeN787vWCp19v99ITlPr/95/SE5d6+u5yesNT2rXemJyznZQgASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASLv886d/mN6w3MXhOD1hqe+89XR6wnIP22l6wlLXj26mJyz33se/n56w3Ac/+cH0hKVO+zY9Ybn3//i36QnLPXvnG9MTlnrv3WfTE5bzMgQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIC04+uH3+7TI1a7f7idnrDU4+PN9ATe4P54mp6w3L/vPpuesNy3b96enrDUtm/TE5b74u7T6QnLPb/7ZHrCUt9/8u70hOW8DAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACDtuG0f7dMjgP9Dp/vpBetdXk8v4A1uH76anrDczaO3pifwBl6GAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkHZ5v91Ob1juYTtNT1jq8uJ6esJyV2d2ptfb/fSE5faLbXrCcscz+04P+3nddYfD4fDl/fPpCctdP76ZnrDUvp/f3eBlCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGlfA43TkfjdNPLgAAAAAElFTkSuQmCC" id="image1136461858" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAI/UlEQVR4nO3YwYqkVx2H4aqe7qYn4oAyashScCfBhRtn49o7yRW4DNl7HcYbEEQk2Yjixo24E3ciISRjnMyE7p7q78sljMKRv9T7PFfwO3zUqZdz3P71y/1wbl5+Nr1gqf3z8zrP4XA4/OPnv56esNTf//JqesJyP/3wZ9MTljv+6MfTE9Y6XkwvWO/FJ9ML1rt5Mr1gqV997xfTE5Y7w18SAMB/TgwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKQd706/2adHrLYftukJSx3PsFmvLq6nJyx1v91OT1ju6q9/mp6w3OmHz6YnLHXa7qcnLPfq9GJ6wnJPz+x6eP3k6fSE5c7vXxYA4L8ghgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0i6vXn0xvWG9u6+mF6y1b9ML1nv8ZHrBUtfTA/4H9hevpicsd/Xl8+kJS11tp+kJyz0+x/vu9uX0gqWuLs/vxvMyBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgLTjafvdPj1itX3fpicstZ3ZeQ6Hw+Hq4np6wlIP+2l6wnKPXj6fnrDeN787vWCp19v99ITlPr/95/SE5d6+u5yesNT2rXemJyznZQgASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASLv886d/mN6w3MXhOD1hqe+89XR6wnIP22l6wlLXj26mJyz33se/n56w3Ac/+cH0hKVO+zY9Ybn3//i36QnLPXvnG9MTlnrv3WfTE5bzMgQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIC04+uH3+7TI1a7f7idnrDU4+PN9ATe4P54mp6w3L/vPpuesNy3b96enrDUtm/TE5b74u7T6QnLPb/7ZHrCUt9/8u70hOW8DAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACDtuG0f7dMjgP9Dp/vpBetdXk8v4A1uH76anrDczaO3pifwBl6GAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkHZ5v91Ob1juYTtNT1jq8uJ6esJyV2d2ptfb/fSE5faLbXrCcscz+04P+3nddYfD4fDl/fPpCctdP76ZnrDUvp/f3eBlCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGlfA43TkfjdNPLgAAAAAElFTkSuQmCC" id="image429efa8482" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m3ebb4651c8" d="M 0 0 
+       <path id="m7f9887f35c" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m3ebb4651c8" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7f9887f35c" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m3ebb4651c8" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7f9887f35c" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m3ebb4651c8" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7f9887f35c" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m3ebb4651c8" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7f9887f35c" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m3ebb4651c8" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7f9887f35c" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m3ebb4651c8" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7f9887f35c" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m3ebb4651c8" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7f9887f35c" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m3ebb4651c8" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7f9887f35c" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m3ebb4651c8" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7f9887f35c" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m3ebb4651c8" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7f9887f35c" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m3ebb4651c8" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7f9887f35c" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="mc6a3cb7f33" d="M 0 0 
+       <path id="m87c5064cad" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mc6a3cb7f33" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m87c5064cad" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#mc6a3cb7f33" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m87c5064cad" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mc6a3cb7f33" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m87c5064cad" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#mc6a3cb7f33" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m87c5064cad" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#mc6a3cb7f33" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m87c5064cad" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#mc6a3cb7f33" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m87c5064cad" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mc6a3cb7f33" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m87c5064cad" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#mc6a3cb7f33" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m87c5064cad" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -2092,18 +2092,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="imagebb264887df" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
+iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="image616546ebd3" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="m1e397d9456" d="M 0 0 
+       <path id="mc3e6d0f588" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m1e397d9456" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc3e6d0f588" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
@@ -2129,7 +2129,7 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m1e397d9456" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc3e6d0f588" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
@@ -2146,7 +2146,7 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m1e397d9456" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc3e6d0f588" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
@@ -2163,7 +2163,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m1e397d9456" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc3e6d0f588" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
@@ -2180,7 +2180,7 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m1e397d9456" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc3e6d0f588" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_112">
@@ -2196,7 +2196,7 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m1e397d9456" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc3e6d0f588" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
@@ -2212,7 +2212,7 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m1e397d9456" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc3e6d0f588" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
@@ -2228,7 +2228,7 @@ z
     <g id="ytick_16">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#m1e397d9456" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc3e6d0f588" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_115">
@@ -2244,7 +2244,7 @@ z
     <g id="ytick_17">
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m1e397d9456" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc3e6d0f588" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_116">
@@ -2882,8 +2882,8 @@ z
    </g>
   </g>
   <g id="text_119">
-   <!-- 2026-07-06T22:02:31Z  ·  Linux chungus2 x86_64  ·  commit ac74ebaf  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(17.919844 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-07T02:05:28Z  ·  Linux chungus2 x86_64  ·  commit 1a899305  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(16.462422 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2950,16 +2950,16 @@ z
     <use xlink:href="#DejaVuSans-37" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2999,109 +2999,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3133.154297 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3188.134766 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3251.757812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3315.380859 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3376.904297 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3440.380859 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3501.660156 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3536.865234 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3568.652344 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3600.439453 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3632.226562 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3664.013672 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3695.800781 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3723.583984 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3785.107422 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3846.386719 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3909.765625 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3973.242188 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4012.105469 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4073.287109 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4132.466797 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4193.990234 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4235.103516 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4268.794922 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4296.578125 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4358.101562 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4419.380859 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4482.759766 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4546.382812 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4580.074219 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4639.253906 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4702.876953 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4734.664062 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4798.287109 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4861.910156 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4893.697266 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4957.320312 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4993.404297 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5032.267578 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5087.248047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5150.871094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5182.658203 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5214.445312 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5246.232422 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5278.019531 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5309.806641 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5349.015625 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5412.394531 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5451.257812 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5512.439453 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5575.818359 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5639.294922 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5702.673828 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5766.150391 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5829.529297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5868.738281 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5900.525391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5984.314453 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6016.101562 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6113.513672 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6175.037109 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6238.513672 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6266.296875 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6327.576172 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6390.955078 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6422.742188 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6474.841797 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6538.220703 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6599.5 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6662.976562 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6715.076172 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6778.455078 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6839.636719 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6878.845703 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6912.537109 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6944.324219 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6985.4375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7046.716797 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7085.925781 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7113.708984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7174.890625 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7206.677734 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7234.460938 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7286.560547 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7318.347656 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7381.824219 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7443.347656 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7482.556641 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7544.080078 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7583.443359 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7680.855469 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7708.638672 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7772.017578 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7799.800781 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7851.900391 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7891.109375 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7918.892578 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3196.777344 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3260.400391 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3324.023438 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3387.646484 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3451.269531 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3514.892578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3578.515625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3610.302734 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3642.089844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3673.876953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3705.664062 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3737.451172 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3765.234375 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3826.757812 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3888.037109 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3951.416016 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4014.892578 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4053.755859 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4114.9375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4174.117188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4235.640625 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4276.753906 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4310.445312 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4338.228516 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4399.751953 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4461.03125 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4524.410156 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4588.033203 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4621.724609 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4680.904297 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4744.527344 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4776.314453 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4839.9375 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4903.560547 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4935.347656 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4998.970703 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5035.054688 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5073.917969 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5128.898438 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5192.521484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5224.308594 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5256.095703 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5287.882812 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5319.669922 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5351.457031 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5390.666016 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5454.044922 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5492.908203 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5554.089844 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5617.46875 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5680.945312 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5744.324219 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5807.800781 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5871.179688 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5910.388672 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5942.175781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6025.964844 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6057.751953 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6155.164062 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6216.6875 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6280.164062 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6307.947266 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6369.226562 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6432.605469 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6464.392578 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6516.492188 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6579.871094 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6641.150391 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6704.626953 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6756.726562 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6820.105469 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6881.287109 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6920.496094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6954.1875 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6985.974609 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7027.087891 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7088.367188 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7127.576172 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7155.359375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7216.541016 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7248.328125 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7276.111328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7328.210938 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7359.998047 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7423.474609 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7484.998047 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7524.207031 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7585.730469 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7625.09375 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7722.505859 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7750.289062 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7813.667969 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7841.451172 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7893.550781 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7932.759766 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7960.542969 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pc002732282">
+  <clipPath id="pd225242cc5">
    <rect x="95.67625" y="49.4355" width="416.571298" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_summary.svg
+++ b/bench/graphs/canterbury_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="572.560313pt" height="386.202469pt" viewBox="0 0 572.560313 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="575.475156pt" height="386.202469pt" viewBox="0 0 575.475156 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,232 +22,232 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 386.202469 
-L 572.560313 386.202469 
-L 572.560313 0 
+L 575.475156 386.202469 
+L 575.475156 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 188.405156 104.1264 
-L 293.030156 104.1264 
-L 293.030156 74.7432 
-L 188.405156 74.7432 
+    <path d="M 189.862578 104.1264 
+L 294.487578 104.1264 
+L 294.487578 74.7432 
+L 189.862578 74.7432 
 z
-" clip-path="url(#pa5599bfb8d)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8db67597a3)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 293.030156 104.1264 
-L 397.655156 104.1264 
-L 397.655156 74.7432 
-L 293.030156 74.7432 
+    <path d="M 294.487578 104.1264 
+L 399.112578 104.1264 
+L 399.112578 74.7432 
+L 294.487578 74.7432 
 z
-" clip-path="url(#pa5599bfb8d)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8db67597a3)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 397.655156 104.1264 
-L 502.280156 104.1264 
-L 502.280156 74.7432 
-L 397.655156 74.7432 
+    <path d="M 399.112578 104.1264 
+L 503.737578 104.1264 
+L 503.737578 74.7432 
+L 399.112578 74.7432 
 z
-" clip-path="url(#pa5599bfb8d)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8db67597a3)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 188.405156 133.5096 
-L 293.030156 133.5096 
-L 293.030156 104.1264 
-L 188.405156 104.1264 
+    <path d="M 189.862578 133.5096 
+L 294.487578 133.5096 
+L 294.487578 104.1264 
+L 189.862578 104.1264 
 z
-" clip-path="url(#pa5599bfb8d)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8db67597a3)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 293.030156 133.5096 
-L 397.655156 133.5096 
-L 397.655156 104.1264 
-L 293.030156 104.1264 
+    <path d="M 294.487578 133.5096 
+L 399.112578 133.5096 
+L 399.112578 104.1264 
+L 294.487578 104.1264 
 z
-" clip-path="url(#pa5599bfb8d)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8db67597a3)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 397.655156 133.5096 
-L 502.280156 133.5096 
-L 502.280156 104.1264 
-L 397.655156 104.1264 
+    <path d="M 399.112578 133.5096 
+L 503.737578 133.5096 
+L 503.737578 104.1264 
+L 399.112578 104.1264 
 z
-" clip-path="url(#pa5599bfb8d)" style="fill: #fdb768; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8db67597a3)" style="fill: #fdb768; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 188.405156 162.8928 
-L 293.030156 162.8928 
-L 293.030156 133.5096 
-L 188.405156 133.5096 
+    <path d="M 189.862578 162.8928 
+L 294.487578 162.8928 
+L 294.487578 133.5096 
+L 189.862578 133.5096 
 z
-" clip-path="url(#pa5599bfb8d)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8db67597a3)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 293.030156 162.8928 
-L 397.655156 162.8928 
-L 397.655156 133.5096 
-L 293.030156 133.5096 
+    <path d="M 294.487578 162.8928 
+L 399.112578 162.8928 
+L 399.112578 133.5096 
+L 294.487578 133.5096 
 z
-" clip-path="url(#pa5599bfb8d)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8db67597a3)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 397.655156 162.8928 
-L 502.280156 162.8928 
-L 502.280156 133.5096 
-L 397.655156 133.5096 
+    <path d="M 399.112578 162.8928 
+L 503.737578 162.8928 
+L 503.737578 133.5096 
+L 399.112578 133.5096 
 z
-" clip-path="url(#pa5599bfb8d)" style="fill: #bbe278; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8db67597a3)" style="fill: #bbe278; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 188.405156 192.276 
-L 293.030156 192.276 
-L 293.030156 162.8928 
-L 188.405156 162.8928 
+    <path d="M 189.862578 192.276 
+L 294.487578 192.276 
+L 294.487578 162.8928 
+L 189.862578 162.8928 
 z
-" clip-path="url(#pa5599bfb8d)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8db67597a3)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 293.030156 192.276 
-L 397.655156 192.276 
-L 397.655156 162.8928 
-L 293.030156 162.8928 
+    <path d="M 294.487578 192.276 
+L 399.112578 192.276 
+L 399.112578 162.8928 
+L 294.487578 162.8928 
 z
-" clip-path="url(#pa5599bfb8d)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8db67597a3)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 397.655156 192.276 
-L 502.280156 192.276 
-L 502.280156 162.8928 
-L 397.655156 162.8928 
+    <path d="M 399.112578 192.276 
+L 503.737578 192.276 
+L 503.737578 162.8928 
+L 399.112578 162.8928 
 z
-" clip-path="url(#pa5599bfb8d)" style="fill: #fdc776; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8db67597a3)" style="fill: #fdc776; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 188.405156 221.6592 
-L 293.030156 221.6592 
-L 293.030156 192.276 
-L 188.405156 192.276 
+    <path d="M 189.862578 221.6592 
+L 294.487578 221.6592 
+L 294.487578 192.276 
+L 189.862578 192.276 
 z
-" clip-path="url(#pa5599bfb8d)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8db67597a3)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 293.030156 221.6592 
-L 397.655156 221.6592 
-L 397.655156 192.276 
-L 293.030156 192.276 
+    <path d="M 294.487578 221.6592 
+L 399.112578 221.6592 
+L 399.112578 192.276 
+L 294.487578 192.276 
 z
-" clip-path="url(#pa5599bfb8d)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8db67597a3)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 397.655156 221.6592 
-L 502.280156 221.6592 
-L 502.280156 192.276 
-L 397.655156 192.276 
+    <path d="M 399.112578 221.6592 
+L 503.737578 221.6592 
+L 503.737578 192.276 
+L 399.112578 192.276 
 z
-" clip-path="url(#pa5599bfb8d)" style="fill: #addc6f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8db67597a3)" style="fill: #addc6f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 188.405156 251.0424 
-L 293.030156 251.0424 
-L 293.030156 221.6592 
-L 188.405156 221.6592 
+    <path d="M 189.862578 251.0424 
+L 294.487578 251.0424 
+L 294.487578 221.6592 
+L 189.862578 221.6592 
 z
-" clip-path="url(#pa5599bfb8d)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8db67597a3)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 293.030156 251.0424 
-L 397.655156 251.0424 
-L 397.655156 221.6592 
-L 293.030156 221.6592 
+    <path d="M 294.487578 251.0424 
+L 399.112578 251.0424 
+L 399.112578 221.6592 
+L 294.487578 221.6592 
 z
-" clip-path="url(#pa5599bfb8d)" style="fill: #fdbd6d; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8db67597a3)" style="fill: #fdbd6d; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 397.655156 251.0424 
-L 502.280156 251.0424 
-L 502.280156 221.6592 
-L 397.655156 221.6592 
+    <path d="M 399.112578 251.0424 
+L 503.737578 251.0424 
+L 503.737578 221.6592 
+L 399.112578 221.6592 
 z
-" clip-path="url(#pa5599bfb8d)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8db67597a3)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 188.405156 280.4256 
-L 293.030156 280.4256 
-L 293.030156 251.0424 
-L 188.405156 251.0424 
+    <path d="M 189.862578 280.4256 
+L 294.487578 280.4256 
+L 294.487578 251.0424 
+L 189.862578 251.0424 
 z
-" clip-path="url(#pa5599bfb8d)" style="fill: #ebf7a3; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8db67597a3)" style="fill: #ebf7a3; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 293.030156 280.4256 
-L 397.655156 280.4256 
-L 397.655156 251.0424 
-L 293.030156 251.0424 
+    <path d="M 294.487578 280.4256 
+L 399.112578 280.4256 
+L 399.112578 251.0424 
+L 294.487578 251.0424 
 z
-" clip-path="url(#pa5599bfb8d)" style="fill: #fb9d59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8db67597a3)" style="fill: #fb9d59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 397.655156 280.4256 
-L 502.280156 280.4256 
-L 502.280156 251.0424 
-L 397.655156 251.0424 
+    <path d="M 399.112578 280.4256 
+L 503.737578 280.4256 
+L 503.737578 251.0424 
+L 399.112578 251.0424 
 z
-" clip-path="url(#pa5599bfb8d)" style="fill: #f36b42; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8db67597a3)" style="fill: #f26841; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 188.405156 309.8088 
-L 293.030156 309.8088 
-L 293.030156 280.4256 
-L 188.405156 280.4256 
+    <path d="M 189.862578 309.8088 
+L 294.487578 309.8088 
+L 294.487578 280.4256 
+L 189.862578 280.4256 
 z
-" clip-path="url(#pa5599bfb8d)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8db67597a3)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 293.030156 309.8088 
-L 397.655156 309.8088 
-L 397.655156 280.4256 
-L 293.030156 280.4256 
+    <path d="M 294.487578 309.8088 
+L 399.112578 309.8088 
+L 399.112578 280.4256 
+L 294.487578 280.4256 
 z
-" clip-path="url(#pa5599bfb8d)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8db67597a3)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 397.655156 309.8088 
-L 502.280156 309.8088 
-L 502.280156 280.4256 
-L 397.655156 280.4256 
+    <path d="M 399.112578 309.8088 
+L 503.737578 309.8088 
+L 503.737578 280.4256 
+L 399.112578 280.4256 
 z
-" clip-path="url(#pa5599bfb8d)" style="fill: #ee613e; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8db67597a3)" style="fill: #ee613e; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 188.405156 339.192 
-L 293.030156 339.192 
-L 293.030156 309.8088 
-L 188.405156 309.8088 
+    <path d="M 189.862578 339.192 
+L 294.487578 339.192 
+L 294.487578 309.8088 
+L 189.862578 309.8088 
 z
-" clip-path="url(#pa5599bfb8d)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8db67597a3)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 293.030156 339.192 
-L 397.655156 339.192 
-L 397.655156 309.8088 
-L 293.030156 309.8088 
+    <path d="M 294.487578 339.192 
+L 399.112578 339.192 
+L 399.112578 309.8088 
+L 294.487578 309.8088 
 z
-" clip-path="url(#pa5599bfb8d)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8db67597a3)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 397.655156 339.192 
-L 502.280156 339.192 
-L 502.280156 309.8088 
-L 397.655156 309.8088 
+    <path d="M 399.112578 339.192 
+L 503.737578 339.192 
+L 503.737578 309.8088 
+L 399.112578 309.8088 
 z
-" clip-path="url(#pa5599bfb8d)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8db67597a3)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(121.392422 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(122.849844 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(228.676641 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(230.134063 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(307.24875 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(308.706172 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(405.600469 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(407.057891 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(117.330156 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(118.787578 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.296 -->
-    <g transform="translate(229.266406 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(230.723828 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -946,7 +946,7 @@ z
    </g>
    <g id="text_7">
     <!-- 158 -->
-    <g transform="translate(337.707656 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(339.165078 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -1034,7 +1034,7 @@ z
    </g>
    <g id="text_8">
     <!-- 925 -->
-    <g transform="translate(442.332656 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(443.790078 91.6423) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-39"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
@@ -1042,7 +1042,7 @@ z
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(111.968281 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(113.425703 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1141,7 +1141,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.299 -->
-    <g transform="translate(229.266406 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(230.723828 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1151,7 +1151,7 @@ z
    </g>
    <g id="text_11">
     <!-- 73 -->
-    <g transform="translate(340.252656 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(341.710078 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -1202,7 +1202,7 @@ z
    </g>
    <g id="text_12">
     <!-- 283 -->
-    <g transform="translate(442.332656 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(443.790078 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(127.246094 0)"/>
@@ -1210,7 +1210,7 @@ z
    </g>
    <g id="text_13">
     <!-- zlib -->
-    <g transform="translate(129.231406 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(130.688828 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1234,7 +1234,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.299 -->
-    <g transform="translate(229.266406 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(230.723828 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1244,14 +1244,14 @@ z
    </g>
    <g id="text_15">
     <!-- 55 -->
-    <g transform="translate(340.252656 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(341.710078 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
     <!-- 692 -->
-    <g transform="translate(442.332656 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(443.790078 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-36"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
@@ -1259,7 +1259,7 @@ z
    </g>
    <g id="text_17">
     <!-- Go compress/flate -->
-    <g transform="translate(99.661406 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(101.118828 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -1430,7 +1430,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.299 -->
-    <g transform="translate(229.266406 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(230.723828 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1440,14 +1440,14 @@ z
    </g>
    <g id="text_19">
     <!-- 52 -->
-    <g transform="translate(340.252656 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(341.710078 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
     <!-- 323 -->
-    <g transform="translate(442.332656 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(443.790078 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(127.246094 0)"/>
@@ -1455,7 +1455,7 @@ z
    </g>
    <g id="text_21">
     <!-- miniz_oxide -->
-    <g transform="translate(112.537656 209.06385) scale(0.08 -0.08)">
+    <g transform="translate(113.995078 209.06385) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6e" d="M 3513 2113 
 L 3513 0 
@@ -1514,7 +1514,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.299 -->
-    <g transform="translate(229.266406 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(230.723828 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1524,14 +1524,14 @@ z
    </g>
    <g id="text_23">
     <!-- 51 -->
-    <g transform="translate(340.252656 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(341.710078 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_24">
     <!-- 729 -->
-    <g transform="translate(442.332656 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(443.790078 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-37"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(127.246094 0)"/>
@@ -1539,7 +1539,7 @@ z
    </g>
    <g id="text_25">
     <!-- JS fflate -->
-    <g transform="translate(120.693906 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(122.151328 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1599,7 +1599,7 @@ z
    </g>
    <g id="text_26">
     <!-- 0.307 -->
-    <g transform="translate(229.266406 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(230.723828 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1609,7 +1609,7 @@ z
    </g>
    <g id="text_27">
     <!-- 41 -->
-    <g transform="translate(340.252656 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(341.710078 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1637,14 +1637,14 @@ z
    </g>
    <g id="text_28">
     <!-- 80 -->
-    <g transform="translate(444.877656 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(446.335078 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-38"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_29">
     <!-- lean-zip (native) -->
-    <g transform="translate(99.039531 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(100.496953 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1753,7 +1753,7 @@ z
    </g>
    <g id="text_30">
     <!-- 0.297 -->
-    <g transform="translate(228.065781 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(229.523203 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1854,15 +1854,56 @@ z
     </g>
    </g>
    <g id="text_31">
-    <!-- 29 -->
-    <g transform="translate(339.776406 267.9415) scale(0.08 -0.08)">
+    <!-- 28 -->
+    <g transform="translate(341.233828 267.9415) scale(0.08 -0.08)">
+     <defs>
+      <path id="DejaVuSans-Bold-38" d="M 2228 2088 
+Q 1891 2088 1709 1903 
+Q 1528 1719 1528 1375 
+Q 1528 1031 1709 848 
+Q 1891 666 2228 666 
+Q 2563 666 2741 848 
+Q 2919 1031 2919 1375 
+Q 2919 1722 2741 1905 
+Q 2563 2088 2228 2088 
+z
+M 1350 2484 
+Q 925 2613 709 2878 
+Q 494 3144 494 3541 
+Q 494 4131 934 4440 
+Q 1375 4750 2228 4750 
+Q 3075 4750 3515 4442 
+Q 3956 4134 3956 3541 
+Q 3956 3144 3739 2878 
+Q 3522 2613 3097 2484 
+Q 3572 2353 3814 2058 
+Q 4056 1763 4056 1313 
+Q 4056 619 3595 264 
+Q 3134 -91 2228 -91 
+Q 1319 -91 855 264 
+Q 391 619 391 1313 
+Q 391 1763 633 2058 
+Q 875 2353 1350 2484 
+z
+M 1631 3419 
+Q 1631 3141 1786 2991 
+Q 1941 2841 2228 2841 
+Q 2509 2841 2662 2991 
+Q 2816 3141 2816 3419 
+Q 2816 3697 2662 3845 
+Q 2509 3994 2228 3994 
+Q 1941 3994 1786 3844 
+Q 1631 3694 1631 3419 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-Bold-32"/>
-     <use xlink:href="#DejaVuSans-Bold-39" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-38" transform="translate(69.580078 0)"/>
     </g>
    </g>
    <g id="text_32">
     <!-- 135 -->
-    <g transform="translate(441.618281 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(443.075703 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-31" d="M 750 831 
 L 1813 831 
@@ -1943,7 +1984,7 @@ z
    </g>
    <g id="text_33">
     <!-- OCaml decompress -->
-    <g transform="translate(97.154531 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(98.611953 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -2008,7 +2049,7 @@ z
    </g>
    <g id="text_34">
     <!-- 0.321 -->
-    <g transform="translate(229.266406 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(230.723828 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -2018,14 +2059,14 @@ z
    </g>
    <g id="text_35">
     <!-- 23 -->
-    <g transform="translate(340.252656 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(341.710078 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_36">
     <!-- 117 -->
-    <g transform="translate(442.332656 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(443.790078 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
@@ -2033,7 +2074,7 @@ z
    </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(125.375781 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(126.833203 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -2044,7 +2085,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.279 -->
-    <g transform="translate(229.266406 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(230.723828 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -2054,13 +2095,13 @@ z
    </g>
    <g id="text_39">
     <!-- 0 -->
-    <g transform="translate(342.797656 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(344.255078 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(445.967656 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(447.425078 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2076,7 +2117,7 @@ z
   </g>
   <g id="text_41">
    <!-- canterbury — geomean over files, level 6 -->
-   <g transform="translate(135.788906 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(137.246328 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-62" d="M 2400 722 
 Q 2759 722 2948 984 
@@ -2289,7 +2330,7 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-07-06T22:02:31Z  ·  Linux chungus2 x86_64  ·  commit ac74ebaf  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-07-07T02:05:28Z  ·  Linux chungus2 x86_64  ·  commit 1a899305  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2428,16 +2469,16 @@ z
     <use xlink:href="#DejaVuSans-37" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2477,110 +2518,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3133.154297 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3188.134766 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3251.757812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3315.380859 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3376.904297 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3440.380859 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3501.660156 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3536.865234 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3568.652344 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3600.439453 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3632.226562 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3664.013672 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3695.800781 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3723.583984 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3785.107422 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3846.386719 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3909.765625 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3973.242188 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4012.105469 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4073.287109 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4132.466797 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4193.990234 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4235.103516 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4268.794922 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4296.578125 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4358.101562 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4419.380859 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4482.759766 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4546.382812 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4580.074219 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4639.253906 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4702.876953 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4734.664062 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4798.287109 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4861.910156 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4893.697266 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4957.320312 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4993.404297 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5032.267578 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5087.248047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5150.871094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5182.658203 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5214.445312 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5246.232422 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5278.019531 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5309.806641 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5349.015625 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5412.394531 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5451.257812 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5512.439453 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5575.818359 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5639.294922 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5702.673828 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5766.150391 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5829.529297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5868.738281 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5900.525391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5984.314453 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6016.101562 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6113.513672 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6175.037109 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6238.513672 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6266.296875 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6327.576172 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6390.955078 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6422.742188 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6474.841797 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6538.220703 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6599.5 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6662.976562 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6715.076172 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6778.455078 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6839.636719 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6878.845703 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6912.537109 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6944.324219 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6985.4375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7046.716797 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7085.925781 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7113.708984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7174.890625 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7206.677734 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7234.460938 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7286.560547 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7318.347656 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7381.824219 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7443.347656 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7482.556641 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7544.080078 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7583.443359 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7680.855469 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7708.638672 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7772.017578 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7799.800781 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7851.900391 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7891.109375 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7918.892578 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3196.777344 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3260.400391 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3324.023438 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3387.646484 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3451.269531 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3514.892578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3578.515625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3610.302734 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3642.089844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3673.876953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3705.664062 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3737.451172 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3765.234375 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3826.757812 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3888.037109 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3951.416016 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4014.892578 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4053.755859 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4114.9375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4174.117188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4235.640625 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4276.753906 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4310.445312 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4338.228516 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4399.751953 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4461.03125 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4524.410156 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4588.033203 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4621.724609 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4680.904297 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4744.527344 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4776.314453 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4839.9375 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4903.560547 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4935.347656 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4998.970703 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5035.054688 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5073.917969 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5128.898438 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5192.521484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5224.308594 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5256.095703 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5287.882812 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5319.669922 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5351.457031 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5390.666016 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5454.044922 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5492.908203 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5554.089844 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5617.46875 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5680.945312 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5744.324219 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5807.800781 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5871.179688 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5910.388672 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5942.175781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6025.964844 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6057.751953 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6155.164062 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6216.6875 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6280.164062 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6307.947266 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6369.226562 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6432.605469 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6464.392578 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6516.492188 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6579.871094 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6641.150391 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6704.626953 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6756.726562 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6820.105469 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6881.287109 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6920.496094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6954.1875 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6985.974609 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7027.087891 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7088.367188 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7127.576172 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7155.359375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7216.541016 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7248.328125 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7276.111328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7328.210938 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7359.998047 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7423.474609 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7484.998047 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7524.207031 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7585.730469 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7625.09375 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7722.505859 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7750.289062 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7813.667969 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7841.451172 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7893.550781 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7932.759766 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7960.542969 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pa5599bfb8d">
-   <rect x="83.780156" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="p8db67597a3">
+   <rect x="85.237578" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/graphs/silesia_compress_heatmap.svg
+++ b/bench/graphs/silesia_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.34175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#pd532c30007)">
+   <g clip-path="url(#pd7d900058d)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAqAAAAGaCAYAAADQNfGTAAAJ9klEQVR4nO3YwY6kVR2HYbq7uukZtTNA7DiEDW6McWEwIcbb4DpcseUavAF2LL0AF25YsDDBDUsSEkkAjQTjRCbDUHZXV3sR5Lz/8cvzXMGvcurU99Z3cvz3B/cvbdnN8+kFa52cTi9Y63iYXrDW1s/vcDO9YK2Hj6YXrPXfZ9ML+CHOLqYXrLX17+f55fSCpTb+9AMA4EUjQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASO0+OXw5vWGpi/Pd9ISl9oeb6QlLPb56fXrCUl88/Wp6wlKHk7vpCUv98sGr0xOWOrx8OT1hqX88+/v0hKWuH1xPT1hqf3GYnrDUyUvPpycs5Q0oAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQ2l0/vJ7esNTjH/18esJS3zz/cnrCUj/bb/s/0tVrv56esNTF2eX0hKXujofpCUtt/fw2//lOt/35dqdvTE9Y6nK/n56w1Laf7gAAvHAEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAqd3LZw+nNyz1ZP/19ISltn5+d6+8Oj1hqa/+88n0hKWe3e6nJyz19itvT09Y6ub+MD1hqS+efj49Yalfvfab6QlLffz1X6YnLPXWT7d9ft6AAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKRO7j569356xFLH4/QCfoitn9+p/4AwZuv3z+/n/7fDYXrBUhs/PQAAXjQCFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACA1O7640+nNyx1dnE2PWGpbz791/SEpd7//VvTE5b6w1+3fX6/e+NqesJSf/zw8+kJS733zi+mJyz1p799Oz1hqTcfPZiesNST72+nJyz128cPpycs5Q0oAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQOrm9+/P99IiVzm5vpiesdXYxvWCtw356wVq7y+kFa53tphesdX+cXrDW7cbv38nG38Gcbvv+3Z5s+/6dHw7TE5ba+O0DAOBFI0ABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEjtvjs8nd6w1NXNcXrCUscfX05PWOr02yfTE9b6yfX0grUO++kFS92eX0xPWOr8u43fv0evTy9Y67jt59/5Pz+bnrDW1bafD96AAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKT+Bx7vfNJv/UspAAAAAElFTkSuQmCC" id="image6b584b2b1a" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="483.84" height="295.2"/>
+iVBORw0KGgoAAAANSUhEUgAAAqAAAAGaCAYAAADQNfGTAAAJ+ElEQVR4nO3YP27lVx2H4di+djzDaMgfsDIoDTQIUaAgRYhtsA4qWtbABuhSsgAKGgoKpNCkjIREpCQgjUIyQDRMLvbPNouIzvud/PQ8K/hcHR/f956Tuy/eu39lz65fTC9Y6+R0esFad9v0grX2fn7b9fSCtR6+Nr1grf89n17A13F2Mb1grb3/fZ5fTi9YaufffgAAvGwEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAqcMH2yfTG5a6OD9MT1jquF1PT1jqyePvTU9Y6uMvP52esNR2cjs9YakfPXhjesJS26uX0xOW+sfzv09PWOrqwdX0hKWOF9v0hKVOXnkxPWEpL6AAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEDqcPXwanrDUk++9YPpCUt99uKT6QlLvXXc92+kx2/+ZHrCUhdnl9MTlrq926YnLLX389v95zvd9+c7nL49PWGpy+NxesJS+/52BwDgpSNAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBIHV49ezi9Yalnx6fTE5ba+/ndvv7G9ISlPv33B9MTlnp+c5yesNS7r787PWGp6/ttesJSH3/50fSEpX785k+nJyz1/tM/T09Y6p3v7vv8vIACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApE5u//Sr++kRS93dTS/g69j7+Z36DQhj9n7//P/8Ztu26QVL7fz0AAB42QhQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSh6v3P5zesNTZxdn0hKU++/Cf0xOW+u0v35mesNRv/rLv8/v524+nJyz1uz9+ND1hqV//4ofTE5b6/d/+Mz1hqe+/9mB6wlLPvrqZnrDUz548nJ6wlBdQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgdXJz+4f76RErnd1cT09Y6+xiesFa23F6wVqHy+kFa50dphesdX83vWCtm53fv5Odv8Gc7vv+3Zzs+/6db9v0hKV2fvsAAHjZCFAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFKHr7bn0xuWenS9TU9Y6u7R5fSEpU7/9fn0hLW+/db0grW24/SCpa7PD9MTlrr477PpCWs93vn9u7+bXrDU+dO/Tk9Y69F3phcs5QUUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAIPV/m+58yjWMNvYAAAAASUVORK5CYII=" id="image17aec7e6c0" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="483.84" height="295.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m29f963ec73" d="M 0 0 
+       <path id="medc31bb404" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m29f963ec73" x="115.814949" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#medc31bb404" x="115.814949" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m29f963ec73" x="156.092348" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#medc31bb404" x="156.092348" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m29f963ec73" x="196.369746" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#medc31bb404" x="196.369746" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m29f963ec73" x="236.647145" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#medc31bb404" x="236.647145" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m29f963ec73" x="276.924544" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#medc31bb404" x="276.924544" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m29f963ec73" x="317.201942" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#medc31bb404" x="317.201942" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m29f963ec73" x="357.479341" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#medc31bb404" x="357.479341" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m29f963ec73" x="397.756739" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#medc31bb404" x="397.756739" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m29f963ec73" x="438.034138" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#medc31bb404" x="438.034138" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m29f963ec73" x="478.311536" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#medc31bb404" x="478.311536" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m29f963ec73" x="518.588935" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#medc31bb404" x="518.588935" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m29f963ec73" x="558.866334" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#medc31bb404" x="558.866334" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="m219fbdc8ba" d="M 0 0 
+       <path id="m0ba62e1a64" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m219fbdc8ba" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0ba62e1a64" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m219fbdc8ba" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0ba62e1a64" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m219fbdc8ba" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0ba62e1a64" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m219fbdc8ba" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0ba62e1a64" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -836,7 +836,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m219fbdc8ba" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0ba62e1a64" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -899,7 +899,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m219fbdc8ba" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0ba62e1a64" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -966,7 +966,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m219fbdc8ba" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0ba62e1a64" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1047,7 +1047,7 @@ z
     <g id="ytick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m219fbdc8ba" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0ba62e1a64" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -1138,7 +1138,7 @@ L 579.005033 49.34175
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_21">
-    <!-- +22 -->
+    <!-- +21 -->
     <g transform="translate(108.955926 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-2b" d="M 2944 4013 
@@ -1180,45 +1180,53 @@ Q 2828 2175 2409 1742
 Q 1991 1309 1228 531 
 z
 " transform="scale(0.015625)"/>
+      <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_22">
-    <!-- -25 -->
+    <!-- -24 -->
     <g transform="translate(150.784184 69.553235) scale(0.065 -0.065)">
      <defs>
-      <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
+      <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_23">
@@ -1312,23 +1320,52 @@ z
     </g>
    </g>
    <g id="text_25">
-    <!-- -10 -->
+    <!-- -12 -->
     <g transform="translate(271.616379 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_26">
+    <!-- -15 -->
+    <g transform="translate(311.893778 69.553235) scale(0.065 -0.065)">
      <defs>
-      <path id="DejaVuSans-31" d="M 794 531 
-L 1825 531 
-L 1825 4091 
-L 703 3866 
-L 703 4441 
-L 1819 4666 
-L 2450 4666 
-L 2450 531 
-L 3481 531 
-L 3481 0 
-L 794 0 
-L 794 531 
+      <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
 z
 " transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_27">
+    <!-- +10 -->
+    <g transform="translate(350.620317 69.553235) scale(0.065 -0.065)">
+     <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
 Q 1056 3291 1056 2328 
@@ -1351,43 +1388,56 @@ Q 1250 4750 2034 4750
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
     </g>
    </g>
-   <g id="text_26">
-    <!-- -14 -->
-    <g transform="translate(311.893778 69.553235) scale(0.065 -0.065)">
+   <g id="text_28">
+    <!-- -35 -->
+    <g transform="translate(392.448575 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_29">
+    <!-- -5 -->
+    <g transform="translate(434.793786 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_30">
+    <!-- -7 -->
+    <g transform="translate(475.071185 69.553235) scale(0.065 -0.065)">
      <defs>
-      <path id="DejaVuSans-34" d="M 2419 4116 
-L 825 1625 
-L 2419 1625 
-L 2419 4116 
-z
-M 2253 4666 
-L 3047 4666 
-L 3047 1625 
-L 3713 1625 
-L 3713 1100 
-L 3047 1100 
-L 3047 0 
-L 2419 0 
-L 2419 1100 
-L 313 1100 
-L 313 1709 
-L 2253 4666 
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_31">
+    <!-- -54 -->
+    <g transform="translate(513.280771 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
     </g>
    </g>
-   <g id="text_27">
-    <!-- +9 -->
-    <g transform="translate(352.68813 69.553235) scale(0.065 -0.065)">
+   <g id="text_32">
+    <!-- -29 -->
+    <g transform="translate(553.558169 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-39" d="M 703 97 
 L 703 672 
@@ -1420,58 +1470,9 @@ Q 1534 2075 1959 2075
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_28">
-    <!-- -34 -->
-    <g transform="translate(392.448575 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_29">
-    <!-- -5 -->
-    <g transform="translate(434.793786 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_30">
-    <!-- -7 -->
-    <g transform="translate(475.071185 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_31">
-    <!-- -52 -->
-    <g transform="translate(513.280771 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_32">
-    <!-- -28 -->
-    <g transform="translate(553.558169 69.553235) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_33">
@@ -2192,18 +2193,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB1ElEQVR4nO2b0a3DMAwD7cSzvM3fmI47gvpxCK6ENABhnkQ5aZH5P/7OAGpdFyEzBiQDnija2qSEghnZhIIZCa3NyWQkmZFOKJhRsDXsOopmJJwjaEPOmxHirE3MWjOqhSBr2EAGMyKtMVpc+ynYwe3viNQVbA0LrZDRFbxGbNbWyM3auG0RGbo1Qp0IZCSMiG2OgtNvbL+Oke6BvddIWaQ1qP3RjGSTLXypwdaIMP2ctWb0olAzKkr4LhLMCPvnOJiRbo6CrTWjF4WCGYHWJtU1TKgZvSZkfNAKZhRsDftFa96MkJCRrf29ausyWrOtWiMjmxDH6FAfDJzzIEKctQc60ToDEqJOBLbfZs04RxQjobWOSFXrjM0IdURqIaG1jkhVPmvGOUqOCPLJMdh+6kRk+zFGMtjKOdK13zbZ2EBGMxLOkSz90YygK9tozSbUa6Qu4RxtRifZ2np0jDY32YiOc44gIQo2aI1ZkB2Rb4SiIyJbtcr0Q0IPdCQyIpCQDnZHpC5uQ27uOtJFBBptH2zlHOnab+uaMSK29htXrW2NKK0hOtlrxLaPjIxys4a99x9dRKgTgUK69gsZ9RxVFWzNyIi6RZIZtbXfE+qI1BU8R5i1D2e5X2tFkZmlAAAAAElFTkSuQmCC" id="image683497b7d8" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-69.84" width="12.96" height="253.44"/>
+iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB1ElEQVR4nO2b0a3DMAwD7cSzvM3fmI47gvpxCK6ENABhnkQ5aZH5P/7OAGpdFyEzBiQDnija2qSEghnZhIIZCa3NyWQkmZFOKJhRsDXsOopmJJwjaEPOmxHirE3MWjOqhSBr2EAGMyKtMVpc+ynYwe3viNQVbA0LrZDRFbxGbNbWyM3auG0RGbo1Qp0IZCSMiG2OgtNvbL+Oke6BvddIWaQ1qP3RjGSTLXypwdaIMP2ctWb0olAzKkr4LhLMCPvnOJiRbo6CrTWjF4WCGYHWJtU1TKgZvSZkfNAKZhRsDftFa96MkJCRrf29ausyWrOtWiMjmxDH6FAfDJzzIEKctQc60ToDEqJOBLbfZs04RxQjobWOSFXrjM0IdURqIaG1jkhVPmvGOUqOCPLJMdh+6kRk+zFGMtjKOdK13zbZ2EBGMxLOkSz90YygK9tozSbUa6Qu4RxtRifZ2np0jDY32YiOc44gIQo2aI1ZkB2Rb4SiIyJbtcr0Q0IPdCQyIpCQDnZHpC5uQ27uOtJFBBptH2zlHOnab+uaMSK29htXrW2NKK0hOtlrxLaPjIxys4a99x9dRKgTgUK69gsZ9RxVFWzNyIi6RZIZtbXfE+qI1BU8R5i1D2e5X2tFkZmlAAAAAElFTkSuQmCC" id="image679ef497bd" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-69.84" width="12.96" height="253.44"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_21">
       <defs>
-       <path id="mb1f4fc96df" d="M 0 0 
+       <path id="m1a44dbcddb" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mb1f4fc96df" x="601.779688" y="322.507463" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1a44dbcddb" x="601.779688" y="322.507463" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_117">
@@ -2226,7 +2227,7 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#mb1f4fc96df" x="601.779688" y="280.566603" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1a44dbcddb" x="601.779688" y="280.566603" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_118">
@@ -2240,7 +2241,7 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#mb1f4fc96df" x="601.779688" y="238.625742" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1a44dbcddb" x="601.779688" y="238.625742" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_119">
@@ -2254,7 +2255,7 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mb1f4fc96df" x="601.779688" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1a44dbcddb" x="601.779688" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_120">
@@ -2267,7 +2268,7 @@ z
     <g id="ytick_13">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#mb1f4fc96df" x="601.779688" y="154.74402" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1a44dbcddb" x="601.779688" y="154.74402" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_121">
@@ -2280,7 +2281,7 @@ z
     <g id="ytick_14">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mb1f4fc96df" x="601.779688" y="112.803159" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1a44dbcddb" x="601.779688" y="112.803159" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_122">
@@ -2293,7 +2294,7 @@ z
     <g id="ytick_15">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#mb1f4fc96df" x="601.779688" y="70.862298" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1a44dbcddb" x="601.779688" y="70.862298" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_123">
@@ -2909,8 +2910,8 @@ z
    </g>
   </g>
   <g id="text_126">
-   <!-- 2026-07-06T22:02:31Z  ·  Linux chungus2 x86_64  ·  commit ac74ebaf  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(44.919844 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-07T02:05:28Z  ·  Linux chungus2 x86_64  ·  commit 1a899305  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(43.462422 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2999,16 +3000,16 @@ z
     <use xlink:href="#DejaVuSans-37" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3048,109 +3049,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3133.154297 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3188.134766 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3251.757812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3315.380859 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3376.904297 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3440.380859 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3501.660156 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3536.865234 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3568.652344 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3600.439453 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3632.226562 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3664.013672 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3695.800781 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3723.583984 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3785.107422 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3846.386719 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3909.765625 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3973.242188 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4012.105469 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4073.287109 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4132.466797 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4193.990234 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4235.103516 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4268.794922 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4296.578125 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4358.101562 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4419.380859 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4482.759766 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4546.382812 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4580.074219 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4639.253906 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4702.876953 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4734.664062 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4798.287109 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4861.910156 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4893.697266 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4957.320312 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4993.404297 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5032.267578 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5087.248047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5150.871094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5182.658203 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5214.445312 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5246.232422 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5278.019531 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5309.806641 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5349.015625 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5412.394531 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5451.257812 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5512.439453 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5575.818359 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5639.294922 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5702.673828 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5766.150391 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5829.529297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5868.738281 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5900.525391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5984.314453 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6016.101562 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6113.513672 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6175.037109 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6238.513672 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6266.296875 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6327.576172 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6390.955078 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6422.742188 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6474.841797 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6538.220703 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6599.5 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6662.976562 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6715.076172 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6778.455078 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6839.636719 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6878.845703 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6912.537109 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6944.324219 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6985.4375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7046.716797 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7085.925781 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7113.708984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7174.890625 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7206.677734 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7234.460938 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7286.560547 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7318.347656 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7381.824219 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7443.347656 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7482.556641 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7544.080078 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7583.443359 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7680.855469 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7708.638672 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7772.017578 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7799.800781 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7851.900391 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7891.109375 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7918.892578 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3196.777344 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3260.400391 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3324.023438 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3387.646484 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3451.269531 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3514.892578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3578.515625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3610.302734 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3642.089844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3673.876953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3705.664062 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3737.451172 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3765.234375 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3826.757812 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3888.037109 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3951.416016 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4014.892578 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4053.755859 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4114.9375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4174.117188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4235.640625 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4276.753906 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4310.445312 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4338.228516 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4399.751953 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4461.03125 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4524.410156 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4588.033203 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4621.724609 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4680.904297 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4744.527344 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4776.314453 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4839.9375 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4903.560547 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4935.347656 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4998.970703 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5035.054688 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5073.917969 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5128.898438 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5192.521484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5224.308594 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5256.095703 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5287.882812 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5319.669922 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5351.457031 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5390.666016 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5454.044922 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5492.908203 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5554.089844 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5617.46875 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5680.945312 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5744.324219 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5807.800781 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5871.179688 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5910.388672 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5942.175781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6025.964844 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6057.751953 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6155.164062 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6216.6875 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6280.164062 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6307.947266 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6369.226562 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6432.605469 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6464.392578 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6516.492188 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6579.871094 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6641.150391 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6704.626953 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6756.726562 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6820.105469 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6881.287109 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6920.496094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6954.1875 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6985.974609 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7027.087891 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7088.367188 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7127.576172 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7155.359375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7216.541016 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7248.328125 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7276.111328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7328.210938 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7359.998047 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7423.474609 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7484.998047 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7524.207031 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7585.730469 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7625.09375 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7722.505859 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7750.289062 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7813.667969 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7841.451172 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7893.550781 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7932.759766 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7960.542969 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pd532c30007">
+  <clipPath id="pd7d900058d">
    <rect x="95.67625" y="49.34175" width="483.328783" height="294.686261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_compress_pareto.svg
+++ b/bench/graphs/silesia_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 61.085542 412.80375 
 L 61.085542 48.323125 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m393140e48f" d="M 0 0 
+       <path id="ma729e4c47c" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m393140e48f" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma729e4c47c" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -130,11 +130,11 @@ z
      <g id="line2d_3">
       <path d="M 145.270284 412.80375 
 L 145.270284 48.323125 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m393140e48f" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma729e4c47c" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -177,11 +177,11 @@ z
      <g id="line2d_5">
       <path d="M 229.455026 412.80375 
 L 229.455026 48.323125 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m393140e48f" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma729e4c47c" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -219,11 +219,11 @@ z
      <g id="line2d_7">
       <path d="M 313.639768 412.80375 
 L 313.639768 48.323125 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m393140e48f" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma729e4c47c" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -272,11 +272,11 @@ z
      <g id="line2d_9">
       <path d="M 397.82451 412.80375 
 L 397.82451 48.323125 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m393140e48f" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma729e4c47c" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -334,11 +334,11 @@ z
      <g id="line2d_11">
       <path d="M 482.009253 412.80375 
 L 482.009253 48.323125 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m393140e48f" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma729e4c47c" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -355,11 +355,11 @@ L 482.009253 48.323125
      <g id="line2d_13">
       <path d="M 566.193995 412.80375 
 L 566.193995 48.323125 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m393140e48f" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma729e4c47c" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -856,16 +856,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 368.08164 
 L 637.2 368.08164 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="mdb0298850e" d="M 0 0 
+       <path id="m2ce0ae807a" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mdb0298850e" x="49.078125" y="368.08164" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2ce0ae807a" x="49.078125" y="368.08164" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -897,11 +897,11 @@ z
      <g id="line2d_17">
       <path d="M 49.078125 243.439835 
 L 637.2 243.439835 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mdb0298850e" x="49.078125" y="243.439835" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2ce0ae807a" x="49.078125" y="243.439835" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -917,11 +917,11 @@ L 637.2 243.439835
      <g id="line2d_19">
       <path d="M 49.078125 118.798029 
 L 637.2 118.798029 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#mdb0298850e" x="49.078125" y="118.798029" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2ce0ae807a" x="49.078125" y="118.798029" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -937,16 +937,16 @@ L 637.2 118.798029
      <g id="line2d_21">
       <path d="M 49.078125 405.602562 
 L 637.2 405.602562 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="mdddd0c50ac" d="M 0 0 
+       <path id="m65d5b1df80" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#mdddd0c50ac" x="49.078125" y="405.602562" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m65d5b1df80" x="49.078125" y="405.602562" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -954,11 +954,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 395.733268 
 L 637.2 395.733268 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mdddd0c50ac" x="49.078125" y="395.733268" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m65d5b1df80" x="49.078125" y="395.733268" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -966,11 +966,11 @@ L 637.2 395.733268
      <g id="line2d_25">
       <path d="M 49.078125 387.3889 
 L 637.2 387.3889 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mdddd0c50ac" x="49.078125" y="387.3889" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m65d5b1df80" x="49.078125" y="387.3889" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -978,11 +978,11 @@ L 637.2 387.3889
      <g id="line2d_27">
       <path d="M 49.078125 380.160679 
 L 637.2 380.160679 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#mdddd0c50ac" x="49.078125" y="380.160679" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m65d5b1df80" x="49.078125" y="380.160679" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -990,11 +990,11 @@ L 637.2 380.160679
      <g id="line2d_29">
       <path d="M 49.078125 373.784936 
 L 637.2 373.784936 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#mdddd0c50ac" x="49.078125" y="373.784936" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m65d5b1df80" x="49.078125" y="373.784936" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1002,11 +1002,11 @@ L 637.2 373.784936
      <g id="line2d_31">
       <path d="M 49.078125 330.560718 
 L 637.2 330.560718 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#mdddd0c50ac" x="49.078125" y="330.560718" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m65d5b1df80" x="49.078125" y="330.560718" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1014,11 +1014,11 @@ L 637.2 330.560718
      <g id="line2d_33">
       <path d="M 49.078125 308.612385 
 L 637.2 308.612385 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#mdddd0c50ac" x="49.078125" y="308.612385" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m65d5b1df80" x="49.078125" y="308.612385" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1026,11 +1026,11 @@ L 637.2 308.612385
      <g id="line2d_35">
       <path d="M 49.078125 293.039796 
 L 637.2 293.039796 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#mdddd0c50ac" x="49.078125" y="293.039796" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m65d5b1df80" x="49.078125" y="293.039796" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1038,11 +1038,11 @@ L 637.2 293.039796
      <g id="line2d_37">
       <path d="M 49.078125 280.960757 
 L 637.2 280.960757 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#mdddd0c50ac" x="49.078125" y="280.960757" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m65d5b1df80" x="49.078125" y="280.960757" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1050,11 +1050,11 @@ L 637.2 280.960757
      <g id="line2d_39">
       <path d="M 49.078125 271.091463 
 L 637.2 271.091463 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#mdddd0c50ac" x="49.078125" y="271.091463" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m65d5b1df80" x="49.078125" y="271.091463" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1062,11 +1062,11 @@ L 637.2 271.091463
      <g id="line2d_41">
       <path d="M 49.078125 262.747094 
 L 637.2 262.747094 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#mdddd0c50ac" x="49.078125" y="262.747094" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m65d5b1df80" x="49.078125" y="262.747094" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1074,11 +1074,11 @@ L 637.2 262.747094
      <g id="line2d_43">
       <path d="M 49.078125 255.518874 
 L 637.2 255.518874 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#mdddd0c50ac" x="49.078125" y="255.518874" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m65d5b1df80" x="49.078125" y="255.518874" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1086,11 +1086,11 @@ L 637.2 255.518874
      <g id="line2d_45">
       <path d="M 49.078125 249.143131 
 L 637.2 249.143131 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#mdddd0c50ac" x="49.078125" y="249.143131" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m65d5b1df80" x="49.078125" y="249.143131" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1098,11 +1098,11 @@ L 637.2 249.143131
      <g id="line2d_47">
       <path d="M 49.078125 205.918912 
 L 637.2 205.918912 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#mdddd0c50ac" x="49.078125" y="205.918912" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m65d5b1df80" x="49.078125" y="205.918912" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1110,11 +1110,11 @@ L 637.2 205.918912
      <g id="line2d_49">
       <path d="M 49.078125 183.97058 
 L 637.2 183.97058 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#mdddd0c50ac" x="49.078125" y="183.97058" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m65d5b1df80" x="49.078125" y="183.97058" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1122,11 +1122,11 @@ L 637.2 183.97058
      <g id="line2d_51">
       <path d="M 49.078125 168.39799 
 L 637.2 168.39799 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#mdddd0c50ac" x="49.078125" y="168.39799" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m65d5b1df80" x="49.078125" y="168.39799" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1134,11 +1134,11 @@ L 637.2 168.39799
      <g id="line2d_53">
       <path d="M 49.078125 156.318951 
 L 637.2 156.318951 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#mdddd0c50ac" x="49.078125" y="156.318951" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m65d5b1df80" x="49.078125" y="156.318951" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1146,11 +1146,11 @@ L 637.2 156.318951
      <g id="line2d_55">
       <path d="M 49.078125 146.449658 
 L 637.2 146.449658 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#mdddd0c50ac" x="49.078125" y="146.449658" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m65d5b1df80" x="49.078125" y="146.449658" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1158,11 +1158,11 @@ L 637.2 146.449658
      <g id="line2d_57">
       <path d="M 49.078125 138.105289 
 L 637.2 138.105289 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#mdddd0c50ac" x="49.078125" y="138.105289" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m65d5b1df80" x="49.078125" y="138.105289" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1170,11 +1170,11 @@ L 637.2 138.105289
      <g id="line2d_59">
       <path d="M 49.078125 130.877068 
 L 637.2 130.877068 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#mdddd0c50ac" x="49.078125" y="130.877068" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m65d5b1df80" x="49.078125" y="130.877068" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1182,11 +1182,11 @@ L 637.2 130.877068
      <g id="line2d_61">
       <path d="M 49.078125 124.501326 
 L 637.2 124.501326 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#mdddd0c50ac" x="49.078125" y="124.501326" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m65d5b1df80" x="49.078125" y="124.501326" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1194,11 +1194,11 @@ L 637.2 124.501326
      <g id="line2d_63">
       <path d="M 49.078125 81.277107 
 L 637.2 81.277107 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#mdddd0c50ac" x="49.078125" y="81.277107" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m65d5b1df80" x="49.078125" y="81.277107" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1206,11 +1206,11 @@ L 637.2 81.277107
      <g id="line2d_65">
       <path d="M 49.078125 59.328775 
 L 637.2 59.328775 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#mdddd0c50ac" x="49.078125" y="59.328775" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m65d5b1df80" x="49.078125" y="59.328775" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1332,7 +1332,7 @@ L 637.2 48.323125
    </g>
    <g id="text_13">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(324.643112 122.714396) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(324.643112 123.206672) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1364,7 +1364,7 @@ z
    </g>
    <g id="text_14">
     <!-- L10 -->
-    <g style="fill: #d62728" transform="translate(102.799363 311.465426) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(102.799363 312.435797) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1686,23 +1686,23 @@ z
    </g>
    <g id="line2d_67">
     <defs>
-     <path id="mdd1d902bb3" d="M -2.5 2.5 
+     <path id="m98efb0f5ae" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p2071de76a5)">
-     <use xlink:href="#mdd1d902bb3" x="377.110281" y="104.685421" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdd1d902bb3" x="323.801439" y="110.409833" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdd1d902bb3" x="272.665744" y="126.308323" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdd1d902bb3" x="235.168828" y="128.026741" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdd1d902bb3" x="186.228265" y="149.377587" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdd1d902bb3" x="158.303164" y="171.457731" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdd1d902bb3" x="149.489547" y="182.192614" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdd1d902bb3" x="140.563162" y="202.482797" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdd1d902bb3" x="138.984853" y="209.328911" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p6655eb9f26)">
+     <use xlink:href="#m98efb0f5ae" x="377.110281" y="104.685421" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m98efb0f5ae" x="323.801439" y="110.409833" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m98efb0f5ae" x="272.665744" y="126.308323" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m98efb0f5ae" x="235.168828" y="128.026741" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m98efb0f5ae" x="186.228265" y="149.377587" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m98efb0f5ae" x="158.303164" y="171.457731" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m98efb0f5ae" x="149.489547" y="182.192614" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m98efb0f5ae" x="140.563162" y="202.482797" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m98efb0f5ae" x="138.984853" y="209.328911" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_68">
@@ -1755,7 +1755,7 @@ L 327.133241 110.069256
 L 326.02264 110.18302 
 L 324.91204 110.296545 
 L 323.801439 110.409833 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_69">
     <path d="M 323.801439 110.409833 
@@ -1807,7 +1807,7 @@ L 275.861725 125.44037
 L 274.796398 125.731236 
 L 273.731071 126.020548 
 L 272.665744 126.308323 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_70">
     <path d="M 272.665744 126.308323 
@@ -1859,7 +1859,7 @@ L 237.512385 127.920923
 L 236.7312 127.956219 
 L 235.950014 127.991491 
 L 235.168828 128.026741 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_71">
     <path d="M 235.168828 128.026741 
@@ -1911,7 +1911,7 @@ L 189.28705 148.263499
 L 188.267455 148.637415 
 L 187.24786 149.008766 
 L 186.228265 149.377587 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_72">
     <path d="M 186.228265 149.377587 
@@ -1963,7 +1963,7 @@ L 160.048483 170.312481
 L 159.46671 170.696929 
 L 158.884937 171.078667 
 L 158.303164 171.457731 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_73">
     <path d="M 158.303164 171.457731 
@@ -2015,7 +2015,7 @@ L 150.040398 181.580576
 L 149.856781 181.785359 
 L 149.673164 181.989369 
 L 149.489547 182.192614 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_74">
     <path d="M 149.489547 182.192614 
@@ -2067,7 +2067,7 @@ L 141.121061 201.414753
 L 140.935095 201.773114 
 L 140.749129 202.129119 
 L 140.563162 202.482797 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_75">
     <path d="M 140.563162 202.482797 
@@ -2119,26 +2119,26 @@ L 139.083497 208.925481
 L 139.050616 209.060292 
 L 139.017734 209.194768 
 L 138.984853 209.328911 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_76">
     <defs>
-     <path id="md3aec797c7" d="M 0 -2.5 
+     <path id="me038930ba1" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p2071de76a5)">
-     <use xlink:href="#md3aec797c7" x="610.467187" y="71.939349" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md3aec797c7" x="319.880958" y="101.884157" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md3aec797c7" x="210.281253" y="129.778154" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md3aec797c7" x="196.287076" y="133.586625" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md3aec797c7" x="176.054419" y="147.38645" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md3aec797c7" x="152.161413" y="174.753272" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md3aec797c7" x="146.720208" y="186.587648" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md3aec797c7" x="143.994022" y="196.356323" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md3aec797c7" x="142.666037" y="200.180971" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p6655eb9f26)">
+     <use xlink:href="#me038930ba1" x="610.467187" y="71.939349" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me038930ba1" x="319.880958" y="101.884157" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me038930ba1" x="210.281253" y="129.778154" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me038930ba1" x="196.287076" y="133.586625" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me038930ba1" x="176.054419" y="147.38645" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me038930ba1" x="152.161413" y="174.753272" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me038930ba1" x="146.720208" y="186.587648" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me038930ba1" x="143.994022" y="196.356323" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me038930ba1" x="142.666037" y="200.180971" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_77">
@@ -2191,7 +2191,7 @@ L 338.042598 100.427247
 L 331.988718 100.917253 
 L 325.934838 101.402864 
 L 319.880958 101.884157 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_78">
     <path d="M 319.880958 101.884157 
@@ -2243,7 +2243,7 @@ L 217.131235 128.398367
 L 214.847908 128.862215 
 L 212.564581 129.322122 
 L 210.281253 129.778154 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_79">
     <path d="M 210.281253 129.778154 
@@ -2295,7 +2295,7 @@ L 197.161712 133.356286
 L 196.870166 133.433175 
 L 196.578621 133.509954 
 L 196.287076 133.586625 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_80">
     <path d="M 196.287076 133.586625 
@@ -2347,7 +2347,7 @@ L 177.31896 146.619719
 L 176.897447 146.876504 
 L 176.475933 147.132078 
 L 176.054419 147.38645 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_81">
     <path d="M 176.054419 147.38645 
@@ -2399,7 +2399,7 @@ L 153.654726 173.393769
 L 153.156955 173.850741 
 L 152.659184 174.303887 
 L 152.161413 174.753272 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_82">
     <path d="M 152.161413 174.753272 
@@ -2451,7 +2451,7 @@ L 147.060283 185.919158
 L 146.946925 186.142906 
 L 146.833566 186.365734 
 L 146.720208 186.587648 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_83">
     <path d="M 146.720208 186.587648 
@@ -2503,7 +2503,7 @@ L 144.164409 195.794799
 L 144.107613 195.982622 
 L 144.050817 196.169795 
 L 143.994022 196.356323 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_84">
     <path d="M 143.994022 196.356323 
@@ -2555,30 +2555,30 @@ L 142.749036 199.949687
 L 142.72137 200.026891 
 L 142.693704 200.103986 
 L 142.666037 200.180971 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_85">
     <defs>
-     <path id="m2dd8d890e2" d="M -0 3.535534 
+     <path id="m6e85406288" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p2071de76a5)">
-     <use xlink:href="#m2dd8d890e2" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2dd8d890e2" x="242.839153" y="80.778898" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2dd8d890e2" x="218.251194" y="86.377096" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2dd8d890e2" x="197.814984" y="90.309617" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2dd8d890e2" x="166.378359" y="99.066934" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2dd8d890e2" x="145.830392" y="110.431955" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2dd8d890e2" x="134.598477" y="126.026287" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2dd8d890e2" x="124.077268" y="149.033155" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2dd8d890e2" x="122.462976" y="157.476606" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2dd8d890e2" x="81.012077" y="220.06889" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2dd8d890e2" x="77.44276" y="239.652656" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2dd8d890e2" x="76.953425" y="252.706566" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p6655eb9f26)">
+     <use xlink:href="#m6e85406288" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6e85406288" x="242.839153" y="80.778898" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6e85406288" x="218.251194" y="86.377096" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6e85406288" x="197.814984" y="90.309617" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6e85406288" x="166.378359" y="99.066934" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6e85406288" x="145.830392" y="110.431955" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6e85406288" x="134.598477" y="126.026287" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6e85406288" x="124.077268" y="149.033155" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6e85406288" x="122.462976" y="157.476606" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6e85406288" x="81.012077" y="220.06889" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6e85406288" x="77.44276" y="239.652656" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6e85406288" x="76.953425" y="252.706566" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_86">
@@ -2631,7 +2631,7 @@ L 245.91379 79.91142
 L 244.888911 80.202126 
 L 243.864032 80.49128 
 L 242.839153 80.778898 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_87">
     <path d="M 242.839153 80.778898 
@@ -2683,7 +2683,7 @@ L 219.787941 86.043669
 L 219.275692 86.155039 
 L 218.763443 86.266182 
 L 218.251194 86.377096 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_88">
     <path d="M 218.251194 86.377096 
@@ -2735,7 +2735,7 @@ L 199.092247 90.072029
 L 198.666492 90.151341 
 L 198.240738 90.230537 
 L 197.814984 90.309617 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_89">
     <path d="M 197.814984 90.309617 
@@ -2787,7 +2787,7 @@ L 168.343148 98.559208
 L 167.688219 98.72898 
 L 167.033289 98.898221 
 L 166.378359 99.066934 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_90">
     <path d="M 166.378359 99.066934 
@@ -2839,7 +2839,7 @@ L 147.11464 109.78743
 L 146.686557 110.003126 
 L 146.258475 110.217965 
 L 145.830392 110.431955 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_91">
     <path d="M 145.830392 110.431955 
@@ -2891,7 +2891,7 @@ L 135.300472 125.172774
 L 135.066474 125.458776 
 L 134.832476 125.743276 
 L 134.598477 126.026287 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_92">
     <path d="M 134.598477 126.026287 
@@ -2943,7 +2943,7 @@ L 124.734843 147.848882
 L 124.515652 148.246526 
 L 124.29646 148.641269 
 L 124.077268 149.033155 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_93">
     <path d="M 124.077268 149.033155 
@@ -2995,7 +2995,7 @@ L 122.56387 156.985769
 L 122.530239 157.149876 
 L 122.496607 157.313488 
 L 122.462976 157.476606 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_94">
     <path d="M 122.462976 157.476606 
@@ -3047,7 +3047,7 @@ L 83.602758 217.699074
 L 82.739198 218.500595 
 L 81.875637 219.290422 
 L 81.012077 220.06889 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_95">
     <path d="M 81.012077 220.06889 
@@ -3099,7 +3099,7 @@ L 77.665842 238.615761
 L 77.591481 238.963605 
 L 77.517121 239.309227 
 L 77.44276 239.652656 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_96">
     <path d="M 77.44276 239.652656 
@@ -3151,23 +3151,23 @@ L 76.984008 251.97672
 L 76.973814 252.221097 
 L 76.96362 252.464376 
 L 76.953425 252.706566 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_97">
     <defs>
-     <path id="m8ec25e26c5" d="M -0 2.5 
+     <path id="m59fb70793a" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p2071de76a5)">
-     <use xlink:href="#m8ec25e26c5" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p6655eb9f26)">
+     <use xlink:href="#m59fb70793a" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_98">
     <defs>
-     <path id="md5029cc76a" d="M -0.833333 2.5 
+     <path id="m8e1b4c9a64" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -3182,16 +3182,16 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p2071de76a5)">
-     <use xlink:href="#md5029cc76a" x="432.495268" y="96.067622" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md5029cc76a" x="300.62247" y="112.493412" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md5029cc76a" x="266.967623" y="120.8136" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md5029cc76a" x="226.040946" y="122.099593" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md5029cc76a" x="180.985721" y="141.85872" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md5029cc76a" x="164.441833" y="156.106179" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md5029cc76a" x="157.761315" y="165.23787" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md5029cc76a" x="151.269082" y="178.700983" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md5029cc76a" x="150.327087" y="185.23695" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p6655eb9f26)">
+     <use xlink:href="#m8e1b4c9a64" x="432.495268" y="96.067622" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8e1b4c9a64" x="300.62247" y="112.493412" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8e1b4c9a64" x="266.967623" y="120.8136" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8e1b4c9a64" x="226.040946" y="122.099593" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8e1b4c9a64" x="180.985721" y="141.85872" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8e1b4c9a64" x="164.441833" y="156.106179" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8e1b4c9a64" x="157.761315" y="165.23787" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8e1b4c9a64" x="151.269082" y="178.700983" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8e1b4c9a64" x="150.327087" y="185.23695" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_99">
@@ -3244,7 +3244,7 @@ L 308.86452 111.600609
 L 306.11717 111.899849 
 L 303.36982 112.197444 
 L 300.62247 112.493412 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_100">
     <path d="M 300.62247 112.493412 
@@ -3296,7 +3296,7 @@ L 269.071051 120.329422
 L 268.369908 120.491297 
 L 267.668766 120.652688 
 L 266.967623 120.8136 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_101">
     <path d="M 266.967623 120.8136 
@@ -3348,7 +3348,7 @@ L 228.598863 122.020108
 L 227.746224 122.046616 
 L 226.893585 122.073111 
 L 226.040946 122.099593 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_102">
     <path d="M 226.040946 122.099593 
@@ -3400,7 +3400,7 @@ L 183.801673 140.814056
 L 182.863022 141.164522 
 L 181.924372 141.512734 
 L 180.985721 141.85872 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_103">
     <path d="M 180.985721 141.85872 
@@ -3452,7 +3452,7 @@ L 165.475826 155.317544
 L 165.131161 155.581701 
 L 164.786497 155.844575 
 L 164.441833 156.106179 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_104">
     <path d="M 164.441833 156.106179 
@@ -3504,7 +3504,7 @@ L 158.178848 164.710119
 L 158.03967 164.886608 
 L 157.900493 165.062524 
 L 157.761315 165.23787 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_105">
     <path d="M 157.761315 165.23787 
@@ -3556,7 +3556,7 @@ L 151.674847 177.950842
 L 151.539592 178.202046 
 L 151.404337 178.452089 
 L 151.269082 178.700983 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_106">
     <path d="M 151.269082 178.700983 
@@ -3608,11 +3608,11 @@ L 150.385962 184.850776
 L 150.366337 184.979807 
 L 150.346712 185.108531 
 L 150.327087 185.23695 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_107">
     <defs>
-     <path id="md26de4199a" d="M -1.25 2.5 
+     <path id="mef770a3dc4" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -3627,16 +3627,16 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p2071de76a5)">
-     <use xlink:href="#md26de4199a" x="345.030867" y="136.859359" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md26de4199a" x="273.364924" y="143.571257" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md26de4199a" x="240.719951" y="149.310846" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md26de4199a" x="221.353978" y="154.160538" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md26de4199a" x="207.129625" y="156.092215" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md26de4199a" x="181.064802" y="166.758473" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md26de4199a" x="179.282169" y="170.289343" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md26de4199a" x="177.719335" y="175.489948" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md26de4199a" x="177.643939" y="181.552088" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p6655eb9f26)">
+     <use xlink:href="#mef770a3dc4" x="345.030867" y="136.859359" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mef770a3dc4" x="273.364924" y="143.571257" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mef770a3dc4" x="240.719951" y="149.310846" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mef770a3dc4" x="221.353978" y="154.160538" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mef770a3dc4" x="207.129625" y="156.092215" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mef770a3dc4" x="181.064802" y="166.758473" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mef770a3dc4" x="179.282169" y="170.289343" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mef770a3dc4" x="177.719335" y="175.489948" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mef770a3dc4" x="177.643939" y="181.552088" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_108">
@@ -3689,7 +3689,7 @@ L 277.844045 143.175283
 L 276.351005 143.307597 
 L 274.857964 143.439587 
 L 273.364924 143.571257 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_109">
     <path d="M 273.364924 143.571257 
@@ -3741,7 +3741,7 @@ L 242.760262 148.96941
 L 242.080158 149.083462 
 L 241.400055 149.197273 
 L 240.719951 149.310846 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_110">
     <path d="M 240.719951 149.310846 
@@ -3793,7 +3793,7 @@ L 222.564351 153.869835
 L 222.160893 153.966909 
 L 221.757435 154.06381 
 L 221.353978 154.160538 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_111">
     <path d="M 221.353978 154.160538 
@@ -3845,7 +3845,7 @@ L 208.018647 155.973483
 L 207.722306 156.013089 
 L 207.425965 156.052666 
 L 207.129625 156.092215 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_112">
     <path d="M 207.129625 156.092215 
@@ -3897,7 +3897,7 @@ L 182.693853 166.149994
 L 182.150836 166.353581 
 L 181.607819 166.556405 
 L 181.064802 166.758473 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_113">
     <path d="M 181.064802 166.758473 
@@ -3949,7 +3949,7 @@ L 179.393584 170.075284
 L 179.356445 170.146731 
 L 179.319307 170.218084 
 L 179.282169 170.289343 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_114">
     <path d="M 179.282169 170.289343 
@@ -4001,7 +4001,7 @@ L 177.817012 175.179146
 L 177.784453 175.282945 
 L 177.751894 175.386546 
 L 177.719335 175.489948 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_115">
     <path d="M 177.719335 175.489948 
@@ -4053,11 +4053,11 @@ L 177.648651 181.192458
 L 177.64708 181.3126 
 L 177.645509 181.432477 
 L 177.643939 181.552088 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_116">
     <defs>
-     <path id="m20c5b18558" d="M 0 -2.5 
+     <path id="mdb9bb12b4f" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -4070,16 +4070,16 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p2071de76a5)">
-     <use xlink:href="#m20c5b18558" x="226.871027" y="113.224491" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m20c5b18558" x="226.871027" y="113.066324" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m20c5b18558" x="226.871027" y="113.178221" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m20c5b18558" x="226.871027" y="113.089884" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m20c5b18558" x="177.768423" y="132.327899" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m20c5b18558" x="160.37503" y="145.652356" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m20c5b18558" x="153.995779" y="152.678629" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m20c5b18558" x="147.106887" y="168.143801" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m20c5b18558" x="145.871703" y="175.118358" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p6655eb9f26)">
+     <use xlink:href="#mdb9bb12b4f" x="226.871027" y="113.224491" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mdb9bb12b4f" x="226.871027" y="113.066324" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mdb9bb12b4f" x="226.871027" y="113.178221" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mdb9bb12b4f" x="226.871027" y="113.089884" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mdb9bb12b4f" x="177.768423" y="132.327899" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mdb9bb12b4f" x="160.37503" y="145.652356" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mdb9bb12b4f" x="153.995779" y="152.678629" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mdb9bb12b4f" x="147.106887" y="168.143801" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mdb9bb12b4f" x="145.871703" y="175.118358" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_117">
@@ -4132,7 +4132,7 @@ L 226.871027 113.076223
 L 226.871027 113.072924 
 L 226.871027 113.069624 
 L 226.871027 113.066324 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_118">
     <path d="M 226.871027 113.066324 
@@ -4184,7 +4184,7 @@ L 226.871027 113.171234
 L 226.871027 113.173563 
 L 226.871027 113.175892 
 L 226.871027 113.178221 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_119">
     <path d="M 226.871027 113.178221 
@@ -4236,7 +4236,7 @@ L 226.871027 113.09541
 L 226.871027 113.093568 
 L 226.871027 113.091726 
 L 226.871027 113.089884 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_120">
     <path d="M 226.871027 113.089884 
@@ -4288,7 +4288,7 @@ L 180.837336 131.306392
 L 179.814365 131.649041 
 L 178.791394 131.989534 
 L 177.768423 132.327899 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_121">
     <path d="M 177.768423 132.327899 
@@ -4340,7 +4340,7 @@ L 161.462117 144.909076
 L 161.099755 145.157972 
 L 160.737393 145.405728 
 L 160.37503 145.652356 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_122">
     <path d="M 160.37503 145.652356 
@@ -4392,7 +4392,7 @@ L 154.394483 152.265218
 L 154.261581 152.403373 
 L 154.12868 152.541176 
 L 153.995779 152.678629 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_123">
     <path d="M 153.995779 152.678629 
@@ -4444,7 +4444,7 @@ L 147.537442 167.296442
 L 147.393924 167.580372 
 L 147.250405 167.862819 
 L 147.106887 168.143801 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_124">
     <path d="M 147.106887 168.143801 
@@ -4496,11 +4496,11 @@ L 145.948902 174.70781
 L 145.923169 174.845005 
 L 145.897436 174.981854 
 L 145.871703 175.118358 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_125">
     <defs>
-     <path id="m6ffc1bd139" d="M 0 -2.5 
+     <path id="m77047718ef" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -4509,16 +4509,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p2071de76a5)">
-     <use xlink:href="#m6ffc1bd139" x="585.66883" y="173.051371" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6ffc1bd139" x="527.144592" y="175.326465" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6ffc1bd139" x="457.339427" y="183.688849" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6ffc1bd139" x="292.124837" y="178.486631" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6ffc1bd139" x="243.129344" y="190.369032" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6ffc1bd139" x="213.541392" y="204.43395" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6ffc1bd139" x="204.551957" y="212.140784" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6ffc1bd139" x="195.860087" y="228.582256" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6ffc1bd139" x="194.019853" y="234.294862" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p6655eb9f26)">
+     <use xlink:href="#m77047718ef" x="585.66883" y="173.051371" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m77047718ef" x="527.144592" y="175.326465" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m77047718ef" x="457.339427" y="183.688849" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m77047718ef" x="292.124837" y="178.486631" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m77047718ef" x="243.129344" y="190.369032" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m77047718ef" x="213.541392" y="204.43395" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m77047718ef" x="204.551957" y="212.140784" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m77047718ef" x="195.860087" y="228.582256" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m77047718ef" x="194.019853" y="234.294862" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_126">
@@ -4571,7 +4571,7 @@ L 530.802357 175.187039
 L 529.583102 175.233554 
 L 528.363847 175.28003 
 L 527.144592 175.326465 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_127">
     <path d="M 527.144592 175.326465 
@@ -4623,7 +4623,7 @@ L 461.70225 183.20239
 L 460.247976 183.36503 
 L 458.793701 183.527182 
 L 457.339427 183.688849 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_128">
     <path d="M 457.339427 183.688849 
@@ -4675,7 +4675,7 @@ L 302.450749 178.826834
 L 299.008779 178.713671 
 L 295.566808 178.60027 
 L 292.124837 178.486631 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_129">
     <path d="M 292.124837 178.486631 
@@ -4727,7 +4727,7 @@ L 246.191563 189.6981
 L 245.170823 189.922669 
 L 244.150084 190.146311 
 L 243.129344 190.369032 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_130">
     <path d="M 243.129344 190.369032 
@@ -4779,7 +4779,7 @@ L 215.390639 203.654226
 L 214.774224 203.915384 
 L 214.157808 204.175288 
 L 213.541392 204.43395 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_131">
     <path d="M 213.541392 204.43395 
@@ -4831,7 +4831,7 @@ L 205.113797 211.689953
 L 204.926517 211.840648 
 L 204.739237 211.990924 
 L 204.551957 212.140784 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_132">
     <path d="M 204.551957 212.140784 
@@ -4883,7 +4883,7 @@ L 196.403329 227.688717
 L 196.222248 227.988205 
 L 196.041168 228.286045 
 L 195.860087 228.582256 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_133">
     <path d="M 195.860087 228.582256 
@@ -4935,7 +4935,7 @@ L 194.134867 233.954953
 L 194.096529 234.068494 
 L 194.058191 234.181796 
 L 194.019853 234.294862 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="legend_1">
     <g id="patch_7">
@@ -4953,7 +4953,7 @@ z
     </g>
     <g id="line2d_134">
      <defs>
-      <path id="m551ae11399" d="M 0 3.5 
+      <path id="m6bd04fad8f" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -4966,7 +4966,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m551ae11399" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m6bd04fad8f" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -5025,7 +5025,7 @@ z
     </g>
     <g id="line2d_135">
      <g>
-      <use xlink:href="#mdd1d902bb3" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m98efb0f5ae" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -5039,7 +5039,7 @@ z
     </g>
     <g id="line2d_136">
      <g>
-      <use xlink:href="#md3aec797c7" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#me038930ba1" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -5084,7 +5084,7 @@ z
     </g>
     <g id="line2d_137">
      <g>
-      <use xlink:href="#m2dd8d890e2" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m6e85406288" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -5127,7 +5127,7 @@ z
     </g>
     <g id="line2d_138">
      <g>
-      <use xlink:href="#m8ec25e26c5" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m59fb70793a" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -5143,7 +5143,7 @@ z
     </g>
     <g id="line2d_139">
      <g>
-      <use xlink:href="#md5029cc76a" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m8e1b4c9a64" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -5197,7 +5197,7 @@ z
     </g>
     <g id="line2d_140">
      <g>
-      <use xlink:href="#md26de4199a" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mef770a3dc4" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -5262,7 +5262,7 @@ z
     </g>
     <g id="line2d_141">
      <g>
-      <use xlink:href="#m20c5b18558" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#mdb9bb12b4f" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -5300,7 +5300,7 @@ z
     </g>
     <g id="line2d_142">
      <g>
-      <use xlink:href="#m6ffc1bd139" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m77047718ef" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -5370,486 +5370,486 @@ z
     </g>
    </g>
    <g id="line2d_143">
-    <g clip-path="url(#p2071de76a5)">
-     <use xlink:href="#m551ae11399" x="319.643112" y="127.714396" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m551ae11399" x="269.129958" y="143.311677" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m551ae11399" x="247.452898" y="148.356901" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m551ae11399" x="192.820547" y="160.509693" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m551ae11399" x="180.389901" y="170.784058" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m551ae11399" x="156.350594" y="181.841484" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m551ae11399" x="147.843012" y="190.562838" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m551ae11399" x="146.231533" y="194.467256" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m551ae11399" x="119.590386" y="288.854472" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m551ae11399" x="97.799363" y="316.465426" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <g clip-path="url(#p6655eb9f26)">
+     <use xlink:href="#m6bd04fad8f" x="319.643112" y="128.206672" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m6bd04fad8f" x="269.129958" y="143.901385" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m6bd04fad8f" x="247.452898" y="149.033151" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m6bd04fad8f" x="192.820547" y="160.73925" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m6bd04fad8f" x="180.389901" y="170.787759" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m6bd04fad8f" x="156.350594" y="182.308316" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m6bd04fad8f" x="147.843012" y="190.985697" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m6bd04fad8f" x="146.231533" y="194.726733" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m6bd04fad8f" x="119.590386" y="289.537405" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m6bd04fad8f" x="97.799363" y="317.435797" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
    <g id="line2d_144">
-    <path d="M 319.643112 127.714396 
-L 318.590755 128.089689 
-L 317.538397 128.462399 
-L 316.48604 128.832559 
-L 315.433682 129.200206 
-L 314.381325 129.565373 
-L 313.328968 129.928093 
-L 312.27661 130.288398 
-L 311.224253 130.646321 
-L 310.171896 131.001893 
-L 309.119538 131.355144 
-L 308.067181 131.706106 
-L 307.014823 132.054806 
-L 305.962466 132.401274 
-L 304.910109 132.745539 
-L 303.857751 133.087629 
-L 302.805394 133.42757 
-L 301.753037 133.765389 
-L 300.700679 134.101114 
-L 299.648322 134.434769 
-L 298.595965 134.76638 
-L 297.543607 135.095972 
-L 296.49125 135.423569 
-L 295.438892 135.749196 
-L 294.386535 136.072875 
-L 293.334178 136.394631 
-L 292.28182 136.714485 
-L 291.229463 137.03246 
-L 290.177106 137.348579 
-L 289.124748 137.662862 
-L 288.072391 137.975331 
-L 287.020033 138.286007 
-L 285.967676 138.594909 
-L 284.915319 138.902059 
-L 283.862961 139.207476 
-L 282.810604 139.51118 
-L 281.758247 139.813189 
-L 280.705889 140.113522 
-L 279.653532 140.412198 
-L 278.601175 140.709235 
-L 277.548817 141.004652 
-L 276.49646 141.298464 
-L 275.444102 141.590691 
-L 274.391745 141.881349 
-L 273.339388 142.170454 
-L 272.28703 142.458023 
-L 271.234673 142.744073 
-L 270.182316 143.028619 
-L 269.129958 143.311677 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 319.643112 128.206672 
+L 318.590755 128.584656 
+L 317.538397 128.96002 
+L 316.48604 129.332799 
+L 315.433682 129.703028 
+L 314.381325 130.070742 
+L 313.328968 130.435976 
+L 312.27661 130.798761 
+L 311.224253 131.159131 
+L 310.171896 131.517118 
+L 309.119538 131.872753 
+L 308.067181 132.226067 
+L 307.014823 132.577089 
+L 305.962466 132.92585 
+L 304.910109 133.272379 
+L 303.857751 133.616703 
+L 302.805394 133.958851 
+L 301.753037 134.298849 
+L 300.700679 134.636726 
+L 299.648322 134.972506 
+L 298.595965 135.306217 
+L 297.543607 135.637883 
+L 296.49125 135.967529 
+L 295.438892 136.29518 
+L 294.386535 136.620859 
+L 293.334178 136.944591 
+L 292.28182 137.266398 
+L 291.229463 137.586304 
+L 290.177106 137.904329 
+L 289.124748 138.220498 
+L 288.072391 138.53483 
+L 287.020033 138.847348 
+L 285.967676 139.158072 
+L 284.915319 139.467022 
+L 283.862961 139.774219 
+L 282.810604 140.079682 
+L 281.758247 140.383432 
+L 280.705889 140.685486 
+L 279.653532 140.985865 
+L 278.601175 141.284585 
+L 277.548817 141.581667 
+L 276.49646 141.877126 
+L 275.444102 142.170982 
+L 274.391745 142.463251 
+L 273.339388 142.753951 
+L 272.28703 143.043098 
+L 271.234673 143.330708 
+L 270.182316 143.616799 
+L 269.129958 143.901385 
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_145">
-    <path d="M 269.129958 143.311677 
-L 268.678353 143.421728 
-L 268.226747 143.531555 
-L 267.775142 143.641161 
-L 267.323537 143.750544 
-L 266.871931 143.859708 
-L 266.420326 143.968651 
-L 265.96872 144.077376 
-L 265.517115 144.185883 
-L 265.065509 144.294172 
-L 264.613904 144.402246 
-L 264.162299 144.510104 
-L 263.710693 144.617748 
-L 263.259088 144.725178 
-L 262.807482 144.832395 
-L 262.355877 144.9394 
-L 261.904271 145.046194 
-L 261.452666 145.152778 
-L 261.001061 145.259153 
-L 260.549455 145.365319 
-L 260.09785 145.471277 
-L 259.646244 145.577028 
-L 259.194639 145.682572 
-L 258.743034 145.787912 
-L 258.291428 145.893047 
-L 257.839823 145.997978 
-L 257.388217 146.102706 
-L 256.936612 146.207232 
-L 256.485006 146.311556 
-L 256.033401 146.41568 
-L 255.581796 146.519603 
-L 255.13019 146.623328 
-L 254.678585 146.726854 
-L 254.226979 146.830183 
-L 253.775374 146.933315 
-L 253.323769 147.036251 
-L 252.872163 147.138991 
-L 252.420558 147.241537 
-L 251.968952 147.343888 
-L 251.517347 147.446047 
-L 251.065741 147.548013 
-L 250.614136 147.649788 
-L 250.162531 147.751371 
-L 249.710925 147.852764 
-L 249.25932 147.953968 
-L 248.807714 148.054983 
-L 248.356109 148.155809 
-L 247.904503 148.256449 
-L 247.452898 148.356901 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 269.129958 143.901385 
+L 268.678353 144.013413 
+L 268.226747 144.125209 
+L 267.775142 144.236775 
+L 267.323537 144.348111 
+L 266.871931 144.459219 
+L 266.420326 144.570099 
+L 265.96872 144.680752 
+L 265.517115 144.79118 
+L 265.065509 144.901383 
+L 264.613904 145.011362 
+L 264.162299 145.121118 
+L 263.710693 145.230652 
+L 263.259088 145.339965 
+L 262.807482 145.449058 
+L 262.355877 145.557931 
+L 261.904271 145.666585 
+L 261.452666 145.775022 
+L 261.001061 145.883242 
+L 260.549455 145.991246 
+L 260.09785 146.099035 
+L 259.646244 146.20661 
+L 259.194639 146.313972 
+L 258.743034 146.421121 
+L 258.291428 146.528058 
+L 257.839823 146.634785 
+L 257.388217 146.741301 
+L 256.936612 146.847608 
+L 256.485006 146.953707 
+L 256.033401 147.059599 
+L 255.581796 147.165283 
+L 255.13019 147.270762 
+L 254.678585 147.376036 
+L 254.226979 147.481105 
+L 253.775374 147.58597 
+L 253.323769 147.690633 
+L 252.872163 147.795094 
+L 252.420558 147.899354 
+L 251.968952 148.003413 
+L 251.517347 148.107273 
+L 251.065741 148.210934 
+L 250.614136 148.314397 
+L 250.162531 148.417662 
+L 249.710925 148.520731 
+L 249.25932 148.623603 
+L 248.807714 148.726281 
+L 248.356109 148.828764 
+L 247.904503 148.931054 
+L 247.452898 149.033151 
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_146">
-    <path d="M 247.452898 148.356901 
-L 246.314724 148.640015 
-L 245.17655 148.921656 
-L 244.038376 149.201839 
-L 242.900202 149.480579 
-L 241.762028 149.757891 
-L 240.623854 150.03379 
-L 239.48568 150.30829 
-L 238.347506 150.581405 
-L 237.209332 150.853149 
-L 236.071158 151.123535 
-L 234.932984 151.392578 
-L 233.79481 151.66029 
-L 232.656636 151.926684 
-L 231.518462 152.191774 
-L 230.380288 152.455572 
-L 229.242114 152.718091 
-L 228.10394 152.979343 
-L 226.965766 153.23934 
-L 225.827592 153.498094 
-L 224.689418 153.755617 
-L 223.551244 154.011921 
-L 222.41307 154.267016 
-L 221.274896 154.520916 
-L 220.136722 154.77363 
-L 218.998548 155.02517 
-L 217.860374 155.275546 
-L 216.7222 155.524769 
-L 215.584026 155.772851 
-L 214.445852 156.0198 
-L 213.307678 156.265628 
-L 212.169505 156.510345 
-L 211.031331 156.75396 
-L 209.893157 156.996484 
-L 208.754983 157.237927 
-L 207.616809 157.478297 
-L 206.478635 157.717604 
-L 205.340461 157.955858 
-L 204.202287 158.193068 
-L 203.064113 158.429243 
-L 201.925939 158.664393 
-L 200.787765 158.898525 
-L 199.649591 159.131648 
-L 198.511417 159.363772 
-L 197.373243 159.594905 
-L 196.235069 159.825056 
-L 195.096895 160.054231 
-L 193.958721 160.282441 
-L 192.820547 160.509693 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 247.452898 149.033151 
+L 246.314724 149.304723 
+L 245.17655 149.57494 
+L 244.038376 149.843815 
+L 242.900202 150.111361 
+L 241.762028 150.377591 
+L 240.623854 150.642518 
+L 239.48568 150.906155 
+L 238.347506 151.168513 
+L 237.209332 151.429607 
+L 236.071158 151.689447 
+L 234.932984 151.948046 
+L 233.79481 152.205415 
+L 232.656636 152.461567 
+L 231.518462 152.716512 
+L 230.380288 152.970262 
+L 229.242114 153.222828 
+L 228.10394 153.474221 
+L 226.965766 153.724452 
+L 225.827592 153.973532 
+L 224.689418 154.22147 
+L 223.551244 154.468278 
+L 222.41307 154.713966 
+L 221.274896 154.958544 
+L 220.136722 155.202022 
+L 218.998548 155.44441 
+L 217.860374 155.685717 
+L 216.7222 155.925953 
+L 215.584026 156.165128 
+L 214.445852 156.40325 
+L 213.307678 156.64033 
+L 212.169505 156.876376 
+L 211.031331 157.111397 
+L 209.893157 157.345402 
+L 208.754983 157.578399 
+L 207.616809 157.810399 
+L 206.478635 158.041408 
+L 205.340461 158.271435 
+L 204.202287 158.500489 
+L 203.064113 158.728578 
+L 201.925939 158.95571 
+L 200.787765 159.181893 
+L 199.649591 159.407134 
+L 198.511417 159.631443 
+L 197.373243 159.854825 
+L 196.235069 160.07729 
+L 195.096895 160.298844 
+L 193.958721 160.519495 
+L 192.820547 160.73925 
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_147">
-    <path d="M 192.820547 160.509693 
-L 192.561575 160.744893 
-L 192.302603 160.979075 
-L 192.043631 161.212249 
-L 191.78466 161.444422 
-L 191.525688 161.675604 
-L 191.266716 161.905803 
-L 191.007744 162.135027 
-L 190.748773 162.363285 
-L 190.489801 162.590584 
-L 190.230829 162.816932 
-L 189.971857 163.042338 
-L 189.712885 163.26681 
-L 189.453914 163.490354 
-L 189.194942 163.712979 
-L 188.93597 163.934692 
-L 188.676998 164.155501 
-L 188.418027 164.375412 
-L 188.159055 164.594434 
-L 187.900083 164.812574 
-L 187.641111 165.029837 
-L 187.382139 165.246233 
-L 187.123168 165.461766 
-L 186.864196 165.676445 
-L 186.605224 165.890276 
-L 186.346252 166.103265 
-L 186.087281 166.31542 
-L 185.828309 166.526746 
-L 185.569337 166.737251 
-L 185.310365 166.94694 
-L 185.051393 167.15582 
-L 184.792422 167.363897 
-L 184.53345 167.571177 
-L 184.274478 167.777667 
-L 184.015506 167.983372 
-L 183.756535 168.188298 
-L 183.497563 168.392451 
-L 183.238591 168.595838 
-L 182.979619 168.798463 
-L 182.720647 169.000332 
-L 182.461676 169.201451 
-L 182.202704 169.401826 
-L 181.943732 169.601462 
-L 181.68476 169.800364 
-L 181.425789 169.998538 
-L 181.166817 170.195989 
-L 180.907845 170.392723 
-L 180.648873 170.588744 
-L 180.389901 170.784058 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 192.820547 160.73925 
+L 192.561575 160.968798 
+L 192.302603 161.197376 
+L 192.043631 161.424992 
+L 191.78466 161.651656 
+L 191.525688 161.877375 
+L 191.266716 162.102156 
+L 191.007744 162.326008 
+L 190.748773 162.548938 
+L 190.489801 162.770953 
+L 190.230829 162.992062 
+L 189.971857 163.212271 
+L 189.712885 163.431588 
+L 189.453914 163.65002 
+L 189.194942 163.867574 
+L 188.93597 164.084257 
+L 188.676998 164.300076 
+L 188.418027 164.515038 
+L 188.159055 164.72915 
+L 187.900083 164.942419 
+L 187.641111 165.15485 
+L 187.382139 165.366451 
+L 187.123168 165.577229 
+L 186.864196 165.787188 
+L 186.605224 165.996336 
+L 186.346252 166.20468 
+L 186.087281 166.412224 
+L 185.828309 166.618976 
+L 185.569337 166.824941 
+L 185.310365 167.030126 
+L 185.051393 167.234536 
+L 184.792422 167.438176 
+L 184.53345 167.641054 
+L 184.274478 167.843174 
+L 184.015506 168.044542 
+L 183.756535 168.245163 
+L 183.497563 168.445044 
+L 183.238591 168.64419 
+L 182.979619 168.842605 
+L 182.720647 169.040296 
+L 182.461676 169.237268 
+L 182.202704 169.433526 
+L 181.943732 169.629074 
+L 181.68476 169.823919 
+L 181.425789 170.018065 
+L 181.166817 170.211516 
+L 180.907845 170.40428 
+L 180.648873 170.596359 
+L 180.389901 170.787759 
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_148">
-    <path d="M 180.389901 170.784058 
-L 179.889083 171.039035 
-L 179.388264 171.292817 
-L 178.887445 171.545414 
-L 178.386626 171.796838 
-L 177.885807 172.0471 
-L 177.384988 172.29621 
-L 176.884169 172.544179 
-L 176.38335 172.791018 
-L 175.882531 173.036735 
-L 175.381713 173.281343 
-L 174.880894 173.52485 
-L 174.380075 173.767266 
-L 173.879256 174.008602 
-L 173.378437 174.248867 
-L 172.877618 174.488069 
-L 172.376799 174.72622 
-L 171.87598 174.963327 
-L 171.375161 175.199401 
-L 170.874342 175.434449 
-L 170.373524 175.668481 
-L 169.872705 175.901505 
-L 169.371886 176.133531 
-L 168.871067 176.364566 
-L 168.370248 176.59462 
-L 167.869429 176.8237 
-L 167.36861 177.051814 
-L 166.867791 177.278972 
-L 166.366972 177.50518 
-L 165.866154 177.730446 
-L 165.365335 177.954779 
-L 164.864516 178.178187 
-L 164.363697 178.400676 
-L 163.862878 178.622254 
-L 163.362059 178.842929 
-L 162.86124 179.062708 
-L 162.360421 179.281598 
-L 161.859602 179.499607 
-L 161.358783 179.716741 
-L 160.857965 179.933008 
-L 160.357146 180.148414 
-L 159.856327 180.362966 
-L 159.355508 180.576672 
-L 158.854689 180.789537 
-L 158.35387 181.001568 
-L 157.853051 181.212772 
-L 157.352232 181.423155 
-L 156.851413 181.632723 
-L 156.350594 181.841484 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 180.389901 170.787759 
+L 179.889083 171.054565 
+L 179.388264 171.320062 
+L 178.887445 171.584263 
+L 178.386626 171.847182 
+L 177.885807 172.108829 
+L 177.384988 172.369218 
+L 176.884169 172.62836 
+L 176.38335 172.886268 
+L 175.882531 173.142952 
+L 175.381713 173.398426 
+L 174.880894 173.652699 
+L 174.380075 173.905783 
+L 173.879256 174.15769 
+L 173.378437 174.408429 
+L 172.877618 174.658013 
+L 172.376799 174.906451 
+L 171.87598 175.153754 
+L 171.375161 175.399932 
+L 170.874342 175.644996 
+L 170.373524 175.888956 
+L 169.872705 176.131821 
+L 169.371886 176.373601 
+L 168.871067 176.614306 
+L 168.370248 176.853945 
+L 167.869429 177.092528 
+L 167.36861 177.330065 
+L 166.867791 177.566563 
+L 166.366972 177.802033 
+L 165.866154 178.036483 
+L 165.365335 178.269922 
+L 164.864516 178.502358 
+L 164.363697 178.733801 
+L 163.862878 178.964258 
+L 163.362059 179.193738 
+L 162.86124 179.42225 
+L 162.360421 179.649801 
+L 161.859602 179.876399 
+L 161.358783 180.102053 
+L 160.857965 180.32677 
+L 160.357146 180.550558 
+L 159.856327 180.773424 
+L 159.355508 180.995377 
+L 158.854689 181.216424 
+L 158.35387 181.436571 
+L 157.853051 181.655827 
+L 157.352232 181.874198 
+L 156.851413 182.091692 
+L 156.350594 182.308316 
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_149">
-    <path d="M 156.350594 181.841484 
-L 156.173353 182.038276 
-L 155.996112 182.234356 
-L 155.818871 182.429727 
-L 155.641629 182.624397 
-L 155.464388 182.818368 
-L 155.287147 183.011647 
-L 155.109905 183.204239 
-L 154.932664 183.396147 
-L 154.755423 183.587378 
-L 154.578182 183.777936 
-L 154.40094 183.967825 
-L 154.223699 184.15705 
-L 154.046458 184.345616 
-L 153.869216 184.533528 
-L 153.691975 184.720789 
-L 153.514734 184.907405 
-L 153.337492 185.09338 
-L 153.160251 185.278717 
-L 152.98301 185.463423 
-L 152.805769 185.6475 
-L 152.628527 185.830954 
-L 152.451286 186.013788 
-L 152.274045 186.196006 
-L 152.096803 186.377614 
-L 151.919562 186.558614 
-L 151.742321 186.73901 
-L 151.56508 186.918808 
-L 151.387838 187.09801 
-L 151.210597 187.276621 
-L 151.033356 187.454645 
-L 150.856114 187.632085 
-L 150.678873 187.808945 
-L 150.501632 187.985229 
-L 150.32439 188.160942 
-L 150.147149 188.336085 
-L 149.969908 188.510664 
-L 149.792667 188.684681 
-L 149.615425 188.858141 
-L 149.438184 189.031047 
-L 149.260943 189.203402 
-L 149.083701 189.375211 
-L 148.90646 189.546475 
-L 148.729219 189.7172 
-L 148.551977 189.887388 
-L 148.374736 190.057042 
-L 148.197495 190.226166 
-L 148.020254 190.394764 
-L 147.843012 190.562838 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 156.350594 182.308316 
+L 156.173353 182.504036 
+L 155.996112 182.699052 
+L 155.818871 182.893367 
+L 155.641629 183.086987 
+L 155.464388 183.279917 
+L 155.287147 183.472162 
+L 155.109905 183.663727 
+L 154.932664 183.854616 
+L 154.755423 184.044834 
+L 154.578182 184.234387 
+L 154.40094 184.423277 
+L 154.223699 184.611511 
+L 154.046458 184.799093 
+L 153.869216 184.986027 
+L 153.691975 185.172317 
+L 153.514734 185.357969 
+L 153.337492 185.542986 
+L 153.160251 185.727373 
+L 152.98301 185.911134 
+L 152.805769 186.094273 
+L 152.628527 186.276795 
+L 152.451286 186.458703 
+L 152.274045 186.640002 
+L 152.096803 186.820696 
+L 151.919562 187.000789 
+L 151.742321 187.180284 
+L 151.56508 187.359187 
+L 151.387838 187.5375 
+L 151.210597 187.715227 
+L 151.033356 187.892373 
+L 150.856114 188.068941 
+L 150.678873 188.244935 
+L 150.501632 188.420359 
+L 150.32439 188.595216 
+L 150.147149 188.76951 
+L 149.969908 188.943245 
+L 149.792667 189.116424 
+L 149.615425 189.28905 
+L 149.438184 189.461128 
+L 149.260943 189.63266 
+L 149.083701 189.803651 
+L 148.90646 189.974103 
+L 148.729219 190.14402 
+L 148.551977 190.313406 
+L 148.374736 190.482263 
+L 148.197495 190.650595 
+L 148.020254 190.818405 
+L 147.843012 190.985697 
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_150">
-    <path d="M 147.843012 190.562838 
-L 147.80944 190.64712 
-L 147.775867 190.73127 
-L 147.742295 190.81529 
-L 147.708722 190.89918 
-L 147.67515 190.982941 
-L 147.641577 191.066571 
-L 147.608005 191.150073 
-L 147.574432 191.233446 
-L 147.54086 191.316691 
-L 147.507287 191.399808 
-L 147.473715 191.482798 
-L 147.440142 191.56566 
-L 147.40657 191.648396 
-L 147.372997 191.731006 
-L 147.339425 191.81349 
-L 147.305852 191.895848 
-L 147.27228 191.978081 
-L 147.238707 192.06019 
-L 147.205135 192.142174 
-L 147.171562 192.224034 
-L 147.13799 192.30577 
-L 147.104417 192.387384 
-L 147.070845 192.468874 
-L 147.037273 192.550242 
-L 147.0037 192.631488 
-L 146.970128 192.712612 
-L 146.936555 192.793614 
-L 146.902983 192.874496 
-L 146.86941 192.955257 
-L 146.835838 193.035898 
-L 146.802265 193.116418 
-L 146.768693 193.196819 
-L 146.73512 193.277101 
-L 146.701548 193.357264 
-L 146.667975 193.437309 
-L 146.634403 193.517235 
-L 146.60083 193.597043 
-L 146.567258 193.676734 
-L 146.533685 193.756308 
-L 146.500113 193.835765 
-L 146.46654 193.915105 
-L 146.432968 193.99433 
-L 146.399395 194.073438 
-L 146.365823 194.152431 
-L 146.33225 194.231309 
-L 146.298678 194.310073 
-L 146.265105 194.388721 
-L 146.231533 194.467256 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 147.843012 190.985697 
+L 147.80944 191.066331 
+L 147.775867 191.146846 
+L 147.742295 191.227241 
+L 147.708722 191.307516 
+L 147.67515 191.387673 
+L 147.641577 191.467712 
+L 147.608005 191.547632 
+L 147.574432 191.627434 
+L 147.54086 191.707119 
+L 147.507287 191.786687 
+L 147.473715 191.866138 
+L 147.440142 191.945472 
+L 147.40657 192.024691 
+L 147.372997 192.103793 
+L 147.339425 192.182781 
+L 147.305852 192.261653 
+L 147.27228 192.34041 
+L 147.238707 192.419053 
+L 147.205135 192.497582 
+L 147.171562 192.575997 
+L 147.13799 192.654299 
+L 147.104417 192.732487 
+L 147.070845 192.810563 
+L 147.037273 192.888527 
+L 147.0037 192.966378 
+L 146.970128 193.044117 
+L 146.936555 193.121745 
+L 146.902983 193.199262 
+L 146.86941 193.276668 
+L 146.835838 193.353963 
+L 146.802265 193.431149 
+L 146.768693 193.508224 
+L 146.73512 193.58519 
+L 146.701548 193.662046 
+L 146.667975 193.738793 
+L 146.634403 193.815432 
+L 146.60083 193.891963 
+L 146.567258 193.968385 
+L 146.533685 194.0447 
+L 146.500113 194.120907 
+L 146.46654 194.197007 
+L 146.432968 194.273 
+L 146.399395 194.348887 
+L 146.365823 194.424668 
+L 146.33225 194.500342 
+L 146.298678 194.575911 
+L 146.265105 194.651375 
+L 146.231533 194.726733 
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_151">
-    <path d="M 146.231533 194.467256 
-L 145.676509 199.542701 
-L 145.121485 204.182791 
-L 144.566461 208.456348 
-L 144.011437 212.417064 
-L 143.456413 216.107633 
-L 142.901389 219.562566 
-L 142.346365 222.810155 
-L 141.791342 225.873884 
-L 141.236318 228.773462 
-L 140.681294 231.525586 
-L 140.12627 234.144531 
-L 139.571246 236.642594 
-L 139.016222 239.030444 
-L 138.461198 241.317395 
-L 137.906174 243.51163 
-L 137.35115 245.620375 
-L 136.796126 247.650043 
-L 136.241103 249.606349 
-L 135.686079 251.494414 
-L 135.131055 253.318838 
-L 134.576031 255.083772 
-L 134.021007 256.792973 
-L 133.465983 258.449853 
-L 132.910959 260.057521 
-L 132.355935 261.618816 
-L 131.800911 263.136339 
-L 131.245887 264.612477 
-L 130.690864 266.049428 
-L 130.13584 267.449218 
-L 129.580816 268.813721 
-L 129.025792 270.144672 
-L 128.470768 271.443683 
-L 127.915744 272.71225 
-L 127.36072 273.951768 
-L 126.805696 275.163536 
-L 126.250672 276.348772 
-L 125.695648 277.508611 
-L 125.140625 278.644119 
-L 124.585601 279.756296 
-L 124.030577 280.846082 
-L 123.475553 281.91436 
-L 122.920529 282.961963 
-L 122.365505 283.989677 
-L 121.810481 284.998241 
-L 121.255457 285.988357 
-L 120.700433 286.960688 
-L 120.145409 287.915861 
-L 119.590386 288.854472 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 146.231533 194.726733 
+L 145.676509 199.84827 
+L 145.121485 204.52685 
+L 144.566461 208.833032 
+L 144.011437 212.821753 
+L 143.456413 216.536624 
+L 142.901389 220.012844 
+L 142.346365 223.279235 
+L 141.791342 226.359691 
+L 141.236318 229.274246 
+L 140.681294 232.03986 
+L 140.12627 234.671017 
+L 139.571246 237.180188 
+L 139.016222 239.578185 
+L 138.461198 241.874443 
+L 137.906174 244.077243 
+L 137.35115 246.193898 
+L 136.796126 248.230892 
+L 136.241103 250.194005 
+L 135.686079 252.088408 
+L 135.131055 253.918749 
+L 134.576031 255.68922 
+L 134.021007 257.403613 
+L 133.465983 259.065373 
+L 132.910959 260.677634 
+L 132.355935 262.243261 
+L 131.800911 263.764875 
+L 131.245887 265.244884 
+L 130.690864 266.685503 
+L 130.13584 268.088774 
+L 129.580816 269.456584 
+L 129.025792 270.790682 
+L 128.470768 272.09269 
+L 127.915744 273.364114 
+L 127.36072 274.60636 
+L 126.805696 275.820737 
+L 126.250672 277.008466 
+L 125.695648 278.170694 
+L 125.140625 279.308492 
+L 124.585601 280.422865 
+L 124.030577 281.514759 
+L 123.475553 282.585063 
+L 122.920529 283.634615 
+L 122.365505 284.664203 
+L 121.810481 285.674573 
+L 121.255457 286.666429 
+L 120.700433 287.640438 
+L 120.145409 288.597231 
+L 119.590386 289.537405 
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_152">
-    <path d="M 119.590386 288.854472 
-L 119.136406 289.599729 
-L 118.682426 290.334865 
-L 118.228447 291.060151 
-L 117.774467 291.775848 
-L 117.320487 292.482205 
-L 116.866508 293.179464 
-L 116.412528 293.867855 
-L 115.958549 294.547602 
-L 115.504569 295.218919 
-L 115.050589 295.882012 
-L 114.59661 296.537081 
-L 114.14263 297.184317 
-L 113.68865 297.823906 
-L 113.234671 298.456026 
-L 112.780691 299.080849 
-L 112.326712 299.698542 
-L 111.872732 300.309266 
-L 111.418752 300.913177 
-L 110.964773 301.510425 
-L 110.510793 302.101154 
-L 110.056813 302.685507 
-L 109.602834 303.263619 
-L 109.148854 303.835622 
-L 108.694874 304.401643 
-L 108.240895 304.961808 
-L 107.786915 305.516234 
-L 107.332936 306.06504 
-L 106.878956 306.608338 
-L 106.424976 307.146237 
-L 105.970997 307.678843 
-L 105.517017 308.20626 
-L 105.063037 308.728588 
-L 104.609058 309.245923 
-L 104.155078 309.758362 
-L 103.701099 310.265994 
-L 103.247119 310.768911 
-L 102.793139 311.267198 
-L 102.33916 311.76094 
-L 101.88518 312.250219 
-L 101.4312 312.735115 
-L 100.977221 313.215706 
-L 100.523241 313.692068 
-L 100.069262 314.164274 
-L 99.615282 314.632397 
-L 99.161302 315.096506 
-L 98.707323 315.55667 
-L 98.253343 316.012955 
-L 97.799363 316.465426 
-" clip-path="url(#p2071de76a5)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 119.590386 289.537405 
+L 119.136406 290.292524 
+L 118.682426 291.037254 
+L 118.228447 291.771878 
+L 117.774467 292.496664 
+L 117.320487 293.211875 
+L 116.866508 293.917759 
+L 116.412528 294.614556 
+L 115.958549 295.302498 
+L 115.504569 295.981806 
+L 115.050589 296.652695 
+L 114.59661 297.315371 
+L 114.14263 297.970033 
+L 113.68865 298.616871 
+L 113.234671 299.256072 
+L 112.780691 299.887812 
+L 112.326712 300.512265 
+L 111.872732 301.129596 
+L 111.418752 301.739966 
+L 110.964773 302.343531 
+L 110.510793 302.94044 
+L 110.056813 303.530838 
+L 109.602834 304.114867 
+L 109.148854 304.692661 
+L 108.694874 305.264354 
+L 108.240895 305.830071 
+L 107.786915 306.389938 
+L 107.332936 306.944073 
+L 106.878956 307.492593 
+L 106.424976 308.03561 
+L 105.970997 308.573234 
+L 105.517017 309.105572 
+L 105.063037 309.632724 
+L 104.609058 310.154793 
+L 104.155078 310.671875 
+L 103.701099 311.184064 
+L 103.247119 311.691452 
+L 102.793139 312.194128 
+L 102.33916 312.69218 
+L 101.88518 313.18569 
+L 101.4312 313.674742 
+L 100.977221 314.159415 
+L 100.523241 314.639787 
+L 100.069262 315.115933 
+L 99.615282 315.587928 
+L 99.161302 316.055843 
+L 98.707323 316.519747 
+L 98.253343 316.97971 
+L 97.799363 317.435797 
+" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
   </g>
   <g id="text_25">
@@ -6166,8 +6166,8 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-07-06T22:02:31Z  ·  Linux chungus2 x86_64  ·  commit ac74ebaf  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(44.919844 465.66) scale(0.07 -0.07)">
+   <!-- 2026-07-07T02:05:28Z  ·  Linux chungus2 x86_64  ·  commit 1a899305  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(43.462422 465.66) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -6201,6 +6201,31 @@ L 1409 3309
 L 1409 2516 
 L 750 2516 
 L 750 3309 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-b7" d="M 684 2619 
@@ -6260,6 +6285,36 @@ Q 2894 3584 3203 3211
 Q 3513 2838 3513 2113 
 z
 " transform="scale(0.015625)"/>
+     <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
      <path id="DejaVuSans-3d" d="M 678 2906 
 L 4684 2906 
 L 4684 2381 
@@ -6298,16 +6353,16 @@ z
     <use xlink:href="#DejaVuSans-37" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -6347,109 +6402,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3133.154297 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3188.134766 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3251.757812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3315.380859 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3376.904297 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3440.380859 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3501.660156 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3536.865234 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3568.652344 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3600.439453 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3632.226562 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3664.013672 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3695.800781 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3723.583984 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3785.107422 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3846.386719 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3909.765625 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3973.242188 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4012.105469 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4073.287109 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4132.466797 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4193.990234 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4235.103516 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4268.794922 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4296.578125 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4358.101562 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4419.380859 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4482.759766 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4546.382812 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4580.074219 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4639.253906 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4702.876953 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4734.664062 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4798.287109 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4861.910156 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4893.697266 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4957.320312 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4993.404297 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5032.267578 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5087.248047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5150.871094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5182.658203 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5214.445312 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5246.232422 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5278.019531 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5309.806641 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5349.015625 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5412.394531 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5451.257812 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5512.439453 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5575.818359 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5639.294922 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5702.673828 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5766.150391 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5829.529297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5868.738281 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5900.525391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5984.314453 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6016.101562 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6113.513672 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6175.037109 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6238.513672 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6266.296875 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6327.576172 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6390.955078 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6422.742188 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6474.841797 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6538.220703 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6599.5 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6662.976562 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6715.076172 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6778.455078 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6839.636719 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6878.845703 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6912.537109 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6944.324219 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6985.4375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7046.716797 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7085.925781 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7113.708984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7174.890625 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7206.677734 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7234.460938 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7286.560547 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7318.347656 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7381.824219 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7443.347656 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7482.556641 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7544.080078 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7583.443359 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7680.855469 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7708.638672 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7772.017578 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7799.800781 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7851.900391 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7891.109375 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7918.892578 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3196.777344 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3260.400391 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3324.023438 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3387.646484 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3451.269531 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3514.892578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3578.515625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3610.302734 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3642.089844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3673.876953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3705.664062 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3737.451172 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3765.234375 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3826.757812 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3888.037109 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3951.416016 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4014.892578 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4053.755859 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4114.9375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4174.117188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4235.640625 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4276.753906 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4310.445312 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4338.228516 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4399.751953 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4461.03125 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4524.410156 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4588.033203 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4621.724609 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4680.904297 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4744.527344 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4776.314453 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4839.9375 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4903.560547 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4935.347656 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4998.970703 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5035.054688 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5073.917969 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5128.898438 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5192.521484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5224.308594 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5256.095703 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5287.882812 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5319.669922 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5351.457031 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5390.666016 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5454.044922 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5492.908203 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5554.089844 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5617.46875 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5680.945312 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5744.324219 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5807.800781 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5871.179688 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5910.388672 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5942.175781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6025.964844 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6057.751953 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6155.164062 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6216.6875 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6280.164062 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6307.947266 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6369.226562 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6432.605469 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6464.392578 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6516.492188 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6579.871094 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6641.150391 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6704.626953 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6756.726562 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6820.105469 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6881.287109 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6920.496094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6954.1875 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6985.974609 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7027.087891 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7088.367188 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7127.576172 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7155.359375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7216.541016 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7248.328125 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7276.111328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7328.210938 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7359.998047 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7423.474609 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7484.998047 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7524.207031 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7585.730469 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7625.09375 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7722.505859 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7750.289062 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7813.667969 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7841.451172 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7893.550781 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7932.759766 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7960.542969 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p2071de76a5">
+  <clipPath id="p6655eb9f26">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_decode_density.svg
+++ b/bench/graphs/silesia_decode_density.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 82.373685 412.80375 
 L 82.373685 47.3475 
-" clip-path="url(#p87980de34e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5a77d57261)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m89cf7fdf13" d="M 0 0 
+       <path id="m9fc22e82fc" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m89cf7fdf13" x="82.373685" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9fc22e82fc" x="82.373685" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -111,11 +111,11 @@ z
      <g id="line2d_3">
       <path d="M 165.44644 412.80375 
 L 165.44644 47.3475 
-" clip-path="url(#p87980de34e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5a77d57261)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m89cf7fdf13" x="165.44644" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9fc22e82fc" x="165.44644" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -157,11 +157,11 @@ z
      <g id="line2d_5">
       <path d="M 248.519195 412.80375 
 L 248.519195 47.3475 
-" clip-path="url(#p87980de34e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5a77d57261)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m89cf7fdf13" x="248.519195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9fc22e82fc" x="248.519195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -211,11 +211,11 @@ z
      <g id="line2d_7">
       <path d="M 331.59195 412.80375 
 L 331.59195 47.3475 
-" clip-path="url(#p87980de34e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5a77d57261)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m89cf7fdf13" x="331.59195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9fc22e82fc" x="331.59195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -252,11 +252,11 @@ z
      <g id="line2d_9">
       <path d="M 414.664704 412.80375 
 L 414.664704 47.3475 
-" clip-path="url(#p87980de34e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5a77d57261)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m89cf7fdf13" x="414.664704" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9fc22e82fc" x="414.664704" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -299,11 +299,11 @@ z
      <g id="line2d_11">
       <path d="M 497.737459 412.80375 
 L 497.737459 47.3475 
-" clip-path="url(#p87980de34e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5a77d57261)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m89cf7fdf13" x="497.737459" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9fc22e82fc" x="497.737459" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -351,11 +351,11 @@ z
      <g id="line2d_13">
       <path d="M 580.810214 412.80375 
 L 580.810214 47.3475 
-" clip-path="url(#p87980de34e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5a77d57261)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m89cf7fdf13" x="580.810214" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9fc22e82fc" x="580.810214" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -897,16 +897,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 391.82245 
 L 637.2 391.82245 
-" clip-path="url(#p87980de34e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5a77d57261)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="m899810f2f2" d="M 0 0 
+       <path id="mdd691718a6" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m899810f2f2" x="49.078125" y="391.82245" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdd691718a6" x="49.078125" y="391.82245" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -922,11 +922,11 @@ L -3.5 0
      <g id="line2d_17">
       <path d="M 49.078125 265.911133 
 L 637.2 265.911133 
-" clip-path="url(#p87980de34e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5a77d57261)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m899810f2f2" x="49.078125" y="265.911133" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdd691718a6" x="49.078125" y="265.911133" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -942,11 +942,11 @@ L 637.2 265.911133
      <g id="line2d_19">
       <path d="M 49.078125 139.999816 
 L 637.2 139.999816 
-" clip-path="url(#p87980de34e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5a77d57261)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m899810f2f2" x="49.078125" y="139.999816" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdd691718a6" x="49.078125" y="139.999816" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -962,16 +962,16 @@ L 637.2 139.999816
      <g id="line2d_21">
       <path d="M 49.078125 411.32636 
 L 637.2 411.32636 
-" clip-path="url(#p87980de34e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5a77d57261)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="m706f7731a2" d="M 0 0 
+       <path id="mf3a6061827" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m706f7731a2" x="49.078125" y="411.32636" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf3a6061827" x="49.078125" y="411.32636" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -979,11 +979,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 404.024518 
 L 637.2 404.024518 
-" clip-path="url(#p87980de34e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5a77d57261)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m706f7731a2" x="49.078125" y="404.024518" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf3a6061827" x="49.078125" y="404.024518" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -991,11 +991,11 @@ L 637.2 404.024518
      <g id="line2d_25">
       <path d="M 49.078125 397.583836 
 L 637.2 397.583836 
-" clip-path="url(#p87980de34e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5a77d57261)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m706f7731a2" x="49.078125" y="397.583836" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf3a6061827" x="49.078125" y="397.583836" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1003,11 +1003,11 @@ L 637.2 397.583836
      <g id="line2d_27">
       <path d="M 49.078125 353.919367 
 L 637.2 353.919367 
-" clip-path="url(#p87980de34e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5a77d57261)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m706f7731a2" x="49.078125" y="353.919367" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf3a6061827" x="49.078125" y="353.919367" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1015,11 +1015,11 @@ L 637.2 353.919367
      <g id="line2d_29">
       <path d="M 49.078125 331.747485 
 L 637.2 331.747485 
-" clip-path="url(#p87980de34e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5a77d57261)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m706f7731a2" x="49.078125" y="331.747485" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf3a6061827" x="49.078125" y="331.747485" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1027,11 +1027,11 @@ L 637.2 331.747485
      <g id="line2d_31">
       <path d="M 49.078125 316.016284 
 L 637.2 316.016284 
-" clip-path="url(#p87980de34e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5a77d57261)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m706f7731a2" x="49.078125" y="316.016284" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf3a6061827" x="49.078125" y="316.016284" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1039,11 +1039,11 @@ L 637.2 316.016284
      <g id="line2d_33">
       <path d="M 49.078125 303.814216 
 L 637.2 303.814216 
-" clip-path="url(#p87980de34e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5a77d57261)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m706f7731a2" x="49.078125" y="303.814216" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf3a6061827" x="49.078125" y="303.814216" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1051,11 +1051,11 @@ L 637.2 303.814216
      <g id="line2d_35">
       <path d="M 49.078125 293.844402 
 L 637.2 293.844402 
-" clip-path="url(#p87980de34e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5a77d57261)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m706f7731a2" x="49.078125" y="293.844402" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf3a6061827" x="49.078125" y="293.844402" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1063,11 +1063,11 @@ L 637.2 293.844402
      <g id="line2d_37">
       <path d="M 49.078125 285.415043 
 L 637.2 285.415043 
-" clip-path="url(#p87980de34e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5a77d57261)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m706f7731a2" x="49.078125" y="285.415043" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf3a6061827" x="49.078125" y="285.415043" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1075,11 +1075,11 @@ L 637.2 285.415043
      <g id="line2d_39">
       <path d="M 49.078125 278.113201 
 L 637.2 278.113201 
-" clip-path="url(#p87980de34e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5a77d57261)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m706f7731a2" x="49.078125" y="278.113201" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf3a6061827" x="49.078125" y="278.113201" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1087,11 +1087,11 @@ L 637.2 278.113201
      <g id="line2d_41">
       <path d="M 49.078125 271.672519 
 L 637.2 271.672519 
-" clip-path="url(#p87980de34e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5a77d57261)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m706f7731a2" x="49.078125" y="271.672519" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf3a6061827" x="49.078125" y="271.672519" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1099,11 +1099,11 @@ L 637.2 271.672519
      <g id="line2d_43">
       <path d="M 49.078125 228.00805 
 L 637.2 228.00805 
-" clip-path="url(#p87980de34e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5a77d57261)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m706f7731a2" x="49.078125" y="228.00805" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf3a6061827" x="49.078125" y="228.00805" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1111,11 +1111,11 @@ L 637.2 228.00805
      <g id="line2d_45">
       <path d="M 49.078125 205.836168 
 L 637.2 205.836168 
-" clip-path="url(#p87980de34e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5a77d57261)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m706f7731a2" x="49.078125" y="205.836168" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf3a6061827" x="49.078125" y="205.836168" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1123,11 +1123,11 @@ L 637.2 205.836168
      <g id="line2d_47">
       <path d="M 49.078125 190.104967 
 L 637.2 190.104967 
-" clip-path="url(#p87980de34e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5a77d57261)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m706f7731a2" x="49.078125" y="190.104967" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf3a6061827" x="49.078125" y="190.104967" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1135,11 +1135,11 @@ L 637.2 190.104967
      <g id="line2d_49">
       <path d="M 49.078125 177.9029 
 L 637.2 177.9029 
-" clip-path="url(#p87980de34e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5a77d57261)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m706f7731a2" x="49.078125" y="177.9029" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf3a6061827" x="49.078125" y="177.9029" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1147,11 +1147,11 @@ L 637.2 177.9029
      <g id="line2d_51">
       <path d="M 49.078125 167.933085 
 L 637.2 167.933085 
-" clip-path="url(#p87980de34e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5a77d57261)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m706f7731a2" x="49.078125" y="167.933085" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf3a6061827" x="49.078125" y="167.933085" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1159,11 +1159,11 @@ L 637.2 167.933085
      <g id="line2d_53">
       <path d="M 49.078125 159.503726 
 L 637.2 159.503726 
-" clip-path="url(#p87980de34e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5a77d57261)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#m706f7731a2" x="49.078125" y="159.503726" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf3a6061827" x="49.078125" y="159.503726" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1171,11 +1171,11 @@ L 637.2 159.503726
      <g id="line2d_55">
       <path d="M 49.078125 152.201884 
 L 637.2 152.201884 
-" clip-path="url(#p87980de34e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5a77d57261)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#m706f7731a2" x="49.078125" y="152.201884" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf3a6061827" x="49.078125" y="152.201884" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1183,11 +1183,11 @@ L 637.2 152.201884
      <g id="line2d_57">
       <path d="M 49.078125 145.761202 
 L 637.2 145.761202 
-" clip-path="url(#p87980de34e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5a77d57261)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#m706f7731a2" x="49.078125" y="145.761202" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf3a6061827" x="49.078125" y="145.761202" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1195,11 +1195,11 @@ L 637.2 145.761202
      <g id="line2d_59">
       <path d="M 49.078125 102.096733 
 L 637.2 102.096733 
-" clip-path="url(#p87980de34e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5a77d57261)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#m706f7731a2" x="49.078125" y="102.096733" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf3a6061827" x="49.078125" y="102.096733" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1207,11 +1207,11 @@ L 637.2 102.096733
      <g id="line2d_61">
       <path d="M 49.078125 79.924851 
 L 637.2 79.924851 
-" clip-path="url(#p87980de34e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5a77d57261)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#m706f7731a2" x="49.078125" y="79.924851" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf3a6061827" x="49.078125" y="79.924851" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1219,11 +1219,11 @@ L 637.2 79.924851
      <g id="line2d_63">
       <path d="M 49.078125 64.19365 
 L 637.2 64.19365 
-" clip-path="url(#p87980de34e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5a77d57261)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#m706f7731a2" x="49.078125" y="64.19365" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf3a6061827" x="49.078125" y="64.19365" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1231,11 +1231,11 @@ L 637.2 64.19365
      <g id="line2d_65">
       <path d="M 49.078125 51.991583 
 L 637.2 51.991583 
-" clip-path="url(#p87980de34e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5a77d57261)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#m706f7731a2" x="49.078125" y="51.991583" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf3a6061827" x="49.078125" y="51.991583" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1398,7 +1398,7 @@ z
    <g id="line2d_67">
     <path d="M 49.078125 63.959148 
 L 637.2 63.959148 
-" clip-path="url(#p87980de34e)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
+" clip-path="url(#p5a77d57261)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
    </g>
    <g id="patch_3">
     <path d="M 49.078125 412.80375 
@@ -1762,78 +1762,78 @@ z
    </g>
    <g id="line2d_68">
     <defs>
-     <path id="mbb80818abb" d="M -2.5 2.5 
+     <path id="m89c9166434" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p87980de34e)">
-     <use xlink:href="#mbb80818abb" x="75.810937" y="263.216607" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbb80818abb" x="105.634056" y="269.620798" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbb80818abb" x="204.490635" y="301.215031" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbb80818abb" x="234.479899" y="307.658059" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbb80818abb" x="242.537956" y="315.917944" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbb80818abb" x="300.771958" y="298.734802" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbb80818abb" x="303.26414" y="310.074879" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbb80818abb" x="304.261013" y="319.328576" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbb80818abb" x="313.897453" y="319.101018" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbb80818abb" x="414.166268" y="335.426532" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbb80818abb" x="587.289889" y="328.826648" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbb80818abb" x="610.467187" y="319.678275" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p5a77d57261)">
+     <use xlink:href="#m89c9166434" x="75.810937" y="263.216607" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m89c9166434" x="105.634056" y="269.620798" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m89c9166434" x="204.490635" y="301.215031" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m89c9166434" x="234.479899" y="307.658059" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m89c9166434" x="242.537956" y="315.917944" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m89c9166434" x="300.771958" y="298.734802" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m89c9166434" x="303.26414" y="310.074879" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m89c9166434" x="304.261013" y="319.328576" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m89c9166434" x="313.897453" y="319.101018" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m89c9166434" x="414.166268" y="335.426532" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m89c9166434" x="587.289889" y="328.826648" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m89c9166434" x="610.467187" y="319.678275" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_69">
     <defs>
-     <path id="mbab7cc77c7" d="M 0 -2.5 
+     <path id="m8feb3d8607" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p87980de34e)">
-     <use xlink:href="#mbab7cc77c7" x="75.810937" y="262.505003" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbab7cc77c7" x="105.634056" y="256.516219" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbab7cc77c7" x="204.490635" y="300.455891" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbab7cc77c7" x="234.479899" y="298.72384" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbab7cc77c7" x="242.537956" y="307.046683" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbab7cc77c7" x="300.771958" y="287.726284" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbab7cc77c7" x="303.26414" y="300.256724" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbab7cc77c7" x="304.261013" y="315.235818" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbab7cc77c7" x="313.897453" y="307.4765" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbab7cc77c7" x="414.166268" y="326.223389" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbab7cc77c7" x="587.289889" y="329.609806" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbab7cc77c7" x="610.467187" y="318.379704" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p5a77d57261)">
+     <use xlink:href="#m8feb3d8607" x="75.810937" y="262.505003" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8feb3d8607" x="105.634056" y="256.516219" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8feb3d8607" x="204.490635" y="300.455891" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8feb3d8607" x="234.479899" y="298.72384" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8feb3d8607" x="242.537956" y="307.046683" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8feb3d8607" x="300.771958" y="287.726284" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8feb3d8607" x="303.26414" y="300.256724" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8feb3d8607" x="304.261013" y="315.235818" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8feb3d8607" x="313.897453" y="307.4765" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8feb3d8607" x="414.166268" y="326.223389" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8feb3d8607" x="587.289889" y="329.609806" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8feb3d8607" x="610.467187" y="318.379704" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_70">
     <defs>
-     <path id="mc4c28bd8c5" d="M -0 3.535534 
+     <path id="m6a57ba31c9" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p87980de34e)">
-     <use xlink:href="#mc4c28bd8c5" x="75.810937" y="231.044207" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc4c28bd8c5" x="105.634056" y="233.464672" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc4c28bd8c5" x="204.490635" y="259.725746" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc4c28bd8c5" x="234.479899" y="262.023129" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc4c28bd8c5" x="242.537956" y="273.368182" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc4c28bd8c5" x="300.771958" y="259.408271" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc4c28bd8c5" x="303.26414" y="270.926655" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc4c28bd8c5" x="304.261013" y="281.595692" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc4c28bd8c5" x="313.897453" y="277.309155" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc4c28bd8c5" x="414.166268" y="296.377475" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc4c28bd8c5" x="587.289889" y="301.735817" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc4c28bd8c5" x="610.467187" y="297.040139" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p5a77d57261)">
+     <use xlink:href="#m6a57ba31c9" x="75.810937" y="231.044207" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a57ba31c9" x="105.634056" y="233.464672" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a57ba31c9" x="204.490635" y="259.725746" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a57ba31c9" x="234.479899" y="262.023129" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a57ba31c9" x="242.537956" y="273.368182" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a57ba31c9" x="300.771958" y="259.408271" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a57ba31c9" x="303.26414" y="270.926655" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a57ba31c9" x="304.261013" y="281.595692" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a57ba31c9" x="313.897453" y="277.309155" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a57ba31c9" x="414.166268" y="296.377475" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a57ba31c9" x="587.289889" y="301.735817" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a57ba31c9" x="610.467187" y="297.040139" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_71">
     <defs>
-     <path id="m3c093a3022" d="M -0.833333 2.5 
+     <path id="m34151a164b" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -1848,24 +1848,24 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p87980de34e)">
-     <use xlink:href="#m3c093a3022" x="75.810937" y="286.910165" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3c093a3022" x="105.634056" y="294.974253" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3c093a3022" x="204.490635" y="327.107019" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3c093a3022" x="234.479899" y="335.778593" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3c093a3022" x="242.537956" y="341.647351" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3c093a3022" x="300.771958" y="337.663009" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3c093a3022" x="303.26414" y="345.502509" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3c093a3022" x="304.261013" y="345.645685" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3c093a3022" x="313.897453" y="351.930007" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3c093a3022" x="414.166268" y="363.456717" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3c093a3022" x="587.289889" y="368.243436" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3c093a3022" x="610.467187" y="356.848113" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p5a77d57261)">
+     <use xlink:href="#m34151a164b" x="75.810937" y="286.910165" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m34151a164b" x="105.634056" y="294.974253" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m34151a164b" x="204.490635" y="327.107019" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m34151a164b" x="234.479899" y="335.778593" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m34151a164b" x="242.537956" y="341.647351" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m34151a164b" x="300.771958" y="337.663009" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m34151a164b" x="303.26414" y="345.502509" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m34151a164b" x="304.261013" y="345.645685" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m34151a164b" x="313.897453" y="351.930007" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m34151a164b" x="414.166268" y="363.456717" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m34151a164b" x="587.289889" y="368.243436" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m34151a164b" x="610.467187" y="356.848113" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_72">
     <defs>
-     <path id="mb3a7d636b2" d="M -1.25 2.5 
+     <path id="m874c3963ea" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -1880,24 +1880,24 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p87980de34e)">
-     <use xlink:href="#mb3a7d636b2" x="75.810937" y="328.907922" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb3a7d636b2" x="105.634056" y="342.121252" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb3a7d636b2" x="204.490635" y="364.316276" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb3a7d636b2" x="234.479899" y="371.357513" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb3a7d636b2" x="242.537956" y="368.122771" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb3a7d636b2" x="300.771958" y="365.072092" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb3a7d636b2" x="303.26414" y="374.607784" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb3a7d636b2" x="304.261013" y="366.131688" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb3a7d636b2" x="313.897453" y="378.589014" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb3a7d636b2" x="414.166268" y="386.15027" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb3a7d636b2" x="587.289889" y="392.30027" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb3a7d636b2" x="610.467187" y="391.11076" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p5a77d57261)">
+     <use xlink:href="#m874c3963ea" x="75.810937" y="328.907922" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m874c3963ea" x="105.634056" y="342.121252" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m874c3963ea" x="204.490635" y="364.316276" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m874c3963ea" x="234.479899" y="371.357513" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m874c3963ea" x="242.537956" y="368.122771" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m874c3963ea" x="300.771958" y="365.072092" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m874c3963ea" x="303.26414" y="374.607784" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m874c3963ea" x="304.261013" y="366.131688" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m874c3963ea" x="313.897453" y="378.589014" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m874c3963ea" x="414.166268" y="386.15027" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m874c3963ea" x="587.289889" y="392.30027" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m874c3963ea" x="610.467187" y="391.11076" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_73">
     <defs>
-     <path id="m6ba87b7b01" d="M 0 -2.5 
+     <path id="mf13218babd" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -1910,24 +1910,24 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p87980de34e)">
-     <use xlink:href="#m6ba87b7b01" x="75.810937" y="274.450514" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m6ba87b7b01" x="105.634056" y="287.578172" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m6ba87b7b01" x="204.490635" y="320.76932" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m6ba87b7b01" x="234.479899" y="321.538199" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m6ba87b7b01" x="242.537956" y="326.688339" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m6ba87b7b01" x="300.771958" y="333.426229" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m6ba87b7b01" x="303.26414" y="337.000867" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m6ba87b7b01" x="304.261013" y="346.386297" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m6ba87b7b01" x="313.897453" y="336.174424" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m6ba87b7b01" x="414.166268" y="357.767316" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m6ba87b7b01" x="587.289889" y="366.526213" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m6ba87b7b01" x="610.467187" y="361.324423" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p5a77d57261)">
+     <use xlink:href="#mf13218babd" x="75.810937" y="274.450514" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf13218babd" x="105.634056" y="287.578172" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf13218babd" x="204.490635" y="320.76932" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf13218babd" x="234.479899" y="321.538199" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf13218babd" x="242.537956" y="326.688339" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf13218babd" x="300.771958" y="333.426229" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf13218babd" x="303.26414" y="337.000867" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf13218babd" x="304.261013" y="346.386297" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf13218babd" x="313.897453" y="336.174424" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf13218babd" x="414.166268" y="357.767316" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf13218babd" x="587.289889" y="366.526213" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf13218babd" x="610.467187" y="361.324423" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_74">
     <defs>
-     <path id="m7d6660ad2c" d="M 0 -2.5 
+     <path id="m370cc1c0f3" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -1936,19 +1936,19 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p87980de34e)">
-     <use xlink:href="#m7d6660ad2c" x="75.810937" y="345.30596" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7d6660ad2c" x="105.634056" y="352.048776" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7d6660ad2c" x="204.490635" y="367.386827" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7d6660ad2c" x="234.479899" y="374.711659" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7d6660ad2c" x="242.537956" y="380.187639" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7d6660ad2c" x="300.771958" y="368.991079" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7d6660ad2c" x="303.26414" y="375.43221" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7d6660ad2c" x="304.261013" y="381.227374" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7d6660ad2c" x="313.897453" y="385.221601" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7d6660ad2c" x="414.166268" y="390.900659" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7d6660ad2c" x="587.289889" y="396.192102" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7d6660ad2c" x="610.467187" y="386.05669" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p5a77d57261)">
+     <use xlink:href="#m370cc1c0f3" x="75.810937" y="345.30596" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m370cc1c0f3" x="105.634056" y="352.048776" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m370cc1c0f3" x="204.490635" y="367.386827" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m370cc1c0f3" x="234.479899" y="374.711659" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m370cc1c0f3" x="242.537956" y="380.187639" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m370cc1c0f3" x="300.771958" y="368.991079" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m370cc1c0f3" x="303.26414" y="375.43221" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m370cc1c0f3" x="304.261013" y="381.227374" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m370cc1c0f3" x="313.897453" y="385.221601" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m370cc1c0f3" x="414.166268" y="390.900659" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m370cc1c0f3" x="587.289889" y="396.192102" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m370cc1c0f3" x="610.467187" y="386.05669" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="legend_1">
@@ -1967,7 +1967,7 @@ z
     </g>
     <g id="line2d_75">
      <defs>
-      <path id="m23081b4a7e" d="M 0 3.5 
+      <path id="mce59d5e35d" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -1980,7 +1980,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m23081b4a7e" x="434.04625" y="211.758125" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#mce59d5e35d" x="434.04625" y="211.758125" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_15">
@@ -2039,7 +2039,7 @@ z
     </g>
     <g id="line2d_76">
      <g>
-      <use xlink:href="#mbb80818abb" x="434.04625" y="223.500625" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m89c9166434" x="434.04625" y="223.500625" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_16">
@@ -2053,7 +2053,7 @@ z
     </g>
     <g id="line2d_77">
      <g>
-      <use xlink:href="#mbab7cc77c7" x="434.04625" y="235.243125" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m8feb3d8607" x="434.04625" y="235.243125" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -2098,7 +2098,7 @@ z
     </g>
     <g id="line2d_78">
      <g>
-      <use xlink:href="#mc4c28bd8c5" x="434.04625" y="247.208125" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m6a57ba31c9" x="434.04625" y="247.208125" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -2118,7 +2118,7 @@ z
     </g>
     <g id="line2d_79">
      <g>
-      <use xlink:href="#m3c093a3022" x="537.72375" y="211.758125" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m34151a164b" x="537.72375" y="211.758125" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -2145,7 +2145,7 @@ z
     </g>
     <g id="line2d_80">
      <g>
-      <use xlink:href="#mb3a7d636b2" x="537.72375" y="223.500625" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m874c3963ea" x="537.72375" y="223.500625" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -2210,7 +2210,7 @@ z
     </g>
     <g id="line2d_81">
      <g>
-      <use xlink:href="#m6ba87b7b01" x="537.72375" y="235.243125" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#mf13218babd" x="537.72375" y="235.243125" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_21">
@@ -2248,7 +2248,7 @@ z
     </g>
     <g id="line2d_82">
      <g>
-      <use xlink:href="#m7d6660ad2c" x="537.72375" y="246.985625" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m370cc1c0f3" x="537.72375" y="246.985625" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -2318,19 +2318,19 @@ z
     </g>
    </g>
    <g id="line2d_83">
-    <g clip-path="url(#p87980de34e)">
-     <use xlink:href="#m23081b4a7e" x="75.810937" y="298.510024" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m23081b4a7e" x="105.634056" y="315.672864" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m23081b4a7e" x="204.490635" y="347.595466" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m23081b4a7e" x="234.479899" y="355.186159" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m23081b4a7e" x="242.537956" y="354.419257" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m23081b4a7e" x="300.771958" y="342.079401" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m23081b4a7e" x="303.26414" y="366.152202" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m23081b4a7e" x="304.261013" y="375.092892" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m23081b4a7e" x="313.897453" y="369.574066" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m23081b4a7e" x="414.166268" y="382.204646" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m23081b4a7e" x="587.289889" y="393.510593" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m23081b4a7e" x="610.467187" y="371.196024" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <g clip-path="url(#p5a77d57261)">
+     <use xlink:href="#mce59d5e35d" x="75.810937" y="298.510024" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mce59d5e35d" x="105.634056" y="315.672864" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mce59d5e35d" x="204.490635" y="347.595466" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mce59d5e35d" x="234.479899" y="355.186159" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mce59d5e35d" x="242.537956" y="354.419257" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mce59d5e35d" x="300.771958" y="342.079401" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mce59d5e35d" x="303.26414" y="366.152202" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mce59d5e35d" x="304.261013" y="375.092892" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mce59d5e35d" x="313.897453" y="369.574066" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mce59d5e35d" x="414.166268" y="382.204646" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mce59d5e35d" x="587.289889" y="393.510593" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mce59d5e35d" x="610.467187" y="371.196024" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
   </g>
@@ -3184,7 +3184,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p87980de34e">
+  <clipPath id="p5a77d57261">
    <rect x="49.078125" y="47.3475" width="588.121875" height="365.45625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_decode_ranking.svg
+++ b/bench/graphs/silesia_decode_ranking.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 290.788615 308.04375 
 L 290.788615 56.7075 
-" clip-path="url(#p93f3b36cbb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p9492024f93)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m2b1db8827c" d="M 0 0 
+       <path id="m1aefb0db73" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m2b1db8827c" x="290.788615" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1aefb0db73" x="290.788615" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -136,11 +136,11 @@ z
      <g id="line2d_3">
       <path d="M 447.590599 308.04375 
 L 447.590599 56.7075 
-" clip-path="url(#p93f3b36cbb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p9492024f93)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m2b1db8827c" x="447.590599" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1aefb0db73" x="447.590599" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -177,16 +177,16 @@ z
      <g id="line2d_5">
       <path d="M 181.188732 308.04375 
 L 181.188732 56.7075 
-" clip-path="url(#p93f3b36cbb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p9492024f93)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <defs>
-       <path id="ma0ec0b5b23" d="M 0 0 
+       <path id="ma5c57bd3bf" d="M 0 0 
 L 0 2 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#ma0ec0b5b23" x="181.188732" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma5c57bd3bf" x="181.188732" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -194,11 +194,11 @@ L 0 2
      <g id="line2d_7">
       <path d="M 208.800191 308.04375 
 L 208.800191 56.7075 
-" clip-path="url(#p93f3b36cbb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p9492024f93)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#ma0ec0b5b23" x="208.800191" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma5c57bd3bf" x="208.800191" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -206,11 +206,11 @@ L 208.800191 56.7075
      <g id="line2d_9">
       <path d="M 228.390833 308.04375 
 L 228.390833 56.7075 
-" clip-path="url(#p93f3b36cbb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p9492024f93)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#ma0ec0b5b23" x="228.390833" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma5c57bd3bf" x="228.390833" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -218,11 +218,11 @@ L 228.390833 56.7075
      <g id="line2d_11">
       <path d="M 243.586515 308.04375 
 L 243.586515 56.7075 
-" clip-path="url(#p93f3b36cbb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p9492024f93)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#ma0ec0b5b23" x="243.586515" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma5c57bd3bf" x="243.586515" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -230,11 +230,11 @@ L 243.586515 56.7075
      <g id="line2d_13">
       <path d="M 256.002291 308.04375 
 L 256.002291 56.7075 
-" clip-path="url(#p93f3b36cbb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p9492024f93)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#ma0ec0b5b23" x="256.002291" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma5c57bd3bf" x="256.002291" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -242,11 +242,11 @@ L 256.002291 56.7075
      <g id="line2d_15">
       <path d="M 266.499681 308.04375 
 L 266.499681 56.7075 
-" clip-path="url(#p93f3b36cbb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p9492024f93)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <g>
-       <use xlink:href="#ma0ec0b5b23" x="266.499681" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma5c57bd3bf" x="266.499681" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -254,11 +254,11 @@ L 266.499681 56.7075
      <g id="line2d_17">
       <path d="M 275.592933 308.04375 
 L 275.592933 56.7075 
-" clip-path="url(#p93f3b36cbb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p9492024f93)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#ma0ec0b5b23" x="275.592933" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma5c57bd3bf" x="275.592933" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -266,11 +266,11 @@ L 275.592933 56.7075
      <g id="line2d_19">
       <path d="M 283.61375 308.04375 
 L 283.61375 56.7075 
-" clip-path="url(#p93f3b36cbb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p9492024f93)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#ma0ec0b5b23" x="283.61375" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma5c57bd3bf" x="283.61375" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -278,11 +278,11 @@ L 283.61375 56.7075
      <g id="line2d_21">
       <path d="M 337.990716 308.04375 
 L 337.990716 56.7075 
-" clip-path="url(#p93f3b36cbb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p9492024f93)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#ma0ec0b5b23" x="337.990716" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma5c57bd3bf" x="337.990716" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -290,11 +290,11 @@ L 337.990716 56.7075
      <g id="line2d_23">
       <path d="M 365.602174 308.04375 
 L 365.602174 56.7075 
-" clip-path="url(#p93f3b36cbb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p9492024f93)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#ma0ec0b5b23" x="365.602174" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma5c57bd3bf" x="365.602174" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -302,11 +302,11 @@ L 365.602174 56.7075
      <g id="line2d_25">
       <path d="M 385.192816 308.04375 
 L 385.192816 56.7075 
-" clip-path="url(#p93f3b36cbb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p9492024f93)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#ma0ec0b5b23" x="385.192816" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma5c57bd3bf" x="385.192816" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -314,11 +314,11 @@ L 385.192816 56.7075
      <g id="line2d_27">
       <path d="M 400.388498 308.04375 
 L 400.388498 56.7075 
-" clip-path="url(#p93f3b36cbb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p9492024f93)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#ma0ec0b5b23" x="400.388498" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma5c57bd3bf" x="400.388498" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -326,11 +326,11 @@ L 400.388498 56.7075
      <g id="line2d_29">
       <path d="M 412.804275 308.04375 
 L 412.804275 56.7075 
-" clip-path="url(#p93f3b36cbb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p9492024f93)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#ma0ec0b5b23" x="412.804275" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma5c57bd3bf" x="412.804275" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -338,11 +338,11 @@ L 412.804275 56.7075
      <g id="line2d_31">
       <path d="M 423.301664 308.04375 
 L 423.301664 56.7075 
-" clip-path="url(#p93f3b36cbb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p9492024f93)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#ma0ec0b5b23" x="423.301664" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma5c57bd3bf" x="423.301664" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -350,11 +350,11 @@ L 423.301664 56.7075
      <g id="line2d_33">
       <path d="M 432.394917 308.04375 
 L 432.394917 56.7075 
-" clip-path="url(#p93f3b36cbb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p9492024f93)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#ma0ec0b5b23" x="432.394917" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma5c57bd3bf" x="432.394917" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -362,11 +362,11 @@ L 432.394917 56.7075
      <g id="line2d_35">
       <path d="M 440.415734 308.04375 
 L 440.415734 56.7075 
-" clip-path="url(#p93f3b36cbb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p9492024f93)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#ma0ec0b5b23" x="440.415734" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma5c57bd3bf" x="440.415734" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -374,11 +374,11 @@ L 440.415734 56.7075
      <g id="line2d_37">
       <path d="M 494.792699 308.04375 
 L 494.792699 56.7075 
-" clip-path="url(#p93f3b36cbb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p9492024f93)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#ma0ec0b5b23" x="494.792699" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma5c57bd3bf" x="494.792699" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -386,11 +386,11 @@ L 494.792699 56.7075
      <g id="line2d_39">
       <path d="M 522.404158 308.04375 
 L 522.404158 56.7075 
-" clip-path="url(#p93f3b36cbb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p9492024f93)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#ma0ec0b5b23" x="522.404158" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma5c57bd3bf" x="522.404158" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -398,11 +398,11 @@ L 522.404158 56.7075
      <g id="line2d_41">
       <path d="M 541.9948 308.04375 
 L 541.9948 56.7075 
-" clip-path="url(#p93f3b36cbb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p9492024f93)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#ma0ec0b5b23" x="541.9948" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma5c57bd3bf" x="541.9948" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -410,11 +410,11 @@ L 541.9948 56.7075
      <g id="line2d_43">
       <path d="M 557.190482 308.04375 
 L 557.190482 56.7075 
-" clip-path="url(#p93f3b36cbb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p9492024f93)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#ma0ec0b5b23" x="557.190482" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma5c57bd3bf" x="557.190482" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -985,12 +985,12 @@ z
     <g id="ytick_1">
      <g id="line2d_45">
       <defs>
-       <path id="m35b81e5394" d="M 0 0 
+       <path id="m3930b8e024" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m35b81e5394" x="139.360469" y="296.619375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3930b8e024" x="139.360469" y="296.619375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -1062,7 +1062,7 @@ z
     <g id="ytick_2">
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m35b81e5394" x="139.360469" y="263.978304" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3930b8e024" x="139.360469" y="263.978304" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -1129,7 +1129,7 @@ z
     <g id="ytick_3">
      <g id="line2d_47">
       <g>
-       <use xlink:href="#m35b81e5394" x="139.360469" y="231.337232" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3930b8e024" x="139.360469" y="231.337232" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -1242,7 +1242,7 @@ z
     <g id="ytick_4">
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m35b81e5394" x="139.360469" y="198.696161" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3930b8e024" x="139.360469" y="198.696161" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -1298,7 +1298,7 @@ z
     <g id="ytick_5">
      <g id="line2d_49">
       <g>
-       <use xlink:href="#m35b81e5394" x="139.360469" y="166.055089" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3930b8e024" x="139.360469" y="166.055089" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -1345,7 +1345,7 @@ z
     <g id="ytick_6">
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m35b81e5394" x="139.360469" y="133.414018" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3930b8e024" x="139.360469" y="133.414018" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -1361,7 +1361,7 @@ z
     <g id="ytick_7">
      <g id="line2d_51">
       <g>
-       <use xlink:href="#m35b81e5394" x="139.360469" y="100.772946" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3930b8e024" x="139.360469" y="100.772946" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -1408,7 +1408,7 @@ z
     <g id="ytick_8">
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m35b81e5394" x="139.360469" y="68.131875" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3930b8e024" x="139.360469" y="68.131875" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -1431,47 +1431,47 @@ z
    <g id="LineCollection_1">
     <path d="M 139.360469 296.619375 
 L 154.556151 296.619375 
-" clip-path="url(#p93f3b36cbb)" style="fill: none; stroke: #17becf; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p9492024f93)" style="fill: none; stroke: #17becf; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_2">
     <path d="M 139.360469 263.978304 
 L 162.32653 263.978304 
-" clip-path="url(#p93f3b36cbb)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p9492024f93)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_3">
     <path d="M 139.360469 231.337232 
 L 178.681331 231.337232 
-" clip-path="url(#p93f3b36cbb)" style="fill: none; stroke: #d62728; stroke-opacity: 0.9; stroke-width: 2.4"/>
+" clip-path="url(#p9492024f93)" style="fill: none; stroke: #d62728; stroke-opacity: 0.9; stroke-width: 2.4"/>
    </g>
    <g id="LineCollection_4">
     <path d="M 139.360469 198.696161 
 L 201.044126 198.696161 
-" clip-path="url(#p93f3b36cbb)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p9492024f93)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_5">
     <path d="M 139.360469 166.055089 
 L 209.976983 166.055089 
-" clip-path="url(#p93f3b36cbb)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p9492024f93)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_6">
     <path d="M 139.360469 133.414018 
 L 239.121093 133.414018 
-" clip-path="url(#p93f3b36cbb)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p9492024f93)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_7">
     <path d="M 139.360469 100.772946 
 L 247.282543 100.772946 
-" clip-path="url(#p93f3b36cbb)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p9492024f93)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_8">
     <path d="M 139.360469 68.131875 
 L 285.279501 68.131875 
-" clip-path="url(#p93f3b36cbb)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p9492024f93)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="line2d_53">
     <path d="M 542.286834 308.04375 
 L 542.286834 56.7075 
-" clip-path="url(#p93f3b36cbb)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
+" clip-path="url(#p9492024f93)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
    </g>
    <g id="patch_3">
     <path d="M 139.360469 308.04375 
@@ -1875,7 +1875,7 @@ z
    </g>
    <g id="line2d_54">
     <defs>
-     <path id="mc5cabbe595" d="M 0 3 
+     <path id="m8a0de763ec" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1887,13 +1887,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #17becf"/>
     </defs>
-    <g clip-path="url(#p93f3b36cbb)">
-     <use xlink:href="#mc5cabbe595" x="154.556151" y="296.619375" style="fill: #17becf; stroke: #17becf"/>
+    <g clip-path="url(#p9492024f93)">
+     <use xlink:href="#m8a0de763ec" x="154.556151" y="296.619375" style="fill: #17becf; stroke: #17becf"/>
     </g>
    </g>
    <g id="line2d_55">
     <defs>
-     <path id="m71df8c9b52" d="M 0 3 
+     <path id="me608b17f9e" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1905,13 +1905,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #e377c2"/>
     </defs>
-    <g clip-path="url(#p93f3b36cbb)">
-     <use xlink:href="#m71df8c9b52" x="162.32653" y="263.978304" style="fill: #e377c2; stroke: #e377c2"/>
+    <g clip-path="url(#p9492024f93)">
+     <use xlink:href="#me608b17f9e" x="162.32653" y="263.978304" style="fill: #e377c2; stroke: #e377c2"/>
     </g>
    </g>
    <g id="line2d_56">
     <defs>
-     <path id="m68c2db3b82" d="M 0 5 
+     <path id="m0403e17e87" d="M 0 5 
 C 1.326016 5 2.597899 4.473168 3.535534 3.535534 
 C 4.473168 2.597899 5 1.326016 5 0 
 C 5 -1.326016 4.473168 -2.597899 3.535534 -3.535534 
@@ -1923,13 +1923,13 @@ C -2.597899 4.473168 -1.326016 5 0 5
 z
 " style="stroke: #d62728"/>
     </defs>
-    <g clip-path="url(#p93f3b36cbb)">
-     <use xlink:href="#m68c2db3b82" x="178.681331" y="231.337232" style="fill: #d62728; stroke: #d62728"/>
+    <g clip-path="url(#p9492024f93)">
+     <use xlink:href="#m0403e17e87" x="178.681331" y="231.337232" style="fill: #d62728; stroke: #d62728"/>
     </g>
    </g>
    <g id="line2d_57">
     <defs>
-     <path id="md26d6439d7" d="M 0 3 
+     <path id="m44c8552612" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1941,13 +1941,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #8c564b"/>
     </defs>
-    <g clip-path="url(#p93f3b36cbb)">
-     <use xlink:href="#md26d6439d7" x="201.044126" y="198.696161" style="fill: #8c564b; stroke: #8c564b"/>
+    <g clip-path="url(#p9492024f93)">
+     <use xlink:href="#m44c8552612" x="201.044126" y="198.696161" style="fill: #8c564b; stroke: #8c564b"/>
     </g>
    </g>
    <g id="line2d_58">
     <defs>
-     <path id="m9a06260fe5" d="M 0 3 
+     <path id="mfd32cc826c" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1959,13 +1959,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #bcbd22"/>
     </defs>
-    <g clip-path="url(#p93f3b36cbb)">
-     <use xlink:href="#m9a06260fe5" x="209.976983" y="166.055089" style="fill: #bcbd22; stroke: #bcbd22"/>
+    <g clip-path="url(#p9492024f93)">
+     <use xlink:href="#mfd32cc826c" x="209.976983" y="166.055089" style="fill: #bcbd22; stroke: #bcbd22"/>
     </g>
    </g>
    <g id="line2d_59">
     <defs>
-     <path id="m641f048e82" d="M 0 3 
+     <path id="m2a5c9c0a25" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1977,13 +1977,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #1f77b4"/>
     </defs>
-    <g clip-path="url(#p93f3b36cbb)">
-     <use xlink:href="#m641f048e82" x="239.121093" y="133.414018" style="fill: #1f77b4; stroke: #1f77b4"/>
+    <g clip-path="url(#p9492024f93)">
+     <use xlink:href="#m2a5c9c0a25" x="239.121093" y="133.414018" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_60">
     <defs>
-     <path id="m217e984ee6" d="M 0 3 
+     <path id="m9f530d1a0f" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1995,13 +1995,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #2ca02c"/>
     </defs>
-    <g clip-path="url(#p93f3b36cbb)">
-     <use xlink:href="#m217e984ee6" x="247.282543" y="100.772946" style="fill: #2ca02c; stroke: #2ca02c"/>
+    <g clip-path="url(#p9492024f93)">
+     <use xlink:href="#m9f530d1a0f" x="247.282543" y="100.772946" style="fill: #2ca02c; stroke: #2ca02c"/>
     </g>
    </g>
    <g id="line2d_61">
     <defs>
-     <path id="m853ce0ebfd" d="M 0 3 
+     <path id="md52c44bc45" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -2013,8 +2013,8 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #9467bd"/>
     </defs>
-    <g clip-path="url(#p93f3b36cbb)">
-     <use xlink:href="#m853ce0ebfd" x="285.279501" y="68.131875" style="fill: #9467bd; stroke: #9467bd"/>
+    <g clip-path="url(#p9492024f93)">
+     <use xlink:href="#md52c44bc45" x="285.279501" y="68.131875" style="fill: #9467bd; stroke: #9467bd"/>
     </g>
    </g>
   </g>
@@ -2869,7 +2869,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p93f3b36cbb">
+  <clipPath id="p9492024f93">
    <rect x="139.360469" y="56.7075" width="425.839531" height="251.33625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_ratio_heatmap.svg
+++ b/bench/graphs/silesia_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.34175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#pefcf5685e6)">
+   <g clip-path="url(#p00b904c5ea)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAosAAAGaCAYAAABniAm0AAAJ/klEQVR4nO3Yu45eVx2H4ZnM+IDHmbEtSCLCQcJRQAqBEoWCKhWCgmvgCmioqBB3QMUN0KGI0k1KpACBEAogSkIQB1lDjB1jGXs8Mx9X8BYoWvqjT89zBT9pb6397rV7fvsnm50tdPLTW9MTlrjw6svTE5bZfebT0xOW2Lz1u+kJS+x+5aXpCUtsHt6fnrDM8fdfm56wxDM/+tb0hCV2bzw7PWGNk4fTC5Y5/+V2nvdPTQ8AAOD/l1gEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACDt/vvktc30iBUO/nU8PWGJDw+vTE9Y5j+nD6YnLPHZj06mJyzx0aeem56wxPnmfHrCMtf3b0xPWOPOB9MLlrh/fTuf19N//tP0hGU2L35tesISbhYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEj7B3duT29Y48q16QVLbDYn0xOW+czrv56esMar35xesMTRh/+YnrDG+en0gnUOtvT8uHR1esESh//czu/z3c/fnJ6wzPW/vj09YQk3iwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEDafXJ2azM9YoW94/enJyxx++mL0xOWefDk3vSEJW7+5d70hCVOv/z16QlLPDy9Pz1hmaO9a9MTlti896vpCUs8+sLL0xOWuPz2G9MTlnn81VemJyzhZhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIuz9/73ub6REr3Lh8MD1hiXfu3ZmesMx3f/yb6QlL/PaH356esMTRpaPpCUv84BdvTk9Y5hvPX56esMR3br4yPWGJ1//2xvSEJa5e2M73cGdnZ+dn796dnrCEm0UAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAg7T45u7WZHrHC3cfH0xOWONg/nJ6wzDv3fj89YYkXrr00PWGJzeZ8esISV0+39x/67+fbeS4+f/DC9IQlHp09nJ6wxLaeHTs7Ozt7T+1PT1hie09FAAA+NrEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAApP293f3pDUt8cu/G9IQ19i5OL1jm6NLR9IQlDvYPpycscbY5nZ6wxPmF7f2Hfm5zZXoC/4Nt/T6fbB5NT1jm/uPj6QlLbO+pCADAxyYWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBI+4/OHk5vWOLy7v70hCU+ePDH6QnLnJ6fTE9Y4/jd6QVL3D86nJ6wxOHFG9MTljk5ezQ9YYlP3H5/esISj5/93PSEJQ7+8Nb0hGUef/FL0xOWcLMIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAApP8Cc6OciHDVLsgAAAAASUVORK5CYII=" id="image03a6505331" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="468.72" height="295.2"/>
+iVBORw0KGgoAAAANSUhEUgAAAosAAAGaCAYAAABniAm0AAAJ/klEQVR4nO3Yu45eVx2H4ZnM+IDHmbEtSCLCQcJRQAqBEoWCKhWCgmvgCmioqBB3QMUN0KGI0k1KpACBEAogSkIQB1lDjB1jGXs8Mx9X8BYoWvqjT89zBT9pb6397rV7fvsnm50tdPLTW9MTlrjw6svTE5bZfebT0xOW2Lz1u+kJS+x+5aXpCUtsHt6fnrDM8fdfm56wxDM/+tb0hCV2bzw7PWGNk4fTC5Y5/+V2nvdPTQ8AAOD/l1gEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACDt/vvktc30iBUO/nU8PWGJDw+vTE9Y5j+nD6YnLPHZj06mJyzx0aeem56wxPnmfHrCMtf3b0xPWOPOB9MLlrh/fTuf19N//tP0hGU2L35tesISbhYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEj7B3duT29Y48q16QVLbDYn0xOW+czrv56esMar35xesMTRh/+YnrDG+en0gnUOtvT8uHR1esESh//czu/z3c/fnJ6wzPW/vj09YQk3iwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEDafXJ2azM9YoW94/enJyxx++mL0xOWefDk3vSEJW7+5d70hCVOv/z16QlLPDy9Pz1hmaO9a9MTlti896vpCUs8+sLL0xOWuPz2G9MTlnn81VemJyzhZhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIuz9/73ub6REr3Lh8MD1hiXfu3ZmesMx3f/yb6QlL/PaH356esMTRpaPpCUv84BdvTk9Y5hvPX56esMR3br4yPWGJ1//2xvSEJa5e2M73cGdnZ+dn796dnrCEm0UAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAg7T45u7WZHrHC3cfH0xOWONg/nJ6wzDv3fj89YYkXrr00PWGJzeZ8esISV0+39x/67+fbeS4+f/DC9IQlHp09nJ6wxLaeHTs7Ozt7T+1PT1hie09FAAA+NrEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAApP293f3pDUt8cu/G9IQ19i5OL1jm6NLR9IQlDvYPpycscbY5nZ6wxPmF7f2Hfm5zZXoC/4Nt/T6fbB5NT1jm/uPj6QlLbO+pCADAxyYWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBI+4/OHk5vWOLy7v70hCU+ePDH6QnLnJ6fTE9Y4/jd6QVL3D86nJ6wxOHFG9MTljk5ezQ9YYlP3H5/esISj5/93PSEJQ7+8Nb0hGUef/FL0xOWcLMIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAApP8Cc6OciHDVLsgAAAAASUVORK5CYII=" id="imagebf4923a7d4" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="468.72" height="295.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m42e45076f0" d="M 0 0 
+       <path id="m7d744fcc73" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m42e45076f0" x="115.182137" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7d744fcc73" x="115.182137" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m42e45076f0" x="154.193912" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7d744fcc73" x="154.193912" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m42e45076f0" x="193.205687" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7d744fcc73" x="193.205687" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m42e45076f0" x="232.217462" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7d744fcc73" x="232.217462" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m42e45076f0" x="271.229237" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7d744fcc73" x="271.229237" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m42e45076f0" x="310.241012" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7d744fcc73" x="310.241012" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m42e45076f0" x="349.252787" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7d744fcc73" x="349.252787" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m42e45076f0" x="388.264562" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7d744fcc73" x="388.264562" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m42e45076f0" x="427.276336" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7d744fcc73" x="427.276336" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m42e45076f0" x="466.288111" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7d744fcc73" x="466.288111" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m42e45076f0" x="505.299886" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7d744fcc73" x="505.299886" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m42e45076f0" x="544.311661" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7d744fcc73" x="544.311661" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="me0c1383484" d="M 0 0 
+       <path id="m71ed69b621" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#me0c1383484" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m71ed69b621" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#me0c1383484" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m71ed69b621" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#me0c1383484" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m71ed69b621" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#me0c1383484" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m71ed69b621" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -836,7 +836,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#me0c1383484" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m71ed69b621" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -899,7 +899,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#me0c1383484" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m71ed69b621" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -966,7 +966,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#me0c1383484" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m71ed69b621" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1047,7 +1047,7 @@ z
     <g id="ytick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#me0c1383484" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m71ed69b621" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -2060,18 +2060,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABEAAAFUCAYAAADCj9eRAAAB2ElEQVR4nO2aQY7EIAwEIeFP+6X9/33C3MPcKKSS1TygZRftNlLS2//fbJtn9KvvajAi17ZCM7Uzeg+TEyJhsh4TE8D25ZhYRMJkPSYmmZ0zIhfQEMPkJq74JpgQlUBMABkIrOV2KLMRItXMhrQjqcQUSszsbGuomFSbHULEAlblE0klor1zMaG0XwnDBDAsBVY0O4CIBizlE4ntEbCijK3mE8vKUPkEEIF8YslYje2RZFP5BJkdCxOonf1i6jEhRICOyjEBzFaPiWd2iChoYbKKhMkqgmSsh4kkHkU+6UyeACJEJaLZ6QQTzy7WtGPyicX2Kp/c+yKaATTliSWoTXsnPllEEtTLGX37f+7WRpuPQ4RhomlntCdMTohATIDbKceEaGfOD1BJZueIiImJZQBNTCxgw2Q91N7Zf7RBsxMmR0TqMdmvxPRmI0TmDJNVJExWkTBZRcJkFSnFZH6Q5aVhQrQzkYUOVEIxIXxSjAnRDjQ7mndsZud9VEwsPtFcsWjvaNZofHKoEpFPELCPJmORdqblMWxiYjEbw+QJk/dR+SQD+BbROFbEJAP4Q4RgQpiNCupKIhAT4gewakws7YTJIREoY4FPeNWYaNoJk18iQNqXY1LKJ1/07Ct/l+QCQgAAAABJRU5ErkJggg==" id="image15d5dc6a96" transform="scale(1 -1) translate(0 -244.8)" x="573.84" y="-74.16" width="12.24" height="244.8"/>
+iVBORw0KGgoAAAANSUhEUgAAABEAAAFUCAYAAADCj9eRAAAB2ElEQVR4nO2aQY7EIAwEIeFP+6X9/33C3MPcKKSS1TygZRftNlLS2//fbJtn9KvvajAi17ZCM7Uzeg+TEyJhsh4TE8D25ZhYRMJkPSYmmZ0zIhfQEMPkJq74JpgQlUBMABkIrOV2KLMRItXMhrQjqcQUSszsbGuomFSbHULEAlblE0klor1zMaG0XwnDBDAsBVY0O4CIBizlE4ntEbCijK3mE8vKUPkEEIF8YslYje2RZFP5BJkdCxOonf1i6jEhRICOyjEBzFaPiWd2iChoYbKKhMkqgmSsh4kkHkU+6UyeACJEJaLZ6QQTzy7WtGPyicX2Kp/c+yKaATTliSWoTXsnPllEEtTLGX37f+7WRpuPQ4RhomlntCdMTohATIDbKceEaGfOD1BJZueIiImJZQBNTCxgw2Q91N7Zf7RBsxMmR0TqMdmvxPRmI0TmDJNVJExWkTBZRcJkFSnFZH6Q5aVhQrQzkYUOVEIxIXxSjAnRDjQ7mndsZud9VEwsPtFcsWjvaNZofHKoEpFPELCPJmORdqblMWxiYjEbw+QJk/dR+SQD+BbROFbEJAP4Q4RgQpiNCupKIhAT4gewakws7YTJIREoY4FPeNWYaNoJk18iQNqXY1LKJ1/07Ct/l+QCQgAAAABJRU5ErkJggg==" id="imaged6e0973c46" transform="scale(1 -1) translate(0 -244.8)" x="573.84" y="-74.16" width="12.24" height="244.8"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_21">
       <defs>
-       <path id="m4b5a4d1f21" d="M 0 0 
+       <path id="m494aba25a1" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m4b5a4d1f21" x="585.876562" y="282.022672" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m494aba25a1" x="585.876562" y="282.022672" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_117">
@@ -2097,7 +2097,7 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m4b5a4d1f21" x="585.876562" y="239.353777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m494aba25a1" x="585.876562" y="239.353777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_118">
@@ -2114,7 +2114,7 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m4b5a4d1f21" x="585.876562" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m494aba25a1" x="585.876562" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_119">
@@ -2130,7 +2130,7 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m4b5a4d1f21" x="585.876562" y="154.015985" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m494aba25a1" x="585.876562" y="154.015985" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_120">
@@ -2146,7 +2146,7 @@ z
     <g id="ytick_13">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m4b5a4d1f21" x="585.876562" y="111.347089" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m494aba25a1" x="585.876562" y="111.347089" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_121">
@@ -2739,8 +2739,8 @@ z
    </g>
   </g>
   <g id="text_124">
-   <!-- 2026-07-06T22:02:31Z  ·  Linux chungus2 x86_64  ·  commit ac74ebaf  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(44.919844 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-07T02:05:28Z  ·  Linux chungus2 x86_64  ·  commit 1a899305  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(43.462422 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2764,44 +2764,6 @@ L 1409 3309
 L 1409 2516 
 L 750 2516 
 L 750 3309 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-b7" d="M 684 2619 
-L 1344 2619 
-L 1344 1825 
-L 684 1825 
-L 684 2619 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-4c" d="M 628 4666 
-L 1259 4666 
-L 1259 531 
-L 3531 531 
-L 3531 0 
-L 628 0 
-L 628 4666 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-75" d="M 544 1381 
-L 544 3500 
-L 1119 3500 
-L 1119 1403 
-Q 1119 906 1312 657 
-Q 1506 409 1894 409 
-Q 2359 409 2629 706 
-Q 2900 1003 2900 1516 
-L 2900 3500 
-L 3475 3500 
-L 3475 0 
-L 2900 0 
-L 2900 538 
-Q 2691 219 2414 64 
-Q 2138 -91 1772 -91 
-Q 1169 -91 856 284 
-Q 544 659 544 1381 
-z
-M 1991 3584 
-L 1991 3584 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-38" d="M 2034 2216 
@@ -2843,6 +2805,44 @@ Q 1625 4250 1398 4047
 Q 1172 3844 1172 3481 
 z
 " transform="scale(0.015625)"/>
+     <path id="DejaVuSans-b7" d="M 684 2619 
+L 1344 2619 
+L 1344 1825 
+L 684 1825 
+L 684 2619 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-4c" d="M 628 4666 
+L 1259 4666 
+L 1259 531 
+L 3531 531 
+L 3531 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-75" d="M 544 1381 
+L 544 3500 
+L 1119 3500 
+L 1119 1403 
+Q 1119 906 1312 657 
+Q 1506 409 1894 409 
+Q 2359 409 2629 706 
+Q 2900 1003 2900 1516 
+L 2900 3500 
+L 3475 3500 
+L 3475 0 
+L 2900 0 
+L 2900 538 
+Q 2691 219 2414 64 
+Q 2138 -91 1772 -91 
+Q 1169 -91 856 284 
+Q 544 659 544 1381 
+z
+M 1991 3584 
+L 1991 3584 
+z
+" transform="scale(0.015625)"/>
      <path id="DejaVuSans-3b" d="M 750 3309 
 L 1409 3309 
 L 1409 2516 
@@ -2868,16 +2868,16 @@ z
     <use xlink:href="#DejaVuSans-37" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2917,109 +2917,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3133.154297 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3188.134766 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3251.757812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3315.380859 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3376.904297 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3440.380859 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3501.660156 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3536.865234 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3568.652344 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3600.439453 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3632.226562 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3664.013672 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3695.800781 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3723.583984 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3785.107422 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3846.386719 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3909.765625 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3973.242188 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4012.105469 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4073.287109 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4132.466797 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4193.990234 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4235.103516 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4268.794922 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4296.578125 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4358.101562 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4419.380859 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4482.759766 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4546.382812 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4580.074219 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4639.253906 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4702.876953 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4734.664062 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4798.287109 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4861.910156 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4893.697266 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4957.320312 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4993.404297 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5032.267578 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5087.248047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5150.871094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5182.658203 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5214.445312 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5246.232422 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5278.019531 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5309.806641 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5349.015625 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5412.394531 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5451.257812 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5512.439453 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5575.818359 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5639.294922 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5702.673828 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5766.150391 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5829.529297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5868.738281 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5900.525391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5984.314453 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6016.101562 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6113.513672 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6175.037109 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6238.513672 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6266.296875 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6327.576172 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6390.955078 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6422.742188 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6474.841797 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6538.220703 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6599.5 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6662.976562 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6715.076172 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6778.455078 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6839.636719 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6878.845703 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6912.537109 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6944.324219 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6985.4375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7046.716797 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7085.925781 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7113.708984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7174.890625 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7206.677734 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7234.460938 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7286.560547 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7318.347656 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7381.824219 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7443.347656 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7482.556641 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7544.080078 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7583.443359 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7680.855469 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7708.638672 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7772.017578 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7799.800781 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7851.900391 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7891.109375 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7918.892578 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3196.777344 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3260.400391 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3324.023438 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3387.646484 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3451.269531 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3514.892578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3578.515625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3610.302734 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3642.089844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3673.876953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3705.664062 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3737.451172 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3765.234375 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3826.757812 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3888.037109 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3951.416016 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4014.892578 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4053.755859 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4114.9375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4174.117188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4235.640625 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4276.753906 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4310.445312 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4338.228516 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4399.751953 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4461.03125 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4524.410156 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4588.033203 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4621.724609 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4680.904297 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4744.527344 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4776.314453 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4839.9375 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4903.560547 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4935.347656 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4998.970703 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5035.054688 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5073.917969 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5128.898438 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5192.521484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5224.308594 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5256.095703 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5287.882812 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5319.669922 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5351.457031 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5390.666016 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5454.044922 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5492.908203 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5554.089844 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5617.46875 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5680.945312 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5744.324219 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5807.800781 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5871.179688 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5910.388672 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5942.175781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6025.964844 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6057.751953 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6155.164062 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6216.6875 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6280.164062 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6307.947266 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6369.226562 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6432.605469 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6464.392578 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6516.492188 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6579.871094 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6641.150391 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6704.626953 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6756.726562 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6820.105469 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6881.287109 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6920.496094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6954.1875 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6985.974609 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7027.087891 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7088.367188 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7127.576172 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7155.359375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7216.541016 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7248.328125 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7276.111328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7328.210938 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7359.998047 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7423.474609 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7484.998047 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7524.207031 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7585.730469 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7625.09375 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7722.505859 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7750.289062 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7813.667969 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7841.451172 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7893.550781 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7932.759766 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7960.542969 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pefcf5685e6">
+  <clipPath id="p00b904c5ea">
    <rect x="95.67625" y="49.34175" width="468.141298" height="294.686261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_summary.svg
+++ b/bench/graphs/silesia_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="572.560313pt" height="386.202469pt" viewBox="0 0 572.560313 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="575.475156pt" height="386.202469pt" viewBox="0 0 575.475156 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,232 +22,232 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 386.202469 
-L 572.560313 386.202469 
-L 572.560313 0 
+L 575.475156 386.202469 
+L 575.475156 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 188.405156 104.1264 
-L 293.030156 104.1264 
-L 293.030156 74.7432 
-L 188.405156 74.7432 
+    <path d="M 189.862578 104.1264 
+L 294.487578 104.1264 
+L 294.487578 74.7432 
+L 189.862578 74.7432 
 z
-" clip-path="url(#p8ee2427d5d)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc239fd0050)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 293.030156 104.1264 
-L 397.655156 104.1264 
-L 397.655156 74.7432 
-L 293.030156 74.7432 
+    <path d="M 294.487578 104.1264 
+L 399.112578 104.1264 
+L 399.112578 74.7432 
+L 294.487578 74.7432 
 z
-" clip-path="url(#p8ee2427d5d)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc239fd0050)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 397.655156 104.1264 
-L 502.280156 104.1264 
-L 502.280156 74.7432 
-L 397.655156 74.7432 
+    <path d="M 399.112578 104.1264 
+L 503.737578 104.1264 
+L 503.737578 74.7432 
+L 399.112578 74.7432 
 z
-" clip-path="url(#p8ee2427d5d)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc239fd0050)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 188.405156 133.5096 
-L 293.030156 133.5096 
-L 293.030156 104.1264 
-L 188.405156 104.1264 
+    <path d="M 189.862578 133.5096 
+L 294.487578 133.5096 
+L 294.487578 104.1264 
+L 189.862578 104.1264 
 z
-" clip-path="url(#p8ee2427d5d)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc239fd0050)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 293.030156 133.5096 
-L 397.655156 133.5096 
-L 397.655156 104.1264 
-L 293.030156 104.1264 
+    <path d="M 294.487578 133.5096 
+L 399.112578 133.5096 
+L 399.112578 104.1264 
+L 294.487578 104.1264 
 z
-" clip-path="url(#p8ee2427d5d)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc239fd0050)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 397.655156 133.5096 
-L 502.280156 133.5096 
-L 502.280156 104.1264 
-L 397.655156 104.1264 
+    <path d="M 399.112578 133.5096 
+L 503.737578 133.5096 
+L 503.737578 104.1264 
+L 399.112578 104.1264 
 z
-" clip-path="url(#p8ee2427d5d)" style="fill: #fece7c; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc239fd0050)" style="fill: #fece7c; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 188.405156 162.8928 
-L 293.030156 162.8928 
-L 293.030156 133.5096 
-L 188.405156 133.5096 
+    <path d="M 189.862578 162.8928 
+L 294.487578 162.8928 
+L 294.487578 133.5096 
+L 189.862578 133.5096 
 z
-" clip-path="url(#p8ee2427d5d)" style="fill: #fee08b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc239fd0050)" style="fill: #fee08b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 293.030156 162.8928 
-L 397.655156 162.8928 
-L 397.655156 133.5096 
-L 293.030156 133.5096 
+    <path d="M 294.487578 162.8928 
+L 399.112578 162.8928 
+L 399.112578 133.5096 
+L 294.487578 133.5096 
 z
-" clip-path="url(#p8ee2427d5d)" style="fill: #feefa3; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc239fd0050)" style="fill: #feefa3; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 397.655156 162.8928 
-L 502.280156 162.8928 
-L 502.280156 133.5096 
-L 397.655156 133.5096 
+    <path d="M 399.112578 162.8928 
+L 503.737578 162.8928 
+L 503.737578 133.5096 
+L 399.112578 133.5096 
 z
-" clip-path="url(#p8ee2427d5d)" style="fill: #fdbf6f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc239fd0050)" style="fill: #fdbf6f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 188.405156 192.276 
-L 293.030156 192.276 
-L 293.030156 162.8928 
-L 188.405156 162.8928 
+    <path d="M 189.862578 192.276 
+L 294.487578 192.276 
+L 294.487578 162.8928 
+L 189.862578 162.8928 
 z
-" clip-path="url(#p8ee2427d5d)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc239fd0050)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 293.030156 192.276 
-L 397.655156 192.276 
-L 397.655156 162.8928 
-L 293.030156 162.8928 
+    <path d="M 294.487578 192.276 
+L 399.112578 192.276 
+L 399.112578 162.8928 
+L 294.487578 162.8928 
 z
-" clip-path="url(#p8ee2427d5d)" style="fill: #fede89; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc239fd0050)" style="fill: #fede89; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 397.655156 192.276 
-L 502.280156 192.276 
-L 502.280156 162.8928 
-L 397.655156 162.8928 
+    <path d="M 399.112578 192.276 
+L 503.737578 192.276 
+L 503.737578 162.8928 
+L 399.112578 162.8928 
 z
-" clip-path="url(#p8ee2427d5d)" style="fill: #f7814c; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc239fd0050)" style="fill: #f7814c; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 188.405156 221.6592 
-L 293.030156 221.6592 
-L 293.030156 192.276 
-L 188.405156 192.276 
+    <path d="M 189.862578 221.6592 
+L 294.487578 221.6592 
+L 294.487578 192.276 
+L 189.862578 192.276 
 z
-" clip-path="url(#p8ee2427d5d)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc239fd0050)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 293.030156 221.6592 
-L 397.655156 221.6592 
-L 397.655156 192.276 
-L 293.030156 192.276 
+    <path d="M 294.487578 221.6592 
+L 399.112578 221.6592 
+L 399.112578 192.276 
+L 294.487578 192.276 
 z
-" clip-path="url(#p8ee2427d5d)" style="fill: #fed27f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc239fd0050)" style="fill: #fed27f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 397.655156 221.6592 
-L 502.280156 221.6592 
-L 502.280156 192.276 
-L 397.655156 192.276 
+    <path d="M 399.112578 221.6592 
+L 503.737578 221.6592 
+L 503.737578 192.276 
+L 399.112578 192.276 
 z
-" clip-path="url(#p8ee2427d5d)" style="fill: #fffcba; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc239fd0050)" style="fill: #fffcba; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 188.405156 251.0424 
-L 293.030156 251.0424 
-L 293.030156 221.6592 
-L 188.405156 221.6592 
+    <path d="M 189.862578 251.0424 
+L 294.487578 251.0424 
+L 294.487578 221.6592 
+L 189.862578 221.6592 
 z
-" clip-path="url(#p8ee2427d5d)" style="fill: #fff3ac; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc239fd0050)" style="fill: #fff3ac; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 293.030156 251.0424 
-L 397.655156 251.0424 
-L 397.655156 221.6592 
-L 293.030156 221.6592 
+    <path d="M 294.487578 251.0424 
+L 399.112578 251.0424 
+L 399.112578 221.6592 
+L 294.487578 221.6592 
 z
-" clip-path="url(#p8ee2427d5d)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc239fd0050)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 397.655156 251.0424 
-L 502.280156 251.0424 
-L 502.280156 221.6592 
-L 397.655156 221.6592 
+    <path d="M 399.112578 251.0424 
+L 503.737578 251.0424 
+L 503.737578 221.6592 
+L 399.112578 221.6592 
 z
-" clip-path="url(#p8ee2427d5d)" style="fill: #e8f59f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc239fd0050)" style="fill: #e8f59f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 188.405156 280.4256 
-L 293.030156 280.4256 
-L 293.030156 251.0424 
-L 188.405156 251.0424 
+    <path d="M 189.862578 280.4256 
+L 294.487578 280.4256 
+L 294.487578 251.0424 
+L 189.862578 251.0424 
 z
-" clip-path="url(#p8ee2427d5d)" style="fill: #feec9f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc239fd0050)" style="fill: #feec9f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 293.030156 280.4256 
-L 397.655156 280.4256 
-L 397.655156 251.0424 
-L 293.030156 251.0424 
+    <path d="M 294.487578 280.4256 
+L 399.112578 280.4256 
+L 399.112578 251.0424 
+L 294.487578 251.0424 
 z
-" clip-path="url(#p8ee2427d5d)" style="fill: #fdbf6f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc239fd0050)" style="fill: #fdbf6f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 397.655156 280.4256 
-L 502.280156 280.4256 
-L 502.280156 251.0424 
-L 397.655156 251.0424 
+    <path d="M 399.112578 280.4256 
+L 503.737578 280.4256 
+L 503.737578 251.0424 
+L 399.112578 251.0424 
 z
-" clip-path="url(#p8ee2427d5d)" style="fill: #f88c51; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc239fd0050)" style="fill: #f88950; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 188.405156 309.8088 
-L 293.030156 309.8088 
-L 293.030156 280.4256 
-L 188.405156 280.4256 
+    <path d="M 189.862578 309.8088 
+L 294.487578 309.8088 
+L 294.487578 280.4256 
+L 189.862578 280.4256 
 z
-" clip-path="url(#p8ee2427d5d)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc239fd0050)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 293.030156 309.8088 
-L 397.655156 309.8088 
-L 397.655156 280.4256 
-L 293.030156 280.4256 
+    <path d="M 294.487578 309.8088 
+L 399.112578 309.8088 
+L 399.112578 280.4256 
+L 294.487578 280.4256 
 z
-" clip-path="url(#p8ee2427d5d)" style="fill: #fa9b58; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc239fd0050)" style="fill: #fa9b58; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 397.655156 309.8088 
-L 502.280156 309.8088 
-L 502.280156 280.4256 
-L 397.655156 280.4256 
+    <path d="M 399.112578 309.8088 
+L 503.737578 309.8088 
+L 503.737578 280.4256 
+L 399.112578 280.4256 
 z
-" clip-path="url(#p8ee2427d5d)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc239fd0050)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 188.405156 339.192 
-L 293.030156 339.192 
-L 293.030156 309.8088 
-L 188.405156 309.8088 
+    <path d="M 189.862578 339.192 
+L 294.487578 339.192 
+L 294.487578 309.8088 
+L 189.862578 309.8088 
 z
-" clip-path="url(#p8ee2427d5d)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc239fd0050)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 293.030156 339.192 
-L 397.655156 339.192 
-L 397.655156 309.8088 
-L 293.030156 309.8088 
+    <path d="M 294.487578 339.192 
+L 399.112578 339.192 
+L 399.112578 309.8088 
+L 294.487578 309.8088 
 z
-" clip-path="url(#p8ee2427d5d)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc239fd0050)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 397.655156 339.192 
-L 502.280156 339.192 
-L 502.280156 309.8088 
-L 397.655156 309.8088 
+    <path d="M 399.112578 339.192 
+L 503.737578 339.192 
+L 503.737578 309.8088 
+L 399.112578 309.8088 
 z
-" clip-path="url(#p8ee2427d5d)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc239fd0050)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(121.392422 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(122.849844 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(228.676641 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(230.134063 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(307.24875 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(308.706172 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(405.600469 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(407.057891 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(117.330156 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(118.787578 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.320 -->
-    <g transform="translate(229.266406 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(230.723828 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -918,7 +918,7 @@ z
    </g>
    <g id="text_7">
     <!-- 117 -->
-    <g transform="translate(337.707656 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(339.165078 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -952,7 +952,7 @@ z
    </g>
    <g id="text_8">
     <!-- 852 -->
-    <g transform="translate(442.332656 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(443.790078 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -1026,7 +1026,7 @@ z
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(111.968281 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(113.425703 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1125,7 +1125,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.324 -->
-    <g transform="translate(229.266406 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(230.723828 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1156,7 +1156,7 @@ z
    </g>
    <g id="text_11">
     <!-- 61 -->
-    <g transform="translate(340.252656 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(341.710078 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -1195,7 +1195,7 @@ z
    </g>
    <g id="text_12">
     <!-- 312 -->
-    <g transform="translate(442.332656 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(443.790078 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
@@ -1203,7 +1203,7 @@ z
    </g>
    <g id="text_13">
     <!-- Go compress/flate -->
-    <g transform="translate(99.661406 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(101.118828 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -1374,7 +1374,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.325 -->
-    <g transform="translate(229.266406 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(230.723828 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1384,14 +1384,14 @@ z
    </g>
    <g id="text_15">
     <!-- 50 -->
-    <g transform="translate(340.252656 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(341.710078 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
     <!-- 275 -->
-    <g transform="translate(442.332656 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(443.790078 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
@@ -1399,7 +1399,7 @@ z
    </g>
    <g id="text_17">
     <!-- JS fflate -->
-    <g transform="translate(120.693906 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(122.151328 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1459,7 +1459,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.329 -->
-    <g transform="translate(229.266406 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(230.723828 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-39" d="M 703 97 
 L 703 672 
@@ -1501,14 +1501,14 @@ z
    </g>
    <g id="text_19">
     <!-- 41 -->
-    <g transform="translate(340.252656 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(341.710078 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
     <!-- 160 -->
-    <g transform="translate(442.332656 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(443.790078 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -1516,7 +1516,7 @@ z
    </g>
    <g id="text_21">
     <!-- zlib -->
-    <g transform="translate(129.231406 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(130.688828 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1540,7 +1540,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.323 -->
-    <g transform="translate(229.266406 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(230.723828 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1550,14 +1550,14 @@ z
    </g>
    <g id="text_23">
     <!-- 38 -->
-    <g transform="translate(340.252656 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(341.710078 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_24">
     <!-- 448 -->
-    <g transform="translate(442.332656 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(443.790078 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(127.246094 0)"/>
@@ -1565,7 +1565,7 @@ z
    </g>
    <g id="text_25">
     <!-- miniz_oxide -->
-    <g transform="translate(112.537656 238.44705) scale(0.08 -0.08)">
+    <g transform="translate(113.995078 238.44705) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6e" d="M 3513 2113 
 L 3513 0 
@@ -1624,7 +1624,7 @@ z
    </g>
    <g id="text_26">
     <!-- 0.322 -->
-    <g transform="translate(229.266406 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(230.723828 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1634,14 +1634,14 @@ z
    </g>
    <g id="text_27">
     <!-- 36 -->
-    <g transform="translate(340.252656 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(341.710078 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_28">
     <!-- 527 -->
-    <g transform="translate(442.332656 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(443.790078 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
@@ -1649,7 +1649,7 @@ z
    </g>
    <g id="text_29">
     <!-- lean-zip (native) -->
-    <g transform="translate(99.039531 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(100.496953 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1758,7 +1758,7 @@ z
    </g>
    <g id="text_30">
     <!-- 0.323 -->
-    <g transform="translate(228.065781 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(229.523203 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1852,7 +1852,7 @@ z
    </g>
    <g id="text_31">
     <!-- 31 -->
-    <g transform="translate(339.776406 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(341.233828 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-31" d="M 750 831 
 L 1813 831 
@@ -1874,8 +1874,8 @@ z
     </g>
    </g>
    <g id="text_32">
-    <!-- 177 -->
-    <g transform="translate(441.618281 267.9415) scale(0.08 -0.08)">
+    <!-- 176 -->
+    <g transform="translate(443.075703 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-37" d="M 428 4666 
 L 3944 4666 
@@ -1887,15 +1887,45 @@ L 428 3781
 L 428 4666 
 z
 " transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-36" d="M 2316 2303 
+Q 2000 2303 1842 2098 
+Q 1684 1894 1684 1484 
+Q 1684 1075 1842 870 
+Q 2000 666 2316 666 
+Q 2634 666 2792 870 
+Q 2950 1075 2950 1484 
+Q 2950 1894 2792 2098 
+Q 2634 2303 2316 2303 
+z
+M 3803 4544 
+L 3803 3681 
+Q 3506 3822 3243 3889 
+Q 2981 3956 2731 3956 
+Q 2194 3956 1894 3657 
+Q 1594 3359 1544 2772 
+Q 1750 2925 1990 3001 
+Q 2231 3078 2516 3078 
+Q 3231 3078 3670 2659 
+Q 4109 2241 4109 1563 
+Q 4109 813 3618 361 
+Q 3128 -91 2303 -91 
+Q 1394 -91 895 523 
+Q 397 1138 397 2266 
+Q 397 3422 980 4083 
+Q 1563 4744 2578 4744 
+Q 2900 4744 3203 4694 
+Q 3506 4644 3803 4544 
+z
+" transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-Bold-31"/>
      <use xlink:href="#DejaVuSans-Bold-37" transform="translate(69.580078 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-37" transform="translate(139.160156 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-36" transform="translate(139.160156 0)"/>
     </g>
    </g>
    <g id="text_33">
     <!-- OCaml decompress -->
-    <g transform="translate(97.154531 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(98.611953 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -1960,7 +1990,7 @@ z
    </g>
    <g id="text_34">
     <!-- 0.336 -->
-    <g transform="translate(229.266406 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(230.723828 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1970,21 +2000,21 @@ z
    </g>
    <g id="text_35">
     <!-- 21 -->
-    <g transform="translate(340.252656 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(341.710078 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_36">
     <!-- 69 -->
-    <g transform="translate(444.877656 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(446.335078 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-36"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(125.375781 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(126.833203 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -1995,7 +2025,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.303 -->
-    <g transform="translate(229.266406 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(230.723828 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -2005,13 +2035,13 @@ z
    </g>
    <g id="text_39">
     <!-- 1 -->
-    <g transform="translate(342.797656 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(344.255078 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(445.967656 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(447.425078 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2027,7 +2057,7 @@ z
   </g>
   <g id="text_41">
    <!-- silesia — geomean over files, level 6 -->
-   <g transform="translate(152.881875 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(154.339297 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-2014" d="M 344 2156 
 L 6056 2156 
@@ -2100,36 +2130,6 @@ L 653 256
 L 653 1209 
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Bold-36" d="M 2316 2303 
-Q 2000 2303 1842 2098 
-Q 1684 1894 1684 1484 
-Q 1684 1075 1842 870 
-Q 2000 666 2316 666 
-Q 2634 666 2792 870 
-Q 2950 1075 2950 1484 
-Q 2950 1894 2792 2098 
-Q 2634 2303 2316 2303 
-z
-M 3803 4544 
-L 3803 3681 
-Q 3506 3822 3243 3889 
-Q 2981 3956 2731 3956 
-Q 2194 3956 1894 3657 
-Q 1594 3359 1544 2772 
-Q 1750 2925 1990 3001 
-Q 2231 3078 2516 3078 
-Q 3231 3078 3670 2659 
-Q 4109 2241 4109 1563 
-Q 4109 813 3618 361 
-Q 3128 -91 2303 -91 
-Q 1394 -91 895 523 
-Q 397 1138 397 2266 
-Q 397 3422 980 4083 
-Q 1563 4744 2578 4744 
-Q 2900 4744 3203 4694 
-Q 3506 4644 3803 4544 
-z
-" transform="scale(0.015625)"/>
     </defs>
     <use xlink:href="#DejaVuSans-Bold-73"/>
     <use xlink:href="#DejaVuSans-Bold-69" transform="translate(59.521484 0)"/>
@@ -2171,7 +2171,7 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-07-06T22:02:31Z  ·  Linux chungus2 x86_64  ·  commit ac74ebaf  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-07-07T02:05:28Z  ·  Linux chungus2 x86_64  ·  commit 1a899305  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2310,16 +2310,16 @@ z
     <use xlink:href="#DejaVuSans-37" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2359,110 +2359,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3133.154297 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3188.134766 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3251.757812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3315.380859 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3376.904297 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3440.380859 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3501.660156 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3536.865234 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3568.652344 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3600.439453 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3632.226562 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3664.013672 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3695.800781 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3723.583984 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3785.107422 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3846.386719 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3909.765625 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3973.242188 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4012.105469 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4073.287109 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4132.466797 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4193.990234 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4235.103516 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4268.794922 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4296.578125 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4358.101562 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4419.380859 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4482.759766 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4546.382812 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4580.074219 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4639.253906 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4702.876953 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4734.664062 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4798.287109 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4861.910156 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4893.697266 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4957.320312 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4993.404297 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5032.267578 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5087.248047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5150.871094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5182.658203 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5214.445312 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5246.232422 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5278.019531 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5309.806641 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5349.015625 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5412.394531 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5451.257812 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5512.439453 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5575.818359 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5639.294922 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5702.673828 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5766.150391 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5829.529297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5868.738281 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5900.525391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5984.314453 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6016.101562 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6113.513672 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6175.037109 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6238.513672 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6266.296875 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6327.576172 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6390.955078 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6422.742188 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6474.841797 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6538.220703 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6599.5 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6662.976562 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6715.076172 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6778.455078 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6839.636719 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6878.845703 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6912.537109 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6944.324219 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6985.4375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7046.716797 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7085.925781 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7113.708984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7174.890625 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7206.677734 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7234.460938 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7286.560547 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7318.347656 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7381.824219 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7443.347656 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7482.556641 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7544.080078 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7583.443359 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7680.855469 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7708.638672 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7772.017578 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7799.800781 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7851.900391 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7891.109375 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7918.892578 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3196.777344 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3260.400391 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3324.023438 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3387.646484 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3451.269531 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3514.892578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3578.515625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3610.302734 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3642.089844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3673.876953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3705.664062 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3737.451172 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3765.234375 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3826.757812 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3888.037109 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3951.416016 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4014.892578 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4053.755859 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4114.9375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4174.117188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4235.640625 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4276.753906 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4310.445312 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4338.228516 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4399.751953 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4461.03125 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4524.410156 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4588.033203 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4621.724609 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4680.904297 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4744.527344 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4776.314453 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4839.9375 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4903.560547 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4935.347656 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4998.970703 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5035.054688 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5073.917969 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5128.898438 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5192.521484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5224.308594 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5256.095703 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5287.882812 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5319.669922 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5351.457031 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5390.666016 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5454.044922 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5492.908203 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5554.089844 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5617.46875 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5680.945312 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5744.324219 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5807.800781 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5871.179688 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5910.388672 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5942.175781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6025.964844 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6057.751953 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6155.164062 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6216.6875 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6280.164062 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6307.947266 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6369.226562 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6432.605469 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6464.392578 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6516.492188 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6579.871094 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6641.150391 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6704.626953 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6756.726562 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6820.105469 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6881.287109 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6920.496094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6954.1875 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6985.974609 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7027.087891 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7088.367188 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7127.576172 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7155.359375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7216.541016 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7248.328125 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7276.111328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7328.210938 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7359.998047 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7423.474609 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7484.998047 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7524.207031 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7585.730469 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7625.09375 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7722.505859 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7750.289062 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7813.667969 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7841.451172 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7893.550781 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7932.759766 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7960.542969 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p8ee2427d5d">
-   <rect x="83.780156" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="pc239fd0050">
+   <rect x="85.237578" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/results/latest.json
+++ b/bench/results/latest.json
@@ -1,8 +1,8 @@
 {
  "meta": {
-  "date": "2026-07-06T22:02:31Z",
+  "date": "2026-07-07T02:05:28Z",
   "machine": "Linux chungus2 x86_64",
-  "git_commit": "ac74ebaf",
+  "git_commit": "1a899305",
   "toolchain": "leanprover/lean4:v4.30.0-rc2",
   "note": "compress_mbps/decompress_mbps are a median-of-5 snapshot on the machine above; ratio is deterministic"
  },
@@ -14,8 +14,8 @@
    "level": 1,
    "out_size": 60455,
    "ratio": 0.3975,
-   "compress_mbps": 67.58,
-   "decompress_mbps": 109.67
+   "compress_mbps": 67.22,
+   "decompress_mbps": 109.18
   },
   {
    "compressor": "native",
@@ -24,8 +24,8 @@
    "level": 2,
    "out_size": 56316,
    "ratio": 0.3703,
-   "compress_mbps": 48.81,
-   "decompress_mbps": 121.48
+   "compress_mbps": 48.8,
+   "decompress_mbps": 120.91
   },
   {
    "compressor": "native",
@@ -34,8 +34,8 @@
    "level": 3,
    "out_size": 55646,
    "ratio": 0.3659,
-   "compress_mbps": 43.09,
-   "decompress_mbps": 132.08
+   "compress_mbps": 42.97,
+   "decompress_mbps": 131.75
   },
   {
    "compressor": "native",
@@ -44,8 +44,8 @@
    "level": 4,
    "out_size": 54357,
    "ratio": 0.3574,
-   "compress_mbps": 34.38,
-   "decompress_mbps": 135.76
+   "compress_mbps": 34.2,
+   "decompress_mbps": 135.12
   },
   {
    "compressor": "native",
@@ -54,8 +54,8 @@
    "level": 5,
    "out_size": 54078,
    "ratio": 0.3556,
-   "compress_mbps": 27.57,
-   "decompress_mbps": 143.23
+   "compress_mbps": 27.67,
+   "decompress_mbps": 142.1
   },
   {
    "compressor": "native",
@@ -64,8 +64,8 @@
    "level": 6,
    "out_size": 54013,
    "ratio": 0.3551,
-   "compress_mbps": 26.24,
-   "decompress_mbps": 147.32
+   "compress_mbps": 26.29,
+   "decompress_mbps": 146.61
   },
   {
    "compressor": "native",
@@ -74,8 +74,8 @@
    "level": 7,
    "out_size": 53772,
    "ratio": 0.3536,
-   "compress_mbps": 22.18,
-   "decompress_mbps": 148.27
+   "compress_mbps": 22.24,
+   "decompress_mbps": 147.94
   },
   {
    "compressor": "native",
@@ -84,8 +84,8 @@
    "level": 8,
    "out_size": 53753,
    "ratio": 0.3534,
-   "compress_mbps": 21.25,
-   "decompress_mbps": 148.93
+   "compress_mbps": 21.33,
+   "decompress_mbps": 148.36
   },
   {
    "compressor": "native",
@@ -94,8 +94,8 @@
    "level": 9,
    "out_size": 52732,
    "ratio": 0.3467,
-   "compress_mbps": 4.08,
-   "decompress_mbps": 148.86
+   "compress_mbps": 4.11,
+   "decompress_mbps": 148.06
   },
   {
    "compressor": "native",
@@ -114,8 +114,8 @@
    "level": 1,
    "out_size": 53135,
    "ratio": 0.4245,
-   "compress_mbps": 62.16,
-   "decompress_mbps": 102.99
+   "compress_mbps": 61.58,
+   "decompress_mbps": 103.34
   },
   {
    "compressor": "native",
@@ -124,8 +124,8 @@
    "level": 2,
    "out_size": 50187,
    "ratio": 0.4009,
-   "compress_mbps": 46.35,
-   "decompress_mbps": 110.46
+   "compress_mbps": 45.75,
+   "decompress_mbps": 110.86
   },
   {
    "compressor": "native",
@@ -134,8 +134,8 @@
    "level": 3,
    "out_size": 49810,
    "ratio": 0.3979,
-   "compress_mbps": 41.97,
-   "decompress_mbps": 119.62
+   "compress_mbps": 41.35,
+   "decompress_mbps": 120.03
   },
   {
    "compressor": "native",
@@ -144,8 +144,8 @@
    "level": 4,
    "out_size": 48687,
    "ratio": 0.3889,
-   "compress_mbps": 32.44,
-   "decompress_mbps": 124.25
+   "compress_mbps": 32.23,
+   "decompress_mbps": 124.37
   },
   {
    "compressor": "native",
@@ -154,8 +154,8 @@
    "level": 5,
    "out_size": 48586,
    "ratio": 0.3881,
-   "compress_mbps": 28.12,
-   "decompress_mbps": 128.34
+   "compress_mbps": 27.91,
+   "decompress_mbps": 130.39
   },
   {
    "compressor": "native",
@@ -164,8 +164,8 @@
    "level": 6,
    "out_size": 48373,
    "ratio": 0.3864,
-   "compress_mbps": 25.25,
-   "decompress_mbps": 133.05
+   "compress_mbps": 25.14,
+   "decompress_mbps": 133.16
   },
   {
    "compressor": "native",
@@ -174,8 +174,8 @@
    "level": 7,
    "out_size": 48288,
    "ratio": 0.3858,
-   "compress_mbps": 23.1,
-   "decompress_mbps": 133.55
+   "compress_mbps": 22.99,
+   "decompress_mbps": 133.13
   },
   {
    "compressor": "native",
@@ -184,8 +184,8 @@
    "level": 8,
    "out_size": 48284,
    "ratio": 0.3857,
-   "compress_mbps": 22.8,
-   "decompress_mbps": 133.9
+   "compress_mbps": 22.76,
+   "decompress_mbps": 133.62
   },
   {
    "compressor": "native",
@@ -194,8 +194,8 @@
    "level": 9,
    "out_size": 47430,
    "ratio": 0.3789,
-   "compress_mbps": 4.5,
-   "decompress_mbps": 134.06
+   "compress_mbps": 4.47,
+   "decompress_mbps": 133.68
   },
   {
    "compressor": "native",
@@ -204,7 +204,7 @@
    "level": 10,
    "out_size": 46865,
    "ratio": 0.3744,
-   "compress_mbps": 2.71,
+   "compress_mbps": 2.67,
    "decompress_mbps": null
   },
   {
@@ -214,8 +214,8 @@
    "level": 1,
    "out_size": 8476,
    "ratio": 0.3445,
-   "compress_mbps": 61.29,
-   "decompress_mbps": 123.09
+   "compress_mbps": 61.26,
+   "decompress_mbps": 123.0
   },
   {
    "compressor": "native",
@@ -224,8 +224,8 @@
    "level": 2,
    "out_size": 8271,
    "ratio": 0.3362,
-   "compress_mbps": 51.16,
-   "decompress_mbps": 126.4
+   "compress_mbps": 49.86,
+   "decompress_mbps": 126.95
   },
   {
    "compressor": "native",
@@ -234,8 +234,8 @@
    "level": 3,
    "out_size": 8158,
    "ratio": 0.3316,
-   "compress_mbps": 49.03,
-   "decompress_mbps": 130.1
+   "compress_mbps": 48.13,
+   "decompress_mbps": 130.01
   },
   {
    "compressor": "native",
@@ -244,8 +244,8 @@
    "level": 4,
    "out_size": 7948,
    "ratio": 0.3231,
-   "compress_mbps": 43.89,
-   "decompress_mbps": 136.12
+   "compress_mbps": 43.22,
+   "decompress_mbps": 136.0
   },
   {
    "compressor": "native",
@@ -254,8 +254,8 @@
    "level": 5,
    "out_size": 7899,
    "ratio": 0.3211,
-   "compress_mbps": 37.43,
-   "decompress_mbps": 140.55
+   "compress_mbps": 37.04,
+   "decompress_mbps": 140.25
   },
   {
    "compressor": "native",
@@ -264,8 +264,8 @@
    "level": 6,
    "out_size": 7912,
    "ratio": 0.3216,
-   "compress_mbps": 36.83,
-   "decompress_mbps": 141.14
+   "compress_mbps": 36.45,
+   "decompress_mbps": 141.59
   },
   {
    "compressor": "native",
@@ -274,8 +274,8 @@
    "level": 7,
    "out_size": 7897,
    "ratio": 0.321,
-   "compress_mbps": 33.3,
-   "decompress_mbps": 143.92
+   "compress_mbps": 33.25,
+   "decompress_mbps": 143.05
   },
   {
    "compressor": "native",
@@ -284,8 +284,8 @@
    "level": 8,
    "out_size": 7897,
    "ratio": 0.321,
-   "compress_mbps": 33.48,
-   "decompress_mbps": 143.94
+   "compress_mbps": 33.33,
+   "decompress_mbps": 141.37
   },
   {
    "compressor": "native",
@@ -294,8 +294,8 @@
    "level": 9,
    "out_size": 7803,
    "ratio": 0.3172,
-   "compress_mbps": 4.71,
-   "decompress_mbps": 143.89
+   "compress_mbps": 4.64,
+   "decompress_mbps": 141.62
   },
   {
    "compressor": "native",
@@ -304,7 +304,7 @@
    "level": 10,
    "out_size": 7737,
    "ratio": 0.3145,
-   "compress_mbps": 2.8,
+   "compress_mbps": 2.78,
    "decompress_mbps": null
   },
   {
@@ -314,8 +314,8 @@
    "level": 1,
    "out_size": 3509,
    "ratio": 0.3147,
-   "compress_mbps": 46.64,
-   "decompress_mbps": 99.48
+   "compress_mbps": 46.78,
+   "decompress_mbps": 98.8
   },
   {
    "compressor": "native",
@@ -324,8 +324,8 @@
    "level": 2,
    "out_size": 3269,
    "ratio": 0.2932,
-   "compress_mbps": 40.49,
-   "decompress_mbps": 102.71
+   "compress_mbps": 40.66,
+   "decompress_mbps": 100.97
   },
   {
    "compressor": "native",
@@ -334,8 +334,8 @@
    "level": 3,
    "out_size": 3208,
    "ratio": 0.2877,
-   "compress_mbps": 39.19,
-   "decompress_mbps": 106.16
+   "compress_mbps": 39.53,
+   "decompress_mbps": 105.6
   },
   {
    "compressor": "native",
@@ -344,8 +344,8 @@
    "level": 4,
    "out_size": 3128,
    "ratio": 0.2805,
-   "compress_mbps": 36.64,
-   "decompress_mbps": 108.38
+   "compress_mbps": 36.69,
+   "decompress_mbps": 107.41
   },
   {
    "compressor": "native",
@@ -354,8 +354,8 @@
    "level": 5,
    "out_size": 3111,
    "ratio": 0.279,
-   "compress_mbps": 32.81,
-   "decompress_mbps": 110.66
+   "compress_mbps": 32.93,
+   "decompress_mbps": 109.54
   },
   {
    "compressor": "native",
@@ -364,8 +364,8 @@
    "level": 6,
    "out_size": 3119,
    "ratio": 0.2797,
-   "compress_mbps": 32.97,
-   "decompress_mbps": 111.38
+   "compress_mbps": 33.17,
+   "decompress_mbps": 110.51
   },
   {
    "compressor": "native",
@@ -374,8 +374,8 @@
    "level": 7,
    "out_size": 3111,
    "ratio": 0.279,
-   "compress_mbps": 31.02,
-   "decompress_mbps": 111.8
+   "compress_mbps": 31.13,
+   "decompress_mbps": 110.96
   },
   {
    "compressor": "native",
@@ -384,8 +384,8 @@
    "level": 8,
    "out_size": 3111,
    "ratio": 0.279,
-   "compress_mbps": 30.76,
-   "decompress_mbps": 111.69
+   "compress_mbps": 31.06,
+   "decompress_mbps": 110.86
   },
   {
    "compressor": "native",
@@ -394,8 +394,8 @@
    "level": 9,
    "out_size": 3056,
    "ratio": 0.2741,
-   "compress_mbps": 5.22,
-   "decompress_mbps": 111.23
+   "compress_mbps": 5.2,
+   "decompress_mbps": 110.52
   },
   {
    "compressor": "native",
@@ -404,7 +404,7 @@
    "level": 10,
    "out_size": 3032,
    "ratio": 0.2719,
-   "compress_mbps": 2.94,
+   "compress_mbps": 2.9,
    "decompress_mbps": null
   },
   {
@@ -414,8 +414,8 @@
    "level": 1,
    "out_size": 1282,
    "ratio": 0.3445,
-   "compress_mbps": 24.31,
-   "decompress_mbps": 56.33
+   "compress_mbps": 24.34,
+   "decompress_mbps": 56.31
   },
   {
    "compressor": "native",
@@ -424,8 +424,8 @@
    "level": 2,
    "out_size": 1225,
    "ratio": 0.3292,
-   "compress_mbps": 23.25,
-   "decompress_mbps": 57.28
+   "compress_mbps": 22.93,
+   "decompress_mbps": 57.01
   },
   {
    "compressor": "native",
@@ -434,8 +434,8 @@
    "level": 3,
    "out_size": 1220,
    "ratio": 0.3279,
-   "compress_mbps": 22.99,
-   "decompress_mbps": 57.55
+   "compress_mbps": 22.62,
+   "decompress_mbps": 56.87
   },
   {
    "compressor": "native",
@@ -444,8 +444,8 @@
    "level": 4,
    "out_size": 1213,
    "ratio": 0.326,
-   "compress_mbps": 22.42,
-   "decompress_mbps": 58.71
+   "compress_mbps": 22.21,
+   "decompress_mbps": 58.11
   },
   {
    "compressor": "native",
@@ -454,8 +454,8 @@
    "level": 5,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 21.61,
-   "decompress_mbps": 59.09
+   "compress_mbps": 21.33,
+   "decompress_mbps": 58.8
   },
   {
    "compressor": "native",
@@ -464,8 +464,8 @@
    "level": 6,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 21.16,
-   "decompress_mbps": 59.4
+   "compress_mbps": 21.06,
+   "decompress_mbps": 58.77
   },
   {
    "compressor": "native",
@@ -474,8 +474,8 @@
    "level": 7,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 21.04,
-   "decompress_mbps": 59.26
+   "compress_mbps": 20.84,
+   "decompress_mbps": 58.9
   },
   {
    "compressor": "native",
@@ -484,8 +484,8 @@
    "level": 8,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 21.04,
-   "decompress_mbps": 59.32
+   "compress_mbps": 20.87,
+   "decompress_mbps": 58.8
   },
   {
    "compressor": "native",
@@ -494,8 +494,8 @@
    "level": 9,
    "out_size": 1205,
    "ratio": 0.3238,
-   "compress_mbps": 4.79,
-   "decompress_mbps": 59.11
+   "compress_mbps": 4.75,
+   "decompress_mbps": 58.76
   },
   {
    "compressor": "native",
@@ -504,7 +504,7 @@
    "level": 10,
    "out_size": 1191,
    "ratio": 0.3201,
-   "compress_mbps": 2.87,
+   "compress_mbps": 2.83,
    "decompress_mbps": null
   },
   {
@@ -514,8 +514,8 @@
    "level": 1,
    "out_size": 251793,
    "ratio": 0.2445,
-   "compress_mbps": 128.44,
-   "decompress_mbps": 199.77
+   "compress_mbps": 129.53,
+   "decompress_mbps": 203.89
   },
   {
    "compressor": "native",
@@ -524,8 +524,8 @@
    "level": 2,
    "out_size": 242565,
    "ratio": 0.2356,
-   "compress_mbps": 89.53,
-   "decompress_mbps": 215.7
+   "compress_mbps": 89.75,
+   "decompress_mbps": 218.38
   },
   {
    "compressor": "native",
@@ -534,8 +534,8 @@
    "level": 3,
    "out_size": 242532,
    "ratio": 0.2355,
-   "compress_mbps": 76.7,
-   "decompress_mbps": 224.75
+   "compress_mbps": 76.33,
+   "decompress_mbps": 226.74
   },
   {
    "compressor": "native",
@@ -544,8 +544,8 @@
    "level": 4,
    "out_size": 239953,
    "ratio": 0.233,
-   "compress_mbps": 74.11,
-   "decompress_mbps": 232.53
+   "compress_mbps": 73.66,
+   "decompress_mbps": 233.53
   },
   {
    "compressor": "native",
@@ -554,8 +554,8 @@
    "level": 5,
    "out_size": 218565,
    "ratio": 0.2123,
-   "compress_mbps": 49.28,
-   "decompress_mbps": 229.19
+   "compress_mbps": 49.77,
+   "decompress_mbps": 231.63
   },
   {
    "compressor": "native",
@@ -564,8 +564,8 @@
    "level": 6,
    "out_size": 202676,
    "ratio": 0.1968,
-   "compress_mbps": 37.28,
-   "decompress_mbps": 236.44
+   "compress_mbps": 37.12,
+   "decompress_mbps": 237.54
   },
   {
    "compressor": "native",
@@ -574,8 +574,8 @@
    "level": 7,
    "out_size": 201403,
    "ratio": 0.1956,
-   "compress_mbps": 27.59,
-   "decompress_mbps": 238.68
+   "compress_mbps": 27.5,
+   "decompress_mbps": 239.92
   },
   {
    "compressor": "native",
@@ -584,8 +584,8 @@
    "level": 8,
    "out_size": 200798,
    "ratio": 0.195,
-   "compress_mbps": 21.01,
-   "decompress_mbps": 243.0
+   "compress_mbps": 20.99,
+   "decompress_mbps": 242.41
   },
   {
    "compressor": "native",
@@ -594,8 +594,8 @@
    "level": 9,
    "out_size": 182508,
    "ratio": 0.1772,
-   "compress_mbps": 3.37,
-   "decompress_mbps": 243.85
+   "compress_mbps": 3.31,
+   "decompress_mbps": 243.82
   },
   {
    "compressor": "native",
@@ -614,8 +614,8 @@
    "level": 1,
    "out_size": 160674,
    "ratio": 0.3765,
-   "compress_mbps": 73.43,
-   "decompress_mbps": 117.36
+   "compress_mbps": 73.24,
+   "decompress_mbps": 116.61
   },
   {
    "compressor": "native",
@@ -624,8 +624,8 @@
    "level": 2,
    "out_size": 149787,
    "ratio": 0.351,
-   "compress_mbps": 52.38,
-   "decompress_mbps": 125.96
+   "compress_mbps": 51.47,
+   "decompress_mbps": 125.79
   },
   {
    "compressor": "native",
@@ -634,8 +634,8 @@
    "level": 3,
    "out_size": 148055,
    "ratio": 0.3469,
-   "compress_mbps": 46.44,
-   "decompress_mbps": 138.47
+   "compress_mbps": 45.44,
+   "decompress_mbps": 138.43
   },
   {
    "compressor": "native",
@@ -644,8 +644,8 @@
    "level": 4,
    "out_size": 144750,
    "ratio": 0.3392,
-   "compress_mbps": 36.81,
-   "decompress_mbps": 143.03
+   "compress_mbps": 36.75,
+   "decompress_mbps": 142.63
   },
   {
    "compressor": "native",
@@ -654,8 +654,8 @@
    "level": 5,
    "out_size": 144408,
    "ratio": 0.3384,
-   "compress_mbps": 29.75,
-   "decompress_mbps": 150.73
+   "compress_mbps": 29.71,
+   "decompress_mbps": 150.03
   },
   {
    "compressor": "native",
@@ -664,8 +664,8 @@
    "level": 6,
    "out_size": 144070,
    "ratio": 0.3376,
-   "compress_mbps": 28.05,
-   "decompress_mbps": 154.17
+   "compress_mbps": 27.98,
+   "decompress_mbps": 153.71
   },
   {
    "compressor": "native",
@@ -674,8 +674,8 @@
    "level": 7,
    "out_size": 143628,
    "ratio": 0.3366,
-   "compress_mbps": 24.07,
-   "decompress_mbps": 153.36
+   "compress_mbps": 23.81,
+   "decompress_mbps": 154.4
   },
   {
    "compressor": "native",
@@ -684,8 +684,8 @@
    "level": 8,
    "out_size": 143569,
    "ratio": 0.3364,
-   "compress_mbps": 23.35,
-   "decompress_mbps": 155.29
+   "compress_mbps": 23.11,
+   "decompress_mbps": 154.16
   },
   {
    "compressor": "native",
@@ -694,8 +694,8 @@
    "level": 9,
    "out_size": 140322,
    "ratio": 0.3288,
-   "compress_mbps": 4.15,
-   "decompress_mbps": 156.03
+   "compress_mbps": 4.08,
+   "decompress_mbps": 155.28
   },
   {
    "compressor": "native",
@@ -704,7 +704,7 @@
    "level": 10,
    "out_size": 138830,
    "ratio": 0.3253,
-   "compress_mbps": 2.41,
+   "compress_mbps": 2.38,
    "decompress_mbps": null
   },
   {
@@ -714,8 +714,8 @@
    "level": 1,
    "out_size": 212588,
    "ratio": 0.4412,
-   "compress_mbps": 62.68,
-   "decompress_mbps": 97.45
+   "compress_mbps": 62.42,
+   "decompress_mbps": 97.01
   },
   {
    "compressor": "native",
@@ -724,8 +724,8 @@
    "level": 2,
    "out_size": 199981,
    "ratio": 0.415,
-   "compress_mbps": 45.04,
-   "decompress_mbps": 106.08
+   "compress_mbps": 44.2,
+   "decompress_mbps": 105.76
   },
   {
    "compressor": "native",
@@ -734,8 +734,8 @@
    "level": 3,
    "out_size": 198551,
    "ratio": 0.4121,
-   "compress_mbps": 39.97,
-   "decompress_mbps": 116.1
+   "compress_mbps": 38.94,
+   "decompress_mbps": 115.1
   },
   {
    "compressor": "native",
@@ -744,8 +744,8 @@
    "level": 4,
    "out_size": 193783,
    "ratio": 0.4022,
-   "compress_mbps": 29.43,
-   "decompress_mbps": 120.01
+   "compress_mbps": 29.28,
+   "decompress_mbps": 119.1
   },
   {
    "compressor": "native",
@@ -754,8 +754,8 @@
    "level": 5,
    "out_size": 193223,
    "ratio": 0.401,
-   "compress_mbps": 24.68,
-   "decompress_mbps": 126.14
+   "compress_mbps": 24.6,
+   "decompress_mbps": 125.4
   },
   {
    "compressor": "native",
@@ -764,8 +764,8 @@
    "level": 6,
    "out_size": 193416,
    "ratio": 0.4014,
-   "compress_mbps": 24.22,
-   "decompress_mbps": 130.42
+   "compress_mbps": 23.88,
+   "decompress_mbps": 128.73
   },
   {
    "compressor": "native",
@@ -774,8 +774,8 @@
    "level": 7,
    "out_size": 192664,
    "ratio": 0.3998,
-   "compress_mbps": 20.46,
-   "decompress_mbps": 130.4
+   "compress_mbps": 20.28,
+   "decompress_mbps": 128.97
   },
   {
    "compressor": "native",
@@ -784,8 +784,8 @@
    "level": 8,
    "out_size": 192638,
    "ratio": 0.3998,
-   "compress_mbps": 19.88,
-   "decompress_mbps": 130.35
+   "compress_mbps": 19.65,
+   "decompress_mbps": 129.82
   },
   {
    "compressor": "native",
@@ -794,8 +794,8 @@
    "level": 9,
    "out_size": 189365,
    "ratio": 0.393,
-   "compress_mbps": 3.96,
-   "decompress_mbps": 130.67
+   "compress_mbps": 3.9,
+   "decompress_mbps": 129.92
   },
   {
    "compressor": "native",
@@ -804,7 +804,7 @@
    "level": 10,
    "out_size": 186147,
    "ratio": 0.3863,
-   "compress_mbps": 2.37,
+   "compress_mbps": 2.34,
    "decompress_mbps": null
   },
   {
@@ -814,8 +814,8 @@
    "level": 1,
    "out_size": 60161,
    "ratio": 0.1172,
-   "compress_mbps": 209.22,
-   "decompress_mbps": 341.14
+   "compress_mbps": 206.75,
+   "decompress_mbps": 336.1
   },
   {
    "compressor": "native",
@@ -824,8 +824,8 @@
    "level": 2,
    "out_size": 58873,
    "ratio": 0.1147,
-   "compress_mbps": 155.15,
-   "decompress_mbps": 356.25
+   "compress_mbps": 149.3,
+   "decompress_mbps": 351.42
   },
   {
    "compressor": "native",
@@ -834,8 +834,8 @@
    "level": 3,
    "out_size": 58327,
    "ratio": 0.1137,
-   "compress_mbps": 133.54,
-   "decompress_mbps": 380.63
+   "compress_mbps": 130.13,
+   "decompress_mbps": 373.66
   },
   {
    "compressor": "native",
@@ -844,8 +844,8 @@
    "level": 4,
    "out_size": 55588,
    "ratio": 0.1083,
-   "compress_mbps": 90.54,
-   "decompress_mbps": 348.8
+   "compress_mbps": 90.15,
+   "decompress_mbps": 344.76
   },
   {
    "compressor": "native",
@@ -854,8 +854,8 @@
    "level": 5,
    "out_size": 55097,
    "ratio": 0.1074,
-   "compress_mbps": 68.45,
-   "decompress_mbps": 376.15
+   "compress_mbps": 68.18,
+   "decompress_mbps": 367.52
   },
   {
    "compressor": "native",
@@ -864,8 +864,8 @@
    "level": 6,
    "out_size": 55195,
    "ratio": 0.1075,
-   "compress_mbps": 55.85,
-   "decompress_mbps": 404.53
+   "compress_mbps": 55.01,
+   "decompress_mbps": 400.1
   },
   {
    "compressor": "native",
@@ -874,8 +874,8 @@
    "level": 7,
    "out_size": 54316,
    "ratio": 0.1058,
-   "compress_mbps": 43.7,
-   "decompress_mbps": 427.64
+   "compress_mbps": 43.1,
+   "decompress_mbps": 422.91
   },
   {
    "compressor": "native",
@@ -884,8 +884,8 @@
    "level": 8,
    "out_size": 53091,
    "ratio": 0.1034,
-   "compress_mbps": 35.15,
-   "decompress_mbps": 452.35
+   "compress_mbps": 34.69,
+   "decompress_mbps": 450.67
   },
   {
    "compressor": "native",
@@ -894,8 +894,8 @@
    "level": 9,
    "out_size": 52605,
    "ratio": 0.1025,
-   "compress_mbps": 5.42,
-   "decompress_mbps": 467.67
+   "compress_mbps": 5.37,
+   "decompress_mbps": 465.54
   },
   {
    "compressor": "native",
@@ -904,7 +904,7 @@
    "level": 10,
    "out_size": 52234,
    "ratio": 0.1018,
-   "compress_mbps": 3.52,
+   "compress_mbps": 3.53,
    "decompress_mbps": null
   },
   {
@@ -914,8 +914,8 @@
    "level": 1,
    "out_size": 14249,
    "ratio": 0.3726,
-   "compress_mbps": 52.12,
-   "decompress_mbps": 113.18
+   "compress_mbps": 51.89,
+   "decompress_mbps": 112.36
   },
   {
    "compressor": "native",
@@ -924,8 +924,8 @@
    "level": 2,
    "out_size": 13825,
    "ratio": 0.3615,
-   "compress_mbps": 45.53,
-   "decompress_mbps": 115.6
+   "compress_mbps": 45.03,
+   "decompress_mbps": 114.75
   },
   {
    "compressor": "native",
@@ -934,8 +934,8 @@
    "level": 3,
    "out_size": 13751,
    "ratio": 0.3596,
-   "compress_mbps": 43.79,
-   "decompress_mbps": 117.24
+   "compress_mbps": 43.35,
+   "decompress_mbps": 116.05
   },
   {
    "compressor": "native",
@@ -944,8 +944,8 @@
    "level": 4,
    "out_size": 13287,
    "ratio": 0.3475,
-   "compress_mbps": 38.97,
-   "decompress_mbps": 123.02
+   "compress_mbps": 38.98,
+   "decompress_mbps": 122.33
   },
   {
    "compressor": "native",
@@ -954,8 +954,8 @@
    "level": 5,
    "out_size": 13240,
    "ratio": 0.3462,
-   "compress_mbps": 34.46,
-   "decompress_mbps": 129.31
+   "compress_mbps": 34.56,
+   "decompress_mbps": 128.87
   },
   {
    "compressor": "native",
@@ -964,8 +964,8 @@
    "level": 6,
    "out_size": 12944,
    "ratio": 0.3385,
-   "compress_mbps": 18.87,
-   "decompress_mbps": 131.74
+   "compress_mbps": 18.33,
+   "decompress_mbps": 131.05
   },
   {
    "compressor": "native",
@@ -974,8 +974,8 @@
    "level": 7,
    "out_size": 12929,
    "ratio": 0.3381,
-   "compress_mbps": 17.39,
-   "decompress_mbps": 133.06
+   "compress_mbps": 16.91,
+   "decompress_mbps": 131.45
   },
   {
    "compressor": "native",
@@ -984,8 +984,8 @@
    "level": 8,
    "out_size": 12921,
    "ratio": 0.3379,
-   "compress_mbps": 16.13,
-   "decompress_mbps": 133.94
+   "compress_mbps": 15.72,
+   "decompress_mbps": 133.52
   },
   {
    "compressor": "native",
@@ -994,8 +994,8 @@
    "level": 9,
    "out_size": 12427,
    "ratio": 0.325,
-   "compress_mbps": 5.22,
-   "decompress_mbps": 136.17
+   "compress_mbps": 5.15,
+   "decompress_mbps": 135.01
   },
   {
    "compressor": "native",
@@ -1004,7 +1004,7 @@
    "level": 10,
    "out_size": 12274,
    "ratio": 0.321,
-   "compress_mbps": 2.97,
+   "compress_mbps": 2.93,
    "decompress_mbps": null
   },
   {
@@ -1014,8 +1014,8 @@
    "level": 1,
    "out_size": 1800,
    "ratio": 0.4258,
-   "compress_mbps": 25.99,
-   "decompress_mbps": 58.17
+   "compress_mbps": 25.2,
+   "decompress_mbps": 58.06
   },
   {
    "compressor": "native",
@@ -1024,7 +1024,7 @@
    "level": 2,
    "out_size": 1750,
    "ratio": 0.414,
-   "compress_mbps": 24.47,
+   "compress_mbps": 23.61,
    "decompress_mbps": 58.62
   },
   {
@@ -1034,8 +1034,8 @@
    "level": 3,
    "out_size": 1742,
    "ratio": 0.4121,
-   "compress_mbps": 24.32,
-   "decompress_mbps": 58.68
+   "compress_mbps": 23.63,
+   "decompress_mbps": 58.64
   },
   {
    "compressor": "native",
@@ -1044,8 +1044,8 @@
    "level": 4,
    "out_size": 1726,
    "ratio": 0.4083,
-   "compress_mbps": 23.87,
-   "decompress_mbps": 59.82
+   "compress_mbps": 23.27,
+   "decompress_mbps": 60.09
   },
   {
    "compressor": "native",
@@ -1054,8 +1054,8 @@
    "level": 5,
    "out_size": 1722,
    "ratio": 0.4074,
-   "compress_mbps": 23.46,
-   "decompress_mbps": 60.32
+   "compress_mbps": 22.82,
+   "decompress_mbps": 60.26
   },
   {
    "compressor": "native",
@@ -1064,7 +1064,7 @@
    "level": 6,
    "out_size": 1722,
    "ratio": 0.4074,
-   "compress_mbps": 22.43,
+   "compress_mbps": 21.82,
    "decompress_mbps": 60.3
   },
   {
@@ -1074,7 +1074,7 @@
    "level": 7,
    "out_size": 1722,
    "ratio": 0.4074,
-   "compress_mbps": 22.42,
+   "compress_mbps": 21.89,
    "decompress_mbps": 60.27
   },
   {
@@ -1084,8 +1084,8 @@
    "level": 8,
    "out_size": 1722,
    "ratio": 0.4074,
-   "compress_mbps": 22.42,
-   "decompress_mbps": 60.19
+   "compress_mbps": 21.9,
+   "decompress_mbps": 60.25
   },
   {
    "compressor": "native",
@@ -1094,8 +1094,8 @@
    "level": 9,
    "out_size": 1708,
    "ratio": 0.4041,
-   "compress_mbps": 5.35,
-   "decompress_mbps": 60.31
+   "compress_mbps": 5.22,
+   "decompress_mbps": 59.94
   },
   {
    "compressor": "native",
@@ -1104,7 +1104,7 @@
    "level": 10,
    "out_size": 1693,
    "ratio": 0.4005,
-   "compress_mbps": 3.21,
+   "compress_mbps": 3.14,
    "decompress_mbps": null
   },
   {
@@ -4414,8 +4414,8 @@
    "level": 1,
    "out_size": 4259644,
    "ratio": 0.4179,
-   "compress_mbps": 65.28,
-   "decompress_mbps": 102.58
+   "compress_mbps": 64.94,
+   "decompress_mbps": 102.31
   },
   {
    "compressor": "native",
@@ -4424,8 +4424,8 @@
    "level": 2,
    "out_size": 3977395,
    "ratio": 0.3902,
-   "compress_mbps": 46.64,
-   "decompress_mbps": 110.43
+   "compress_mbps": 46.35,
+   "decompress_mbps": 110.74
   },
   {
    "compressor": "native",
@@ -4434,8 +4434,8 @@
    "level": 3,
    "out_size": 3945296,
    "ratio": 0.3871,
-   "compress_mbps": 41.38,
-   "decompress_mbps": 121.45
+   "compress_mbps": 40.51,
+   "decompress_mbps": 121.9
   },
   {
    "compressor": "native",
@@ -4444,8 +4444,8 @@
    "level": 4,
    "out_size": 3851998,
    "ratio": 0.3779,
-   "compress_mbps": 31.19,
-   "decompress_mbps": 123.92
+   "compress_mbps": 31.08,
+   "decompress_mbps": 124.15
   },
   {
    "compressor": "native",
@@ -4454,8 +4454,8 @@
    "level": 5,
    "out_size": 3840481,
    "ratio": 0.3768,
-   "compress_mbps": 26.25,
-   "decompress_mbps": 130.35
+   "compress_mbps": 26.33,
+   "decompress_mbps": 130.58
   },
   {
    "compressor": "native",
@@ -4464,8 +4464,8 @@
    "level": 6,
    "out_size": 3847941,
    "ratio": 0.3775,
-   "compress_mbps": 25.83,
-   "decompress_mbps": 134.85
+   "compress_mbps": 25.57,
+   "decompress_mbps": 134.95
   },
   {
    "compressor": "native",
@@ -4474,8 +4474,8 @@
    "level": 7,
    "out_size": 3834802,
    "ratio": 0.3762,
-   "compress_mbps": 21.81,
-   "decompress_mbps": 135.43
+   "compress_mbps": 21.56,
+   "decompress_mbps": 135.41
   },
   {
    "compressor": "native",
@@ -4484,8 +4484,8 @@
    "level": 8,
    "out_size": 3833946,
    "ratio": 0.3762,
-   "compress_mbps": 20.97,
-   "decompress_mbps": 134.7
+   "compress_mbps": 21.04,
+   "decompress_mbps": 135.04
   },
   {
    "compressor": "native",
@@ -4494,8 +4494,8 @@
    "level": 9,
    "out_size": 3766584,
    "ratio": 0.3695,
-   "compress_mbps": 4.01,
-   "decompress_mbps": 138.53
+   "compress_mbps": 4.03,
+   "decompress_mbps": 137.78
   },
   {
    "compressor": "native",
@@ -4504,7 +4504,7 @@
    "level": 10,
    "out_size": 3711172,
    "ratio": 0.3641,
-   "compress_mbps": 2.4,
+   "compress_mbps": 2.33,
    "decompress_mbps": null
   },
   {
@@ -4514,8 +4514,8 @@
    "level": 1,
    "out_size": 21267086,
    "ratio": 0.4152,
-   "compress_mbps": 80.09,
-   "decompress_mbps": 130.38
+   "compress_mbps": 80.64,
+   "decompress_mbps": 131.27
   },
   {
    "compressor": "native",
@@ -4524,8 +4524,8 @@
    "level": 2,
    "out_size": 20802983,
    "ratio": 0.4061,
-   "compress_mbps": 62.66,
-   "decompress_mbps": 137.36
+   "compress_mbps": 62.91,
+   "decompress_mbps": 138.11
   },
   {
    "compressor": "native",
@@ -4534,8 +4534,8 @@
    "level": 3,
    "out_size": 20665485,
    "ratio": 0.4035,
-   "compress_mbps": 59.05,
-   "decompress_mbps": 141.17
+   "compress_mbps": 58.69,
+   "decompress_mbps": 142.03
   },
   {
    "compressor": "native",
@@ -4544,8 +4544,8 @@
    "level": 4,
    "out_size": 20356893,
    "ratio": 0.3974,
-   "compress_mbps": 48.83,
-   "decompress_mbps": 145.24
+   "compress_mbps": 47.87,
+   "decompress_mbps": 145.76
   },
   {
    "compressor": "native",
@@ -4554,8 +4554,8 @@
    "level": 5,
    "out_size": 20209289,
    "ratio": 0.3946,
-   "compress_mbps": 38.66,
-   "decompress_mbps": 158.23
+   "compress_mbps": 38.45,
+   "decompress_mbps": 157.29
   },
   {
    "compressor": "native",
@@ -4564,8 +4564,8 @@
    "level": 6,
    "out_size": 19174181,
    "ratio": 0.3743,
-   "compress_mbps": 25.84,
-   "decompress_mbps": 161.19
+   "compress_mbps": 25.93,
+   "decompress_mbps": 160.6
   },
   {
    "compressor": "native",
@@ -4574,8 +4574,8 @@
    "level": 7,
    "out_size": 19127630,
    "ratio": 0.3734,
-   "compress_mbps": 21.52,
-   "decompress_mbps": 161.88
+   "compress_mbps": 21.43,
+   "decompress_mbps": 161.53
   },
   {
    "compressor": "native",
@@ -4584,8 +4584,8 @@
    "level": 8,
    "out_size": 19117840,
    "ratio": 0.3732,
-   "compress_mbps": 18.58,
-   "decompress_mbps": 162.6
+   "compress_mbps": 18.56,
+   "decompress_mbps": 162.63
   },
   {
    "compressor": "native",
@@ -4594,8 +4594,8 @@
    "level": 9,
    "out_size": 18686872,
    "ratio": 0.3648,
-   "compress_mbps": 4.2,
-   "decompress_mbps": 157.7
+   "compress_mbps": 4.17,
+   "decompress_mbps": 157.85
   },
   {
    "compressor": "native",
@@ -4604,7 +4604,7 @@
    "level": 10,
    "out_size": 18539905,
    "ratio": 0.362,
-   "compress_mbps": 2.25,
+   "compress_mbps": 2.2,
    "decompress_mbps": null
   },
   {
@@ -4614,8 +4614,8 @@
    "level": 1,
    "out_size": 3864163,
    "ratio": 0.3876,
-   "compress_mbps": 78.96,
-   "decompress_mbps": 120.38
+   "compress_mbps": 78.65,
+   "decompress_mbps": 118.16
   },
   {
    "compressor": "native",
@@ -4624,8 +4624,8 @@
    "level": 2,
    "out_size": 3734957,
    "ratio": 0.3746,
-   "compress_mbps": 60.45,
-   "decompress_mbps": 128.43
+   "compress_mbps": 60.59,
+   "decompress_mbps": 125.61
   },
   {
    "compressor": "native",
@@ -4634,8 +4634,8 @@
    "level": 3,
    "out_size": 3708443,
    "ratio": 0.3719,
-   "compress_mbps": 52.52,
-   "decompress_mbps": 134.72
+   "compress_mbps": 51.48,
+   "decompress_mbps": 134.18
   },
   {
    "compressor": "native",
@@ -4644,8 +4644,8 @@
    "level": 4,
    "out_size": 3683603,
    "ratio": 0.3694,
-   "compress_mbps": 37.44,
-   "decompress_mbps": 129.76
+   "compress_mbps": 37.31,
+   "decompress_mbps": 129.15
   },
   {
    "compressor": "native",
@@ -4654,8 +4654,8 @@
    "level": 5,
    "out_size": 3677014,
    "ratio": 0.3688,
-   "compress_mbps": 30.26,
-   "decompress_mbps": 135.16
+   "compress_mbps": 30.29,
+   "decompress_mbps": 134.4
   },
   {
    "compressor": "native",
@@ -4664,8 +4664,8 @@
    "level": 6,
    "out_size": 3588221,
    "ratio": 0.3599,
-   "compress_mbps": 27.13,
-   "decompress_mbps": 141.05
+   "compress_mbps": 26.95,
+   "decompress_mbps": 140.5
   },
   {
    "compressor": "native",
@@ -4674,8 +4674,8 @@
    "level": 7,
    "out_size": 3581006,
    "ratio": 0.3592,
-   "compress_mbps": 22.2,
-   "decompress_mbps": 141.85
+   "compress_mbps": 22.14,
+   "decompress_mbps": 141.9
   },
   {
    "compressor": "native",
@@ -4684,8 +4684,8 @@
    "level": 8,
    "out_size": 3580944,
    "ratio": 0.3592,
-   "compress_mbps": 20.13,
-   "decompress_mbps": 146.25
+   "compress_mbps": 19.95,
+   "decompress_mbps": 144.82
   },
   {
    "compressor": "native",
@@ -4694,8 +4694,8 @@
    "level": 9,
    "out_size": 3581441,
    "ratio": 0.3592,
-   "compress_mbps": 4.55,
-   "decompress_mbps": 150.01
+   "compress_mbps": 4.46,
+   "decompress_mbps": 148.79
   },
   {
    "compressor": "native",
@@ -4704,7 +4704,7 @@
    "level": 10,
    "out_size": 3512886,
    "ratio": 0.3523,
-   "compress_mbps": 2.79,
+   "compress_mbps": 2.76,
    "decompress_mbps": null
   },
   {
@@ -4714,8 +4714,8 @@
    "level": 1,
    "out_size": 3785443,
    "ratio": 0.1128,
-   "compress_mbps": 235.72,
-   "decompress_mbps": 359.23
+   "compress_mbps": 230.59,
+   "decompress_mbps": 354.43
   },
   {
    "compressor": "native",
@@ -4724,8 +4724,8 @@
    "level": 2,
    "out_size": 3761560,
    "ratio": 0.1121,
-   "compress_mbps": 148.8,
-   "decompress_mbps": 404.08
+   "compress_mbps": 144.78,
+   "decompress_mbps": 399.28
   },
   {
    "compressor": "native",
@@ -4734,8 +4734,8 @@
    "level": 3,
    "out_size": 3606997,
    "ratio": 0.1075,
-   "compress_mbps": 127.34,
-   "decompress_mbps": 447.81
+   "compress_mbps": 124.78,
+   "decompress_mbps": 444.74
   },
   {
    "compressor": "native",
@@ -4744,8 +4744,8 @@
    "level": 4,
    "out_size": 3201209,
    "ratio": 0.0954,
-   "compress_mbps": 96.27,
-   "decompress_mbps": 462.14
+   "compress_mbps": 96.25,
+   "decompress_mbps": 458.4
   },
   {
    "compressor": "native",
@@ -4754,8 +4754,8 @@
    "level": 5,
    "out_size": 3091564,
    "ratio": 0.0921,
-   "compress_mbps": 73.61,
-   "decompress_mbps": 522.41
+   "compress_mbps": 73.6,
+   "decompress_mbps": 520.74
   },
   {
    "compressor": "native",
@@ -4764,8 +4764,8 @@
    "level": 6,
    "out_size": 3112756,
    "ratio": 0.0928,
-   "compress_mbps": 71.21,
-   "decompress_mbps": 566.53
+   "compress_mbps": 70.93,
+   "decompress_mbps": 561.53
   },
   {
    "compressor": "native",
@@ -4774,8 +4774,8 @@
    "level": 7,
    "out_size": 3062314,
    "ratio": 0.0913,
-   "compress_mbps": 54.83,
-   "decompress_mbps": 578.39
+   "compress_mbps": 54.61,
+   "decompress_mbps": 571.55
   },
   {
    "compressor": "native",
@@ -4784,8 +4784,8 @@
    "level": 8,
    "out_size": 3045348,
    "ratio": 0.0908,
-   "compress_mbps": 46.64,
-   "decompress_mbps": 599.61
+   "compress_mbps": 46.32,
+   "decompress_mbps": 593.54
   },
   {
    "compressor": "native",
@@ -4794,8 +4794,8 @@
    "level": 9,
    "out_size": 3031645,
    "ratio": 0.0904,
-   "compress_mbps": 3.24,
-   "decompress_mbps": 603.74
+   "compress_mbps": 3.11,
+   "decompress_mbps": 596.7
   },
   {
    "compressor": "native",
@@ -4804,7 +4804,7 @@
    "level": 10,
    "out_size": 2902186,
    "ratio": 0.0865,
-   "compress_mbps": 1.85,
+   "compress_mbps": 1.84,
    "decompress_mbps": null
   },
   {
@@ -4814,8 +4814,8 @@
    "level": 1,
    "out_size": 3357083,
    "ratio": 0.5457,
-   "compress_mbps": 57.22,
-   "decompress_mbps": 92.26
+   "compress_mbps": 55.2,
+   "decompress_mbps": 90.49
   },
   {
    "compressor": "native",
@@ -4824,8 +4824,8 @@
    "level": 2,
    "out_size": 3285077,
    "ratio": 0.534,
-   "compress_mbps": 47.06,
-   "decompress_mbps": 93.53
+   "compress_mbps": 46.8,
+   "decompress_mbps": 92.59
   },
   {
    "compressor": "native",
@@ -4834,8 +4834,8 @@
    "level": 3,
    "out_size": 3272746,
    "ratio": 0.532,
-   "compress_mbps": 45.12,
-   "decompress_mbps": 97.66
+   "compress_mbps": 45.17,
+   "decompress_mbps": 97.03
   },
   {
    "compressor": "native",
@@ -4844,8 +4844,8 @@
    "level": 4,
    "out_size": 3228052,
    "ratio": 0.5247,
-   "compress_mbps": 38.39,
-   "decompress_mbps": 103.32
+   "compress_mbps": 38.09,
+   "decompress_mbps": 102.79
   },
   {
    "compressor": "native",
@@ -4854,8 +4854,8 @@
    "level": 5,
    "out_size": 3223415,
    "ratio": 0.5239,
-   "compress_mbps": 34.6,
-   "decompress_mbps": 109.94
+   "compress_mbps": 34.46,
+   "decompress_mbps": 107.74
   },
   {
    "compressor": "native",
@@ -4864,8 +4864,8 @@
    "level": 6,
    "out_size": 3159522,
    "ratio": 0.5136,
-   "compress_mbps": 23.85,
-   "decompress_mbps": 109.7
+   "compress_mbps": 23.29,
+   "decompress_mbps": 108.08
   },
   {
    "compressor": "native",
@@ -4874,8 +4874,8 @@
    "level": 7,
    "out_size": 3156358,
    "ratio": 0.513,
-   "compress_mbps": 22.04,
-   "decompress_mbps": 110.01
+   "compress_mbps": 21.57,
+   "decompress_mbps": 109.4
   },
   {
    "compressor": "native",
@@ -4884,8 +4884,8 @@
    "level": 8,
    "out_size": 3155368,
    "ratio": 0.5129,
-   "compress_mbps": 21.2,
-   "decompress_mbps": 110.14
+   "compress_mbps": 20.98,
+   "decompress_mbps": 109.91
   },
   {
    "compressor": "native",
@@ -4894,8 +4894,8 @@
    "level": 9,
    "out_size": 3048772,
    "ratio": 0.4956,
-   "compress_mbps": 4.96,
-   "decompress_mbps": 112.49
+   "compress_mbps": 4.88,
+   "decompress_mbps": 111.92
   },
   {
    "compressor": "native",
@@ -4904,7 +4904,7 @@
    "level": 10,
    "out_size": 3021986,
    "ratio": 0.4912,
-   "compress_mbps": 3.1,
+   "compress_mbps": 3.04,
    "decompress_mbps": null
   },
   {
@@ -4914,8 +4914,8 @@
    "level": 1,
    "out_size": 3838828,
    "ratio": 0.3806,
-   "compress_mbps": 89.46,
-   "decompress_mbps": 156.82
+   "compress_mbps": 90.14,
+   "decompress_mbps": 151.02
   },
   {
    "compressor": "native",
@@ -4924,8 +4924,8 @@
    "level": 2,
    "out_size": 3792520,
    "ratio": 0.376,
-   "compress_mbps": 67.01,
-   "decompress_mbps": 161.88
+   "compress_mbps": 66.44,
+   "decompress_mbps": 155.98
   },
   {
    "compressor": "native",
@@ -4934,8 +4934,8 @@
    "level": 3,
    "out_size": 3783171,
    "ratio": 0.3751,
-   "compress_mbps": 63.33,
-   "decompress_mbps": 166.01
+   "compress_mbps": 64.19,
+   "decompress_mbps": 159.66
   },
   {
    "compressor": "native",
@@ -4944,8 +4944,8 @@
    "level": 4,
    "out_size": 3648458,
    "ratio": 0.3617,
-   "compress_mbps": 57.97,
-   "decompress_mbps": 178.53
+   "compress_mbps": 57.77,
+   "decompress_mbps": 169.9
   },
   {
    "compressor": "native",
@@ -4954,8 +4954,8 @@
    "level": 5,
    "out_size": 3648472,
    "ratio": 0.3617,
-   "compress_mbps": 53.92,
-   "decompress_mbps": 185.65
+   "compress_mbps": 54.0,
+   "decompress_mbps": 182.89
   },
   {
    "compressor": "native",
@@ -4964,8 +4964,8 @@
    "level": 6,
    "out_size": 3648595,
    "ratio": 0.3618,
-   "compress_mbps": 42.41,
-   "decompress_mbps": 194.13
+   "compress_mbps": 42.32,
+   "decompress_mbps": 185.99
   },
   {
    "compressor": "native",
@@ -4974,8 +4974,8 @@
    "level": 7,
    "out_size": 3648160,
    "ratio": 0.3617,
-   "compress_mbps": 42.41,
-   "decompress_mbps": 196.85
+   "compress_mbps": 42.57,
+   "decompress_mbps": 187.68
   },
   {
    "compressor": "native",
@@ -4984,8 +4984,8 @@
    "level": 8,
    "out_size": 3648156,
    "ratio": 0.3617,
-   "compress_mbps": 42.45,
-   "decompress_mbps": 198.87
+   "compress_mbps": 42.29,
+   "decompress_mbps": 189.18
   },
   {
    "compressor": "native",
@@ -4994,8 +4994,8 @@
    "level": 9,
    "out_size": 3648156,
    "ratio": 0.3617,
-   "compress_mbps": 5.71,
-   "decompress_mbps": 194.54
+   "compress_mbps": 5.75,
+   "decompress_mbps": 194.56
   },
   {
    "compressor": "native",
@@ -5004,7 +5004,7 @@
    "level": 10,
    "out_size": 3647321,
    "ratio": 0.3616,
-   "compress_mbps": 3.28,
+   "compress_mbps": 3.21,
    "decompress_mbps": null
   },
   {
@@ -5014,8 +5014,8 @@
    "level": 1,
    "out_size": 2254442,
    "ratio": 0.3402,
-   "compress_mbps": 83.64,
-   "decompress_mbps": 125.96
+   "compress_mbps": 82.61,
+   "decompress_mbps": 128.38
   },
   {
    "compressor": "native",
@@ -5024,8 +5024,8 @@
    "level": 2,
    "out_size": 2044843,
    "ratio": 0.3086,
-   "compress_mbps": 56.12,
-   "decompress_mbps": 138.23
+   "compress_mbps": 55.81,
+   "decompress_mbps": 137.79
   },
   {
    "compressor": "native",
@@ -5034,8 +5034,8 @@
    "level": 3,
    "out_size": 1992105,
    "ratio": 0.3006,
-   "compress_mbps": 45.84,
-   "decompress_mbps": 154.27
+   "compress_mbps": 45.1,
+   "decompress_mbps": 151.13
   },
   {
    "compressor": "native",
@@ -5044,8 +5044,8 @@
    "level": 4,
    "out_size": 1890729,
    "ratio": 0.2853,
-   "compress_mbps": 32.19,
-   "decompress_mbps": 157.69
+   "compress_mbps": 32.32,
+   "decompress_mbps": 155.14
   },
   {
    "compressor": "native",
@@ -5054,8 +5054,8 @@
    "level": 5,
    "out_size": 1858234,
    "ratio": 0.2804,
-   "compress_mbps": 21.2,
-   "decompress_mbps": 168.01
+   "compress_mbps": 21.31,
+   "decompress_mbps": 168.97
   },
   {
    "compressor": "native",
@@ -5064,8 +5064,8 @@
    "level": 6,
    "out_size": 1856235,
    "ratio": 0.2801,
-   "compress_mbps": 24.9,
-   "decompress_mbps": 180.92
+   "compress_mbps": 25.06,
+   "decompress_mbps": 180.37
   },
   {
    "compressor": "native",
@@ -5074,8 +5074,8 @@
    "level": 7,
    "out_size": 1823963,
    "ratio": 0.2752,
-   "compress_mbps": 16.24,
-   "decompress_mbps": 185.11
+   "compress_mbps": 16.32,
+   "decompress_mbps": 183.56
   },
   {
    "compressor": "native",
@@ -5085,7 +5085,7 @@
    "out_size": 1820112,
    "ratio": 0.2746,
    "compress_mbps": 14.25,
-   "decompress_mbps": 187.59
+   "decompress_mbps": 186.04
   },
   {
    "compressor": "native",
@@ -5094,8 +5094,8 @@
    "level": 9,
    "out_size": 1773447,
    "ratio": 0.2676,
-   "compress_mbps": 2.87,
-   "decompress_mbps": 191.72
+   "compress_mbps": 2.82,
+   "decompress_mbps": 190.62
   },
   {
    "compressor": "native",
@@ -5104,7 +5104,7 @@
    "level": 10,
    "out_size": 1718500,
    "ratio": 0.2593,
-   "compress_mbps": 1.54,
+   "compress_mbps": 1.51,
    "decompress_mbps": null
   },
   {
@@ -5114,8 +5114,8 @@
    "level": 1,
    "out_size": 6406301,
    "ratio": 0.2965,
-   "compress_mbps": 110.63,
-   "decompress_mbps": 193.96
+   "compress_mbps": 110.25,
+   "decompress_mbps": 193.61
   },
   {
    "compressor": "native",
@@ -5124,8 +5124,8 @@
    "level": 2,
    "out_size": 6102377,
    "ratio": 0.2824,
-   "compress_mbps": 82.03,
-   "decompress_mbps": 205.7
+   "compress_mbps": 81.09,
+   "decompress_mbps": 204.9
   },
   {
    "compressor": "native",
@@ -5134,8 +5134,8 @@
    "level": 3,
    "out_size": 6022184,
    "ratio": 0.2787,
-   "compress_mbps": 74.54,
-   "decompress_mbps": 215.24
+   "compress_mbps": 72.2,
+   "decompress_mbps": 214.14
   },
   {
    "compressor": "native",
@@ -5144,8 +5144,8 @@
    "level": 4,
    "out_size": 5880892,
    "ratio": 0.2722,
-   "compress_mbps": 58.0,
-   "decompress_mbps": 225.55
+   "compress_mbps": 57.58,
+   "decompress_mbps": 224.59
   },
   {
    "compressor": "native",
@@ -5154,8 +5154,8 @@
    "level": 5,
    "out_size": 5834363,
    "ratio": 0.27,
-   "compress_mbps": 45.65,
-   "decompress_mbps": 236.47
+   "compress_mbps": 45.47,
+   "decompress_mbps": 235.79
   },
   {
    "compressor": "native",
@@ -5164,8 +5164,8 @@
    "level": 6,
    "out_size": 5409792,
    "ratio": 0.2504,
-   "compress_mbps": 37.52,
-   "decompress_mbps": 241.74
+   "compress_mbps": 36.9,
+   "decompress_mbps": 239.4
   },
   {
    "compressor": "native",
@@ -5174,8 +5174,8 @@
    "level": 7,
    "out_size": 5393735,
    "ratio": 0.2496,
-   "compress_mbps": 32.28,
-   "decompress_mbps": 243.28
+   "compress_mbps": 31.93,
+   "decompress_mbps": 244.38
   },
   {
    "compressor": "native",
@@ -5184,8 +5184,8 @@
    "level": 8,
    "out_size": 5389952,
    "ratio": 0.2495,
-   "compress_mbps": 30.26,
-   "decompress_mbps": 245.78
+   "compress_mbps": 30.28,
+   "decompress_mbps": 246.16
   },
   {
    "compressor": "native",
@@ -5195,7 +5195,7 @@
    "out_size": 5235865,
    "ratio": 0.2423,
    "compress_mbps": 4.52,
-   "decompress_mbps": 245.79
+   "decompress_mbps": 244.53
   },
   {
    "compressor": "native",
@@ -5204,7 +5204,7 @@
    "level": 10,
    "out_size": 5177560,
    "ratio": 0.2396,
-   "compress_mbps": 2.49,
+   "compress_mbps": 2.45,
    "decompress_mbps": null
   },
   {
@@ -5214,8 +5214,8 @@
    "level": 1,
    "out_size": 5612204,
    "ratio": 0.7739,
-   "compress_mbps": 47.58,
-   "decompress_mbps": 90.61
+   "compress_mbps": 46.49,
+   "decompress_mbps": 92.07
   },
   {
    "compressor": "native",
@@ -5224,8 +5224,8 @@
    "level": 2,
    "out_size": 5533875,
    "ratio": 0.7631,
-   "compress_mbps": 39.2,
-   "decompress_mbps": 92.87
+   "compress_mbps": 38.96,
+   "decompress_mbps": 94.03
   },
   {
    "compressor": "native",
@@ -5234,8 +5234,8 @@
    "level": 3,
    "out_size": 5522436,
    "ratio": 0.7615,
-   "compress_mbps": 36.82,
-   "decompress_mbps": 95.67
+   "compress_mbps": 36.7,
+   "decompress_mbps": 96.4
   },
   {
    "compressor": "native",
@@ -5244,8 +5244,8 @@
    "level": 4,
    "out_size": 5494383,
    "ratio": 0.7576,
-   "compress_mbps": 31.69,
-   "decompress_mbps": 98.68
+   "compress_mbps": 31.94,
+   "decompress_mbps": 99.51
   },
   {
    "compressor": "native",
@@ -5254,8 +5254,8 @@
    "level": 5,
    "out_size": 5489807,
    "ratio": 0.757,
-   "compress_mbps": 29.89,
-   "decompress_mbps": 101.06
+   "compress_mbps": 30.29,
+   "decompress_mbps": 102.45
   },
   {
    "compressor": "native",
@@ -5264,8 +5264,8 @@
    "level": 6,
    "out_size": 5470520,
    "ratio": 0.7544,
-   "compress_mbps": 21.95,
-   "decompress_mbps": 104.42
+   "compress_mbps": 21.91,
+   "decompress_mbps": 104.05
   },
   {
    "compressor": "native",
@@ -5274,8 +5274,8 @@
    "level": 7,
    "out_size": 5463682,
    "ratio": 0.7534,
-   "compress_mbps": 20.85,
-   "decompress_mbps": 104.83
+   "compress_mbps": 20.91,
+   "decompress_mbps": 103.84
   },
   {
    "compressor": "native",
@@ -5284,8 +5284,8 @@
    "level": 8,
    "out_size": 5463761,
    "ratio": 0.7534,
-   "compress_mbps": 20.58,
-   "decompress_mbps": 104.88
+   "compress_mbps": 20.8,
+   "decompress_mbps": 104.97
   },
   {
    "compressor": "native",
@@ -5294,8 +5294,8 @@
    "level": 9,
    "out_size": 5284536,
    "ratio": 0.7287,
-   "compress_mbps": 4.98,
-   "decompress_mbps": 105.56
+   "compress_mbps": 4.88,
+   "decompress_mbps": 104.82
   },
   {
    "compressor": "native",
@@ -5304,7 +5304,7 @@
    "level": 10,
    "out_size": 5262319,
    "ratio": 0.7256,
-   "compress_mbps": 3.55,
+   "compress_mbps": 3.46,
    "decompress_mbps": null
   },
   {
@@ -5314,8 +5314,8 @@
    "level": 1,
    "out_size": 13727247,
    "ratio": 0.3311,
-   "compress_mbps": 83.42,
-   "decompress_mbps": 136.1
+   "compress_mbps": 82.93,
+   "decompress_mbps": 130.87
   },
   {
    "compressor": "native",
@@ -5324,8 +5324,8 @@
    "level": 2,
    "out_size": 12940398,
    "ratio": 0.3121,
-   "compress_mbps": 61.3,
-   "decompress_mbps": 146.92
+   "compress_mbps": 60.74,
+   "decompress_mbps": 145.78
   },
   {
    "compressor": "native",
@@ -5334,8 +5334,8 @@
    "level": 3,
    "out_size": 12703756,
    "ratio": 0.3064,
-   "compress_mbps": 56.03,
-   "decompress_mbps": 154.33
+   "compress_mbps": 55.81,
+   "decompress_mbps": 157.32
   },
   {
    "compressor": "native",
@@ -5344,8 +5344,8 @@
    "level": 4,
    "out_size": 12177338,
    "ratio": 0.2937,
-   "compress_mbps": 43.64,
-   "decompress_mbps": 164.65
+   "compress_mbps": 43.18,
+   "decompress_mbps": 164.35
   },
   {
    "compressor": "native",
@@ -5354,8 +5354,8 @@
    "level": 5,
    "out_size": 12051075,
    "ratio": 0.2907,
-   "compress_mbps": 33.77,
-   "decompress_mbps": 173.24
+   "compress_mbps": 33.63,
+   "decompress_mbps": 173.44
   },
   {
    "compressor": "native",
@@ -5364,8 +5364,8 @@
    "level": 6,
    "out_size": 12103573,
    "ratio": 0.2919,
-   "compress_mbps": 33.8,
-   "decompress_mbps": 178.78
+   "compress_mbps": 33.72,
+   "decompress_mbps": 178.34
   },
   {
    "compressor": "native",
@@ -5374,8 +5374,8 @@
    "level": 7,
    "out_size": 12027976,
    "ratio": 0.2901,
-   "compress_mbps": 27.42,
-   "decompress_mbps": 179.82
+   "compress_mbps": 27.32,
+   "decompress_mbps": 179.18
   },
   {
    "compressor": "native",
@@ -5384,8 +5384,8 @@
    "level": 8,
    "out_size": 12019953,
    "ratio": 0.2899,
-   "compress_mbps": 25.94,
-   "decompress_mbps": 181.22
+   "compress_mbps": 25.89,
+   "decompress_mbps": 180.35
   },
   {
    "compressor": "native",
@@ -5394,8 +5394,8 @@
    "level": 9,
    "out_size": 11806466,
    "ratio": 0.2848,
-   "compress_mbps": 3.72,
-   "decompress_mbps": 180.58
+   "compress_mbps": 3.69,
+   "decompress_mbps": 179.47
   },
   {
    "compressor": "native",
@@ -5404,7 +5404,7 @@
    "level": 10,
    "out_size": 11636727,
    "ratio": 0.2807,
-   "compress_mbps": 1.96,
+   "compress_mbps": 1.92,
    "decompress_mbps": null
   },
   {
@@ -5414,8 +5414,8 @@
    "level": 1,
    "out_size": 6438176,
    "ratio": 0.7597,
-   "compress_mbps": 43.26,
-   "decompress_mbps": 76.49
+   "compress_mbps": 42.8,
+   "decompress_mbps": 75.91
   },
   {
    "compressor": "native",
@@ -5424,7 +5424,7 @@
    "level": 2,
    "out_size": 6392101,
    "ratio": 0.7543,
-   "compress_mbps": 42.07,
+   "compress_mbps": 41.43,
    "decompress_mbps": 77.01
   },
   {
@@ -5434,8 +5434,8 @@
    "level": 3,
    "out_size": 6392124,
    "ratio": 0.7543,
-   "compress_mbps": 41.9,
-   "decompress_mbps": 78.7
+   "compress_mbps": 41.49,
+   "decompress_mbps": 78.66
   },
   {
    "compressor": "native",
@@ -5444,8 +5444,8 @@
    "level": 4,
    "out_size": 6360604,
    "ratio": 0.7506,
-   "compress_mbps": 39.24,
-   "decompress_mbps": 78.81
+   "compress_mbps": 39.13,
+   "decompress_mbps": 78.5
   },
   {
    "compressor": "native",
@@ -5454,7 +5454,7 @@
    "level": 5,
    "out_size": 6360567,
    "ratio": 0.7506,
-   "compress_mbps": 39.12,
+   "compress_mbps": 39.01,
    "decompress_mbps": 80.7
   },
   {
@@ -5464,8 +5464,8 @@
    "level": 6,
    "out_size": 6271453,
    "ratio": 0.7401,
-   "compress_mbps": 16.54,
-   "decompress_mbps": 81.79
+   "compress_mbps": 15.98,
+   "decompress_mbps": 81.34
   },
   {
    "compressor": "native",
@@ -5474,8 +5474,8 @@
    "level": 7,
    "out_size": 6271447,
    "ratio": 0.7401,
-   "compress_mbps": 16.49,
-   "decompress_mbps": 82.16
+   "compress_mbps": 15.98,
+   "decompress_mbps": 81.61
   },
   {
    "compressor": "native",
@@ -5484,8 +5484,8 @@
    "level": 8,
    "out_size": 6271447,
    "ratio": 0.7401,
-   "compress_mbps": 16.48,
-   "decompress_mbps": 81.79
+   "compress_mbps": 16.03,
+   "decompress_mbps": 81.41
   },
   {
    "compressor": "native",
@@ -5494,8 +5494,8 @@
    "level": 9,
    "out_size": 5952505,
    "ratio": 0.7024,
-   "compress_mbps": 5.88,
-   "decompress_mbps": 82.22
+   "compress_mbps": 5.77,
+   "decompress_mbps": 82.45
   },
   {
    "compressor": "native",
@@ -5504,7 +5504,7 @@
    "level": 10,
    "out_size": 5848663,
    "ratio": 0.6902,
-   "compress_mbps": 4.25,
+   "compress_mbps": 4.18,
    "decompress_mbps": null
   },
   {
@@ -5514,8 +5514,8 @@
    "level": 1,
    "out_size": 858525,
    "ratio": 0.1606,
-   "compress_mbps": 175.05,
-   "decompress_mbps": 260.33
+   "compress_mbps": 174.9,
+   "decompress_mbps": 261.94
   },
   {
    "compressor": "native",
@@ -5524,8 +5524,8 @@
    "level": 2,
    "out_size": 846807,
    "ratio": 0.1584,
-   "compress_mbps": 113.13,
-   "decompress_mbps": 299.8
+   "compress_mbps": 108.52,
+   "decompress_mbps": 297.15
   },
   {
    "compressor": "native",
@@ -5534,8 +5534,8 @@
    "level": 3,
    "out_size": 806798,
    "ratio": 0.1509,
-   "compress_mbps": 103.41,
-   "decompress_mbps": 334.3
+   "compress_mbps": 100.19,
+   "decompress_mbps": 344.89
   },
   {
    "compressor": "native",
@@ -5544,8 +5544,8 @@
    "level": 4,
    "out_size": 717301,
    "ratio": 0.1342,
-   "compress_mbps": 77.9,
-   "decompress_mbps": 330.32
+   "compress_mbps": 77.61,
+   "decompress_mbps": 324.45
   },
   {
    "compressor": "native",
@@ -5554,8 +5554,8 @@
    "level": 5,
    "out_size": 701552,
    "ratio": 0.1312,
-   "compress_mbps": 61.34,
-   "decompress_mbps": 372.01
+   "compress_mbps": 61.08,
+   "decompress_mbps": 385.5
   },
   {
    "compressor": "native",
@@ -5564,8 +5564,8 @@
    "level": 6,
    "out_size": 678544,
    "ratio": 0.1269,
-   "compress_mbps": 56.98,
-   "decompress_mbps": 381.58
+   "compress_mbps": 56.33,
+   "decompress_mbps": 393.31
   },
   {
    "compressor": "native",
@@ -5574,8 +5574,8 @@
    "level": 7,
    "out_size": 663716,
    "ratio": 0.1242,
-   "compress_mbps": 46.7,
-   "decompress_mbps": 409.8
+   "compress_mbps": 45.99,
+   "decompress_mbps": 425.05
   },
   {
    "compressor": "native",
@@ -5584,8 +5584,8 @@
    "level": 8,
    "out_size": 660481,
    "ratio": 0.1236,
-   "compress_mbps": 41.53,
-   "decompress_mbps": 416.32
+   "compress_mbps": 41.06,
+   "decompress_mbps": 407.07
   },
   {
    "compressor": "native",
@@ -5594,8 +5594,8 @@
    "level": 9,
    "out_size": 659417,
    "ratio": 0.1234,
-   "compress_mbps": 4.27,
-   "decompress_mbps": 421.03
+   "compress_mbps": 4.21,
+   "decompress_mbps": 438.96
   },
   {
    "compressor": "native",
@@ -5604,7 +5604,7 @@
    "level": 10,
    "out_size": 643093,
    "ratio": 0.1203,
-   "compress_mbps": 2.9,
+   "compress_mbps": 2.88,
    "decompress_mbps": null
   },
   {


### PR DESCRIPTION
This PR removes the 64 MiB collapse of native levels 9 and 10 by running the optimal parser in bounded memory above the `optimalMaxSize` gate, so the crown survives on large streams instead of falling through to the L8 split ratio (issue https://github.com/kim-em/lean-zip/issues/2787, "perf(explore): optimal-parse 64 MiB gate collapses L9/L10 to L8 ratio on large streams (windowed DP)").

The gate exists because `computeChoices` allocates two `data.size`-sized `Array Nat` choice arrays — the exact-DP peak's dominant cost (measured ≈2/3 of the resident set at 64 MiB: 1534 MB total, of which ≈1 GB is those arrays). This adds a windowed twin of both the exact and L9-fast parsers that caps live choice storage to a single region: it fills each region's choices into region-local (relative-indexed) buffers, emits that region's tokens immediately via an interleaved emitter, and discards the buffers before the next region, threading the hash-chain finder state across regions exactly as `computeChoicesLoop` does. Because the regions and carried state match the global parse, the token stream is byte-identical — only the choice storage is bounded (`ZipTest.OptimalParse` asserts the equality on the region-crossing inputs). Measured: 64 MiB peak 1534 MB → 543 MB, same tokens, same speed.

`deflateRaw` dispatches to the windowed candidate above the gate at levels 9 and 10; below the gate the existing global parse is unchanged. End-to-end on a 99 MiB input (above the gate): L8 0.2474, L9 0.2389, L10 0.2338 — the crown is kept and L9/L10 are distinct again instead of both collapsing to L8.

The windowed emitter re-verifies every match exactly as `optimalEmit` (the emission guard plus a fresh `countMatch`), so `windowedEmit_valid`/`_encodable` are the same argument extended by one non-emitting refill branch; the region fills are heuristic and opaque to correctness, using panic-checked reads that never fire (`base + r ≤ data.size` holds by construction). Validity, encodability, resolves, and empty contracts are proved once against the shared driver and specialize to both parsers, and the full `deflateRaw` roundtrip quadruple carries through the restructured dispatch.

🤖 Prepared with Claude Code