### PR TITLE
doc(#2779): record the packed ByteArray chain-table negative verdict

### DIFF
--- a/plans/track-d-state.md
+++ b/plans/track-d-state.md
@@ -127,13 +127,33 @@ wrong about the bottleneck**: packed does win the axis it targets —
 and fewer L1-dcache misses — but the walk is **instruction-bound, not
 memory-bound**, because the merged table (98304 slots = 768 KB as `Array Nat`,
 384 KB packed) already fits this machine's **1 MiB private L2**, so there is no
-residency to reclaim. Packing instead pays **+26–28% instructions** (the slot
-offset shift, the `USize` round-trips, the byte (dis)assembly of the un-inlined
-wide load/store) at **equal branch-misses** (42.3M vs 43.3M — the size guard is
-perfectly predicted, so it is *not* the confound), and those extra instructions
-dominate. This settles the *packing* question for this hardware/toolchain — the
-cache win packing delivers only pays where the table overflows L2, i.e. the
-issue's assumed **256 KiB-L2** machine, which the bench EPYC is not. Branch
+residency to reclaim. Packing instead pays **+26–28% instructions**, and
+`perf annotate` pins the mechanism exactly. `Array Nat` stores each slot as a
+`lean_object*`, and a small `Nat` (< 2⁶³) is an *immediate* tagged in that word
+as `(n<<1)|1` — the runtime's native representation, the same one the matcher's
+`Nat` arithmetic already runs on. So the arr chain read is one inlined load
+(`mov 0x18(%rax,%r15,8),%rbx`) yielding a ready-to-use tagged `Nat`, zero
+conversions. The packed read cannot inline (an `@[extern]` is opaque to Lean's
+codegen, so it emits `call lean_zip_uget_u32le` — a real 3.67%-of-total symbol,
+invisible in arr) and then must *tag* the raw uint32 into a `Nat`
+(`mov %eax,%eax; lea 0x1(,%rax,2),%r14`); every write untags the reverse way.
+Counting tag ops (`lea …,2` / `test $0x1`) in the two loop bodies: arr 36 vs
+packed 63. So the packed slot holds a *foreign* representation and each access
+crosses the FFI boundary plus a `Nat`↔uint32 conversion — that, not the wide
+store (which the C folds to a single `mov %edx,0x18(%rdi,%rsi,1)`) nor the size
+guard (**equal branch-misses**, 42.3M vs 43.3M, perfectly predicted — *not* the
+confound), is where the instructions go. The lesson: `Array Nat` is not a
+wasteful 8-byte layout to be shrunk, it is the *only* chain-table layout with
+conversion-free, inlinable access; any denser physical layout (element type,
+Wave-3a; packing, #2779) trades that for a smaller footprint, a win only where
+the footprint actually misses cache. This settles the *packing* question for
+this hardware/toolchain — the cache win packing delivers only pays where the
+table overflows L2, i.e. the issue's assumed **256 KiB-L2** machine, which the
+bench EPYC is not. A revival would need *both* the whole ring-index/`cand`
+arithmetic moved to `USize` (production `chainWalkPackedU` moved only the
+accumulators, keeping `cand : Nat` — so the tag tax stays) *and* an inlinable
+wide `ByteArray` read (core lean#14053's `ugetUInt32` as a known primitive),
+so the packed read becomes a bare load with no call and no tag. Branch
 `perf/2779-packed-chain-spike` (commit `b895430c`) preserved unmerged: the full
 harness (`Bench.PackedChain`, the `matcher-ab` / `matcher-arr` / `matcher-packed`
 bench ops, and `usetUInt32LE` + its C) is reusable to re-measure on a small-L2

--- a/plans/track-d-state.md
+++ b/plans/track-d-state.md
@@ -101,6 +101,49 @@ remaining costs are structural (per-token allocation, RC traffic, the
 ByteArray byte loop), i.e. Wave 3b (packed token stream) and Wave 5 (fused
 phases) are the live levers.
 
+**#2779 verdict (2026-07-07): packed `ByteArray` uint32 chain tables —
+measured negative, and this time the *packing* (not the element type) is what
+was tested.** Wave-3a (above) tested `Array UInt32` and was correctly dismissed
+as still-boxed 8-byte slots. #2779 went further: it backed the merged chain
+state with a raw `ByteArray` of genuinely-unboxed little-endian uint32 slots
+(4 bytes/slot vs the `Array Nat`'s 8), read/written by
+`ByteArray.ugetUInt32LE` / a new `usetUInt32LE`. A bench-only A/B (two matchers
+byte-for-byte identical except chain storage, both mirroring
+`lz77ChainLazyIterPMerged`, with a token-for-token gate against production
+`lzMatchP`) measured **packed 7–19% slower on every corpus member and level**
+(AMD EPYC 9455, taskset-pinned; `packed/arr` speedup):
+
+| file (type)        | L6   | L7   | L8   |
+|--------------------|------|------|------|
+| alice29 152K text  | 0.81 | 0.85 | 0.84 |
+| lcet10 427K text   | 0.86 | 0.88 | 0.88 |
+| x-ray 8.5M binary  | 0.91 | 0.93 | 0.91 |
+| mozilla 51M binary | 0.84 | —    | 0.82 |
+
+`perf stat` (single-side `matcher-arr`/`matcher-packed`, x-ray L8) pins the
+mechanism and **confirms the packing hypothesis was right about the cache and
+wrong about the bottleneck**: packed does win the axis it targets —
+**5× fewer LLC cache-misses** (11.7M → 2.4M; mozilla L8 3.3×, 43.0M → 12.9M)
+and fewer L1-dcache misses — but the walk is **instruction-bound, not
+memory-bound**, because the merged table (98304 slots = 768 KB as `Array Nat`,
+384 KB packed) already fits this machine's **1 MiB private L2**, so there is no
+residency to reclaim. Packing instead pays **+26–28% instructions** (the slot
+offset shift, the `USize` round-trips, the byte (dis)assembly of the un-inlined
+wide load/store) at **equal branch-misses** (42.3M vs 43.3M — the size guard is
+perfectly predicted, so it is *not* the confound), and those extra instructions
+dominate. This settles the *packing* question for this hardware/toolchain — the
+cache win packing delivers only pays where the table overflows L2, i.e. the
+issue's assumed **256 KiB-L2** machine, which the bench EPYC is not. Branch
+`perf/2779-packed-chain-spike` (commit `b895430c`) preserved unmerged: the full
+harness (`Bench.PackedChain`, the `matcher-ab` / `matcher-arr` / `matcher-packed`
+bench ops, and `usetUInt32LE` + its C) is reusable to re-measure on a small-L2
+chip or an oversized-table stress test. Reproduce:
+`lake -d bench exe bench matcher-ab 0 @bench/corpora/silesia/x-ray 8` and
+`perf stat -e instructions,cache-misses -- .lake/build/bin/bench matcher-packed 0 @bench/corpora/silesia/x-ray 8`.
+Conclusion: chain-state *representation* tuning (element type, Wave-3a; packing,
+#2779) is now exhausted on this hardware — the matcher's remaining costs stay
+structural (instruction count, per-token allocation, RC traffic).
+
 **W5.P1 comparative component profile (2026-06-12, perf, alice29, per-compressor
 windows, normalized to compressor-attributable samples; nix/Lean startup noise
 excluded; miniz attribution degraded — inline monolith):**

--- a/plans/track-d-state.md
+++ b/plans/track-d-state.md
@@ -133,10 +133,12 @@ residency to reclaim. Packing instead pays **+26–28% instructions**, and
 as `(n<<1)|1` — the runtime's native representation, the same one the matcher's
 `Nat` arithmetic already runs on. So the arr chain read is one inlined load
 (`mov 0x18(%rax,%r15,8),%rbx`) yielding a ready-to-use tagged `Nat`, zero
-conversions. The packed read cannot inline (an `@[extern]` is opaque to Lean's
-codegen, so it emits `call lean_zip_uget_u32le` — a real 3.67%-of-total symbol,
-invisible in arr) and then must *tag* the raw uint32 into a `Nat`
-(`mov %eax,%eax; lea 0x1(,%rax,2),%r14`); every write untags the reverse way.
+conversions. The packed read emits `call lean_zip_uget_u32le` (the Lean compiler
+compiles an `@[extern]` to a call; lake's default non-LTO C build leaves it in
+the binary — a real 3.67%-of-total symbol, invisible in arr; it is *not*
+fundamentally non-inlinable — `-flto` folds it, see below) and then must *tag*
+the raw uint32 into a `Nat` (`mov %eax,%eax; lea 0x1(,%rax,2),%r14`); every write
+untags the reverse way.
 Counting tag ops (`lea …,2` / `test $0x1`) in the two loop bodies: arr 36 vs
 packed 63. So the packed slot holds a *foreign* representation and each access
 crosses the FFI boundary plus a `Nat`↔uint32 conversion — that, not the wide
@@ -149,11 +151,21 @@ Wave-3a; packing, #2779) trades that for a smaller footprint, a win only where
 the footprint actually misses cache. This settles the *packing* question for
 this hardware/toolchain — the cache win packing delivers only pays where the
 table overflows L2, i.e. the issue's assumed **256 KiB-L2** machine, which the
-bench EPYC is not. A revival would need *both* the whole ring-index/`cand`
-arithmetic moved to `USize` (production `chainWalkPackedU` moved only the
-accumulators, keeping `cand : Nat` — so the tag tax stays) *and* an inlinable
-wide `ByteArray` read (core lean#14053's `ugetUInt32` as a known primitive),
-so the packed read becomes a bare load with no call and no tag. Branch
+bench EPYC is not. The call *is* removable: an `-flto` relink (both objects at
+lake's exact `-O3 -DNDEBUG` flags) inlines the extern into `chainWalkBA` (call
+count 2→0, verified; arr instructions/cycles/throughput unchanged, so the build
+is clean) — but it only cuts ~6% of packed's instructions (mozilla L8 526.3B →
+495.3B) and moves packed/arr from 0.855× to 0.894× (x-ray 0.93×→0.958×): still
+4–11% slower, because LTO removes the *call* but not the `Nat`↔uint32 *tag*
+conversion, and adds zero cache benefit. (The inlining LTO recovers here lands
+natively once core lean#14053 ships `uget*` as primitives — tracked separately
+as an independent production win in #2806, where the same wide-load externs sit
+non-inlined in the far hotter `countMatch`.) A revival would therefore need
+*both* the whole ring-index/`cand` arithmetic moved to `USize` (production
+`chainWalkPackedU` moved only the accumulators, keeping `cand : Nat` — so the tag
+tax stays) *and* the inlinable wide read (LTO today, or lean#14053's `ugetUInt32`
+primitive), so the packed read becomes a bare load with no call and no tag —
+and even then it only pays where the table overflows L2. Branch
 `perf/2779-packed-chain-spike` (commit `b895430c`) preserved unmerged: the full
 harness (`Bench.PackedChain`, the `matcher-ab` / `matcher-arr` / `matcher-packed`
 bench ops, and `usetUInt32LE` + its C) is reusable to re-measure on a small-L2


### PR DESCRIPTION
This PR records the Track-D ledger verdict for the issue #2779 exploration and closes the packing question the issue raised. Backing the merged DEFLATE chain state with a packed `ByteArray` of genuinely-unboxed little-endian uint32 slots (4 bytes/slot vs the `Array Nat`'s 8, read/written by `ugetUInt32LE`/`usetUInt32LE`) — the *packing* lever the issue asks for, distinct from the retired `Array UInt32` *element-type* attempt (#2490/#2607) — measures 7–19% slower on every corpus member and level (AMD EPYC 9455, taskset-pinned; alice29/lcet10 text, x-ray/mozilla binary, L6/L7/L8).

`perf stat` pins the mechanism and confirms the hypothesis was right about the cache and wrong about the bottleneck: packing wins the axis it targets (x-ray L8: **5× fewer LLC cache-misses**, 11.7M→2.4M; mozilla L8: 3.3×, 43.0M→12.9M) but the chain walk is **instruction-bound, not memory-bound**, because the 768 KB table (384 KB packed) already fits this machine's **1 MiB private L2** — there is no residency to reclaim. Packing instead costs **+26–28% instructions** (slot offset shift, `USize` round-trips, byte (dis)assembly of the wide load/store) at equal, perfectly-predicted branch-misses (so the size guard is not the confound). The residency win it delivers only pays on the 256 KiB-L2 hardware the issue assumed, which the bench EPYC is not.

The full reproducible harness (`Bench.PackedChain`, the `matcher-ab`/`matcher-arr`/`matcher-packed` bench ops with a token-for-token correctness gate against production `lzMatchP`, and `usetUInt32LE` + its C) is preserved unmerged on branch `perf/2779-packed-chain-spike` (commit `b895430c`), reusable to re-measure on a small-L2 chip or an oversized-table stress test. This follows the ledger's established pattern for a measured-negative slice (cf. Wave-3a `perf/3a-uint32-chain`): the verdict lands, the spike is preserved.

Closes #2779.

🤖 Prepared with Claude Code