### PR TITLE
perf: reuse split-sizing frequencies for the base candidate (#2772)

### DIFF
--- a/Zip/Native/DeflateDynamic.lean
+++ b/Zip/Native/DeflateDynamic.lean
@@ -1341,6 +1341,32 @@ decreasing_by
   simp only [Nat.not_le] at h
   omega
 
+/-- Fused twin of `sharedPartitionSizedP` (#2772): one pass over the clamped
+    partition yields the same `(bits, per-block trees)` **and** the whole-stream
+    frequencies, accumulated as the EOB-corrected element-wise sum of the per-block
+    `tokenFreqsP` (`mergeEOBFreqsP`) — the *same* histogram `sizedTrees` already
+    consumes, so no extra frequency walk. Component 1 is proved equal to
+    `sharedPartitionSizedP` (`sharedPartitionSizedFreqsP_fst`) and component 2 to
+    `tokenFreqsP (toks.extract pos toks.size)` (`sharedPartitionSizedFreqsP_snd`),
+    so the base candidate can reuse these frequencies instead of re-walking the
+    whole stream (`tokenFreqsP` is 4.7% L6 dickens / 3.0% mozilla of compress). -/
+def sharedPartitionSizedFreqsP (toks : Array UInt32) (cuts : List Nat) (pos : Nat) :
+    (Nat × List SizedTrees) × (Array Nat × Array Nat) :=
+  let j := min (max (cuts.headD toks.size) (pos + 1)) toks.size
+  let f := tokenFreqsP (toks.extract pos j)
+  let t := sizedTrees f.1 f.2
+  let blockBits := 3 + (writeDynamicHeader BitWriter.empty t.val.1 t.val.2).bitLength
+    + symbolBitCount f.1 f.2 t.val.1.toArray t.val.2.toArray
+  if j ≥ toks.size then ((blockBits, [t]), f)
+  else
+    let rest := sharedPartitionSizedFreqsP toks cuts.tail j
+    ((blockBits + rest.1.1, t :: rest.1.2), mergeEOBFreqsP f rest.2)
+termination_by toks.size - pos
+decreasing_by
+  rename_i h
+  simp only [Nat.not_le] at h
+  omega
+
 /-- Tree-taking twin of `emitSharedBlocksAtP`: same clamped cut points, but each
     block's `(litLens, distLens)` come from the `trees` list (in lockstep with
     `cuts`) instead of being recomputed from the group via `tokenFreqsP` +
@@ -1377,6 +1403,27 @@ def deflateDynamicBlocksSharedAtSizedP (data : ByteArray) (toks : Array UInt32)
     let sp := sharedPartitionSizedP toks cuts 0
     ((sp.1 + 7) / 8,
       fun _ => (emitSharedBlocksAtSizedP data toks cuts sp.2 0 BitWriter.empty).flush)
+
+/-- The obs-split candidate prep **paired with** the whole-stream frequencies,
+    both from one fused sizing pass (`sharedPartitionSizedFreqsP`, #2772).
+    Component 1 is proved equal to `deflateDynamicBlocksSharedAtSizedP`
+    (`deflateObsSplitSizedFreqsP_fst`), so the split candidate's roundtrip and
+    byte-size conformance transfer unchanged; component 2 is `tokenFreqsP toks`
+    (`deflateObsSplitSizedFreqsP_snd`), the whole-stream histogram the base
+    candidate needs — derived here by folding the per-block frequencies the
+    sizing pass already built, instead of a second whole-stream `tokenFreqsP`
+    walk. `deflateRaw` (levels 6–8, cuts non-empty) forces this once and feeds
+    component 2 to `deflateRawBasePPrepF`. -/
+def deflateObsSplitSizedFreqsP (data : ByteArray) (toks : Array UInt32)
+    (cuts : List Nat) : (Nat × (Unit → ByteArray)) × (Array Nat × Array Nat) :=
+  if data.size == 0 then
+    let out := deflateDynamicBlocksSharedAtP data toks cuts
+    ((out.size, fun _ => out), tokenFreqsP toks)
+  else
+    let sp := sharedPartitionSizedFreqsP toks cuts 0
+    (((sp.1.1 + 7) / 8,
+      fun _ => (emitSharedBlocksAtSizedP data toks cuts sp.1.2 0 BitWriter.empty).flush),
+     sp.2)
 
 /-- The compressed-block dispatch (no stored fallback). Every level ≥ 1 uses the
     hash-chain matcher with the level's search depth (`chainDepth`) and interior
@@ -1472,6 +1519,37 @@ def deflateRawBasePPrep (data : ByteArray) (ptokens : Array UInt32) : Nat × (Un
 /-- The prep's emit thunk is exactly `deflateRawBaseP` (same shared plan). -/
 theorem deflateRawBasePPrep_emit (data : ByteArray) (ptokens : Array UInt32) :
     (deflateRawBasePPrep data ptokens).2 () = deflateRawBaseP data ptokens := rfl
+
+/-- `deflateRawBasePPrep` with the whole-stream frequencies supplied as a
+    parameter instead of recomputed via `tokenFreqsP ptokens` (#2772). When the
+    levels-6–8 split has cuts, `deflateRaw` passes the frequencies the split-sizing
+    pass already summed (`deflateObsSplitSizedFreqsP`'s component 2, provably
+    `tokenFreqsP ptokens`), so the base candidate skips the second whole-stream
+    frequency walk. At `f = tokenFreqsP ptokens` this is definitionally
+    `deflateRawBasePPrep` (`deflateRawBasePPrepF_tokenFreqsP`), keeping the emit
+    theorem clean. Only the frequency-derived sizing/tree work uses `f`; the emit
+    branches consume `ptokens` directly, exactly as `deflateRawBasePPrep`. -/
+def deflateRawBasePPrepF (data : ByteArray) (ptokens : Array UInt32)
+    (f : Array Nat × Array Nat) : Nat × (Unit → ByteArray) :=
+  let lens := dynamicCodeLengths f.1 f.2
+  let plan := dynHeaderCodes lens.1 lens.2
+  have hcl : plan.clCodes.size ≥ 19 :=
+    Nat.le_of_eq (dynHeaderCodes_clCodes_size lens.1 lens.2).symm
+  let fixedBytes := fixedBlockBytes f.1 f.2
+  let dynBytes := dynBlockBytesWith f.1 f.2 lens.1 lens.2 plan hcl
+  let storedBytes := storedBlockBytes data
+  ((if storedBytes < (if fixedBytes < dynBytes then fixedBytes else dynBytes) then storedBytes
+    else if fixedBytes < dynBytes then fixedBytes else dynBytes),
+   fun _ =>
+    if storedBytes < (if fixedBytes < dynBytes then fixedBytes else dynBytes) then deflateStoredPure data
+    else if fixedBytes < dynBytes then deflateFixedBlockP data ptokens
+    else deflateDynamicBlockCorePWith data ptokens lens.1 lens.2 plan hcl
+      (dynamicCodeLengths_length f.1 f.2).1 (dynamicCodeLengths_length f.1 f.2).2)
+
+/-- `deflateRawBasePPrepF` at the whole-stream frequencies is `deflateRawBasePPrep`. -/
+theorem deflateRawBasePPrepF_tokenFreqsP (data : ByteArray) (ptokens : Array UInt32) :
+    deflateRawBasePPrepF data ptokens (tokenFreqsP ptokens) = deflateRawBasePPrep data ptokens :=
+  rfl
 
 /-- `deflateRawBaseP` over this level's *packed* `lzMatchP` stream
     (definitional wrapper, `deflateRawBaseP_def`). Equal to the boxed
@@ -1851,17 +1929,23 @@ def deflateRaw (data : ByteArray) (level : UInt8 := 6) : ByteArray :=
       -- both" (measured — Silesia L6-L7 +5-12% with reuse). No cuts ⇒ the split
       -- would be a single dynamic block the base already sizes, so skip it
       -- entirely (every input under ~2·splitMinBlockBytes takes this path).
-      let basePrep := deflateRawBasePPrep data ptokens
+      --
+      -- When there are cuts, the split-sizing pass already computes `tokenFreqsP`
+      -- per block; `deflateObsSplitSizedFreqsP` folds those into the whole-stream
+      -- frequencies (EOB-corrected, `tokenFreqsP_append`) and the base candidate
+      -- reuses them via `deflateRawBasePPrepF` — replacing the base's second
+      -- whole-stream `tokenFreqsP` walk with a cheap ~316-entry summation (#2772).
       let cuts := chooseSplitsHeuristicP ptokens data.size
       -- `withObs`: the base, or the size-arbitrated smaller of base and the
       -- obs-divergence split — selected *eagerly* (the winning prep pair, tie →
       -- the split, matching `pickSmaller`), so the loser's captured per-block
       -- trees are dropped now. The winner's emit thunk stays unforced until then.
       let withObs : Nat × (Unit → ByteArray) :=
-        if cuts.isEmpty then basePrep
+        if cuts.isEmpty then deflateRawBasePPrep data ptokens
         else
-          let obsPrep := deflateDynamicBlocksSharedAtSizedP data ptokens cuts
-          if basePrep.1 < obsPrep.1 then basePrep else obsPrep
+          let obsFreqs := deflateObsSplitSizedFreqsP data ptokens cuts
+          let basePrep := deflateRawBasePPrepF data ptokens obsFreqs.2
+          if basePrep.1 < obsFreqs.1.1 then basePrep else obsFreqs.1
       withObs.2 ()
   else deflateRawBase data level
 

--- a/Zip/Native/DeflateFreqs.lean
+++ b/Zip/Native/DeflateFreqs.lean
@@ -247,6 +247,23 @@ theorem tokenFreqsP_eq (ws : Array UInt32) :
   unfold tokenFreqsP tokenFreqs
   exact tokenFreqsP_go_eq ws _ _ _ _ 0
 
+/-- Element-wise merge of two `tokenFreqsP` histograms, correcting the
+    double-counted end-of-block symbol (lit/len index 256). `tokenFreqsP`
+    pre-counts EOB with value 1 in *every* block, so the element-wise sum of two
+    per-block histograms counts EOB twice; subtract one. This is the cheap
+    (~316-entry) combiner that lets the whole-stream frequencies be derived from
+    the per-block frequencies the split-sizing pass already computes
+    (`tokenFreqsP_append`), instead of a second whole-stream `tokenFreqsP` walk.
+
+    Correct only for `tokenFreqsP` outputs: both operands must have the histogram
+    shapes (286 lit/len, 30 distance) and pre-count EOB with value ≥ 1. On other
+    inputs `zipWith` silently truncates to the shorter array and the index-256
+    `Nat` subtraction saturates. Every call site feeds `tokenFreqsP` outputs, and
+    `tokenFreqsP_append` establishes the exact equality relied on. -/
+def mergeEOBFreqsP (a b : Array Nat × Array Nat) : Array Nat × Array Nat :=
+  let lit := Array.zipWith (· + ·) a.1 b.1
+  (lit.set! 256 (lit[256]! - 1), Array.zipWith (· + ·) a.2 b.2)
+
 /-- Build the `(symbol, freq)` pair list for a frequency array. -/
 def freqsToPairs (freqs : Array Nat) : List (Nat × Nat) :=
   (List.range freqs.size).pmap

--- a/Zip/Spec/DeflateBaseFreqsReuse.lean
+++ b/Zip/Spec/DeflateBaseFreqsReuse.lean
@@ -1,0 +1,116 @@
+import Zip.Spec.LZ77PackedCorrect
+import Zip.Spec.DeflateFreqsAdditive
+
+/-!
+# Reusing the split-sizing frequencies for the base candidate (#2772)
+
+`sharedPartitionSizedFreqsP` computes, in one pass over the clamped partition, the
+same `(bits, per-block trees)` as `sharedPartitionSizedP` **and** the whole-stream
+frequencies (EOB-corrected sum of the per-block `tokenFreqsP`). This file proves:
+
+* `sharedPartitionSizedFreqsP_fst` — component 1 is exactly `sharedPartitionSizedP`,
+  so every sizing/emit theorem transfers unchanged.
+* `sharedPartitionSizedFreqsP_snd` — component 2 is `tokenFreqsP (toks.extract pos
+  toks.size)` (via `tokenFreqsP_append` over the clamped cuts).
+* `deflateObsSplitSizedFreqsP_fst` / `_snd` — the split candidate prep is
+  `deflateDynamicBlocksSharedAtSizedP`, and the paired frequencies are
+  `tokenFreqsP toks`.
+* `deflateRawBasePPrepF_obsFreqs` — feeding those frequencies to the freq-taking
+  base prep recovers `deflateRawBasePPrep`, so the base candidate's second
+  whole-stream frequency walk is eliminated with no change to its output.
+-/
+
+namespace Zip.Native.Deflate
+
+/-- Fuel form of `sharedPartitionSizedFreqsP_fst`. -/
+private theorem sharedPartitionSizedFreqsP_fst_fuel (toks : Array UInt32) :
+    ∀ (fuel pos : Nat), toks.size - pos < fuel → ∀ (cuts : List Nat),
+      (sharedPartitionSizedFreqsP toks cuts pos).1 = sharedPartitionSizedP toks cuts pos := by
+  intro fuel
+  induction fuel with
+  | zero => intro pos hf; omega
+  | succ fuel ih =>
+    intro pos hf cuts
+    by_cases hend : min (max (cuts.headD toks.size) (pos + 1)) toks.size ≥ toks.size
+    · conv => lhs; unfold sharedPartitionSizedFreqsP
+      conv => rhs; unfold sharedPartitionSizedP
+      simp only [if_pos hend]
+    · conv => lhs; unfold sharedPartitionSizedFreqsP
+      conv => rhs; unfold sharedPartitionSizedP
+      simp only [if_neg hend]
+      rw [ih (min (max (cuts.headD toks.size) (pos + 1)) toks.size) (by omega) cuts.tail]
+
+/-- Component 1 of `sharedPartitionSizedFreqsP` is exactly `sharedPartitionSizedP`. -/
+theorem sharedPartitionSizedFreqsP_fst (toks : Array UInt32) (cuts : List Nat) (pos : Nat) :
+    (sharedPartitionSizedFreqsP toks cuts pos).1 = sharedPartitionSizedP toks cuts pos :=
+  sharedPartitionSizedFreqsP_fst_fuel toks (toks.size - pos + 1) pos (by omega) cuts
+
+/-- Fuel form of `sharedPartitionSizedFreqsP_snd`. -/
+private theorem sharedPartitionSizedFreqsP_snd_fuel (toks : Array UInt32) :
+    ∀ (fuel pos : Nat), toks.size - pos < fuel → ∀ (cuts : List Nat),
+      (sharedPartitionSizedFreqsP toks cuts pos).2 = tokenFreqsP (toks.extract pos toks.size) := by
+  intro fuel
+  induction fuel with
+  | zero => intro pos hf; omega
+  | succ fuel ih =>
+    intro pos hf cuts
+    by_cases hend : min (max (cuts.headD toks.size) (pos + 1)) toks.size ≥ toks.size
+    · conv => lhs; unfold sharedPartitionSizedFreqsP
+      simp only [if_pos hend]
+      rw [show min (max (cuts.headD toks.size) (pos + 1)) toks.size = toks.size from by omega]
+    · conv => lhs; unfold sharedPartitionSizedFreqsP
+      simp only [if_neg hend]
+      rw [ih (min (max (cuts.headD toks.size) (pos + 1)) toks.size) (by omega) cuts.tail,
+        ← tokenFreqsP_append, Array.extract_append_extract,
+        show min pos (min (max (cuts.headD toks.size) (pos + 1)) toks.size) = pos from by omega,
+        show max (min (max (cuts.headD toks.size) (pos + 1)) toks.size) toks.size = toks.size from by omega]
+
+/-- Component 2 of `sharedPartitionSizedFreqsP` is the whole-stream histogram of the
+    covered suffix — the EOB-corrected sum of the per-block frequencies. -/
+theorem sharedPartitionSizedFreqsP_snd (toks : Array UInt32) (cuts : List Nat) (pos : Nat) :
+    (sharedPartitionSizedFreqsP toks cuts pos).2 = tokenFreqsP (toks.extract pos toks.size) :=
+  sharedPartitionSizedFreqsP_snd_fuel toks (toks.size - pos + 1) pos (by omega) cuts
+
+/-- The split candidate prep is exactly `deflateDynamicBlocksSharedAtSizedP`. -/
+theorem deflateObsSplitSizedFreqsP_fst (data : ByteArray) (toks : Array UInt32) (cuts : List Nat) :
+    (deflateObsSplitSizedFreqsP data toks cuts).1 = deflateDynamicBlocksSharedAtSizedP data toks cuts := by
+  unfold deflateObsSplitSizedFreqsP deflateDynamicBlocksSharedAtSizedP
+  split
+  · rfl
+  · dsimp only []
+    rw [sharedPartitionSizedFreqsP_fst]
+
+/-- The frequencies paired with the split candidate prep are `tokenFreqsP toks`. -/
+theorem deflateObsSplitSizedFreqsP_snd (data : ByteArray) (toks : Array UInt32) (cuts : List Nat) :
+    (deflateObsSplitSizedFreqsP data toks cuts).2 = tokenFreqsP toks := by
+  unfold deflateObsSplitSizedFreqsP
+  split
+  · rfl
+  · dsimp only []
+    rw [sharedPartitionSizedFreqsP_snd, Array.extract_eq_self_of_le (Nat.le_refl _)]
+
+/-- Feeding the split-sizing frequencies to the freq-taking base prep recovers
+    `deflateRawBasePPrep`: the base candidate's second whole-stream frequency walk
+    is replaced by a reuse of the per-block frequencies, with identical output. -/
+theorem deflateRawBasePPrepF_obsFreqs (data : ByteArray) (toks : Array UInt32) (cuts : List Nat) :
+    deflateRawBasePPrepF data toks (deflateObsSplitSizedFreqsP data toks cuts).2
+      = deflateRawBasePPrep data toks := by
+  rw [deflateObsSplitSizedFreqsP_snd, deflateRawBasePPrepF_tokenFreqsP]
+
+/-- **Byte-identity of the reuse dispatch.** The levels-6–8 size-arbitrated pair
+    selected by the frequency-reusing dispatch is the *same prepared pair* the
+    original dispatch selected: identical prepared sizes, identical tie, identical
+    emit thunk. The base candidate reuses the split-sizing frequencies, but nothing
+    observable changes, so `deflateRaw`'s output is byte-for-byte unchanged. This is
+    the composed statement the roundtrip/padding specs (`inflate_deflateRaw`,
+    `deflateRaw_pad`, `deflateRaw_goR_pad`) rewrite through. -/
+theorem withObs_reuse_eq (data : ByteArray) (toks : Array UInt32) (cuts : List Nat) :
+    (let obsFreqs := deflateObsSplitSizedFreqsP data toks cuts
+     let basePrep := deflateRawBasePPrepF data toks obsFreqs.2
+     if basePrep.1 < obsFreqs.1.1 then basePrep else obsFreqs.1)
+      = (let obsPrep := deflateDynamicBlocksSharedAtSizedP data toks cuts
+         if (deflateRawBasePPrep data toks).1 < obsPrep.1 then
+           deflateRawBasePPrep data toks else obsPrep) := by
+  simp only [deflateRawBasePPrepF_obsFreqs, deflateObsSplitSizedFreqsP_fst]
+
+end Zip.Native.Deflate

--- a/Zip/Spec/DeflateFreqsAdditive.lean
+++ b/Zip/Spec/DeflateFreqsAdditive.lean
@@ -1,0 +1,342 @@
+import Zip.Native.DeflateFreqs
+
+/-!
+# `tokenFreqsP` additivity over concatenation
+
+The split-sizing pass (`sharedPartitionSizedP`) computes `tokenFreqsP` per block,
+while the base candidate needs the whole-stream `tokenFreqsP`. This file proves
+that the whole-stream histogram is the end-of-block-corrected element-wise sum of
+the per-block histograms, so the second whole-stream walk can be replaced by a
+cheap `mergeEOBFreqsP` fold over the per-block frequencies.
+
+The core result is `tokenFreqsP_append`:
+
+    tokenFreqsP (a ++ b) = mergeEOBFreqsP (tokenFreqsP a) (tokenFreqsP b)
+
+proven via per-index histogram-counting lemmas: each `tokenFreqsP.go` run bumps
+one lit/len index (and, for references, one distance index) per word, so the
+final count at index `k` is the initial value plus the number of words that bump
+`k` (`litDeltaP`/`distDeltaP`). Those bump-counts are additive over `++`
+(`litDeltaP_append`/`distDeltaP_append`); the only correction is the EOB symbol
+256, which every histogram pre-counts once and no word ever bumps.
+-/
+
+namespace Zip.Native.Deflate
+
+/-- The lit/len index `tokenFreqsP` bumps for the word `ws[i]`: the literal byte
+    for a literal token, or the length code `+ 257` for a reference token —
+    exactly the index `bumpLitFreqP`/`bumpRefLitFreqP` write. -/
+def litBumpIdxP (w : UInt32) : Nat :=
+  if w &&& ((1 : UInt32) <<< 31) = 0 then w.toUInt8.toNat
+  else codeIdx (lenCodeWord (((w >>> 16) &&& 0x7FFF).toNat)) + 257
+
+/-- Number of words in `ws[i:]` whose lit/len bump lands on index `k`. -/
+def litDeltaP (ws : Array UInt32) (i k : Nat) : Nat :=
+  if h : i < ws.size then
+    (if litBumpIdxP ws[i] = k then 1 else 0) + litDeltaP ws (i + 1) k
+  else 0
+termination_by ws.size - i
+
+/-- Number of words in `ws[i:]` whose distance bump lands on index `k`
+    (literal words bump no distance). -/
+def distDeltaP (ws : Array UInt32) (i k : Nat) : Nat :=
+  if h : i < ws.size then
+    (if ws[i] &&& ((1 : UInt32) <<< 31) = 0 then 0
+     else if codeIdx (distCodeWord ((ws[i] &&& 0xFFFF).toNat)) = k then 1 else 0)
+      + distDeltaP ws (i + 1) k
+  else 0
+termination_by ws.size - i
+
+/-- No word ever bumps the end-of-block symbol (256): literals land below 256,
+    references at `≥ 257`. -/
+theorem litBumpIdxP_ne_256 (w : UInt32) : litBumpIdxP w ≠ 256 := by
+  unfold litBumpIdxP
+  split
+  · have := UInt8.toNat_lt w.toUInt8; omega
+  · omega
+
+/-- Consequently `litDeltaP` never counts index 256. -/
+theorem litDeltaP_256 (ws : Array UInt32) (i : Nat) : litDeltaP ws i 256 = 0 := by
+  induction h : ws.size - i using Nat.strongRecOn generalizing i with
+  | _ n ih =>
+    unfold litDeltaP
+    by_cases hi : i < ws.size
+    · rw [dif_pos hi, if_neg (litBumpIdxP_ne_256 _), Nat.zero_add]
+      exact ih (ws.size - (i + 1)) (by omega) (i + 1) rfl
+    · rw [dif_neg hi]
+
+/-- Single-step unfold of `litDeltaP` at a valid index. -/
+theorem litDeltaP_succ (ws : Array UInt32) (i k : Nat) (h : i < ws.size) :
+    litDeltaP ws i k = (if litBumpIdxP ws[i] = k then 1 else 0) + litDeltaP ws (i + 1) k := by
+  rw [litDeltaP, dif_pos h]
+
+/-- `litDeltaP` past the end is zero. -/
+theorem litDeltaP_of_ge (ws : Array UInt32) (i k : Nat) (h : ¬ i < ws.size) :
+    litDeltaP ws i k = 0 := by
+  rw [litDeltaP, dif_neg h]
+
+/-- Words counted from `a.size + j` in `a ++ b` are exactly `b`'s words from `j`. -/
+theorem litDeltaP_shift (a b : Array UInt32) (j k : Nat) :
+    litDeltaP (a ++ b) (a.size + j) k = litDeltaP b j k := by
+  induction h : b.size - j using Nat.strongRecOn generalizing j with
+  | _ n ih =>
+    by_cases hj : j < b.size
+    · have hij : a.size + j < (a ++ b).size := by rw [Array.size_append]; omega
+      rw [litDeltaP_succ _ _ _ hij, litDeltaP_succ _ _ _ hj]
+      have hw : (a ++ b)[a.size + j]'hij = b[j]'hj := by
+        rw [Array.getElem_append_right (by omega)]
+        simp only [Nat.add_sub_cancel_left]
+      rw [hw, show a.size + j + 1 = a.size + (j + 1) by omega]
+      rw [ih (b.size - (j + 1)) (by omega) (j + 1) rfl]
+    · rw [litDeltaP_of_ge _ _ _ (by rw [Array.size_append]; omega),
+        litDeltaP_of_ge _ _ _ hj]
+
+/-- `litDeltaP` is additive over `++`: counting from `i ≤ a.size` in `a ++ b`
+    splits into `a`'s words from `i` plus all of `b`'s words. -/
+theorem litDeltaP_append (a b : Array UInt32) (i k : Nat) (hi : i ≤ a.size) :
+    litDeltaP (a ++ b) i k = litDeltaP a i k + litDeltaP b 0 k := by
+  induction h : a.size - i using Nat.strongRecOn generalizing i with
+  | _ n ih =>
+    by_cases hlt : i < a.size
+    · have hij : i < (a ++ b).size := by rw [Array.size_append]; omega
+      rw [litDeltaP_succ _ _ _ hij, litDeltaP_succ _ _ _ hlt]
+      have hw : (a ++ b)[i]'hij = a[i]'hlt := Array.getElem_append_left hlt
+      rw [hw, Nat.add_assoc, ih (a.size - (i + 1)) (by omega) (i + 1) (by omega) rfl]
+    · have hie : i = a.size := by omega
+      subst hie
+      rw [litDeltaP_of_ge a a.size k (by omega), Nat.zero_add]
+      have := litDeltaP_shift a b 0 k
+      rwa [Nat.add_zero] at this
+
+/-- Single-step unfold of `distDeltaP` at a valid index. -/
+theorem distDeltaP_succ (ws : Array UInt32) (i k : Nat) (h : i < ws.size) :
+    distDeltaP ws i k =
+      (if ws[i] &&& ((1 : UInt32) <<< 31) = 0 then 0
+       else if codeIdx (distCodeWord ((ws[i] &&& 0xFFFF).toNat)) = k then 1 else 0)
+      + distDeltaP ws (i + 1) k := by
+  rw [distDeltaP, dif_pos h]
+
+/-- `distDeltaP` past the end is zero. -/
+theorem distDeltaP_of_ge (ws : Array UInt32) (i k : Nat) (h : ¬ i < ws.size) :
+    distDeltaP ws i k = 0 := by
+  rw [distDeltaP, dif_neg h]
+
+/-- Distance-bump analogue of `litDeltaP_shift`. -/
+theorem distDeltaP_shift (a b : Array UInt32) (j k : Nat) :
+    distDeltaP (a ++ b) (a.size + j) k = distDeltaP b j k := by
+  induction h : b.size - j using Nat.strongRecOn generalizing j with
+  | _ n ih =>
+    by_cases hj : j < b.size
+    · have hij : a.size + j < (a ++ b).size := by rw [Array.size_append]; omega
+      rw [distDeltaP_succ _ _ _ hij, distDeltaP_succ _ _ _ hj]
+      have hw : (a ++ b)[a.size + j]'hij = b[j]'hj := by
+        rw [Array.getElem_append_right (by omega)]
+        simp only [Nat.add_sub_cancel_left]
+      rw [hw, show a.size + j + 1 = a.size + (j + 1) by omega]
+      rw [ih (b.size - (j + 1)) (by omega) (j + 1) rfl]
+    · rw [distDeltaP_of_ge _ _ _ (by rw [Array.size_append]; omega),
+        distDeltaP_of_ge _ _ _ hj]
+
+/-- Distance-bump analogue of `litDeltaP_append`. -/
+theorem distDeltaP_append (a b : Array UInt32) (i k : Nat) (hi : i ≤ a.size) :
+    distDeltaP (a ++ b) i k = distDeltaP a i k + distDeltaP b 0 k := by
+  induction h : a.size - i using Nat.strongRecOn generalizing i with
+  | _ n ih =>
+    by_cases hlt : i < a.size
+    · have hij : i < (a ++ b).size := by rw [Array.size_append]; omega
+      rw [distDeltaP_succ _ _ _ hij, distDeltaP_succ _ _ _ hlt]
+      have hw : (a ++ b)[i]'hij = a[i]'hlt := Array.getElem_append_left hlt
+      rw [hw, Nat.add_assoc, ih (a.size - (i + 1)) (by omega) (i + 1) (by omega) rfl]
+    · have hie : i = a.size := by omega
+      subst hie
+      rw [distDeltaP_of_ge a a.size k (by omega), Nat.zero_add]
+      have := distDeltaP_shift a b 0 k
+      rwa [Nat.add_zero] at this
+
+/-! ## Histogram = initial + bump-count -/
+
+/-- Every `tokenFreqsP.go` run leaves the lit/len entry at `k` equal to its
+    initial value plus the number of processed words that bump `k`. -/
+theorem tokenFreqsP_go_lit (ws : Array UInt32) (lf : {a : Array Nat // a.size = 286})
+    (df : {a : Array Nat // a.size = 30}) (i k : Nat) :
+    (tokenFreqsP.go ws lf df i).1[k]! = lf.val[k]! + litDeltaP ws i k := by
+  induction hh : ws.size - i using Nat.strongRecOn generalizing lf df i with
+  | _ n ih =>
+    unfold tokenFreqsP.go
+    by_cases hi : i < ws.size
+    · simp only [hi, ↓reduceDIte]
+      rw [litDeltaP_succ _ _ _ hi]
+      by_cases hc : ws[i] &&& ((1 : UInt32) <<< 31) = 0
+      · simp only [hc, ↓reduceIte]
+        rw [ih (ws.size - (i + 1)) (by omega) _ _ _ rfl]
+        have hidx : ws[i].toUInt8.toNat < lf.val.size := by
+          have := UInt8.toNat_lt ws[i].toUInt8; rw [lf.property]; omega
+        have hbump : litBumpIdxP ws[i] = ws[i].toUInt8.toNat := by
+          unfold litBumpIdxP; rw [if_pos hc]
+        simp only [bumpLitFreqP, hbump]
+        by_cases hk : k = ws[i].toUInt8.toNat
+        · subst hk
+          rw [Array.getElem!_set!_self _ _ _ hidx, ← getElem!_pos lf.val _ hidx,
+            if_pos rfl]
+          omega
+        · rw [Array.getElem!_set!_ne _ _ _ _ (Ne.symm hk), if_neg (fun h => hk h.symm)]
+          omega
+      · simp only [hc, ↓reduceIte]
+        rw [ih (ws.size - (i + 1)) (by omega) _ _ _ rfl]
+        obtain ⟨⟨li, le, lv⟩, hli⟩ := Option.isSome_iff_exists.mp
+          (findLengthCode_isSome (((ws[i] >>> 16) &&& 0x7FFF).toNat))
+        have hbnd := nativeFindLengthCode_idx_bound _ _ _ _ hli
+        have hidx : codeIdx (lenCodeWord (((ws[i] >>> 16) &&& 0x7FFF).toNat)) + 257 < lf.val.size := by
+          have : codeIdx (lenCodeWord (((ws[i] >>> 16) &&& 0x7FFF).toNat)) = li :=
+            codeIdx_lenCodeWord _ _ _ _ hli
+          rw [lf.property]; omega
+        have hbump : litBumpIdxP ws[i] =
+            codeIdx (lenCodeWord (((ws[i] >>> 16) &&& 0x7FFF).toNat)) + 257 := by
+          unfold litBumpIdxP; rw [if_neg hc]
+        simp only [bumpRefLitFreqP, hbump]
+        by_cases hk : k = codeIdx (lenCodeWord (((ws[i] >>> 16) &&& 0x7FFF).toNat)) + 257
+        · subst hk
+          rw [Array.getElem!_set!_self _ _ _ hidx, ← getElem!_pos lf.val _ hidx,
+            if_pos rfl]
+          omega
+        · rw [Array.getElem!_set!_ne _ _ _ _ (Ne.symm hk), if_neg (fun h => hk h.symm)]
+          omega
+    · rw [dif_neg hi, litDeltaP_of_ge _ _ _ hi]
+      simp
+
+/-- Distance analogue of `tokenFreqsP_go_lit`. -/
+theorem tokenFreqsP_go_dist (ws : Array UInt32) (lf : {a : Array Nat // a.size = 286})
+    (df : {a : Array Nat // a.size = 30}) (i k : Nat) :
+    (tokenFreqsP.go ws lf df i).2[k]! = df.val[k]! + distDeltaP ws i k := by
+  induction hh : ws.size - i using Nat.strongRecOn generalizing lf df i with
+  | _ n ih =>
+    unfold tokenFreqsP.go
+    by_cases hi : i < ws.size
+    · simp only [hi, ↓reduceDIte]
+      rw [distDeltaP_succ _ _ _ hi]
+      by_cases hc : ws[i] &&& ((1 : UInt32) <<< 31) = 0
+      · simp only [hc, ↓reduceIte]
+        rw [ih (ws.size - (i + 1)) (by omega) _ _ _ rfl]
+        omega
+      · simp only [hc, ↓reduceIte]
+        rw [ih (ws.size - (i + 1)) (by omega) _ _ _ rfl]
+        obtain ⟨⟨di, de, dv⟩, hdi⟩ := Option.isSome_iff_exists.mp
+          (findDistCode_isSome ((ws[i] &&& 0xFFFF).toNat))
+        have hbnd := nativeFindDistCode_idx_bound _ _ _ _ hdi
+        have hidx : codeIdx (distCodeWord ((ws[i] &&& 0xFFFF).toNat)) < df.val.size := by
+          have : codeIdx (distCodeWord ((ws[i] &&& 0xFFFF).toNat)) = di :=
+            codeIdx_distCodeWord _ _ _ _ hdi
+          rw [df.property]; omega
+        simp only [bumpRefDistFreqP]
+        by_cases hk : k = codeIdx (distCodeWord ((ws[i] &&& 0xFFFF).toNat))
+        · subst hk
+          rw [Array.getElem!_set!_self _ _ _ hidx, ← getElem!_pos df.val _ hidx,
+            if_pos rfl]
+          omega
+        · rw [Array.getElem!_set!_ne _ _ _ _ (Ne.symm hk), if_neg (fun h => hk h.symm)]
+          omega
+    · rw [dif_neg hi, distDeltaP_of_ge _ _ _ hi]
+      simp
+
+/-- `tokenFreqsP.go` preserves the histogram sizes. -/
+theorem tokenFreqsP_go_size (ws : Array UInt32) (lf : {a : Array Nat // a.size = 286})
+    (df : {a : Array Nat // a.size = 30}) (i : Nat) :
+    (tokenFreqsP.go ws lf df i).1.size = 286 ∧ (tokenFreqsP.go ws lf df i).2.size = 30 := by
+  induction hh : ws.size - i using Nat.strongRecOn generalizing lf df i with
+  | _ n ih =>
+    unfold tokenFreqsP.go
+    by_cases hi : i < ws.size
+    · simp only [hi, ↓reduceDIte]
+      by_cases hc : ws[i] &&& ((1 : UInt32) <<< 31) = 0
+      · simp only [hc, ↓reduceIte]; exact ih (ws.size - (i + 1)) (by omega) _ _ _ rfl
+      · simp only [hc, ↓reduceIte]; exact ih (ws.size - (i + 1)) (by omega) _ _ _ rfl
+    · rw [dif_neg hi]; exact ⟨lf.property, df.property⟩
+
+/-- `tokenFreqsP` produces histograms of size 286 and 30. -/
+theorem tokenFreqsP_size (ws : Array UInt32) :
+    (tokenFreqsP ws).1.size = 286 ∧ (tokenFreqsP ws).2.size = 30 := by
+  unfold tokenFreqsP; exact tokenFreqsP_go_size _ _ _ _
+
+/-- Any index into an all-zero replicate array reads zero (in or out of bounds). -/
+theorem replicate_zero_get (n k : Nat) : (Array.replicate n (0 : Nat))[k]! = 0 := by
+  by_cases hkk : k < n
+  · rw [getElem!_pos _ _ (by rw [Array.size_replicate]; exact hkk), Array.getElem_replicate]
+  · rw [getElem!_neg _ _ (by rw [Array.size_replicate]; omega)]; rfl
+
+/-- Value of the pre-seeded lit/len histogram: EOB (256) counted once, else zero. -/
+theorem initLit_get (k : Nat) :
+    ((Array.replicate 286 (0 : Nat)).set! 256 1)[k]! = if k = 256 then 1 else 0 := by
+  by_cases hk : k = 256
+  · subst hk
+    rw [Array.getElem!_set!_self _ _ _ (by rw [Array.size_replicate]; omega), if_pos rfl]
+  · rw [Array.getElem!_set!_ne _ _ _ _ (fun h => hk h.symm), if_neg hk, replicate_zero_get]
+
+/-- Whole-stream lit/len count at `k`: EOB pre-count plus the words that bump `k`. -/
+theorem tokenFreqsP_lit (ws : Array UInt32) (k : Nat) :
+    (tokenFreqsP ws).1[k]! = (if k = 256 then 1 else 0) + litDeltaP ws 0 k := by
+  unfold tokenFreqsP
+  rw [tokenFreqsP_go_lit, initLit_get]
+
+/-- Whole-stream distance count at `k`: exactly the words that bump `k`. -/
+theorem tokenFreqsP_dist (ws : Array UInt32) (k : Nat) :
+    (tokenFreqsP ws).2[k]! = distDeltaP ws 0 k := by
+  unfold tokenFreqsP
+  rw [tokenFreqsP_go_dist, replicate_zero_get, Nat.zero_add]
+
+/-- Element-wise sum of two equal-size arrays reads as the sum of the elements. -/
+theorem zipWithAdd_get (A B : Array Nat) (k : Nat) (hk : k < A.size) (hAB : A.size = B.size) :
+    (Array.zipWith (· + ·) A B)[k]! = A[k]! + B[k]! := by
+  have hkB : k < B.size := by omega
+  have hsz : k < (Array.zipWith (· + ·) A B).size := by rw [Array.size_zipWith]; omega
+  rw [getElem!_pos (Array.zipWith (· + ·) A B) k hsz, Array.getElem_zipWith,
+    getElem!_pos A k hk, getElem!_pos B k hkB]
+
+/-- **Additivity of `tokenFreqsP` over concatenation.** The whole-stream histogram
+    is the element-wise sum of the two sub-stream histograms, correcting the EOB
+    symbol (256) that both pre-count. This is what lets the split-sizing pass's
+    per-block frequencies be folded (`mergeEOBFreqsP`) into the whole-stream
+    frequencies the base candidate needs, with no second whole-stream walk. -/
+theorem tokenFreqsP_append (a b : Array UInt32) :
+    tokenFreqsP (a ++ b) = mergeEOBFreqsP (tokenFreqsP a) (tokenFreqsP b) := by
+  have hsa := tokenFreqsP_size a
+  have hsb := tokenFreqsP_size b
+  have hsab := tokenFreqsP_size (a ++ b)
+  apply Prod.ext
+  · -- lit/len component
+    apply Array.ext
+    · rw [hsab.1]
+      simp only [mergeEOBFreqsP, Array.size_set!, Array.size_zipWith, hsa.1, hsb.1, Nat.min_self]
+    · intro k hk1 _
+      rw [hsab.1] at hk1
+      rw [← getElem!_pos _ k (by rw [hsab.1]; exact hk1),
+        ← getElem!_pos _ k (by
+          simp only [mergeEOBFreqsP, Array.size_set!, Array.size_zipWith, hsa.1, hsb.1]; exact hk1)]
+      rw [tokenFreqsP_lit (a ++ b) k, litDeltaP_append a b 0 k (Nat.zero_le _)]
+      simp only [mergeEOBFreqsP]
+      by_cases hk256 : k = 256
+      · subst hk256
+        rw [Array.getElem!_set!_self _ _ _ (by rw [Array.size_zipWith, hsa.1, hsb.1]; omega),
+          zipWithAdd_get _ _ _ (by rw [hsa.1]; omega) (by rw [hsa.1, hsb.1]),
+          tokenFreqsP_lit a 256, tokenFreqsP_lit b 256]
+        simp only [↓reduceIte]
+        omega
+      · rw [Array.getElem!_set!_ne _ _ _ _ (fun h => hk256 h.symm),
+          zipWithAdd_get _ _ _ (by rw [hsa.1]; omega) (by rw [hsa.1, hsb.1]),
+          tokenFreqsP_lit a k, tokenFreqsP_lit b k]
+        simp only [if_neg hk256]
+        omega
+  · -- distance component
+    apply Array.ext
+    · rw [hsab.2]
+      simp only [mergeEOBFreqsP, Array.size_zipWith, hsa.2, hsb.2, Nat.min_self]
+    · intro k hk1 _
+      rw [hsab.2] at hk1
+      rw [← getElem!_pos _ k (by rw [hsab.2]; exact hk1),
+        ← getElem!_pos _ k (by
+          simp only [mergeEOBFreqsP, Array.size_zipWith, hsa.2, hsb.2]; exact hk1)]
+      rw [tokenFreqsP_dist (a ++ b) k, distDeltaP_append a b 0 k (Nat.zero_le _)]
+      simp only [mergeEOBFreqsP]
+      rw [zipWithAdd_get _ _ _ (by rw [hsa.2]; omega) (by rw [hsa.2, hsb.2]),
+        tokenFreqsP_dist a k, tokenFreqsP_dist b k]
+
+end Zip.Native.Deflate

--- a/Zip/Spec/DeflateRoundtrip.lean
+++ b/Zip/Spec/DeflateRoundtrip.lean
@@ -2,6 +2,7 @@ import Zip.Spec.DeflateFixedCorrect
 import Zip.Spec.DeflateDynamicCorrect
 import Zip.Spec.LZ77ChainCorrect
 import Zip.Spec.LZ77PackedCorrect
+import Zip.Spec.DeflateBaseFreqsReuse
 import Zip.Spec.DeflateBlockSplit
 
 /-!
@@ -157,16 +158,17 @@ theorem inflate_deflateRaw (data : ByteArray) (level : UInt8)
       p = (if (chooseSplitsHeuristicP (lzMatchP data level) data.size).isEmpty then
             deflateRawBasePPrep data (lzMatchP data level)
           else
-            let obsPrep := deflateDynamicBlocksSharedAtSizedP data (lzMatchP data level)
+            let obsFreqs := deflateObsSplitSizedFreqsP data (lzMatchP data level)
               (chooseSplitsHeuristicP (lzMatchP data level) data.size)
-            if (deflateRawBasePPrep data (lzMatchP data level)).1 < obsPrep.1 then
-              deflateRawBasePPrep data (lzMatchP data level) else obsPrep) →
+            let basePrep := deflateRawBasePPrepF data (lzMatchP data level) obsFreqs.2
+            if basePrep.1 < obsFreqs.1.1 then basePrep else obsFreqs.1) →
       Zip.Native.Inflate.inflateReference (p.2 ()) maxOutputSize = .ok data := by
     intro p hp; subst hp
+    dsimp only []
+    rw [deflateRawBasePPrepF_obsFreqs, deflateObsSplitSizedFreqsP_fst]
     split
     · exact hbase
-    · dsimp only []
-      split
+    · split
       · exact hbase
       · exact hsplit _
   split
@@ -296,17 +298,18 @@ theorem deflateRaw_pad (data : ByteArray) (level : UInt8) :
       p = (if (chooseSplitsHeuristicP (lzMatchP data level) data.size).isEmpty then
             deflateRawBasePPrep data (lzMatchP data level)
           else
-            let obsPrep := deflateDynamicBlocksSharedAtSizedP data (lzMatchP data level)
+            let obsFreqs := deflateObsSplitSizedFreqsP data (lzMatchP data level)
               (chooseSplitsHeuristicP (lzMatchP data level) data.size)
-            if (deflateRawBasePPrep data (lzMatchP data level)).1 < obsPrep.1 then
-              deflateRawBasePPrep data (lzMatchP data level) else obsPrep) →
+            let basePrep := deflateRawBasePPrepF data (lzMatchP data level) obsFreqs.2
+            if basePrep.1 < obsFreqs.1.1 then basePrep else obsFreqs.1) →
       ∃ (contentBits padding : List Bool),
         Deflate.Spec.bytesToBits (p.2 ()) = contentBits ++ padding ∧ padding.length < 8 := by
     intro p hp; subst hp
+    dsimp only []
+    rw [deflateRawBasePPrepF_obsFreqs, deflateObsSplitSizedFreqsP_fst]
     split
     · exact hbase
-    · dsimp only []
-      split
+    · split
       · exact hbase
       · exact hsplit _
   split
@@ -517,18 +520,19 @@ theorem deflateRaw_goR_pad (data : ByteArray) (level : UInt8) :
       p = (if (chooseSplitsHeuristicP (lzMatchP data level) data.size).isEmpty then
             deflateRawBasePPrep data (lzMatchP data level)
           else
-            let obsPrep := deflateDynamicBlocksSharedAtSizedP data (lzMatchP data level)
+            let obsFreqs := deflateObsSplitSizedFreqsP data (lzMatchP data level)
               (chooseSplitsHeuristicP (lzMatchP data level) data.size)
-            if (deflateRawBasePPrep data (lzMatchP data level)).1 < obsPrep.1 then
-              deflateRawBasePPrep data (lzMatchP data level) else obsPrep) →
+            let basePrep := deflateRawBasePPrepF data (lzMatchP data level) obsFreqs.2
+            if basePrep.1 < obsFreqs.1.1 then basePrep else obsFreqs.1) →
       ∃ remaining,
         Deflate.Spec.decode.goR (Deflate.Spec.bytesToBits (p.2 ())) []
           = some (data.data.toList, remaining) ∧ remaining.length < 8 := by
     intro p hp; subst hp
+    dsimp only []
+    rw [deflateRawBasePPrepF_obsFreqs, deflateObsSplitSizedFreqsP_fst]
     split
     · exact hbase
-    · dsimp only []
-      split
+    · split
       · exact hbase
       · exact hsplit _
   split

--- a/bench/graphs/canterbury_compress_heatmap.svg
+++ b/bench/graphs/canterbury_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#pd6d8e8b52b)">
+   <g clip-path="url(#pfa937b0076)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJD0lEQVR4nO3Yv6plZx3H4dlz9tEZcwyDkDEkEAIGbIRUptHe3gvJFdh4Dd6BBNKHgIW1jaWkiSDIEAdCdJJMkjNnzuw/KQR74fPySxbPcwXfxcta+7Pf3enL9893+H65+Xp6wTrPt/ls59ub6QnL7F5+OD1hjR/+aHrBOru70wvWeLHd92yrZ3Z+8sn0hGW2eWIAAIMEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBAbP9o92R6wxK3x5vpCcu8+uDN6QnLXJ0eTk9YYvfs6fSEZf7y7OPpCUu89oNXpicsczwdpics8dXhenrCMofzcXrCEr/88evTE5ZxgwUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAACx/dXlg+kNS5z2p+kJy1zduTc9YZ0vHk0vWOL87On0hGXeeeNX0xOWuD5s98y+2eizvXX1i+kJy9zuDtMTljj/82/TE5ZxgwUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAACx/f2Lq+kNS9wcr6cnrLPbcBffe3l6wRK7DZ/Z5eEwPWGJLZ/ZS/ttvmef3j6enrDM4XQ7PWGJ1196MD1hme1+QQAAhggsAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiO2OH/3+PD0C/ud0ml4A/3XX/8/vHd8PvkN8QQAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACC2f/ezR9Mblnj6/Dg9YZm/Pv5qesIyH/7219MTlvjp/TemJyzz9h/fm56wxG9+9pPpCcv84/Nn0xOWuL+/mJ6wzAd/+vv0hCWu//C76QnLuMECAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACA2O5w+vN5esQKx9NhesIyd3fb7eKLm+vpCWtc7KcXrPPNk+kFSxwfvDo9YZnT+TQ9YYnL3Xbfsxfnbf6mXR62+Vx37rjBAgDICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgNj+7kYb6zg9YKGLzx9PT1jn639PL1jifPtiesIyu9d+Pj2B/9Pt6WZ6whKXzw/TE5a5vL2enrDE+T//mp6wzDbrCgBgkMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIh9C2+nguZFZfrYAAAAAElFTkSuQmCC" id="image4eea8528b2" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJB0lEQVR4nO3YvYpdVQCG4TmZM5qYMQyCMRgIgjaCYKWN9vZeiFdg4zV4ByLYi2BhbWMpNgqCRAmKkmh+ZiaT82Mh2AvvYpnN81zBt1nsfd6zVru/Ptsf8HQ5fzh7wTiPl/ls+4vz2ROGWV27PnvCGM8+N3vBOKtLsxeM8WS579lSz2x/95fZE4ZZ5okBAEwksAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYuvbq7uzNwxxsT2fPWGYGyevzJ4wzPHu+uwJQ6zO7s+eMMzXZ9/PnjDEy8+8OHvCMNvdZvaEIR5sTmdPGGaz386eMMRbz9+cPWEYN1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQWx8fnczeMMRuvZs9YZjjg8uzJ4zz5+3ZC4bYn92fPWGYt2+9M3vCEKeb5Z7Zo4U+22vHb8yeMMzFajN7whD7n76dPWEYN1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQW185PJ69YYjz7ensCeOsFtzFl6/NXjDEasFndrTZzJ4wxJLP7Op6me/Zbxd3Zk8YZrO7mD1hiJtXT2ZPGGa5XxAAgEkEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMRW2+8+2s8eAf/a7WYvgH9c8v/zqeP7wf+ILwgAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDE1h/8fnv2hiHuP97OnjDMN3cezJ4wzBfvvzt7whAvXbk1e8Iwb37y6ewJQ7z36guzJwzz472z2ROGuLI+nD1hmM+//GH2hCFOP/5w9oRh3GABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBAbLXZfbWfPWKE7W4ze8Iwl1bL7eLD89PZE8Y4XM9eMM6ju7MXDLE9uTF7wjC7/W72hCGOVst9z57sl/mbdrRZ5nMdHLjBAgDICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgNh69oBR9ge72ROGObz36+wJ4zz8Y/aCIfYXT2ZPGGZ18/XZE/iPHm9PZ08Y4mi5r9nB0cUyz2z/x8+zJwzjBgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABifwNgWILmYcDVwgAAAABJRU5ErkJggg==" id="image0de40c5a5b" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m00bb4f7fd2" d="M 0 0 
+       <path id="m9d3b5b1483" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m00bb4f7fd2" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9d3b5b1483" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m00bb4f7fd2" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9d3b5b1483" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m00bb4f7fd2" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9d3b5b1483" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m00bb4f7fd2" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9d3b5b1483" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m00bb4f7fd2" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9d3b5b1483" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m00bb4f7fd2" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9d3b5b1483" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m00bb4f7fd2" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9d3b5b1483" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m00bb4f7fd2" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9d3b5b1483" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m00bb4f7fd2" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9d3b5b1483" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m00bb4f7fd2" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9d3b5b1483" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m00bb4f7fd2" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9d3b5b1483" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="m24fedad417" d="M 0 0 
+       <path id="md92ec006b4" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m24fedad417" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md92ec006b4" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m24fedad417" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md92ec006b4" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m24fedad417" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md92ec006b4" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m24fedad417" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md92ec006b4" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m24fedad417" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md92ec006b4" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m24fedad417" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md92ec006b4" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m24fedad417" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md92ec006b4" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m24fedad417" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md92ec006b4" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1303,7 +1303,7 @@ L 527.435033 49.4355
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_20">
-    <!-- +3 -->
+    <!-- +5 -->
     <g transform="translate(110.510438 68.904519) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-2b" d="M 2944 4013 
@@ -1321,54 +1321,14 @@ L 2419 4013
 L 2944 4013 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-33" d="M 2597 2516 
-Q 3050 2419 3304 2112 
-Q 3559 1806 3559 1356 
-Q 3559 666 3084 287 
-Q 2609 -91 1734 -91 
-Q 1441 -91 1130 -33 
-Q 819 25 488 141 
-L 488 750 
-Q 750 597 1062 519 
-Q 1375 441 1716 441 
-Q 2309 441 2620 675 
-Q 2931 909 2931 1356 
-Q 2931 1769 2642 2001 
-Q 2353 2234 1838 2234 
-L 1294 2234 
-L 1294 2753 
-L 1863 2753 
-Q 2328 2753 2575 2939 
-Q 2822 3125 2822 3475 
-Q 2822 3834 2567 4026 
-Q 2313 4219 1838 4219 
-Q 1578 4219 1281 4162 
-Q 984 4106 628 3988 
-L 628 4550 
-Q 988 4650 1302 4700 
-Q 1616 4750 1894 4750 
-Q 2613 4750 3031 4423 
-Q 3450 4097 3450 3541 
-Q 3450 3153 3228 2886 
-Q 3006 2619 2597 2516 
-z
-" transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_21">
-    <!-- +10 -->
+    <!-- +14 -->
     <g transform="translate(147.693424 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_22">
-    <!-- -47 -->
-    <g transform="translate(188.495082 68.904519) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1389,6 +1349,16 @@ L 313 1709
 L 2253 4666 
 z
 " transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_22">
+    <!-- -47 -->
+    <g transform="translate(188.495082 68.904519) scale(0.065 -0.065)">
+     <defs>
       <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
 L 3525 4397 
@@ -1406,8 +1376,16 @@ z
     </g>
    </g>
    <g id="text_23">
-    <!-- -78 -->
+    <!-- -79 -->
     <g transform="translate(227.74588 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_24">
+    <!-- -89 -->
+    <g transform="translate(266.996679 68.904519) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -1450,87 +1428,81 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_24">
-    <!-- -88 -->
-    <g transform="translate(266.996679 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_25">
-    <!-- -26 -->
+    <!-- -25 -->
     <g transform="translate(306.247477 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_26">
+    <!-- +8 -->
+    <g transform="translate(346.015229 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_27">
+    <!-- +27 -->
+    <g transform="translate(383.198215 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_28">
+    <!-- -27 -->
+    <g transform="translate(423.999873 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_29">
+    <!-- -43 -->
+    <g transform="translate(463.250671 68.904519) scale(0.065 -0.065)">
      <defs>
-      <path id="DejaVuSans-36" d="M 2113 2584 
-Q 1688 2584 1439 2293 
-Q 1191 2003 1191 1497 
-Q 1191 994 1439 701 
-Q 1688 409 2113 409 
-Q 2538 409 2786 701 
-Q 3034 994 3034 1497 
-Q 3034 2003 2786 2293 
-Q 2538 2584 2113 2584 
-z
-M 3366 4563 
-L 3366 3988 
-Q 3128 4100 2886 4159 
-Q 2644 4219 2406 4219 
-Q 1781 4219 1451 3797 
-Q 1122 3375 1075 2522 
-Q 1259 2794 1537 2939 
-Q 1816 3084 2150 3084 
-Q 2853 3084 3261 2657 
-Q 3669 2231 3669 1497 
-Q 3669 778 3244 343 
-Q 2819 -91 2113 -91 
-Q 1303 -91 875 529 
-Q 447 1150 447 2328 
-Q 447 3434 972 4092 
-Q 1497 4750 2381 4750 
-Q 2619 4750 2861 4703 
-Q 3103 4656 3366 4563 
+      <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_26">
-    <!-- +6 -->
-    <g transform="translate(346.015229 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_27">
-    <!-- +24 -->
-    <g transform="translate(383.198215 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_28">
-    <!-- -29 -->
-    <g transform="translate(423.999873 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_29">
-    <!-- -45 -->
-    <g transform="translate(463.250671 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_30">
@@ -1663,6 +1635,38 @@ z
    <g id="text_46">
     <!-- +26 -->
     <g transform="translate(265.44582 139.606222) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
@@ -2177,18 +2181,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="image1783b24fb6" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
+iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="image8b2f6524f8" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="mf5ffc6765f" d="M 0 0 
+       <path id="mef04d20138" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mf5ffc6765f" x="547.779688" y="276.293905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mef04d20138" x="547.779688" y="276.293905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
@@ -2211,7 +2215,7 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#mf5ffc6765f" x="547.779688" y="247.808905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mef04d20138" x="547.779688" y="247.808905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
@@ -2225,7 +2229,7 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#mf5ffc6765f" x="547.779688" y="219.323905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mef04d20138" x="547.779688" y="219.323905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
@@ -2239,7 +2243,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#mf5ffc6765f" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mef04d20138" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
@@ -2252,7 +2256,7 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mf5ffc6765f" x="547.779688" y="162.353904" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mef04d20138" x="547.779688" y="162.353904" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_112">
@@ -2265,7 +2269,7 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#mf5ffc6765f" x="547.779688" y="133.868904" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mef04d20138" x="547.779688" y="133.868904" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
@@ -2278,7 +2282,7 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mf5ffc6765f" x="547.779688" y="105.383904" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mef04d20138" x="547.779688" y="105.383904" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
@@ -2939,8 +2943,8 @@ z
    </g>
   </g>
   <g id="text_117">
-   <!-- 2026-07-07T02:05:28Z  ·  Linux chungus2 x86_64  ·  commit 1a899305  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(16.462422 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-07T22:17:01Z  ·  Linux chungus2 x86_64  ·  commit dcf4b958  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(17.687422 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -3009,14 +3013,14 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-37" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3056,109 +3060,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3196.777344 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3260.400391 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3324.023438 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3387.646484 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3451.269531 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3514.892578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3578.515625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3610.302734 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3642.089844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3673.876953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3705.664062 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3737.451172 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3765.234375 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3826.757812 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3888.037109 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3951.416016 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4014.892578 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4053.755859 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4114.9375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4174.117188 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4235.640625 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4276.753906 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4310.445312 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4338.228516 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4399.751953 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4461.03125 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4524.410156 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4588.033203 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4621.724609 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4680.904297 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4744.527344 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4776.314453 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4839.9375 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4903.560547 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4935.347656 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4998.970703 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5035.054688 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5073.917969 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5128.898438 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5192.521484 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5224.308594 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5256.095703 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5287.882812 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5319.669922 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5351.457031 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5390.666016 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5454.044922 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5492.908203 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5554.089844 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5617.46875 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5680.945312 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5744.324219 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5807.800781 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5871.179688 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5910.388672 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5942.175781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6025.964844 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6057.751953 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6155.164062 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6216.6875 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6280.164062 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6307.947266 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6369.226562 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6432.605469 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6464.392578 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6516.492188 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6579.871094 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6641.150391 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6704.626953 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6756.726562 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6820.105469 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6881.287109 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6920.496094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6954.1875 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6985.974609 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7027.087891 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7088.367188 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7127.576172 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7155.359375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7216.541016 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7248.328125 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7276.111328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7328.210938 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7359.998047 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7423.474609 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7484.998047 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7524.207031 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7585.730469 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7625.09375 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7722.505859 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7750.289062 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7813.667969 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7841.451172 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7893.550781 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7932.759766 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7960.542969 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3135.351562 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3190.332031 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3225.537109 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3289.160156 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3352.636719 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3416.259766 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3479.882812 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3543.505859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3575.292969 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3607.080078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3638.867188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3670.654297 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3702.441406 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3730.224609 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3791.748047 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3853.027344 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3916.40625 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3979.882812 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4018.746094 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4079.927734 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4139.107422 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4200.630859 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4241.744141 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4275.435547 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4303.21875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4364.742188 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4426.021484 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4489.400391 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4553.023438 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4586.714844 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4645.894531 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4709.517578 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4741.304688 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4804.927734 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4868.550781 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4900.337891 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4963.960938 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5000.044922 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5038.908203 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5093.888672 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5157.511719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5189.298828 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5221.085938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5252.873047 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5284.660156 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5316.447266 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5355.65625 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5419.035156 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5457.898438 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5519.080078 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5582.458984 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5645.935547 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5709.314453 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5772.791016 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5836.169922 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5875.378906 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5907.166016 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5990.955078 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6022.742188 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6120.154297 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6181.677734 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6245.154297 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6272.9375 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6334.216797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6397.595703 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6429.382812 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6481.482422 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6544.861328 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6606.140625 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6669.617188 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6721.716797 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6785.095703 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6846.277344 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6885.486328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6919.177734 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6950.964844 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6992.078125 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7053.357422 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7092.566406 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7120.349609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7181.53125 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7213.318359 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7241.101562 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7293.201172 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7324.988281 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7388.464844 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7449.988281 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7489.197266 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7550.720703 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7590.083984 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7687.496094 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7715.279297 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7778.658203 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7806.441406 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7858.541016 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7897.75 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7925.533203 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pd6d8e8b52b">
+  <clipPath id="pfa937b0076">
    <rect x="95.67625" y="49.4355" width="431.758783" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_compress_pareto.svg
+++ b/bench/graphs/canterbury_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 79.118387 412.80375 
 L 79.118387 48.323125 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="mb8ecdc507c" d="M 0 0 
+       <path id="m72909e15f7" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mb8ecdc507c" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m72909e15f7" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -161,11 +161,11 @@ z
      <g id="line2d_3">
       <path d="M 166.481434 412.80375 
 L 166.481434 48.323125 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mb8ecdc507c" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m72909e15f7" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -216,11 +216,11 @@ z
      <g id="line2d_5">
       <path d="M 253.844481 412.80375 
 L 253.844481 48.323125 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#mb8ecdc507c" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m72909e15f7" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -237,11 +237,11 @@ L 253.844481 48.323125
      <g id="line2d_7">
       <path d="M 341.207528 412.80375 
 L 341.207528 48.323125 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#mb8ecdc507c" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m72909e15f7" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -279,11 +279,11 @@ z
      <g id="line2d_9">
       <path d="M 428.570575 412.80375 
 L 428.570575 48.323125 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#mb8ecdc507c" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m72909e15f7" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -332,11 +332,11 @@ z
      <g id="line2d_11">
       <path d="M 515.933622 412.80375 
 L 515.933622 48.323125 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#mb8ecdc507c" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m72909e15f7" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -353,11 +353,11 @@ L 515.933622 48.323125
      <g id="line2d_13">
       <path d="M 603.296669 412.80375 
 L 603.296669 48.323125 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mb8ecdc507c" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m72909e15f7" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -854,16 +854,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 347.786382 
 L 637.2 347.786382 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="m10a4cb6b4c" d="M 0 0 
+       <path id="m82a5852e3c" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m10a4cb6b4c" x="49.078125" y="347.786382" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m82a5852e3c" x="49.078125" y="347.786382" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -895,11 +895,11 @@ z
      <g id="line2d_17">
       <path d="M 49.078125 238.646289 
 L 637.2 238.646289 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m10a4cb6b4c" x="49.078125" y="238.646289" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m82a5852e3c" x="49.078125" y="238.646289" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -915,11 +915,11 @@ L 637.2 238.646289
      <g id="line2d_19">
       <path d="M 49.078125 129.506196 
 L 637.2 129.506196 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m10a4cb6b4c" x="49.078125" y="129.506196" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m82a5852e3c" x="49.078125" y="129.506196" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -935,16 +935,16 @@ L 637.2 129.506196
      <g id="line2d_21">
       <path d="M 49.078125 404.853417 
 L 637.2 404.853417 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="mafee7c4355" d="M 0 0 
+       <path id="m2ac1984819" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#mafee7c4355" x="49.078125" y="404.853417" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2ac1984819" x="49.078125" y="404.853417" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -952,11 +952,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 391.217592 
 L 637.2 391.217592 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mafee7c4355" x="49.078125" y="391.217592" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2ac1984819" x="49.078125" y="391.217592" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -964,11 +964,11 @@ L 637.2 391.217592
      <g id="line2d_25">
       <path d="M 49.078125 380.640824 
 L 637.2 380.640824 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mafee7c4355" x="49.078125" y="380.640824" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2ac1984819" x="49.078125" y="380.640824" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -976,11 +976,11 @@ L 637.2 380.640824
      <g id="line2d_27">
       <path d="M 49.078125 371.998975 
 L 637.2 371.998975 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#mafee7c4355" x="49.078125" y="371.998975" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2ac1984819" x="49.078125" y="371.998975" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -988,11 +988,11 @@ L 637.2 371.998975
      <g id="line2d_29">
       <path d="M 49.078125 364.692396 
 L 637.2 364.692396 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#mafee7c4355" x="49.078125" y="364.692396" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2ac1984819" x="49.078125" y="364.692396" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1000,11 +1000,11 @@ L 637.2 364.692396
      <g id="line2d_31">
       <path d="M 49.078125 358.36315 
 L 637.2 358.36315 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#mafee7c4355" x="49.078125" y="358.36315" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2ac1984819" x="49.078125" y="358.36315" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1012,11 +1012,11 @@ L 637.2 358.36315
      <g id="line2d_33">
       <path d="M 49.078125 352.780359 
 L 637.2 352.780359 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#mafee7c4355" x="49.078125" y="352.780359" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2ac1984819" x="49.078125" y="352.780359" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1024,11 +1024,11 @@ L 637.2 352.780359
      <g id="line2d_35">
       <path d="M 49.078125 314.93194 
 L 637.2 314.93194 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#mafee7c4355" x="49.078125" y="314.93194" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2ac1984819" x="49.078125" y="314.93194" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1036,11 +1036,11 @@ L 637.2 314.93194
      <g id="line2d_37">
       <path d="M 49.078125 295.713324 
 L 637.2 295.713324 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#mafee7c4355" x="49.078125" y="295.713324" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2ac1984819" x="49.078125" y="295.713324" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1048,11 +1048,11 @@ L 637.2 295.713324
      <g id="line2d_39">
       <path d="M 49.078125 282.077499 
 L 637.2 282.077499 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#mafee7c4355" x="49.078125" y="282.077499" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2ac1984819" x="49.078125" y="282.077499" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1060,11 +1060,11 @@ L 637.2 282.077499
      <g id="line2d_41">
       <path d="M 49.078125 271.500731 
 L 637.2 271.500731 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#mafee7c4355" x="49.078125" y="271.500731" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2ac1984819" x="49.078125" y="271.500731" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1072,11 +1072,11 @@ L 637.2 271.500731
      <g id="line2d_43">
       <path d="M 49.078125 262.858882 
 L 637.2 262.858882 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#mafee7c4355" x="49.078125" y="262.858882" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2ac1984819" x="49.078125" y="262.858882" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1084,11 +1084,11 @@ L 637.2 262.858882
      <g id="line2d_45">
       <path d="M 49.078125 255.552304 
 L 637.2 255.552304 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#mafee7c4355" x="49.078125" y="255.552304" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2ac1984819" x="49.078125" y="255.552304" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1096,11 +1096,11 @@ L 637.2 255.552304
      <g id="line2d_47">
       <path d="M 49.078125 249.223057 
 L 637.2 249.223057 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#mafee7c4355" x="49.078125" y="249.223057" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2ac1984819" x="49.078125" y="249.223057" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1108,11 +1108,11 @@ L 637.2 249.223057
      <g id="line2d_49">
       <path d="M 49.078125 243.640266 
 L 637.2 243.640266 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#mafee7c4355" x="49.078125" y="243.640266" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2ac1984819" x="49.078125" y="243.640266" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1120,11 +1120,11 @@ L 637.2 243.640266
      <g id="line2d_51">
       <path d="M 49.078125 205.791848 
 L 637.2 205.791848 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#mafee7c4355" x="49.078125" y="205.791848" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2ac1984819" x="49.078125" y="205.791848" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1132,11 +1132,11 @@ L 637.2 205.791848
      <g id="line2d_53">
       <path d="M 49.078125 186.573231 
 L 637.2 186.573231 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#mafee7c4355" x="49.078125" y="186.573231" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2ac1984819" x="49.078125" y="186.573231" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1144,11 +1144,11 @@ L 637.2 186.573231
      <g id="line2d_55">
       <path d="M 49.078125 172.937406 
 L 637.2 172.937406 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#mafee7c4355" x="49.078125" y="172.937406" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2ac1984819" x="49.078125" y="172.937406" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1156,11 +1156,11 @@ L 637.2 172.937406
      <g id="line2d_57">
       <path d="M 49.078125 162.360638 
 L 637.2 162.360638 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#mafee7c4355" x="49.078125" y="162.360638" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2ac1984819" x="49.078125" y="162.360638" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1168,11 +1168,11 @@ L 637.2 162.360638
      <g id="line2d_59">
       <path d="M 49.078125 153.71879 
 L 637.2 153.71879 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#mafee7c4355" x="49.078125" y="153.71879" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2ac1984819" x="49.078125" y="153.71879" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1180,11 +1180,11 @@ L 637.2 153.71879
      <g id="line2d_61">
       <path d="M 49.078125 146.412211 
 L 637.2 146.412211 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#mafee7c4355" x="49.078125" y="146.412211" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2ac1984819" x="49.078125" y="146.412211" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1192,11 +1192,11 @@ L 637.2 146.412211
      <g id="line2d_63">
       <path d="M 49.078125 140.082964 
 L 637.2 140.082964 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#mafee7c4355" x="49.078125" y="140.082964" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2ac1984819" x="49.078125" y="140.082964" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1204,11 +1204,11 @@ L 637.2 140.082964
      <g id="line2d_65">
       <path d="M 49.078125 134.500173 
 L 637.2 134.500173 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#mafee7c4355" x="49.078125" y="134.500173" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2ac1984819" x="49.078125" y="134.500173" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1216,11 +1216,11 @@ L 637.2 134.500173
      <g id="line2d_67">
       <path d="M 49.078125 96.651755 
 L 637.2 96.651755 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_68">
       <g>
-       <use xlink:href="#mafee7c4355" x="49.078125" y="96.651755" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2ac1984819" x="49.078125" y="96.651755" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1228,11 +1228,11 @@ L 637.2 96.651755
      <g id="line2d_69">
       <path d="M 49.078125 77.433138 
 L 637.2 77.433138 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_70">
       <g>
-       <use xlink:href="#mafee7c4355" x="49.078125" y="77.433138" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2ac1984819" x="49.078125" y="77.433138" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1240,11 +1240,11 @@ L 637.2 77.433138
      <g id="line2d_71">
       <path d="M 49.078125 63.797313 
 L 637.2 63.797313 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_72">
       <g>
-       <use xlink:href="#mafee7c4355" x="49.078125" y="63.797313" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2ac1984819" x="49.078125" y="63.797313" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1252,11 +1252,11 @@ L 637.2 63.797313
      <g id="line2d_73">
       <path d="M 49.078125 53.220545 
 L 637.2 53.220545 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_74">
       <g>
-       <use xlink:href="#mafee7c4355" x="49.078125" y="53.220545" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2ac1984819" x="49.078125" y="53.220545" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1378,7 +1378,7 @@ L 637.2 48.323125
    </g>
    <g id="text_13">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(294.669676 147.67497) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(294.669676 148.196321) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1410,7 +1410,7 @@ z
    </g>
    <g id="text_14">
     <!-- L10 -->
-    <g style="fill: #d62728" transform="translate(104.852312 297.661232) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(104.852312 297.578113) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1732,23 +1732,23 @@ z
    </g>
    <g id="line2d_75">
     <defs>
-     <path id="m47be5a6fa4" d="M -2.5 2.5 
+     <path id="m002f6c963e" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p3308c85399)">
-     <use xlink:href="#m47be5a6fa4" x="355.479835" y="95.382063" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m47be5a6fa4" x="308.273931" y="102.754513" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m47be5a6fa4" x="271.230161" y="116.528062" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m47be5a6fa4" x="217.83458" y="120.013651" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m47be5a6fa4" x="177.077692" y="138.43462" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m47be5a6fa4" x="162.880539" y="157.778627" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m47be5a6fa4" x="160.741445" y="165.196647" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m47be5a6fa4" x="153.966678" y="183.405761" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m47be5a6fa4" x="151.589614" y="194.488118" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pc8796b989c)">
+     <use xlink:href="#m002f6c963e" x="355.479835" y="95.382063" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m002f6c963e" x="308.273931" y="102.754513" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m002f6c963e" x="271.230161" y="116.528062" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m002f6c963e" x="217.83458" y="120.013651" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m002f6c963e" x="177.077692" y="138.43462" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m002f6c963e" x="162.880539" y="157.778627" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m002f6c963e" x="160.741445" y="165.196647" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m002f6c963e" x="153.966678" y="183.405761" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m002f6c963e" x="151.589614" y="194.488118" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_76">
@@ -1801,7 +1801,7 @@ L 311.2243 102.325849
 L 310.240844 102.469168 
 L 309.257387 102.612055 
 L 308.273931 102.754513 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_77">
     <path d="M 308.273931 102.754513 
@@ -1853,7 +1853,7 @@ L 273.545396 115.775058
 L 272.773651 116.027391 
 L 272.001906 116.278388 
 L 271.230161 116.528062 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_78">
     <path d="M 271.230161 116.528062 
@@ -1905,7 +1905,7 @@ L 221.171803 119.803152
 L 220.059395 119.873422 
 L 218.946988 119.943588 
 L 217.83458 120.013651 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_79">
     <path d="M 217.83458 120.013651 
@@ -1957,7 +1957,7 @@ L 179.624997 137.470928
 L 178.775895 137.79434 
 L 177.926794 138.115561 
 L 177.077692 138.43462 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_80">
     <path d="M 177.077692 138.43462 
@@ -2009,7 +2009,7 @@ L 163.767861 156.775388
 L 163.472087 157.112166 
 L 163.176313 157.446568 
 L 162.880539 157.778627 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_81">
     <path d="M 162.880539 157.778627 
@@ -2061,7 +2061,7 @@ L 160.875139 164.765525
 L 160.830574 164.909668 
 L 160.78601 165.053375 
 L 160.741445 165.196647 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_82">
     <path d="M 160.741445 165.196647 
@@ -2113,7 +2113,7 @@ L 154.390101 182.45125
 L 154.24896 182.771561 
 L 154.107819 183.089721 
 L 153.966678 183.405761 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_83">
     <path d="M 153.966678 183.405761 
@@ -2165,26 +2165,26 @@ L 151.73818 193.866427
 L 151.688658 194.074564 
 L 151.639136 194.281792 
 L 151.589614 194.488118 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_84">
     <defs>
-     <path id="md8a37bdf59" d="M 0 -2.5 
+     <path id="m808296bf2f" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p3308c85399)">
-     <use xlink:href="#md8a37bdf59" x="531.649087" y="75.963093" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md8a37bdf59" x="283.721324" y="99.020035" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md8a37bdf59" x="218.882044" y="121.069315" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md8a37bdf59" x="187.447228" y="127.10685" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md8a37bdf59" x="176.342474" y="138.36311" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md8a37bdf59" x="163.054314" y="161.312135" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md8a37bdf59" x="162.210539" y="168.753955" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md8a37bdf59" x="159.303811" y="175.753345" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md8a37bdf59" x="157.793928" y="179.494802" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pc8796b989c)">
+     <use xlink:href="#m808296bf2f" x="531.649087" y="75.963093" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m808296bf2f" x="283.721324" y="99.020035" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m808296bf2f" x="218.882044" y="121.069315" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m808296bf2f" x="187.447228" y="127.10685" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m808296bf2f" x="176.342474" y="138.36311" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m808296bf2f" x="163.054314" y="161.312135" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m808296bf2f" x="162.210539" y="168.753955" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m808296bf2f" x="159.303811" y="175.753345" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m808296bf2f" x="157.793928" y="179.494802" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_85">
@@ -2237,7 +2237,7 @@ L 299.21681 97.864971
 L 294.051648 98.253128 
 L 288.886486 98.638133 
 L 283.721324 99.020035 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_86">
     <path d="M 283.721324 99.020035 
@@ -2289,7 +2289,7 @@ L 222.934499 119.954333
 L 221.583681 120.328916 
 L 220.232863 120.700561 
 L 218.882044 121.069315 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_87">
     <path d="M 218.882044 121.069315 
@@ -2341,7 +2341,7 @@ L 189.411904 126.751217
 L 188.757012 126.870058 
 L 188.10212 126.988602 
 L 187.447228 127.10685 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_88">
     <path d="M 187.447228 127.10685 
@@ -2393,7 +2393,7 @@ L 177.036521 137.732718
 L 176.805172 137.943781 
 L 176.573823 138.153909 
 L 176.342474 138.36311 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_89">
     <path d="M 176.342474 138.36311 
@@ -2445,7 +2445,7 @@ L 163.884824 160.161325
 L 163.607987 160.548041 
 L 163.33115 160.931628 
 L 163.054314 161.312135 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_90">
     <path d="M 163.054314 161.312135 
@@ -2497,7 +2497,7 @@ L 162.263275 168.321549
 L 162.245696 168.466124 
 L 162.228118 168.610258 
 L 162.210539 168.753955 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_91">
     <path d="M 162.210539 168.753955 
@@ -2549,7 +2549,7 @@ L 159.485481 175.344896
 L 159.424925 175.481437 
 L 159.364368 175.617586 
 L 159.303811 175.753345 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_92">
     <path d="M 159.303811 175.753345 
@@ -2601,30 +2601,30 @@ L 157.888296 179.269417
 L 157.85684 179.344665 
 L 157.825384 179.419793 
 L 157.793928 179.494802 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_93">
     <defs>
-     <path id="mcb3e6705c5" d="M -0 3.535534 
+     <path id="ma8bc97674d" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p3308c85399)">
-     <use xlink:href="#mcb3e6705c5" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcb3e6705c5" x="203.775848" y="81.750179" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcb3e6705c5" x="186.982691" y="88.344921" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcb3e6705c5" x="179.779306" y="91.045312" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcb3e6705c5" x="157.610419" y="99.395085" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcb3e6705c5" x="148.722526" y="107.864022" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcb3e6705c5" x="144.388162" y="121.237794" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcb3e6705c5" x="127.071247" y="144.560664" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcb3e6705c5" x="124.491988" y="152.083585" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcb3e6705c5" x="92.613662" y="207.637263" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcb3e6705c5" x="87.348715" y="225.457654" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcb3e6705c5" x="86.053433" y="242.017529" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pc8796b989c)">
+     <use xlink:href="#ma8bc97674d" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma8bc97674d" x="203.775848" y="81.750179" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma8bc97674d" x="186.982691" y="88.344921" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma8bc97674d" x="179.779306" y="91.045312" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma8bc97674d" x="157.610419" y="99.395085" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma8bc97674d" x="148.722526" y="107.864022" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma8bc97674d" x="144.388162" y="121.237794" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma8bc97674d" x="127.071247" y="144.560664" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma8bc97674d" x="124.491988" y="152.083585" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma8bc97674d" x="92.613662" y="207.637263" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma8bc97674d" x="87.348715" y="225.457654" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma8bc97674d" x="86.053433" y="242.017529" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_94">
@@ -2677,7 +2677,7 @@ L 206.762331 80.855075
 L 205.766837 81.155325 
 L 204.771342 81.453685 
 L 203.775848 81.750179 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_95">
     <path d="M 203.775848 81.750179 
@@ -2729,7 +2729,7 @@ L 188.032264 87.958568
 L 187.682406 88.087703 
 L 187.332549 88.216487 
 L 186.982691 88.344921 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_96">
     <path d="M 186.982691 88.344921 
@@ -2781,7 +2781,7 @@ L 180.229518 90.88097
 L 180.079447 90.935814 
 L 179.929376 90.990595 
 L 179.779306 91.045312 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_97">
     <path d="M 179.779306 91.045312 
@@ -2833,7 +2833,7 @@ L 158.995974 98.914174
 L 158.534122 99.075021 
 L 158.07227 99.235323 
 L 157.610419 99.395085 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_98">
     <path d="M 157.610419 99.395085 
@@ -2885,7 +2885,7 @@ L 149.27802 107.37681
 L 149.092855 107.539771 
 L 148.907691 107.702174 
 L 148.722526 107.864022 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_99">
     <path d="M 148.722526 107.864022 
@@ -2937,7 +2937,7 @@ L 144.65906 120.50385
 L 144.568761 120.749763 
 L 144.478462 120.994407 
 L 144.388162 121.237794 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_100">
     <path d="M 144.388162 121.237794 
@@ -2989,7 +2989,7 @@ L 128.153555 143.395158
 L 127.792786 143.786853 
 L 127.432016 144.175338 
 L 127.071247 144.560664 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_101">
     <path d="M 127.071247 144.560664 
@@ -3041,7 +3041,7 @@ L 124.653192 151.646811
 L 124.599457 151.79285 
 L 124.545723 151.93844 
 L 124.491988 152.083585 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_102">
     <path d="M 124.491988 152.083585 
@@ -3093,7 +3093,7 @@ L 94.606058 205.546972
 L 93.941926 206.254028 
 L 93.277794 206.950691 
 L 92.613662 207.637263 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_103">
     <path d="M 92.613662 207.637263 
@@ -3145,7 +3145,7 @@ L 87.677774 224.520091
 L 87.568088 224.834677 
 L 87.458402 225.147189 
 L 87.348715 225.457654 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_104">
     <path d="M 87.348715 225.457654 
@@ -3197,23 +3197,23 @@ L 86.134388 241.135848
 L 86.107403 241.431568 
 L 86.080418 241.725454 
 L 86.053433 242.017529 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_105">
     <defs>
-     <path id="m9c59e62ab2" d="M -0 2.5 
+     <path id="me0a934e4a4" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p3308c85399)">
-     <use xlink:href="#m9c59e62ab2" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pc8796b989c)">
+     <use xlink:href="#me0a934e4a4" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_106">
     <defs>
-     <path id="m81e9189b04" d="M -0.833333 2.5 
+     <path id="m012bf5a8af" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -3228,16 +3228,16 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p3308c85399)">
-     <use xlink:href="#m81e9189b04" x="362.865999" y="115.428618" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m81e9189b04" x="278.798176" y="122.858526" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m81e9189b04" x="251.17632" y="128.261574" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m81e9189b04" x="200.806828" y="131.522849" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m81e9189b04" x="169.803221" y="147.931404" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m81e9189b04" x="161.916638" y="160.718659" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m81e9189b04" x="158.697104" y="167.705569" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m81e9189b04" x="154.26679" y="181.026105" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m81e9189b04" x="153.096464" y="191.924265" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pc8796b989c)">
+     <use xlink:href="#m012bf5a8af" x="362.865999" y="115.428618" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m012bf5a8af" x="278.798176" y="122.858526" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m012bf5a8af" x="251.17632" y="128.261574" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m012bf5a8af" x="200.806828" y="131.522849" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m012bf5a8af" x="169.803221" y="147.931404" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m012bf5a8af" x="161.916638" y="160.718659" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m012bf5a8af" x="158.697104" y="167.705569" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m012bf5a8af" x="154.26679" y="181.026105" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m012bf5a8af" x="153.096464" y="191.924265" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_107">
@@ -3290,7 +3290,7 @@ L 284.052415 122.426763
 L 282.301002 122.571121 
 L 280.549589 122.715042 
 L 278.798176 122.858526 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_108">
     <path d="M 278.798176 122.858526 
@@ -3342,7 +3342,7 @@ L 252.902686 127.94134
 L 252.327231 128.048325 
 L 251.751776 128.155069 
 L 251.17632 128.261574 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_109">
     <path d="M 251.17632 128.261574 
@@ -3394,7 +3394,7 @@ L 203.954921 131.325463
 L 202.905557 131.39135 
 L 201.856192 131.457145 
 L 200.806828 131.522849 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_110">
     <path d="M 200.806828 131.522849 
@@ -3446,7 +3446,7 @@ L 171.740947 147.056528
 L 171.095038 147.349951 
 L 170.44913 147.64157 
 L 169.803221 147.931404 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_111">
     <path d="M 169.803221 147.931404 
@@ -3498,7 +3498,7 @@ L 162.409549 160.012958
 L 162.245246 160.249361 
 L 162.080942 160.484591 
 L 161.916638 160.718659 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_112">
     <path d="M 161.916638 160.718659 
@@ -3550,7 +3550,7 @@ L 158.898325 167.297798
 L 158.831251 167.434112 
 L 158.764178 167.570034 
 L 158.697104 167.705569 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_113">
     <path d="M 158.697104 167.705569 
@@ -3602,7 +3602,7 @@ L 154.543684 180.294711
 L 154.451386 180.539765 
 L 154.359088 180.783558 
 L 154.26679 181.026105 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_114">
     <path d="M 154.26679 181.026105 
@@ -3654,11 +3654,11 @@ L 153.16961 191.311823
 L 153.145228 191.516851 
 L 153.120846 191.720996 
 L 153.096464 191.924265 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_115">
     <defs>
-     <path id="m0e3d3f430a" d="M -1.25 2.5 
+     <path id="mee9f8fe1ab" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -3673,16 +3673,16 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p3308c85399)">
-     <use xlink:href="#m0e3d3f430a" x="301.619021" y="150.561849" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0e3d3f430a" x="250.236474" y="156.671134" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0e3d3f430a" x="225.418659" y="160.842551" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0e3d3f430a" x="212.328936" y="161.382211" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0e3d3f430a" x="209.030149" y="166.25091" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0e3d3f430a" x="197.547749" y="171.432451" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0e3d3f430a" x="194.819287" y="175.129495" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0e3d3f430a" x="193.12279" y="181.606362" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0e3d3f430a" x="192.79794" y="189.451167" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pc8796b989c)">
+     <use xlink:href="#mee9f8fe1ab" x="301.619021" y="150.561849" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mee9f8fe1ab" x="250.236474" y="156.671134" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mee9f8fe1ab" x="225.418659" y="160.842551" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mee9f8fe1ab" x="212.328936" y="161.382211" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mee9f8fe1ab" x="209.030149" y="166.25091" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mee9f8fe1ab" x="197.547749" y="171.432451" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mee9f8fe1ab" x="194.819287" y="175.129495" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mee9f8fe1ab" x="193.12279" y="181.606362" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mee9f8fe1ab" x="192.79794" y="189.451167" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_116">
@@ -3735,7 +3735,7 @@ L 253.447883 156.311526
 L 252.377414 156.431699 
 L 251.306944 156.551567 
 L 250.236474 156.671134 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_117">
     <path d="M 250.236474 156.671134 
@@ -3787,7 +3787,7 @@ L 226.969772 160.592321
 L 226.452735 160.675878 
 L 225.935697 160.759287 
 L 225.418659 160.842551 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_118">
     <path d="M 225.418659 160.842551 
@@ -3839,7 +3839,7 @@ L 213.147044 161.348661
 L 212.874341 161.359847 
 L 212.601639 161.37103 
 L 212.328936 161.382211 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_119">
     <path d="M 212.328936 161.382211 
@@ -3891,7 +3891,7 @@ L 209.236323 165.960837
 L 209.167599 166.057725 
 L 209.098874 166.154416 
 L 209.030149 166.25091 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_120">
     <path d="M 209.030149 166.25091 
@@ -3943,7 +3943,7 @@ L 198.265399 171.124681
 L 198.026182 171.227493 
 L 197.786966 171.330083 
 L 197.547749 171.432451 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_121">
     <path d="M 197.547749 171.432451 
@@ -3995,7 +3995,7 @@ L 194.989815 174.906688
 L 194.932972 174.981074 
 L 194.876129 175.055342 
 L 194.819287 175.129495 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_122">
     <path d="M 194.819287 175.129495 
@@ -4047,7 +4047,7 @@ L 193.228821 181.226479
 L 193.193478 181.353445 
 L 193.158134 181.480072 
 L 193.12279 181.606362 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_123">
     <path d="M 193.12279 181.606362 
@@ -4099,11 +4099,11 @@ L 192.818243 188.997124
 L 192.811475 189.148955 
 L 192.804707 189.300302 
 L 192.79794 189.451167 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_124">
     <defs>
-     <path id="meb0b141d91" d="M 0 -2.5 
+     <path id="m851cf456c6" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -4116,16 +4116,16 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p3308c85399)">
-     <use xlink:href="#meb0b141d91" x="206.45578" y="118.584066" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#meb0b141d91" x="206.45578" y="118.258949" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#meb0b141d91" x="206.45578" y="118.759361" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#meb0b141d91" x="206.45578" y="118.234957" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#meb0b141d91" x="171.767499" y="134.097889" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#meb0b141d91" x="163.54283" y="144.663903" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#meb0b141d91" x="160.174881" y="151.505345" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#meb0b141d91" x="154.179217" y="169.303726" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#meb0b141d91" x="152.4406" y="178.584542" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#pc8796b989c)">
+     <use xlink:href="#m851cf456c6" x="206.45578" y="118.584066" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m851cf456c6" x="206.45578" y="118.258949" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m851cf456c6" x="206.45578" y="118.759361" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m851cf456c6" x="206.45578" y="118.234957" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m851cf456c6" x="171.767499" y="134.097889" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m851cf456c6" x="163.54283" y="144.663903" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m851cf456c6" x="160.174881" y="151.505345" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m851cf456c6" x="154.179217" y="169.303726" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m851cf456c6" x="152.4406" y="178.584542" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_125">
@@ -4178,7 +4178,7 @@ L 206.45578 118.279335
 L 206.45578 118.27254 
 L 206.45578 118.265745 
 L 206.45578 118.258949 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_126">
     <path d="M 206.45578 118.258949 
@@ -4230,7 +4230,7 @@ L 206.45578 118.728239
 L 206.45578 118.738615 
 L 206.45578 118.748989 
 L 206.45578 118.759361 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_127">
     <path d="M 206.45578 118.759361 
@@ -4282,7 +4282,7 @@ L 206.45578 118.267903
 L 206.45578 118.256924 
 L 206.45578 118.245942 
 L 206.45578 118.234957 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_128">
     <path d="M 206.45578 118.234957 
@@ -4334,7 +4334,7 @@ L 173.935517 133.247721
 L 173.212844 133.532808 
 L 172.490172 133.816191 
 L 171.767499 134.097889 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_129">
     <path d="M 171.767499 134.097889 
@@ -4386,7 +4386,7 @@ L 164.056872 144.068227
 L 163.885524 144.267619 
 L 163.714177 144.466175 
 L 163.54283 144.663903 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_130">
     <path d="M 163.54283 144.663903 
@@ -4438,7 +4438,7 @@ L 160.385378 151.105499
 L 160.315212 151.239156 
 L 160.245047 151.372438 
 L 160.174881 151.505345 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_131">
     <path d="M 160.174881 151.505345 
@@ -4490,7 +4490,7 @@ L 154.553946 168.367127
 L 154.429036 168.681387 
 L 154.304126 168.993578 
 L 154.179217 169.303726 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_132">
     <path d="M 154.179217 169.303726 
@@ -4542,11 +4542,11 @@ L 152.549264 178.054798
 L 152.513043 178.232038 
 L 152.476822 178.408618 
 L 152.4406 178.584542 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_133">
     <defs>
-     <path id="md4d65a6349" d="M 0 -2.5 
+     <path id="ma40c13d693" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -4555,16 +4555,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p3308c85399)">
-     <use xlink:href="#md4d65a6349" x="610.467188" y="172.829682" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md4d65a6349" x="592.067397" y="173.763838" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md4d65a6349" x="534.807821" y="180.385179" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md4d65a6349" x="327.802209" y="176.172104" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md4d65a6349" x="275.83761" y="186.734601" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md4d65a6349" x="258.25125" y="198.783148" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md4d65a6349" x="256.777056" y="203.737732" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md4d65a6349" x="248.769854" y="217.74136" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md4d65a6349" x="246.264594" y="227.740017" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pc8796b989c)">
+     <use xlink:href="#ma40c13d693" x="610.467188" y="172.829682" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma40c13d693" x="592.067397" y="173.763838" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma40c13d693" x="534.807821" y="180.385179" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma40c13d693" x="327.802209" y="176.172104" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma40c13d693" x="275.83761" y="186.734601" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma40c13d693" x="258.25125" y="198.783148" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma40c13d693" x="256.777056" y="203.737732" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma40c13d693" x="248.769854" y="217.74136" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma40c13d693" x="246.264594" y="227.740017" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_134">
@@ -4617,7 +4617,7 @@ L 593.217384 173.705989
 L 592.834055 173.72528 
 L 592.450726 173.744563 
 L 592.067397 173.763838 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_135">
     <path d="M 592.067397 173.763838 
@@ -4669,7 +4669,7 @@ L 538.386544 179.997367
 L 537.193636 180.126991 
 L 536.000728 180.25626 
 L 534.807821 180.385179 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_136">
     <path d="M 534.807821 180.385179 
@@ -4721,7 +4721,7 @@ L 340.74006 176.446681
 L 336.427443 176.355332 
 L 332.114826 176.263806 
 L 327.802209 176.172104 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_137">
     <path d="M 327.802209 176.172104 
@@ -4773,7 +4773,7 @@ L 279.085397 186.139102
 L 278.002801 186.338434 
 L 276.920205 186.536931 
 L 275.83761 186.734601 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_138">
     <path d="M 275.83761 186.734601 
@@ -4825,7 +4825,7 @@ L 259.350398 198.113494
 L 258.984015 198.337765 
 L 258.617633 198.560979 
 L 258.25125 198.783148 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_139">
     <path d="M 258.25125 198.783148 
@@ -4877,7 +4877,7 @@ L 256.869193 203.442789
 L 256.838481 203.541307 
 L 256.807768 203.639621 
 L 256.777056 203.737732 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_140">
     <path d="M 256.777056 203.737732 
@@ -4929,7 +4929,7 @@ L 249.270304 216.977455
 L 249.103487 217.23346 
 L 248.93667 217.48809 
 L 248.769854 217.74136 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_141">
     <path d="M 248.769854 217.74136 
@@ -4981,7 +4981,7 @@ L 246.421172 227.173237
 L 246.368979 227.362918 
 L 246.316786 227.551842 
 L 246.264594 227.740017 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="legend_1">
     <g id="patch_7">
@@ -4999,7 +4999,7 @@ z
     </g>
     <g id="line2d_142">
      <defs>
-      <path id="me555399f59" d="M 0 3.5 
+      <path id="m61a32e56df" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -5012,7 +5012,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#me555399f59" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m61a32e56df" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -5071,7 +5071,7 @@ z
     </g>
     <g id="line2d_143">
      <g>
-      <use xlink:href="#m47be5a6fa4" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m002f6c963e" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -5085,7 +5085,7 @@ z
     </g>
     <g id="line2d_144">
      <g>
-      <use xlink:href="#md8a37bdf59" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m808296bf2f" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -5130,7 +5130,7 @@ z
     </g>
     <g id="line2d_145">
      <g>
-      <use xlink:href="#mcb3e6705c5" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#ma8bc97674d" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -5173,7 +5173,7 @@ z
     </g>
     <g id="line2d_146">
      <g>
-      <use xlink:href="#m9c59e62ab2" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#me0a934e4a4" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -5189,7 +5189,7 @@ z
     </g>
     <g id="line2d_147">
      <g>
-      <use xlink:href="#m81e9189b04" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m012bf5a8af" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -5243,7 +5243,7 @@ z
     </g>
     <g id="line2d_148">
      <g>
-      <use xlink:href="#m0e3d3f430a" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mee9f8fe1ab" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -5308,7 +5308,7 @@ z
     </g>
     <g id="line2d_149">
      <g>
-      <use xlink:href="#meb0b141d91" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#m851cf456c6" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -5346,7 +5346,7 @@ z
     </g>
     <g id="line2d_150">
      <g>
-      <use xlink:href="#md4d65a6349" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#ma40c13d693" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -5416,486 +5416,486 @@ z
     </g>
    </g>
    <g id="line2d_151">
-    <g clip-path="url(#p3308c85399)">
-     <use xlink:href="#me555399f59" x="289.669676" y="152.67497" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#me555399f59" x="223.847406" y="163.966652" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#me555399f59" x="212.215046" y="167.815997" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#me555399f59" x="181.367844" y="175.139341" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#me555399f59" x="165.231972" y="183.139877" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#me555399f59" x="153.327587" y="189.404203" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#me555399f59" x="148.576453" y="195.302106" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#me555399f59" x="145.287154" y="198.19502" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#me555399f59" x="115.00257" y="276.305881" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#me555399f59" x="99.852312" y="302.661232" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <g clip-path="url(#pc8796b989c)">
+     <use xlink:href="#m61a32e56df" x="289.669676" y="153.196321" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m61a32e56df" x="223.847406" y="163.911304" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m61a32e56df" x="212.215046" y="167.663596" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m61a32e56df" x="181.367844" y="175.419581" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m61a32e56df" x="165.231972" y="183.473767" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m61a32e56df" x="153.327587" y="189.004841" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m61a32e56df" x="148.576453" y="194.92415" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m61a32e56df" x="145.287154" y="198.023662" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m61a32e56df" x="115.00257" y="275.970483" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m61a32e56df" x="99.852312" y="302.578113" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
    <g id="line2d_152">
-    <path d="M 289.669676 152.67497 
-L 288.298379 152.939856 
-L 286.927082 153.203271 
-L 285.555784 153.46523 
-L 284.184487 153.725748 
-L 282.81319 153.984843 
-L 281.441892 154.24253 
-L 280.070595 154.498823 
-L 278.699298 154.753737 
-L 277.328 155.007288 
-L 275.956703 155.25949 
-L 274.585406 155.510357 
-L 273.214109 155.759903 
-L 271.842811 156.008142 
-L 270.471514 156.255088 
-L 269.100217 156.500755 
-L 267.728919 156.745154 
-L 266.357622 156.9883 
-L 264.986325 157.230204 
-L 263.615028 157.470881 
-L 262.24373 157.710341 
-L 260.872433 157.948598 
-L 259.501136 158.185663 
-L 258.129838 158.421549 
-L 256.758541 158.656266 
-L 255.387244 158.889827 
-L 254.015947 159.122242 
-L 252.644649 159.353524 
-L 251.273352 159.583682 
-L 249.902055 159.812728 
-L 248.530757 160.040673 
-L 247.15946 160.267527 
-L 245.788163 160.4933 
-L 244.416866 160.718003 
-L 243.045568 160.941645 
-L 241.674271 161.164238 
-L 240.302974 161.38579 
-L 238.931676 161.606311 
-L 237.560379 161.825811 
-L 236.189082 162.044299 
-L 234.817784 162.261785 
-L 233.446487 162.478277 
-L 232.07519 162.693785 
-L 230.703893 162.908317 
-L 229.332595 163.121883 
-L 227.961298 163.334491 
-L 226.590001 163.54615 
-L 225.218703 163.756867 
-L 223.847406 163.966652 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 289.669676 153.196321 
+L 288.298379 153.446135 
+L 286.927082 153.69464 
+L 285.555784 153.941849 
+L 284.184487 154.187775 
+L 282.81319 154.432432 
+L 281.441892 154.675832 
+L 280.070595 154.917989 
+L 278.699298 155.158915 
+L 277.328 155.398623 
+L 275.956703 155.637124 
+L 274.585406 155.874432 
+L 273.214109 156.110557 
+L 271.842811 156.345512 
+L 270.471514 156.579308 
+L 269.100217 156.811956 
+L 267.728919 157.043468 
+L 266.357622 157.273854 
+L 264.986325 157.503127 
+L 263.615028 157.731295 
+L 262.24373 157.958371 
+L 260.872433 158.184364 
+L 259.501136 158.409284 
+L 258.129838 158.633142 
+L 256.758541 158.855948 
+L 255.387244 159.077711 
+L 254.015947 159.298442 
+L 252.644649 159.51815 
+L 251.273352 159.736843 
+L 249.902055 159.954533 
+L 248.530757 160.171227 
+L 247.15946 160.386935 
+L 245.788163 160.601666 
+L 244.416866 160.815429 
+L 243.045568 161.028231 
+L 241.674271 161.240083 
+L 240.302974 161.450992 
+L 238.931676 161.660966 
+L 237.560379 161.870015 
+L 236.189082 162.078146 
+L 234.817784 162.285366 
+L 233.446487 162.491685 
+L 232.07519 162.697109 
+L 230.703893 162.901647 
+L 229.332595 163.105307 
+L 227.961298 163.308095 
+L 226.590001 163.510019 
+L 225.218703 163.711086 
+L 223.847406 163.911304 
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_153">
-    <path d="M 223.847406 163.966652 
-L 223.605065 164.05012 
-L 223.362724 164.133441 
-L 223.120384 164.216615 
-L 222.878043 164.299644 
-L 222.635702 164.382528 
-L 222.393361 164.465267 
-L 222.15102 164.547861 
-L 221.908679 164.630313 
-L 221.666339 164.712621 
-L 221.423998 164.794786 
-L 221.181657 164.876809 
-L 220.939316 164.95869 
-L 220.696975 165.040431 
-L 220.454635 165.12203 
-L 220.212294 165.203489 
-L 219.969953 165.284809 
-L 219.727612 165.365989 
-L 219.485271 165.44703 
-L 219.24293 165.527933 
-L 219.00059 165.608699 
-L 218.758249 165.689326 
-L 218.515908 165.769817 
-L 218.273567 165.850172 
-L 218.031226 165.93039 
-L 217.788885 166.010473 
-L 217.546545 166.090421 
-L 217.304204 166.170234 
-L 217.061863 166.249913 
-L 216.819522 166.329459 
-L 216.577181 166.408871 
-L 216.33484 166.48815 
-L 216.0925 166.567297 
-L 215.850159 166.646312 
-L 215.607818 166.725195 
-L 215.365477 166.803948 
-L 215.123136 166.88257 
-L 214.880795 166.961061 
-L 214.638455 167.039423 
-L 214.396114 167.117655 
-L 214.153773 167.195759 
-L 213.911432 167.273734 
-L 213.669091 167.351581 
-L 213.42675 167.4293 
-L 213.18441 167.506892 
-L 212.942069 167.584358 
-L 212.699728 167.661697 
-L 212.457387 167.73891 
-L 212.215046 167.815997 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 223.847406 163.911304 
+L 223.605065 163.992585 
+L 223.362724 164.073726 
+L 223.120384 164.154729 
+L 222.878043 164.235593 
+L 222.635702 164.31632 
+L 222.393361 164.39691 
+L 222.15102 164.477362 
+L 221.908679 164.557679 
+L 221.666339 164.637859 
+L 221.423998 164.717905 
+L 221.181657 164.797815 
+L 220.939316 164.877591 
+L 220.696975 164.957232 
+L 220.454635 165.03674 
+L 220.212294 165.116115 
+L 219.969953 165.195358 
+L 219.727612 165.274468 
+L 219.485271 165.353446 
+L 219.24293 165.432293 
+L 219.00059 165.511008 
+L 218.758249 165.589594 
+L 218.515908 165.668049 
+L 218.273567 165.746375 
+L 218.031226 165.824571 
+L 217.788885 165.902639 
+L 217.546545 165.980578 
+L 217.304204 166.058389 
+L 217.061863 166.136073 
+L 216.819522 166.21363 
+L 216.577181 166.29106 
+L 216.33484 166.368363 
+L 216.0925 166.445541 
+L 215.850159 166.522594 
+L 215.607818 166.599521 
+L 215.365477 166.676324 
+L 215.123136 166.753002 
+L 214.880795 166.829556 
+L 214.638455 166.905988 
+L 214.396114 166.982296 
+L 214.153773 167.058481 
+L 213.911432 167.134544 
+L 213.669091 167.210486 
+L 213.42675 167.286305 
+L 213.18441 167.362004 
+L 212.942069 167.437582 
+L 212.699728 167.51304 
+L 212.457387 167.588378 
+L 212.215046 167.663596 
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_154">
-    <path d="M 212.215046 167.815997 
-L 211.572396 167.980698 
-L 210.929746 168.144828 
-L 210.287096 168.308392 
-L 209.644446 168.471394 
-L 209.001796 168.633837 
-L 208.359146 168.795725 
-L 207.716496 168.957062 
-L 207.073846 169.117852 
-L 206.431196 169.278098 
-L 205.788546 169.437804 
-L 205.145896 169.596974 
-L 204.503246 169.755611 
-L 203.860596 169.913719 
-L 203.217946 170.071301 
-L 202.575296 170.228362 
-L 201.932645 170.384903 
-L 201.289995 170.540929 
-L 200.647345 170.696444 
-L 200.004695 170.851449 
-L 199.362045 171.00595 
-L 198.719395 171.159948 
-L 198.076745 171.313448 
-L 197.434095 171.466453 
-L 196.791445 171.618965 
-L 196.148795 171.770987 
-L 195.506145 171.922524 
-L 194.863495 172.073578 
-L 194.220845 172.224152 
-L 193.578195 172.374249 
-L 192.935545 172.523873 
-L 192.292895 172.673025 
-L 191.650245 172.82171 
-L 191.007595 172.96993 
-L 190.364945 173.117687 
-L 189.722294 173.264986 
-L 189.079644 173.411828 
-L 188.436994 173.558217 
-L 187.794344 173.704155 
-L 187.151694 173.849645 
-L 186.509044 173.994689 
-L 185.866394 174.139292 
-L 185.223744 174.283454 
-L 184.581094 174.42718 
-L 183.938444 174.57047 
-L 183.295794 174.713329 
-L 182.653144 174.855759 
-L 182.010494 174.997762 
-L 181.367844 175.139341 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 212.215046 167.663596 
+L 211.572396 167.838826 
+L 210.929746 168.013411 
+L 210.287096 168.187355 
+L 209.644446 168.360664 
+L 209.001796 168.533341 
+L 208.359146 168.705391 
+L 207.716496 168.876818 
+L 207.073846 169.047628 
+L 206.431196 169.217825 
+L 205.788546 169.387413 
+L 205.145896 169.556396 
+L 204.503246 169.724779 
+L 203.860596 169.892566 
+L 203.217946 170.059761 
+L 202.575296 170.226368 
+L 201.932645 170.392392 
+L 201.289995 170.557836 
+L 200.647345 170.722705 
+L 200.004695 170.887002 
+L 199.362045 171.050732 
+L 198.719395 171.213898 
+L 198.076745 171.376504 
+L 197.434095 171.538554 
+L 196.791445 171.700053 
+L 196.148795 171.861003 
+L 195.506145 172.021408 
+L 194.863495 172.181272 
+L 194.220845 172.340599 
+L 193.578195 172.499392 
+L 192.935545 172.657655 
+L 192.292895 172.815391 
+L 191.650245 172.972604 
+L 191.007595 173.129297 
+L 190.364945 173.285474 
+L 189.722294 173.441138 
+L 189.079644 173.596293 
+L 188.436994 173.750941 
+L 187.794344 173.905086 
+L 187.151694 174.058732 
+L 186.509044 174.211881 
+L 185.866394 174.364537 
+L 185.223744 174.516703 
+L 184.581094 174.668382 
+L 183.938444 174.819578 
+L 183.295794 174.970292 
+L 182.653144 175.120529 
+L 182.010494 175.270291 
+L 181.367844 175.419581 
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_155">
-    <path d="M 181.367844 175.139341 
-L 181.03168 175.320565 
-L 180.695516 175.501098 
-L 180.359352 175.680947 
-L 180.023188 175.860116 
-L 179.687024 176.03861 
-L 179.35086 176.216434 
-L 179.014696 176.393594 
-L 178.678532 176.570094 
-L 178.342368 176.745939 
-L 178.006204 176.921135 
-L 177.67004 177.095685 
-L 177.333876 177.269595 
-L 176.997712 177.442869 
-L 176.661548 177.615511 
-L 176.325384 177.787528 
-L 175.98922 177.958922 
-L 175.653056 178.129699 
-L 175.316892 178.299862 
-L 174.980728 178.469417 
-L 174.644564 178.638368 
-L 174.3084 178.806718 
-L 173.972236 178.974473 
-L 173.636072 179.141636 
-L 173.299908 179.308212 
-L 172.963744 179.474204 
-L 172.62758 179.639617 
-L 172.291416 179.804455 
-L 171.955252 179.968721 
-L 171.619088 180.13242 
-L 171.282924 180.295556 
-L 170.94676 180.458132 
-L 170.610596 180.620153 
-L 170.274432 180.781621 
-L 169.938268 180.942541 
-L 169.602104 181.102917 
-L 169.26594 181.262752 
-L 168.929776 181.42205 
-L 168.593612 181.580814 
-L 168.257448 181.739049 
-L 167.921284 181.896756 
-L 167.58512 182.053941 
-L 167.248956 182.210606 
-L 166.912792 182.366756 
-L 166.576628 182.522392 
-L 166.240464 182.677519 
-L 165.9043 182.83214 
-L 165.568136 182.986258 
-L 165.231972 183.139877 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 181.367844 175.419581 
+L 181.03168 175.602124 
+L 180.695516 175.783966 
+L 180.359352 175.965114 
+L 180.023188 176.145572 
+L 179.687024 176.325345 
+L 179.35086 176.504439 
+L 179.014696 176.682859 
+L 178.678532 176.86061 
+L 178.342368 177.037697 
+L 178.006204 177.214124 
+L 177.67004 177.389898 
+L 177.333876 177.565022 
+L 176.997712 177.739501 
+L 176.661548 177.91334 
+L 176.325384 178.086544 
+L 175.98922 178.259118 
+L 175.653056 178.431065 
+L 175.316892 178.602391 
+L 174.980728 178.7731 
+L 174.644564 178.943197 
+L 174.3084 179.112685 
+L 173.972236 179.281569 
+L 173.636072 179.449853 
+L 173.299908 179.617543 
+L 172.963744 179.784641 
+L 172.62758 179.951152 
+L 172.291416 180.11708 
+L 171.955252 180.282429 
+L 171.619088 180.447204 
+L 171.282924 180.611407 
+L 170.94676 180.775044 
+L 170.610596 180.938118 
+L 170.274432 181.100633 
+L 169.938268 181.262592 
+L 169.602104 181.424 
+L 169.26594 181.58486 
+L 168.929776 181.745176 
+L 168.593612 181.904952 
+L 168.257448 182.06419 
+L 167.921284 182.222896 
+L 167.58512 182.381072 
+L 167.248956 182.538722 
+L 166.912792 182.695849 
+L 166.576628 182.852458 
+L 166.240464 183.00855 
+L 165.9043 183.16413 
+L 165.568136 183.319201 
+L 165.231972 183.473767 
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_156">
-    <path d="M 165.231972 183.139877 
-L 164.983964 183.279196 
-L 164.735956 183.418106 
-L 164.487948 183.556611 
-L 164.23994 183.694712 
-L 163.991932 183.832411 
-L 163.743924 183.969712 
-L 163.495916 184.106616 
-L 163.247908 184.243126 
-L 162.9999 184.379244 
-L 162.751892 184.514972 
-L 162.503884 184.650313 
-L 162.255876 184.785268 
-L 162.007868 184.91984 
-L 161.75986 185.054032 
-L 161.511852 185.187844 
-L 161.263844 185.32128 
-L 161.015836 185.454341 
-L 160.767828 185.587029 
-L 160.51982 185.719347 
-L 160.271812 185.851297 
-L 160.023804 185.98288 
-L 159.775796 186.1141 
-L 159.527788 186.244956 
-L 159.27978 186.375453 
-L 159.031772 186.505591 
-L 158.783764 186.635373 
-L 158.535756 186.764801 
-L 158.287748 186.893876 
-L 158.03974 187.022601 
-L 157.791732 187.150977 
-L 157.543724 187.279006 
-L 157.295716 187.406691 
-L 157.047708 187.534032 
-L 156.7997 187.661032 
-L 156.551691 187.787693 
-L 156.303683 187.914016 
-L 156.055675 188.040003 
-L 155.807667 188.165657 
-L 155.559659 188.290978 
-L 155.311651 188.415969 
-L 155.063643 188.540631 
-L 154.815635 188.664966 
-L 154.567627 188.788975 
-L 154.319619 188.912662 
-L 154.071611 189.036026 
-L 153.823603 189.15907 
-L 153.575595 189.281795 
-L 153.327587 189.404203 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 165.231972 183.473767 
+L 164.983964 183.595833 
+L 164.735956 183.717585 
+L 164.487948 183.839025 
+L 164.23994 183.960156 
+L 163.991932 184.080977 
+L 163.743924 184.201491 
+L 163.495916 184.3217 
+L 163.247908 184.441604 
+L 162.9999 184.561206 
+L 162.751892 184.680507 
+L 162.503884 184.799508 
+L 162.255876 184.918212 
+L 162.007868 185.036618 
+L 161.75986 185.15473 
+L 161.511852 185.272548 
+L 161.263844 185.390074 
+L 161.015836 185.50731 
+L 160.767828 185.624256 
+L 160.51982 185.740914 
+L 160.271812 185.857286 
+L 160.023804 185.973373 
+L 159.775796 186.089176 
+L 159.527788 186.204697 
+L 159.27978 186.319937 
+L 159.031772 186.434898 
+L 158.783764 186.54958 
+L 158.535756 186.663986 
+L 158.287748 186.778116 
+L 158.03974 186.891972 
+L 157.791732 187.005555 
+L 157.543724 187.118867 
+L 157.295716 187.231908 
+L 157.047708 187.344681 
+L 156.7997 187.457185 
+L 156.551691 187.569424 
+L 156.303683 187.681397 
+L 156.055675 187.793106 
+L 155.807667 187.904553 
+L 155.559659 188.015738 
+L 155.311651 188.126663 
+L 155.063643 188.23733 
+L 154.815635 188.347738 
+L 154.567627 188.45789 
+L 154.319619 188.567786 
+L 154.071611 188.677428 
+L 153.823603 188.786817 
+L 153.575595 188.895954 
+L 153.327587 189.004841 
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_157">
-    <path d="M 153.327587 189.404203 
-L 153.228605 189.534868 
-L 153.129623 189.665173 
-L 153.030641 189.795121 
-L 152.931659 189.924714 
-L 152.832678 190.053953 
-L 152.733696 190.182841 
-L 152.634714 190.31138 
-L 152.535732 190.439571 
-L 152.43675 190.567416 
-L 152.337768 190.694917 
-L 152.238786 190.822076 
-L 152.139804 190.948895 
-L 152.040822 191.075375 
-L 151.94184 191.201519 
-L 151.842858 191.327328 
-L 151.743876 191.452804 
-L 151.644894 191.577949 
-L 151.545912 191.702764 
-L 151.44693 191.827252 
-L 151.347948 191.951413 
-L 151.248966 192.07525 
-L 151.149984 192.198764 
-L 151.051002 192.321957 
-L 150.95202 192.444831 
-L 150.853038 192.567387 
-L 150.754056 192.689627 
-L 150.655074 192.811553 
-L 150.556093 192.933165 
-L 150.457111 193.054467 
-L 150.358129 193.175459 
-L 150.259147 193.296143 
-L 150.160165 193.41652 
-L 150.061183 193.536592 
-L 149.962201 193.656361 
-L 149.863219 193.775828 
-L 149.764237 193.894995 
-L 149.665255 194.013863 
-L 149.566273 194.132434 
-L 149.467291 194.250708 
-L 149.368309 194.368689 
-L 149.269327 194.486376 
-L 149.170345 194.603772 
-L 149.071363 194.720878 
-L 148.972381 194.837695 
-L 148.873399 194.954225 
-L 148.774417 195.070469 
-L 148.675435 195.186429 
-L 148.576453 195.302106 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 153.327587 189.004841 
+L 153.228605 189.136009 
+L 153.129623 189.266815 
+L 153.030641 189.397262 
+L 152.931659 189.52735 
+L 152.832678 189.657082 
+L 152.733696 189.78646 
+L 152.634714 189.915486 
+L 152.535732 190.044162 
+L 152.43675 190.172489 
+L 152.337768 190.30047 
+L 152.238786 190.428106 
+L 152.139804 190.5554 
+L 152.040822 190.682352 
+L 151.94184 190.808966 
+L 151.842858 190.935242 
+L 151.743876 191.061182 
+L 151.644894 191.186789 
+L 151.545912 191.312064 
+L 151.44693 191.437008 
+L 151.347948 191.561624 
+L 151.248966 191.685914 
+L 151.149984 191.809878 
+L 151.051002 191.933519 
+L 150.95202 192.056838 
+L 150.853038 192.179837 
+L 150.754056 192.302518 
+L 150.655074 192.424882 
+L 150.556093 192.546931 
+L 150.457111 192.668667 
+L 150.358129 192.790091 
+L 150.259147 192.911204 
+L 150.160165 193.032009 
+L 150.061183 193.152507 
+L 149.962201 193.272699 
+L 149.863219 193.392587 
+L 149.764237 193.512173 
+L 149.665255 193.631457 
+L 149.566273 193.750442 
+L 149.467291 193.86913 
+L 149.368309 193.987521 
+L 149.269327 194.105617 
+L 149.170345 194.223419 
+L 149.071363 194.340929 
+L 148.972381 194.458149 
+L 148.873399 194.57508 
+L 148.774417 194.691722 
+L 148.675435 194.808079 
+L 148.576453 194.92415 
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_158">
-    <path d="M 148.576453 195.302106 
-L 148.507926 195.364211 
-L 148.439399 195.426236 
-L 148.370872 195.488179 
-L 148.302345 195.550041 
-L 148.233818 195.611823 
-L 148.165291 195.673524 
-L 148.096764 195.735145 
-L 148.028237 195.796687 
-L 147.95971 195.858148 
-L 147.891183 195.91953 
-L 147.822656 195.980832 
-L 147.754129 196.042055 
-L 147.685602 196.103199 
-L 147.617074 196.164264 
-L 147.548547 196.225251 
-L 147.48002 196.28616 
-L 147.411493 196.34699 
-L 147.342966 196.407742 
-L 147.274439 196.468417 
-L 147.205912 196.529014 
-L 147.137385 196.589533 
-L 147.068858 196.649976 
-L 147.000331 196.710341 
-L 146.931804 196.77063 
-L 146.863277 196.830842 
-L 146.79475 196.890978 
-L 146.726223 196.951037 
-L 146.657696 197.011021 
-L 146.589169 197.070928 
-L 146.520641 197.13076 
-L 146.452114 197.190517 
-L 146.383587 197.250198 
-L 146.31506 197.309805 
-L 146.246533 197.369336 
-L 146.178006 197.428793 
-L 146.109479 197.488175 
-L 146.040952 197.547483 
-L 145.972425 197.606717 
-L 145.903898 197.665877 
-L 145.835371 197.724963 
-L 145.766844 197.783976 
-L 145.698317 197.842915 
-L 145.62979 197.901781 
-L 145.561263 197.960574 
-L 145.492735 198.019294 
-L 145.424208 198.077942 
-L 145.355681 198.136517 
-L 145.287154 198.19502 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 148.576453 194.92415 
+L 148.507926 194.990835 
+L 148.439399 195.057425 
+L 148.370872 195.123922 
+L 148.302345 195.190326 
+L 148.233818 195.256638 
+L 148.165291 195.322856 
+L 148.096764 195.388982 
+L 148.028237 195.455016 
+L 147.95971 195.520958 
+L 147.891183 195.586809 
+L 147.822656 195.652568 
+L 147.754129 195.718236 
+L 147.685602 195.783813 
+L 147.617074 195.8493 
+L 147.548547 195.914696 
+L 147.48002 195.980002 
+L 147.411493 196.045218 
+L 147.342966 196.110345 
+L 147.274439 196.175382 
+L 147.205912 196.240331 
+L 147.137385 196.30519 
+L 147.068858 196.369961 
+L 147.000331 196.434643 
+L 146.931804 196.499237 
+L 146.863277 196.563743 
+L 146.79475 196.628162 
+L 146.726223 196.692493 
+L 146.657696 196.756737 
+L 146.589169 196.820894 
+L 146.520641 196.884964 
+L 146.452114 196.948948 
+L 146.383587 197.012845 
+L 146.31506 197.076657 
+L 146.246533 197.140383 
+L 146.178006 197.204023 
+L 146.109479 197.267578 
+L 146.040952 197.331047 
+L 145.972425 197.394432 
+L 145.903898 197.457732 
+L 145.835371 197.520948 
+L 145.766844 197.58408 
+L 145.698317 197.647127 
+L 145.62979 197.710091 
+L 145.561263 197.772971 
+L 145.492735 197.835768 
+L 145.424208 197.898482 
+L 145.355681 197.961113 
+L 145.287154 198.023662 
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_159">
-    <path d="M 145.287154 198.19502 
-L 144.656225 202.167546 
-L 144.025297 205.832726 
-L 143.394368 209.234722 
-L 142.763439 212.408809 
-L 142.13251 215.383618 
-L 141.501581 218.1827 
-L 140.870652 220.825662 
-L 140.239723 223.329003 
-L 139.608795 225.706738 
-L 138.977866 227.970872 
-L 138.346937 230.131767 
-L 137.716008 232.198428 
-L 137.085079 234.178731 
-L 136.45415 236.079606 
-L 135.823222 237.907179 
-L 135.192293 239.666894 
-L 134.561364 241.363611 
-L 133.930435 243.001684 
-L 133.299506 244.585032 
-L 132.668577 246.117195 
-L 132.037648 247.601377 
-L 131.40672 249.040494 
-L 130.775791 250.4372 
-L 130.144862 251.793926 
-L 129.513933 253.112895 
-L 128.883004 254.396153 
-L 128.252075 255.645582 
-L 127.621147 256.862921 
-L 126.990218 258.049776 
-L 126.359289 259.207637 
-L 125.72836 260.337887 
-L 125.097431 261.441812 
-L 124.466502 262.520611 
-L 123.835573 263.575402 
-L 123.204645 264.60723 
-L 122.573716 265.617074 
-L 121.942787 266.605851 
-L 121.311858 267.574422 
-L 120.680929 268.523597 
-L 120.05 269.454137 
-L 119.419071 270.36676 
-L 118.788143 271.262142 
-L 118.157214 272.140923 
-L 117.526285 273.003708 
-L 116.895356 273.851068 
-L 116.264427 274.683546 
-L 115.633498 275.501654 
-L 115.00257 276.305881 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 145.287154 198.023662 
+L 144.656225 201.979883 
+L 144.025297 205.63118 
+L 143.394368 209.021212 
+L 142.763439 212.184884 
+L 142.13251 215.150542 
+L 141.501581 217.941521 
+L 140.870652 220.577258 
+L 140.239723 223.074117 
+L 139.608795 225.446003 
+L 138.977866 227.704833 
+L 138.346937 229.860896 
+L 137.716008 231.923137 
+L 137.085079 233.899382 
+L 136.45415 235.796517 
+L 135.823222 237.620633 
+L 135.192293 239.377143 
+L 134.561364 241.07088 
+L 133.930435 242.706175 
+L 133.299506 244.286928 
+L 132.668577 245.81666 
+L 132.037648 247.298562 
+L 131.40672 248.735534 
+L 130.775791 250.130221 
+L 130.144862 251.48504 
+L 129.513933 252.802207 
+L 128.883004 254.08376 
+L 128.252075 255.331573 
+L 127.621147 256.547376 
+L 126.990218 257.732773 
+L 126.359289 258.889245 
+L 125.72836 260.018173 
+L 125.097431 261.120836 
+L 124.466502 262.198429 
+L 123.835573 263.252067 
+L 123.204645 264.282793 
+L 122.573716 265.29158 
+L 121.942787 266.279345 
+L 121.311858 267.246944 
+L 120.680929 268.195186 
+L 120.05 269.124829 
+L 119.419071 270.036588 
+L 118.788143 270.93114 
+L 118.157214 271.809122 
+L 117.526285 272.671135 
+L 116.895356 273.517751 
+L 116.264427 274.349511 
+L 115.633498 275.166926 
+L 115.00257 275.970483 
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_160">
-    <path d="M 115.00257 276.305881 
-L 114.686939 277.034677 
-L 114.371309 277.752436 
-L 114.055678 278.459488 
-L 113.740048 279.156148 
-L 113.424418 279.842717 
-L 113.108787 280.519482 
-L 112.793157 281.186721 
-L 112.477527 281.844697 
-L 112.161896 282.493664 
-L 111.846266 283.133866 
-L 111.530636 283.765536 
-L 111.215005 284.388898 
-L 110.899375 285.004168 
-L 110.583745 285.611554 
-L 110.268114 286.211256 
-L 109.952484 286.803464 
-L 109.636853 287.388365 
-L 109.321223 287.966135 
-L 109.005593 288.536948 
-L 108.689962 289.100968 
-L 108.374332 289.658356 
-L 108.058702 290.209265 
-L 107.743071 290.753845 
-L 107.427441 291.292238 
-L 107.111811 291.824585 
-L 106.79618 292.351019 
-L 106.48055 292.871671 
-L 106.16492 293.386666 
-L 105.849289 293.896125 
-L 105.533659 294.400166 
-L 105.218028 294.898904 
-L 104.902398 295.392449 
-L 104.586768 295.880908 
-L 104.271137 296.364384 
-L 103.955507 296.842978 
-L 103.639877 297.316789 
-L 103.324246 297.785909 
-L 103.008616 298.250433 
-L 102.692986 298.710447 
-L 102.377355 299.166041 
-L 102.061725 299.617296 
-L 101.746095 300.064297 
-L 101.430464 300.507121 
-L 101.114834 300.945846 
-L 100.799203 301.380548 
-L 100.483573 301.811299 
-L 100.167943 302.23817 
-L 99.852312 302.661232 
-" clip-path="url(#p3308c85399)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 115.00257 275.970483 
+L 114.686939 276.708327 
+L 114.371309 277.434861 
+L 114.055678 278.150426 
+L 113.740048 278.855349 
+L 113.424418 279.549942 
+L 113.108787 280.234503 
+L 112.793157 280.909318 
+L 112.477527 281.57466 
+L 112.161896 282.230792 
+L 111.846266 282.877965 
+L 111.530636 283.516421 
+L 111.215005 284.146391 
+L 110.899375 284.768097 
+L 110.583745 285.381755 
+L 110.268114 285.98757 
+L 109.952484 286.585738 
+L 109.636853 287.176453 
+L 109.321223 287.759895 
+L 109.005593 288.336244 
+L 108.689962 288.905668 
+L 108.374332 289.468333 
+L 108.058702 290.024396 
+L 107.743071 290.574012 
+L 107.427441 291.117328 
+L 107.111811 291.654486 
+L 106.79618 292.185625 
+L 106.48055 292.710878 
+L 106.16492 293.230374 
+L 105.849289 293.744239 
+L 105.533659 294.252592 
+L 105.218028 294.75555 
+L 104.902398 295.253228 
+L 104.586768 295.745735 
+L 104.271137 296.233176 
+L 103.955507 296.715656 
+L 103.639877 297.193274 
+L 103.324246 297.666127 
+L 103.008616 298.13431 
+L 102.692986 298.597913 
+L 102.377355 299.057026 
+L 102.061725 299.511734 
+L 101.746095 299.962122 
+L 101.430464 300.40827 
+L 101.114834 300.850258 
+L 100.799203 301.288163 
+L 100.483573 301.722059 
+L 100.167943 302.152019 
+L 99.852312 302.578113 
+" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
   </g>
   <g id="text_25">
@@ -6254,8 +6254,8 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-07-07T02:05:28Z  ·  Linux chungus2 x86_64  ·  commit 1a899305  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(43.462422 465.66) scale(0.07 -0.07)">
+   <!-- 2026-07-07T22:17:01Z  ·  Linux chungus2 x86_64  ·  commit dcf4b958  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(44.687422 465.66) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -6289,31 +6289,6 @@ L 1409 3309
 L 1409 2516 
 L 750 2516 
 L 750 3309 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-b7" d="M 684 2619 
@@ -6403,6 +6378,31 @@ Q 1038 2656 1286 2365
 Q 1534 2075 1959 2075 
 z
 " transform="scale(0.015625)"/>
+     <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
      <path id="DejaVuSans-3d" d="M 678 2906 
 L 4684 2906 
 L 4684 2381 
@@ -6443,14 +6443,14 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-37" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -6490,109 +6490,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3196.777344 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3260.400391 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3324.023438 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3387.646484 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3451.269531 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3514.892578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3578.515625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3610.302734 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3642.089844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3673.876953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3705.664062 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3737.451172 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3765.234375 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3826.757812 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3888.037109 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3951.416016 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4014.892578 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4053.755859 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4114.9375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4174.117188 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4235.640625 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4276.753906 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4310.445312 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4338.228516 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4399.751953 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4461.03125 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4524.410156 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4588.033203 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4621.724609 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4680.904297 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4744.527344 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4776.314453 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4839.9375 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4903.560547 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4935.347656 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4998.970703 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5035.054688 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5073.917969 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5128.898438 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5192.521484 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5224.308594 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5256.095703 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5287.882812 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5319.669922 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5351.457031 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5390.666016 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5454.044922 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5492.908203 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5554.089844 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5617.46875 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5680.945312 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5744.324219 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5807.800781 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5871.179688 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5910.388672 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5942.175781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6025.964844 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6057.751953 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6155.164062 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6216.6875 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6280.164062 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6307.947266 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6369.226562 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6432.605469 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6464.392578 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6516.492188 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6579.871094 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6641.150391 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6704.626953 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6756.726562 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6820.105469 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6881.287109 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6920.496094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6954.1875 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6985.974609 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7027.087891 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7088.367188 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7127.576172 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7155.359375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7216.541016 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7248.328125 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7276.111328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7328.210938 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7359.998047 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7423.474609 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7484.998047 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7524.207031 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7585.730469 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7625.09375 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7722.505859 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7750.289062 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7813.667969 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7841.451172 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7893.550781 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7932.759766 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7960.542969 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3135.351562 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3190.332031 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3225.537109 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3289.160156 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3352.636719 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3416.259766 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3479.882812 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3543.505859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3575.292969 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3607.080078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3638.867188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3670.654297 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3702.441406 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3730.224609 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3791.748047 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3853.027344 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3916.40625 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3979.882812 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4018.746094 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4079.927734 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4139.107422 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4200.630859 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4241.744141 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4275.435547 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4303.21875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4364.742188 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4426.021484 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4489.400391 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4553.023438 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4586.714844 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4645.894531 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4709.517578 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4741.304688 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4804.927734 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4868.550781 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4900.337891 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4963.960938 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5000.044922 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5038.908203 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5093.888672 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5157.511719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5189.298828 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5221.085938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5252.873047 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5284.660156 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5316.447266 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5355.65625 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5419.035156 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5457.898438 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5519.080078 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5582.458984 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5645.935547 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5709.314453 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5772.791016 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5836.169922 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5875.378906 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5907.166016 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5990.955078 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6022.742188 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6120.154297 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6181.677734 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6245.154297 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6272.9375 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6334.216797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6397.595703 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6429.382812 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6481.482422 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6544.861328 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6606.140625 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6669.617188 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6721.716797 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6785.095703 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6846.277344 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6885.486328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6919.177734 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6950.964844 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6992.078125 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7053.357422 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7092.566406 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7120.349609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7181.53125 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7213.318359 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7241.101562 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7293.201172 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7324.988281 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7388.464844 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7449.988281 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7489.197266 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7550.720703 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7590.083984 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7687.496094 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7715.279297 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7778.658203 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7806.441406 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7858.541016 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7897.75 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7925.533203 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p3308c85399">
+  <clipPath id="pc8796b989c">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_ratio_heatmap.svg
+++ b/bench/graphs/canterbury_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#pd225242cc5)">
+   <g clip-path="url(#pd25df8895c)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAI/UlEQVR4nO3YwYqkVx2H4aqe7qYn4oAyashScCfBhRtn49o7yRW4DNl7HcYbEEQk2Yjixo24E3ciISRjnMyE7p7q78sljMKRv9T7PFfwO3zUqZdz3P71y/1wbl5+Nr1gqf3z8zrP4XA4/OPnv56esNTf//JqesJyP/3wZ9MTljv+6MfTE9Y6XkwvWO/FJ9ML1rt5Mr1gqV997xfTE5Y7w18SAMB/TgwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKQd706/2adHrLYftukJSx3PsFmvLq6nJyx1v91OT1ju6q9/mp6w3OmHz6YnLHXa7qcnLPfq9GJ6wnJPz+x6eP3k6fSE5c7vXxYA4L8ghgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0i6vXn0xvWG9u6+mF6y1b9ML1nv8ZHrBUtfTA/4H9hevpicsd/Xl8+kJS11tp+kJyz0+x/vu9uX0gqWuLs/vxvMyBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgLTjafvdPj1itX3fpicstZ3ZeQ6Hw+Hq4np6wlIP+2l6wnKPXj6fnrDeN787vWCp19v99ITlPr/95/SE5d6+u5yesNT2rXemJyznZQgASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASLv886d/mN6w3MXhOD1hqe+89XR6wnIP22l6wlLXj26mJyz33se/n56w3Ac/+cH0hKVO+zY9Ybn3//i36QnLPXvnG9MTlnrv3WfTE5bzMgQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIC04+uH3+7TI1a7f7idnrDU4+PN9ATe4P54mp6w3L/vPpuesNy3b96enrDUtm/TE5b74u7T6QnLPb/7ZHrCUt9/8u70hOW8DAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACDtuG0f7dMjgP9Dp/vpBetdXk8v4A1uH76anrDczaO3pifwBl6GAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkHZ5v91Ob1juYTtNT1jq8uJ6esJyV2d2ptfb/fSE5faLbXrCcscz+04P+3nddYfD4fDl/fPpCctdP76ZnrDUvp/f3eBlCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGlfA43TkfjdNPLgAAAAAElFTkSuQmCC" id="image429efa8482" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAI/UlEQVR4nO3YwYqkVx2H4aqe7qYn4oAyashScCfBhRtn49o7yRW4DNl7HcYbEEQk2Yjixo24E3ciISRjnMyE7p7q78sljMKRv9T7PFfwO3zUqZdz3P71y/1wbl5+Nr1gqf3z8zrP4XA4/OPnv56esNTf//JqesJyP/3wZ9MTljv+6MfTE9Y6XkwvWO/FJ9ML1rt5Mr1gqV997xfTE5Y7w18SAMB/TgwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKQd706/2adHrLYftukJSx3PsFmvLq6nJyx1v91OT1ju6q9/mp6w3OmHz6YnLHXa7qcnLPfq9GJ6wnJPz+x6eP3k6fSE5c7vXxYA4L8ghgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0i6vXn0xvWG9u6+mF6y1b9ML1nv8ZHrBUtfTA/4H9hevpicsd/Xl8+kJS11tp+kJyz0+x/vu9uX0gqWuLs/vxvMyBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgLTjafvdPj1itX3fpicstZ3ZeQ6Hw+Hq4np6wlIP+2l6wnKPXj6fnrDeN787vWCp19v99ITlPr/95/SE5d6+u5yesNT2rXemJyznZQgASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASLv886d/mN6w3MXhOD1hqe+89XR6wnIP22l6wlLXj26mJyz33se/n56w3Ac/+cH0hKVO+zY9Ybn3//i36QnLPXvnG9MTlnrv3WfTE5bzMgQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIC04+uH3+7TI1a7f7idnrDU4+PN9ATe4P54mp6w3L/vPpuesNy3b96enrDUtm/TE5b74u7T6QnLPb/7ZHrCUt9/8u70hOW8DAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACDtuG0f7dMjgP9Dp/vpBetdXk8v4A1uH76anrDczaO3pifwBl6GAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkHZ5v91Ob1juYTtNT1jq8uJ6esJyV2d2ptfb/fSE5faLbXrCcscz+04P+3nddYfD4fDl/fPpCctdP76ZnrDUvp/f3eBlCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGlfA43TkfjdNPLgAAAAAElFTkSuQmCC" id="imagef17821226e" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m7f9887f35c" d="M 0 0 
+       <path id="m4cc6495e57" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m7f9887f35c" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4cc6495e57" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m7f9887f35c" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4cc6495e57" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m7f9887f35c" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4cc6495e57" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m7f9887f35c" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4cc6495e57" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m7f9887f35c" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4cc6495e57" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m7f9887f35c" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4cc6495e57" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m7f9887f35c" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4cc6495e57" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m7f9887f35c" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4cc6495e57" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m7f9887f35c" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4cc6495e57" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m7f9887f35c" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4cc6495e57" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m7f9887f35c" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4cc6495e57" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="m87c5064cad" d="M 0 0 
+       <path id="m34d63f1e7b" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m87c5064cad" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m34d63f1e7b" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m87c5064cad" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m34d63f1e7b" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m87c5064cad" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m34d63f1e7b" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m87c5064cad" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m34d63f1e7b" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m87c5064cad" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m34d63f1e7b" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m87c5064cad" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m34d63f1e7b" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m87c5064cad" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m34d63f1e7b" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m87c5064cad" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m34d63f1e7b" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -2092,18 +2092,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="image616546ebd3" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
+iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="image18d5c169cd" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="mc3e6d0f588" d="M 0 0 
+       <path id="mdb404abca3" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mc3e6d0f588" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdb404abca3" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
@@ -2129,7 +2129,7 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#mc3e6d0f588" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdb404abca3" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
@@ -2146,7 +2146,7 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#mc3e6d0f588" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdb404abca3" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
@@ -2163,7 +2163,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#mc3e6d0f588" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdb404abca3" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
@@ -2180,7 +2180,7 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mc3e6d0f588" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdb404abca3" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_112">
@@ -2196,7 +2196,7 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#mc3e6d0f588" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdb404abca3" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
@@ -2212,7 +2212,7 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mc3e6d0f588" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdb404abca3" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
@@ -2228,7 +2228,7 @@ z
     <g id="ytick_16">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#mc3e6d0f588" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdb404abca3" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_115">
@@ -2244,7 +2244,7 @@ z
     <g id="ytick_17">
      <g id="line2d_28">
       <g>
-       <use xlink:href="#mc3e6d0f588" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdb404abca3" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_116">
@@ -2882,8 +2882,8 @@ z
    </g>
   </g>
   <g id="text_119">
-   <!-- 2026-07-07T02:05:28Z  ·  Linux chungus2 x86_64  ·  commit 1a899305  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(16.462422 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-07T22:17:01Z  ·  Linux chungus2 x86_64  ·  commit dcf4b958  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(17.687422 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2952,14 +2952,14 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-37" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2999,109 +2999,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3196.777344 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3260.400391 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3324.023438 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3387.646484 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3451.269531 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3514.892578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3578.515625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3610.302734 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3642.089844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3673.876953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3705.664062 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3737.451172 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3765.234375 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3826.757812 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3888.037109 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3951.416016 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4014.892578 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4053.755859 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4114.9375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4174.117188 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4235.640625 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4276.753906 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4310.445312 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4338.228516 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4399.751953 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4461.03125 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4524.410156 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4588.033203 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4621.724609 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4680.904297 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4744.527344 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4776.314453 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4839.9375 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4903.560547 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4935.347656 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4998.970703 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5035.054688 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5073.917969 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5128.898438 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5192.521484 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5224.308594 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5256.095703 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5287.882812 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5319.669922 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5351.457031 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5390.666016 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5454.044922 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5492.908203 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5554.089844 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5617.46875 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5680.945312 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5744.324219 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5807.800781 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5871.179688 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5910.388672 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5942.175781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6025.964844 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6057.751953 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6155.164062 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6216.6875 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6280.164062 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6307.947266 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6369.226562 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6432.605469 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6464.392578 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6516.492188 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6579.871094 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6641.150391 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6704.626953 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6756.726562 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6820.105469 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6881.287109 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6920.496094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6954.1875 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6985.974609 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7027.087891 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7088.367188 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7127.576172 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7155.359375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7216.541016 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7248.328125 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7276.111328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7328.210938 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7359.998047 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7423.474609 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7484.998047 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7524.207031 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7585.730469 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7625.09375 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7722.505859 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7750.289062 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7813.667969 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7841.451172 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7893.550781 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7932.759766 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7960.542969 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3135.351562 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3190.332031 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3225.537109 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3289.160156 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3352.636719 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3416.259766 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3479.882812 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3543.505859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3575.292969 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3607.080078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3638.867188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3670.654297 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3702.441406 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3730.224609 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3791.748047 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3853.027344 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3916.40625 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3979.882812 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4018.746094 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4079.927734 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4139.107422 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4200.630859 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4241.744141 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4275.435547 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4303.21875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4364.742188 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4426.021484 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4489.400391 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4553.023438 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4586.714844 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4645.894531 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4709.517578 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4741.304688 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4804.927734 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4868.550781 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4900.337891 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4963.960938 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5000.044922 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5038.908203 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5093.888672 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5157.511719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5189.298828 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5221.085938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5252.873047 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5284.660156 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5316.447266 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5355.65625 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5419.035156 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5457.898438 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5519.080078 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5582.458984 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5645.935547 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5709.314453 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5772.791016 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5836.169922 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5875.378906 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5907.166016 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5990.955078 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6022.742188 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6120.154297 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6181.677734 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6245.154297 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6272.9375 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6334.216797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6397.595703 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6429.382812 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6481.482422 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6544.861328 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6606.140625 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6669.617188 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6721.716797 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6785.095703 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6846.277344 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6885.486328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6919.177734 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6950.964844 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6992.078125 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7053.357422 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7092.566406 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7120.349609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7181.53125 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7213.318359 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7241.101562 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7293.201172 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7324.988281 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7388.464844 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7449.988281 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7489.197266 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7550.720703 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7590.083984 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7687.496094 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7715.279297 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7778.658203 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7806.441406 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7858.541016 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7897.75 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7925.533203 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pd225242cc5">
+  <clipPath id="pd25df8895c">
    <rect x="95.67625" y="49.4355" width="416.571298" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_summary.svg
+++ b/bench/graphs/canterbury_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="575.475156pt" height="386.202469pt" viewBox="0 0 575.475156 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="573.025156pt" height="386.202469pt" viewBox="0 0 573.025156 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,232 +22,232 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 386.202469 
-L 575.475156 386.202469 
-L 575.475156 0 
+L 573.025156 386.202469 
+L 573.025156 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 189.862578 104.1264 
-L 294.487578 104.1264 
-L 294.487578 74.7432 
-L 189.862578 74.7432 
+    <path d="M 188.637578 104.1264 
+L 293.262578 104.1264 
+L 293.262578 74.7432 
+L 188.637578 74.7432 
 z
-" clip-path="url(#p8db67597a3)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p85cb60a729)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 294.487578 104.1264 
-L 399.112578 104.1264 
-L 399.112578 74.7432 
-L 294.487578 74.7432 
+    <path d="M 293.262578 104.1264 
+L 397.887578 104.1264 
+L 397.887578 74.7432 
+L 293.262578 74.7432 
 z
-" clip-path="url(#p8db67597a3)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p85cb60a729)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 399.112578 104.1264 
-L 503.737578 104.1264 
-L 503.737578 74.7432 
-L 399.112578 74.7432 
+    <path d="M 397.887578 104.1264 
+L 502.512578 104.1264 
+L 502.512578 74.7432 
+L 397.887578 74.7432 
 z
-" clip-path="url(#p8db67597a3)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p85cb60a729)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 189.862578 133.5096 
-L 294.487578 133.5096 
-L 294.487578 104.1264 
-L 189.862578 104.1264 
+    <path d="M 188.637578 133.5096 
+L 293.262578 133.5096 
+L 293.262578 104.1264 
+L 188.637578 104.1264 
 z
-" clip-path="url(#p8db67597a3)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p85cb60a729)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 294.487578 133.5096 
-L 399.112578 133.5096 
-L 399.112578 104.1264 
-L 294.487578 104.1264 
+    <path d="M 293.262578 133.5096 
+L 397.887578 133.5096 
+L 397.887578 104.1264 
+L 293.262578 104.1264 
 z
-" clip-path="url(#p8db67597a3)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p85cb60a729)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 399.112578 133.5096 
-L 503.737578 133.5096 
-L 503.737578 104.1264 
-L 399.112578 104.1264 
+    <path d="M 397.887578 133.5096 
+L 502.512578 133.5096 
+L 502.512578 104.1264 
+L 397.887578 104.1264 
 z
-" clip-path="url(#p8db67597a3)" style="fill: #fdb768; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p85cb60a729)" style="fill: #fdb768; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 189.862578 162.8928 
-L 294.487578 162.8928 
-L 294.487578 133.5096 
-L 189.862578 133.5096 
+    <path d="M 188.637578 162.8928 
+L 293.262578 162.8928 
+L 293.262578 133.5096 
+L 188.637578 133.5096 
 z
-" clip-path="url(#p8db67597a3)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p85cb60a729)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 294.487578 162.8928 
-L 399.112578 162.8928 
-L 399.112578 133.5096 
-L 294.487578 133.5096 
+    <path d="M 293.262578 162.8928 
+L 397.887578 162.8928 
+L 397.887578 133.5096 
+L 293.262578 133.5096 
 z
-" clip-path="url(#p8db67597a3)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p85cb60a729)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 399.112578 162.8928 
-L 503.737578 162.8928 
-L 503.737578 133.5096 
-L 399.112578 133.5096 
+    <path d="M 397.887578 162.8928 
+L 502.512578 162.8928 
+L 502.512578 133.5096 
+L 397.887578 133.5096 
 z
-" clip-path="url(#p8db67597a3)" style="fill: #bbe278; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p85cb60a729)" style="fill: #bbe278; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 189.862578 192.276 
-L 294.487578 192.276 
-L 294.487578 162.8928 
-L 189.862578 162.8928 
+    <path d="M 188.637578 192.276 
+L 293.262578 192.276 
+L 293.262578 162.8928 
+L 188.637578 162.8928 
 z
-" clip-path="url(#p8db67597a3)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p85cb60a729)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 294.487578 192.276 
-L 399.112578 192.276 
-L 399.112578 162.8928 
-L 294.487578 162.8928 
+    <path d="M 293.262578 192.276 
+L 397.887578 192.276 
+L 397.887578 162.8928 
+L 293.262578 162.8928 
 z
-" clip-path="url(#p8db67597a3)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p85cb60a729)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 399.112578 192.276 
-L 503.737578 192.276 
-L 503.737578 162.8928 
-L 399.112578 162.8928 
+    <path d="M 397.887578 192.276 
+L 502.512578 192.276 
+L 502.512578 162.8928 
+L 397.887578 162.8928 
 z
-" clip-path="url(#p8db67597a3)" style="fill: #fdc776; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p85cb60a729)" style="fill: #fdc776; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 189.862578 221.6592 
-L 294.487578 221.6592 
-L 294.487578 192.276 
-L 189.862578 192.276 
+    <path d="M 188.637578 221.6592 
+L 293.262578 221.6592 
+L 293.262578 192.276 
+L 188.637578 192.276 
 z
-" clip-path="url(#p8db67597a3)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p85cb60a729)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 294.487578 221.6592 
-L 399.112578 221.6592 
-L 399.112578 192.276 
-L 294.487578 192.276 
+    <path d="M 293.262578 221.6592 
+L 397.887578 221.6592 
+L 397.887578 192.276 
+L 293.262578 192.276 
 z
-" clip-path="url(#p8db67597a3)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p85cb60a729)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 399.112578 221.6592 
-L 503.737578 221.6592 
-L 503.737578 192.276 
-L 399.112578 192.276 
+    <path d="M 397.887578 221.6592 
+L 502.512578 221.6592 
+L 502.512578 192.276 
+L 397.887578 192.276 
 z
-" clip-path="url(#p8db67597a3)" style="fill: #addc6f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p85cb60a729)" style="fill: #addc6f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 189.862578 251.0424 
-L 294.487578 251.0424 
-L 294.487578 221.6592 
-L 189.862578 221.6592 
+    <path d="M 188.637578 251.0424 
+L 293.262578 251.0424 
+L 293.262578 221.6592 
+L 188.637578 221.6592 
 z
-" clip-path="url(#p8db67597a3)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p85cb60a729)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 294.487578 251.0424 
-L 399.112578 251.0424 
-L 399.112578 221.6592 
-L 294.487578 221.6592 
+    <path d="M 293.262578 251.0424 
+L 397.887578 251.0424 
+L 397.887578 221.6592 
+L 293.262578 221.6592 
 z
-" clip-path="url(#p8db67597a3)" style="fill: #fdbd6d; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p85cb60a729)" style="fill: #fdbd6d; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 399.112578 251.0424 
-L 503.737578 251.0424 
-L 503.737578 221.6592 
-L 399.112578 221.6592 
+    <path d="M 397.887578 251.0424 
+L 502.512578 251.0424 
+L 502.512578 221.6592 
+L 397.887578 221.6592 
 z
-" clip-path="url(#p8db67597a3)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p85cb60a729)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 189.862578 280.4256 
-L 294.487578 280.4256 
-L 294.487578 251.0424 
-L 189.862578 251.0424 
+    <path d="M 188.637578 280.4256 
+L 293.262578 280.4256 
+L 293.262578 251.0424 
+L 188.637578 251.0424 
 z
-" clip-path="url(#p8db67597a3)" style="fill: #ebf7a3; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p85cb60a729)" style="fill: #ebf7a3; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 294.487578 280.4256 
-L 399.112578 280.4256 
-L 399.112578 251.0424 
-L 294.487578 251.0424 
+    <path d="M 293.262578 280.4256 
+L 397.887578 280.4256 
+L 397.887578 251.0424 
+L 293.262578 251.0424 
 z
-" clip-path="url(#p8db67597a3)" style="fill: #fb9d59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p85cb60a729)" style="fill: #fb9d59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 399.112578 280.4256 
-L 503.737578 280.4256 
-L 503.737578 251.0424 
-L 399.112578 251.0424 
+    <path d="M 397.887578 280.4256 
+L 502.512578 280.4256 
+L 502.512578 251.0424 
+L 397.887578 251.0424 
 z
-" clip-path="url(#p8db67597a3)" style="fill: #f26841; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p85cb60a729)" style="fill: #f36b42; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 189.862578 309.8088 
-L 294.487578 309.8088 
-L 294.487578 280.4256 
-L 189.862578 280.4256 
+    <path d="M 188.637578 309.8088 
+L 293.262578 309.8088 
+L 293.262578 280.4256 
+L 188.637578 280.4256 
 z
-" clip-path="url(#p8db67597a3)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p85cb60a729)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 294.487578 309.8088 
-L 399.112578 309.8088 
-L 399.112578 280.4256 
-L 294.487578 280.4256 
+    <path d="M 293.262578 309.8088 
+L 397.887578 309.8088 
+L 397.887578 280.4256 
+L 293.262578 280.4256 
 z
-" clip-path="url(#p8db67597a3)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p85cb60a729)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 399.112578 309.8088 
-L 503.737578 309.8088 
-L 503.737578 280.4256 
-L 399.112578 280.4256 
+    <path d="M 397.887578 309.8088 
+L 502.512578 309.8088 
+L 502.512578 280.4256 
+L 397.887578 280.4256 
 z
-" clip-path="url(#p8db67597a3)" style="fill: #ee613e; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p85cb60a729)" style="fill: #ee613e; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 189.862578 339.192 
-L 294.487578 339.192 
-L 294.487578 309.8088 
-L 189.862578 309.8088 
+    <path d="M 188.637578 339.192 
+L 293.262578 339.192 
+L 293.262578 309.8088 
+L 188.637578 309.8088 
 z
-" clip-path="url(#p8db67597a3)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p85cb60a729)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 294.487578 339.192 
-L 399.112578 339.192 
-L 399.112578 309.8088 
-L 294.487578 309.8088 
+    <path d="M 293.262578 339.192 
+L 397.887578 339.192 
+L 397.887578 309.8088 
+L 293.262578 309.8088 
 z
-" clip-path="url(#p8db67597a3)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p85cb60a729)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 399.112578 339.192 
-L 503.737578 339.192 
-L 503.737578 309.8088 
-L 399.112578 309.8088 
+    <path d="M 397.887578 339.192 
+L 502.512578 339.192 
+L 502.512578 309.8088 
+L 397.887578 309.8088 
 z
-" clip-path="url(#p8db67597a3)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p85cb60a729)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(122.849844 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(121.624844 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(230.134063 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(228.909063 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(308.706172 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(307.481172 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(407.057891 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(405.832891 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(118.787578 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(117.562578 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.296 -->
-    <g transform="translate(230.723828 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(229.498828 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -946,7 +946,7 @@ z
    </g>
    <g id="text_7">
     <!-- 158 -->
-    <g transform="translate(339.165078 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(337.940078 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -1034,7 +1034,7 @@ z
    </g>
    <g id="text_8">
     <!-- 925 -->
-    <g transform="translate(443.790078 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(442.565078 91.6423) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-39"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
@@ -1042,7 +1042,7 @@ z
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(113.425703 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(112.200703 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1141,7 +1141,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.299 -->
-    <g transform="translate(230.723828 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(229.498828 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1151,7 +1151,7 @@ z
    </g>
    <g id="text_11">
     <!-- 73 -->
-    <g transform="translate(341.710078 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(340.485078 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -1202,7 +1202,7 @@ z
    </g>
    <g id="text_12">
     <!-- 283 -->
-    <g transform="translate(443.790078 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(442.565078 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(127.246094 0)"/>
@@ -1210,7 +1210,7 @@ z
    </g>
    <g id="text_13">
     <!-- zlib -->
-    <g transform="translate(130.688828 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(129.463828 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1234,7 +1234,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.299 -->
-    <g transform="translate(230.723828 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(229.498828 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1244,14 +1244,14 @@ z
    </g>
    <g id="text_15">
     <!-- 55 -->
-    <g transform="translate(341.710078 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(340.485078 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
     <!-- 692 -->
-    <g transform="translate(443.790078 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(442.565078 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-36"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
@@ -1259,7 +1259,7 @@ z
    </g>
    <g id="text_17">
     <!-- Go compress/flate -->
-    <g transform="translate(101.118828 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(99.893828 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -1430,7 +1430,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.299 -->
-    <g transform="translate(230.723828 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(229.498828 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1440,14 +1440,14 @@ z
    </g>
    <g id="text_19">
     <!-- 52 -->
-    <g transform="translate(341.710078 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(340.485078 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
     <!-- 323 -->
-    <g transform="translate(443.790078 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(442.565078 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(127.246094 0)"/>
@@ -1455,7 +1455,7 @@ z
    </g>
    <g id="text_21">
     <!-- miniz_oxide -->
-    <g transform="translate(113.995078 209.06385) scale(0.08 -0.08)">
+    <g transform="translate(112.770078 209.06385) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6e" d="M 3513 2113 
 L 3513 0 
@@ -1514,7 +1514,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.299 -->
-    <g transform="translate(230.723828 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(229.498828 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1524,14 +1524,14 @@ z
    </g>
    <g id="text_23">
     <!-- 51 -->
-    <g transform="translate(341.710078 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(340.485078 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_24">
     <!-- 729 -->
-    <g transform="translate(443.790078 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(442.565078 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-37"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(127.246094 0)"/>
@@ -1539,7 +1539,7 @@ z
    </g>
    <g id="text_25">
     <!-- JS fflate -->
-    <g transform="translate(122.151328 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(120.926328 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1599,7 +1599,7 @@ z
    </g>
    <g id="text_26">
     <!-- 0.307 -->
-    <g transform="translate(230.723828 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(229.498828 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1609,7 +1609,7 @@ z
    </g>
    <g id="text_27">
     <!-- 41 -->
-    <g transform="translate(341.710078 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(340.485078 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1637,14 +1637,14 @@ z
    </g>
    <g id="text_28">
     <!-- 80 -->
-    <g transform="translate(446.335078 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(445.110078 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-38"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_29">
     <!-- lean-zip (native) -->
-    <g transform="translate(100.496953 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(99.271953 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1753,7 +1753,7 @@ z
    </g>
    <g id="text_30">
     <!-- 0.297 -->
-    <g transform="translate(229.523203 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(228.298203 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1855,7 +1855,7 @@ z
    </g>
    <g id="text_31">
     <!-- 28 -->
-    <g transform="translate(341.233828 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(340.008828 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-38" d="M 2228 2088 
 Q 1891 2088 1709 1903 
@@ -1903,7 +1903,7 @@ z
    </g>
    <g id="text_32">
     <!-- 135 -->
-    <g transform="translate(443.075703 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(441.850703 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-31" d="M 750 831 
 L 1813 831 
@@ -1984,7 +1984,7 @@ z
    </g>
    <g id="text_33">
     <!-- OCaml decompress -->
-    <g transform="translate(98.611953 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(97.386953 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -2049,7 +2049,7 @@ z
    </g>
    <g id="text_34">
     <!-- 0.321 -->
-    <g transform="translate(230.723828 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(229.498828 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -2059,14 +2059,14 @@ z
    </g>
    <g id="text_35">
     <!-- 23 -->
-    <g transform="translate(341.710078 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(340.485078 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_36">
     <!-- 117 -->
-    <g transform="translate(443.790078 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(442.565078 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
@@ -2074,7 +2074,7 @@ z
    </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(126.833203 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(125.608203 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -2085,7 +2085,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.279 -->
-    <g transform="translate(230.723828 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(229.498828 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -2095,13 +2095,13 @@ z
    </g>
    <g id="text_39">
     <!-- 0 -->
-    <g transform="translate(344.255078 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(343.030078 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(447.425078 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(446.200078 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2117,7 +2117,7 @@ z
   </g>
   <g id="text_41">
    <!-- canterbury — geomean over files, level 6 -->
-   <g transform="translate(137.246328 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(136.021328 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-62" d="M 2400 722 
 Q 2759 722 2948 984 
@@ -2330,7 +2330,7 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-07-07T02:05:28Z  ·  Linux chungus2 x86_64  ·  commit 1a899305  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-07-07T22:17:01Z  ·  Linux chungus2 x86_64  ·  commit dcf4b958  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2471,14 +2471,14 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-37" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2518,110 +2518,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3196.777344 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3260.400391 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3324.023438 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3387.646484 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3451.269531 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3514.892578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3578.515625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3610.302734 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3642.089844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3673.876953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3705.664062 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3737.451172 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3765.234375 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3826.757812 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3888.037109 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3951.416016 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4014.892578 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4053.755859 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4114.9375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4174.117188 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4235.640625 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4276.753906 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4310.445312 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4338.228516 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4399.751953 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4461.03125 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4524.410156 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4588.033203 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4621.724609 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4680.904297 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4744.527344 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4776.314453 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4839.9375 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4903.560547 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4935.347656 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4998.970703 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5035.054688 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5073.917969 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5128.898438 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5192.521484 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5224.308594 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5256.095703 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5287.882812 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5319.669922 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5351.457031 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5390.666016 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5454.044922 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5492.908203 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5554.089844 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5617.46875 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5680.945312 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5744.324219 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5807.800781 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5871.179688 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5910.388672 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5942.175781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6025.964844 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6057.751953 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6155.164062 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6216.6875 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6280.164062 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6307.947266 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6369.226562 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6432.605469 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6464.392578 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6516.492188 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6579.871094 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6641.150391 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6704.626953 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6756.726562 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6820.105469 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6881.287109 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6920.496094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6954.1875 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6985.974609 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7027.087891 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7088.367188 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7127.576172 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7155.359375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7216.541016 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7248.328125 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7276.111328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7328.210938 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7359.998047 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7423.474609 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7484.998047 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7524.207031 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7585.730469 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7625.09375 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7722.505859 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7750.289062 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7813.667969 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7841.451172 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7893.550781 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7932.759766 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7960.542969 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3135.351562 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3190.332031 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3225.537109 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3289.160156 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3352.636719 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3416.259766 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3479.882812 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3543.505859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3575.292969 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3607.080078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3638.867188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3670.654297 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3702.441406 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3730.224609 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3791.748047 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3853.027344 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3916.40625 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3979.882812 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4018.746094 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4079.927734 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4139.107422 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4200.630859 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4241.744141 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4275.435547 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4303.21875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4364.742188 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4426.021484 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4489.400391 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4553.023438 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4586.714844 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4645.894531 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4709.517578 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4741.304688 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4804.927734 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4868.550781 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4900.337891 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4963.960938 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5000.044922 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5038.908203 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5093.888672 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5157.511719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5189.298828 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5221.085938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5252.873047 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5284.660156 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5316.447266 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5355.65625 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5419.035156 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5457.898438 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5519.080078 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5582.458984 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5645.935547 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5709.314453 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5772.791016 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5836.169922 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5875.378906 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5907.166016 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5990.955078 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6022.742188 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6120.154297 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6181.677734 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6245.154297 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6272.9375 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6334.216797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6397.595703 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6429.382812 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6481.482422 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6544.861328 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6606.140625 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6669.617188 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6721.716797 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6785.095703 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6846.277344 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6885.486328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6919.177734 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6950.964844 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6992.078125 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7053.357422 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7092.566406 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7120.349609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7181.53125 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7213.318359 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7241.101562 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7293.201172 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7324.988281 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7388.464844 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7449.988281 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7489.197266 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7550.720703 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7590.083984 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7687.496094 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7715.279297 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7778.658203 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7806.441406 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7858.541016 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7897.75 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7925.533203 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p8db67597a3">
-   <rect x="85.237578" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="p85cb60a729">
+   <rect x="84.012578" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/graphs/silesia_compress_heatmap.svg
+++ b/bench/graphs/silesia_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.34175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#pd7d900058d)">
+   <g clip-path="url(#pa081a4fe07)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAqAAAAGaCAYAAADQNfGTAAAJ+ElEQVR4nO3YP27lVx2H4di+djzDaMgfsDIoDTQIUaAgRYhtsA4qWtbABuhSsgAKGgoKpNCkjIREpCQgjUIyQDRMLvbPNouIzvud/PQ8K/hcHR/f956Tuy/eu39lz65fTC9Y6+R0esFad9v0grX2fn7b9fSCtR6+Nr1grf89n17A13F2Mb1grb3/fZ5fTi9YaufffgAAvGwEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAqcMH2yfTG5a6OD9MT1jquF1PT1jqyePvTU9Y6uMvP52esNR2cjs9YakfPXhjesJS26uX0xOW+sfzv09PWOrqwdX0hKWOF9v0hKVOXnkxPWEpL6AAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEDqcPXwanrDUk++9YPpCUt99uKT6QlLvXXc92+kx2/+ZHrCUhdnl9MTlrq926YnLLX389v95zvd9+c7nL49PWGpy+NxesJS+/52BwDgpSNAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBIHV49ezi9Yalnx6fTE5ba+/ndvv7G9ISlPv33B9MTlnp+c5yesNS7r787PWGp6/ttesJSH3/50fSEpX785k+nJyz1/tM/T09Y6p3v7vv8vIACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApE5u//Sr++kRS93dTS/g69j7+Z36DQhj9n7//P/8Ztu26QVL7fz0AAB42QhQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSh6v3P5zesNTZxdn0hKU++/Cf0xOW+u0v35mesNRv/rLv8/v524+nJyz1uz9+ND1hqV//4ofTE5b6/d/+Mz1hqe+/9mB6wlLPvrqZnrDUz548nJ6wlBdQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgdXJz+4f76RErnd1cT09Y6+xiesFa23F6wVqHy+kFa50dphesdX83vWCtm53fv5Odv8Gc7vv+3Zzs+/6db9v0hKV2fvsAAHjZCFAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFKHr7bn0xuWenS9TU9Y6u7R5fSEpU7/9fn0hLW+/db0grW24/SCpa7PD9MTlrr477PpCWs93vn9u7+bXrDU+dO/Tk9Y69F3phcs5QUUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAIPV/m+58yjWMNvYAAAAASUVORK5CYII=" id="image17aec7e6c0" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="483.84" height="295.2"/>
+iVBORw0KGgoAAAANSUhEUgAAAqAAAAGaCAYAAADQNfGTAAAJ+UlEQVR4nO3YsW6k1R2HYeyZNd5FchYQFotokiaKUkREQojbyHVQ0XIN3AAdZS4gRRoKikikoSRNkIAkQkRZbdBiHHtscxHovH/n0/NcwW905sy833d0+5+P717YsquL6QVrHR1PL1jr9jC9YK2tn9/hanrBWo8eTy9Y63/Ppxfwc+xOphestfXv54PT6QVLbfzfDwCA+0aAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQ2n9++Hp6w1InD/bTE5a6PFxNT1jqydkb0xOW+ur7b6YnLHU4upmesNRvHr4yPWGpw4un0xOW+ufzf0xPWOr84fn0hKUuTw7TE5Y6euFiesJS3oACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAACp/fmj8+kNSz156VfTE5b67uLr6QlLvX657Weks1d/Nz1hqZPd6fSEpW5uD9MTltr6+W3+8x1v+/Ptj9+cnrDU6eXl9ISltv3vDgDAvSNAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBI7V/cPZresNTTy2+nJyy19fO7efmV6QlLffPs8+kJSz2/vpyesNTbL789PWGpq7vD9ISlvvr+y+kJS/321d9PT1jqs2//Mj1hqbde2/b5eQMKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkDq6+fT9u+kRS93eTi/g59j6+R17BoQxW79/fj//vx0O0wuW2vjpAQBw3whQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABS+/PPvpjesNTuZDc9Yanvvvj39ISlPnrvrekJS334122f37tvnk1PWOqPn3w5PWGpD/7w6+kJS/3p7/+dnrDULx8/nJ6w1NMfr6cnLPXOk0fTE5byBhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgdXd/8+W56xEq766vpCWvtTqYXrHW4nF6w1v50esFau/30grXubqcXrHW98ft3tPF3MMfbvn/XR9u+fw8Oh+kJS2389gEAcN8IUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUvvn18+mNyz1i6vpBWvdvHQyPWGp3Q9Ppyesdfb69IK1ri6mFyx1td/2M/zJxbPpCWs9fmN6wVp3t9MLlnrwr79NT1jr7Hx6wVLb/vUEAODeEaAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKR+AtAie82hecYiAAAAAElFTkSuQmCC" id="image9f23102d8a" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="483.84" height="295.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="medc31bb404" d="M 0 0 
+       <path id="m04360577bb" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#medc31bb404" x="115.814949" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m04360577bb" x="115.814949" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#medc31bb404" x="156.092348" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m04360577bb" x="156.092348" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#medc31bb404" x="196.369746" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m04360577bb" x="196.369746" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#medc31bb404" x="236.647145" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m04360577bb" x="236.647145" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#medc31bb404" x="276.924544" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m04360577bb" x="276.924544" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#medc31bb404" x="317.201942" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m04360577bb" x="317.201942" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#medc31bb404" x="357.479341" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m04360577bb" x="357.479341" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#medc31bb404" x="397.756739" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m04360577bb" x="397.756739" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#medc31bb404" x="438.034138" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m04360577bb" x="438.034138" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#medc31bb404" x="478.311536" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m04360577bb" x="478.311536" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#medc31bb404" x="518.588935" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m04360577bb" x="518.588935" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#medc31bb404" x="558.866334" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m04360577bb" x="558.866334" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="m0ba62e1a64" d="M 0 0 
+       <path id="m26c50d0627" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m0ba62e1a64" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m26c50d0627" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m0ba62e1a64" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m26c50d0627" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m0ba62e1a64" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m26c50d0627" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m0ba62e1a64" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m26c50d0627" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -836,7 +836,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m0ba62e1a64" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m26c50d0627" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -899,7 +899,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m0ba62e1a64" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m26c50d0627" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -966,7 +966,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m0ba62e1a64" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m26c50d0627" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1047,7 +1047,7 @@ z
     <g id="ytick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m0ba62e1a64" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m26c50d0627" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -1138,7 +1138,7 @@ L 579.005033 49.34175
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_21">
-    <!-- +21 -->
+    <!-- +25 -->
     <g transform="translate(108.955926 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-2b" d="M 2944 4013 
@@ -1180,24 +1180,35 @@ Q 2828 2175 2409 1742
 Q 1991 1309 1228 531 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-31" d="M 794 531 
-L 1825 531 
-L 1825 4091 
-L 703 3866 
-L 703 4441 
-L 1819 4666 
-L 2450 4666 
-L 2450 531 
-L 3481 531 
-L 3481 0 
-L 794 0 
-L 794 531 
+      <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_22">
@@ -1230,8 +1241,47 @@ z
     </g>
    </g>
    <g id="text_23">
-    <!-- +3 -->
+    <!-- +6 -->
     <g transform="translate(191.578535 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_24">
+    <!-- -37 -->
+    <g transform="translate(231.338981 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
@@ -1265,153 +1315,6 @@ Q 3450 3153 3228 2886
 Q 3006 2619 2597 2516 
 z
 " transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_24">
-    <!-- -38 -->
-    <g transform="translate(231.338981 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-38" d="M 2034 2216 
-Q 1584 2216 1326 1975 
-Q 1069 1734 1069 1313 
-Q 1069 891 1326 650 
-Q 1584 409 2034 409 
-Q 2484 409 2743 651 
-Q 3003 894 3003 1313 
-Q 3003 1734 2745 1975 
-Q 2488 2216 2034 2216 
-z
-M 1403 2484 
-Q 997 2584 770 2862 
-Q 544 3141 544 3541 
-Q 544 4100 942 4425 
-Q 1341 4750 2034 4750 
-Q 2731 4750 3128 4425 
-Q 3525 4100 3525 3541 
-Q 3525 3141 3298 2862 
-Q 3072 2584 2669 2484 
-Q 3125 2378 3379 2068 
-Q 3634 1759 3634 1313 
-Q 3634 634 3220 271 
-Q 2806 -91 2034 -91 
-Q 1263 -91 848 271 
-Q 434 634 434 1313 
-Q 434 1759 690 2068 
-Q 947 2378 1403 2484 
-z
-M 1172 3481 
-Q 1172 3119 1398 2916 
-Q 1625 2713 2034 2713 
-Q 2441 2713 2670 2916 
-Q 2900 3119 2900 3481 
-Q 2900 3844 2670 4047 
-Q 2441 4250 2034 4250 
-Q 1625 4250 1398 4047 
-Q 1172 3844 1172 3481 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_25">
-    <!-- -12 -->
-    <g transform="translate(271.616379 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_26">
-    <!-- -15 -->
-    <g transform="translate(311.893778 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_27">
-    <!-- +10 -->
-    <g transform="translate(350.620317 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-30" d="M 2034 4250 
-Q 1547 4250 1301 3770 
-Q 1056 3291 1056 2328 
-Q 1056 1369 1301 889 
-Q 1547 409 2034 409 
-Q 2525 409 2770 889 
-Q 3016 1369 3016 2328 
-Q 3016 3291 2770 3770 
-Q 2525 4250 2034 4250 
-z
-M 2034 4750 
-Q 2819 4750 3233 4129 
-Q 3647 3509 3647 2328 
-Q 3647 1150 3233 529 
-Q 2819 -91 2034 -91 
-Q 1250 -91 836 529 
-Q 422 1150 422 2328 
-Q 422 3509 836 4129 
-Q 1250 4750 2034 4750 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_28">
-    <!-- -35 -->
-    <g transform="translate(392.448575 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_29">
-    <!-- -5 -->
-    <g transform="translate(434.793786 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_30">
-    <!-- -7 -->
-    <g transform="translate(475.071185 69.553235) scale(0.065 -0.065)">
-     <defs>
       <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
 L 3525 4397 
@@ -1424,20 +1327,13 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
     </g>
    </g>
-   <g id="text_31">
-    <!-- -54 -->
-    <g transform="translate(513.280771 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_32">
-    <!-- -29 -->
-    <g transform="translate(553.558169 69.553235) scale(0.065 -0.065)">
+   <g id="text_25">
+    <!-- -9 -->
+    <g transform="translate(273.684192 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-39" d="M 703 97 
 L 703 672 
@@ -1471,8 +1367,77 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_26">
+    <!-- -12 -->
+    <g transform="translate(311.893778 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_27">
+    <!-- +11 -->
+    <g transform="translate(350.620317 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_28">
+    <!-- -33 -->
+    <g transform="translate(392.448575 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_29">
+    <!-- -1 -->
+    <g transform="translate(434.793786 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_30">
+    <!-- -5 -->
+    <g transform="translate(475.071185 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_31">
+    <!-- -52 -->
+    <g transform="translate(513.280771 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_32">
+    <!-- -27 -->
+    <g transform="translate(553.558169 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_33">
@@ -1500,38 +1465,6 @@ z
    <g id="text_36">
     <!-- -16 -->
     <g transform="translate(231.338981 106.389018) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-36" d="M 2113 2584 
-Q 1688 2584 1439 2293 
-Q 1191 2003 1191 1497 
-Q 1191 994 1439 701 
-Q 1688 409 2113 409 
-Q 2538 409 2786 701 
-Q 3034 994 3034 1497 
-Q 3034 2003 2786 2293 
-Q 2538 2584 2113 2584 
-z
-M 3366 4563 
-L 3366 3988 
-Q 3128 4100 2886 4159 
-Q 2644 4219 2406 4219 
-Q 1781 4219 1451 3797 
-Q 1122 3375 1075 2522 
-Q 1259 2794 1537 2939 
-Q 1816 3084 2150 3084 
-Q 2853 3084 3261 2657 
-Q 3669 2231 3669 1497 
-Q 3669 778 3244 343 
-Q 2819 -91 2113 -91 
-Q 1303 -91 875 529 
-Q 447 1150 447 2328 
-Q 447 3434 972 4092 
-Q 1497 4750 2381 4750 
-Q 2619 4750 2861 4703 
-Q 3103 4656 3366 4563 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
@@ -1547,6 +1480,29 @@ z
    <g id="text_38">
     <!-- -0 -->
     <g transform="translate(313.961591 106.389018) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(36.083984 0)"/>
     </g>
@@ -1644,6 +1600,47 @@ z
    <g id="text_50">
     <!-- +184 -->
     <g transform="translate(308.275106 143.2248) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-38" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
@@ -2193,18 +2190,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB1ElEQVR4nO2b0a3DMAwD7cSzvM3fmI47gvpxCK6ENABhnkQ5aZH5P/7OAGpdFyEzBiQDnija2qSEghnZhIIZCa3NyWQkmZFOKJhRsDXsOopmJJwjaEPOmxHirE3MWjOqhSBr2EAGMyKtMVpc+ynYwe3viNQVbA0LrZDRFbxGbNbWyM3auG0RGbo1Qp0IZCSMiG2OgtNvbL+Oke6BvddIWaQ1qP3RjGSTLXypwdaIMP2ctWb0olAzKkr4LhLMCPvnOJiRbo6CrTWjF4WCGYHWJtU1TKgZvSZkfNAKZhRsDftFa96MkJCRrf29ausyWrOtWiMjmxDH6FAfDJzzIEKctQc60ToDEqJOBLbfZs04RxQjobWOSFXrjM0IdURqIaG1jkhVPmvGOUqOCPLJMdh+6kRk+zFGMtjKOdK13zbZ2EBGMxLOkSz90YygK9tozSbUa6Qu4RxtRifZ2np0jDY32YiOc44gIQo2aI1ZkB2Rb4SiIyJbtcr0Q0IPdCQyIpCQDnZHpC5uQ27uOtJFBBptH2zlHOnab+uaMSK29htXrW2NKK0hOtlrxLaPjIxys4a99x9dRKgTgUK69gsZ9RxVFWzNyIi6RZIZtbXfE+qI1BU8R5i1D2e5X2tFkZmlAAAAAElFTkSuQmCC" id="image679ef497bd" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-69.84" width="12.96" height="253.44"/>
+iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB1ElEQVR4nO2b0a3DMAwD7cSzvM3fmI47gvpxCK6ENABhnkQ5aZH5P/7OAGpdFyEzBiQDnija2qSEghnZhIIZCa3NyWQkmZFOKJhRsDXsOopmJJwjaEPOmxHirE3MWjOqhSBr2EAGMyKtMVpc+ynYwe3viNQVbA0LrZDRFbxGbNbWyM3auG0RGbo1Qp0IZCSMiG2OgtNvbL+Oke6BvddIWaQ1qP3RjGSTLXypwdaIMP2ctWb0olAzKkr4LhLMCPvnOJiRbo6CrTWjF4WCGYHWJtU1TKgZvSZkfNAKZhRsDftFa96MkJCRrf29ausyWrOtWiMjmxDH6FAfDJzzIEKctQc60ToDEqJOBLbfZs04RxQjobWOSFXrjM0IdURqIaG1jkhVPmvGOUqOCPLJMdh+6kRk+zFGMtjKOdK13zbZ2EBGMxLOkSz90YygK9tozSbUa6Qu4RxtRifZ2np0jDY32YiOc44gIQo2aI1ZkB2Rb4SiIyJbtcr0Q0IPdCQyIpCQDnZHpC5uQ27uOtJFBBptH2zlHOnab+uaMSK29htXrW2NKK0hOtlrxLaPjIxys4a99x9dRKgTgUK69gsZ9RxVFWzNyIi6RZIZtbXfE+qI1BU8R5i1D2e5X2tFkZmlAAAAAElFTkSuQmCC" id="image411661f893" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-69.84" width="12.96" height="253.44"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_21">
       <defs>
-       <path id="m1a44dbcddb" d="M 0 0 
+       <path id="mda4db4a269" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m1a44dbcddb" x="601.779688" y="322.507463" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mda4db4a269" x="601.779688" y="322.507463" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_117">
@@ -2227,7 +2224,7 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m1a44dbcddb" x="601.779688" y="280.566603" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mda4db4a269" x="601.779688" y="280.566603" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_118">
@@ -2241,7 +2238,7 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m1a44dbcddb" x="601.779688" y="238.625742" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mda4db4a269" x="601.779688" y="238.625742" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_119">
@@ -2255,7 +2252,7 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m1a44dbcddb" x="601.779688" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mda4db4a269" x="601.779688" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_120">
@@ -2268,7 +2265,7 @@ z
     <g id="ytick_13">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m1a44dbcddb" x="601.779688" y="154.74402" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mda4db4a269" x="601.779688" y="154.74402" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_121">
@@ -2281,7 +2278,7 @@ z
     <g id="ytick_14">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m1a44dbcddb" x="601.779688" y="112.803159" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mda4db4a269" x="601.779688" y="112.803159" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_122">
@@ -2294,7 +2291,7 @@ z
     <g id="ytick_15">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#m1a44dbcddb" x="601.779688" y="70.862298" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mda4db4a269" x="601.779688" y="70.862298" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_123">
@@ -2910,8 +2907,8 @@ z
    </g>
   </g>
   <g id="text_126">
-   <!-- 2026-07-07T02:05:28Z  ·  Linux chungus2 x86_64  ·  commit 1a899305  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(43.462422 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-07T22:17:01Z  ·  Linux chungus2 x86_64  ·  commit dcf4b958  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(44.687422 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -3002,14 +2999,14 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-37" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3049,109 +3046,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3196.777344 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3260.400391 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3324.023438 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3387.646484 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3451.269531 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3514.892578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3578.515625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3610.302734 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3642.089844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3673.876953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3705.664062 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3737.451172 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3765.234375 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3826.757812 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3888.037109 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3951.416016 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4014.892578 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4053.755859 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4114.9375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4174.117188 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4235.640625 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4276.753906 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4310.445312 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4338.228516 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4399.751953 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4461.03125 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4524.410156 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4588.033203 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4621.724609 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4680.904297 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4744.527344 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4776.314453 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4839.9375 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4903.560547 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4935.347656 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4998.970703 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5035.054688 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5073.917969 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5128.898438 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5192.521484 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5224.308594 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5256.095703 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5287.882812 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5319.669922 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5351.457031 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5390.666016 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5454.044922 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5492.908203 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5554.089844 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5617.46875 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5680.945312 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5744.324219 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5807.800781 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5871.179688 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5910.388672 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5942.175781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6025.964844 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6057.751953 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6155.164062 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6216.6875 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6280.164062 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6307.947266 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6369.226562 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6432.605469 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6464.392578 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6516.492188 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6579.871094 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6641.150391 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6704.626953 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6756.726562 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6820.105469 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6881.287109 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6920.496094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6954.1875 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6985.974609 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7027.087891 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7088.367188 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7127.576172 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7155.359375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7216.541016 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7248.328125 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7276.111328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7328.210938 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7359.998047 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7423.474609 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7484.998047 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7524.207031 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7585.730469 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7625.09375 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7722.505859 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7750.289062 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7813.667969 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7841.451172 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7893.550781 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7932.759766 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7960.542969 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3135.351562 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3190.332031 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3225.537109 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3289.160156 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3352.636719 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3416.259766 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3479.882812 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3543.505859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3575.292969 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3607.080078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3638.867188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3670.654297 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3702.441406 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3730.224609 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3791.748047 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3853.027344 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3916.40625 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3979.882812 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4018.746094 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4079.927734 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4139.107422 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4200.630859 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4241.744141 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4275.435547 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4303.21875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4364.742188 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4426.021484 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4489.400391 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4553.023438 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4586.714844 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4645.894531 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4709.517578 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4741.304688 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4804.927734 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4868.550781 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4900.337891 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4963.960938 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5000.044922 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5038.908203 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5093.888672 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5157.511719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5189.298828 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5221.085938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5252.873047 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5284.660156 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5316.447266 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5355.65625 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5419.035156 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5457.898438 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5519.080078 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5582.458984 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5645.935547 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5709.314453 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5772.791016 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5836.169922 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5875.378906 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5907.166016 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5990.955078 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6022.742188 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6120.154297 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6181.677734 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6245.154297 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6272.9375 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6334.216797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6397.595703 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6429.382812 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6481.482422 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6544.861328 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6606.140625 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6669.617188 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6721.716797 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6785.095703 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6846.277344 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6885.486328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6919.177734 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6950.964844 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6992.078125 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7053.357422 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7092.566406 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7120.349609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7181.53125 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7213.318359 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7241.101562 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7293.201172 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7324.988281 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7388.464844 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7449.988281 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7489.197266 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7550.720703 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7590.083984 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7687.496094 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7715.279297 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7778.658203 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7806.441406 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7858.541016 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7897.75 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7925.533203 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pd7d900058d">
+  <clipPath id="pa081a4fe07">
    <rect x="95.67625" y="49.34175" width="483.328783" height="294.686261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_compress_pareto.svg
+++ b/bench/graphs/silesia_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 61.085542 412.80375 
 L 61.085542 48.323125 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="ma729e4c47c" d="M 0 0 
+       <path id="m3fadb05946" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#ma729e4c47c" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3fadb05946" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -130,11 +130,11 @@ z
      <g id="line2d_3">
       <path d="M 145.270284 412.80375 
 L 145.270284 48.323125 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#ma729e4c47c" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3fadb05946" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -177,11 +177,11 @@ z
      <g id="line2d_5">
       <path d="M 229.455026 412.80375 
 L 229.455026 48.323125 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#ma729e4c47c" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3fadb05946" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -219,11 +219,11 @@ z
      <g id="line2d_7">
       <path d="M 313.639768 412.80375 
 L 313.639768 48.323125 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#ma729e4c47c" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3fadb05946" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -272,11 +272,11 @@ z
      <g id="line2d_9">
       <path d="M 397.82451 412.80375 
 L 397.82451 48.323125 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#ma729e4c47c" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3fadb05946" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -334,11 +334,11 @@ z
      <g id="line2d_11">
       <path d="M 482.009253 412.80375 
 L 482.009253 48.323125 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#ma729e4c47c" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3fadb05946" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -355,11 +355,11 @@ L 482.009253 48.323125
      <g id="line2d_13">
       <path d="M 566.193995 412.80375 
 L 566.193995 48.323125 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#ma729e4c47c" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3fadb05946" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -856,16 +856,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 368.08164 
 L 637.2 368.08164 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="m2ce0ae807a" d="M 0 0 
+       <path id="m5d6eb16867" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m2ce0ae807a" x="49.078125" y="368.08164" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5d6eb16867" x="49.078125" y="368.08164" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -897,11 +897,11 @@ z
      <g id="line2d_17">
       <path d="M 49.078125 243.439835 
 L 637.2 243.439835 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m2ce0ae807a" x="49.078125" y="243.439835" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5d6eb16867" x="49.078125" y="243.439835" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -917,11 +917,11 @@ L 637.2 243.439835
      <g id="line2d_19">
       <path d="M 49.078125 118.798029 
 L 637.2 118.798029 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m2ce0ae807a" x="49.078125" y="118.798029" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5d6eb16867" x="49.078125" y="118.798029" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -937,16 +937,16 @@ L 637.2 118.798029
      <g id="line2d_21">
       <path d="M 49.078125 405.602562 
 L 637.2 405.602562 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="m65d5b1df80" d="M 0 0 
+       <path id="m4b9d2d8365" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m65d5b1df80" x="49.078125" y="405.602562" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4b9d2d8365" x="49.078125" y="405.602562" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -954,11 +954,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 395.733268 
 L 637.2 395.733268 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m65d5b1df80" x="49.078125" y="395.733268" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4b9d2d8365" x="49.078125" y="395.733268" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -966,11 +966,11 @@ L 637.2 395.733268
      <g id="line2d_25">
       <path d="M 49.078125 387.3889 
 L 637.2 387.3889 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m65d5b1df80" x="49.078125" y="387.3889" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4b9d2d8365" x="49.078125" y="387.3889" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -978,11 +978,11 @@ L 637.2 387.3889
      <g id="line2d_27">
       <path d="M 49.078125 380.160679 
 L 637.2 380.160679 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m65d5b1df80" x="49.078125" y="380.160679" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4b9d2d8365" x="49.078125" y="380.160679" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -990,11 +990,11 @@ L 637.2 380.160679
      <g id="line2d_29">
       <path d="M 49.078125 373.784936 
 L 637.2 373.784936 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m65d5b1df80" x="49.078125" y="373.784936" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4b9d2d8365" x="49.078125" y="373.784936" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1002,11 +1002,11 @@ L 637.2 373.784936
      <g id="line2d_31">
       <path d="M 49.078125 330.560718 
 L 637.2 330.560718 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m65d5b1df80" x="49.078125" y="330.560718" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4b9d2d8365" x="49.078125" y="330.560718" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1014,11 +1014,11 @@ L 637.2 330.560718
      <g id="line2d_33">
       <path d="M 49.078125 308.612385 
 L 637.2 308.612385 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m65d5b1df80" x="49.078125" y="308.612385" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4b9d2d8365" x="49.078125" y="308.612385" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1026,11 +1026,11 @@ L 637.2 308.612385
      <g id="line2d_35">
       <path d="M 49.078125 293.039796 
 L 637.2 293.039796 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m65d5b1df80" x="49.078125" y="293.039796" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4b9d2d8365" x="49.078125" y="293.039796" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1038,11 +1038,11 @@ L 637.2 293.039796
      <g id="line2d_37">
       <path d="M 49.078125 280.960757 
 L 637.2 280.960757 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m65d5b1df80" x="49.078125" y="280.960757" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4b9d2d8365" x="49.078125" y="280.960757" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1050,11 +1050,11 @@ L 637.2 280.960757
      <g id="line2d_39">
       <path d="M 49.078125 271.091463 
 L 637.2 271.091463 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m65d5b1df80" x="49.078125" y="271.091463" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4b9d2d8365" x="49.078125" y="271.091463" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1062,11 +1062,11 @@ L 637.2 271.091463
      <g id="line2d_41">
       <path d="M 49.078125 262.747094 
 L 637.2 262.747094 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m65d5b1df80" x="49.078125" y="262.747094" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4b9d2d8365" x="49.078125" y="262.747094" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1074,11 +1074,11 @@ L 637.2 262.747094
      <g id="line2d_43">
       <path d="M 49.078125 255.518874 
 L 637.2 255.518874 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m65d5b1df80" x="49.078125" y="255.518874" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4b9d2d8365" x="49.078125" y="255.518874" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1086,11 +1086,11 @@ L 637.2 255.518874
      <g id="line2d_45">
       <path d="M 49.078125 249.143131 
 L 637.2 249.143131 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m65d5b1df80" x="49.078125" y="249.143131" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4b9d2d8365" x="49.078125" y="249.143131" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1098,11 +1098,11 @@ L 637.2 249.143131
      <g id="line2d_47">
       <path d="M 49.078125 205.918912 
 L 637.2 205.918912 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m65d5b1df80" x="49.078125" y="205.918912" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4b9d2d8365" x="49.078125" y="205.918912" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1110,11 +1110,11 @@ L 637.2 205.918912
      <g id="line2d_49">
       <path d="M 49.078125 183.97058 
 L 637.2 183.97058 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m65d5b1df80" x="49.078125" y="183.97058" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4b9d2d8365" x="49.078125" y="183.97058" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1122,11 +1122,11 @@ L 637.2 183.97058
      <g id="line2d_51">
       <path d="M 49.078125 168.39799 
 L 637.2 168.39799 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m65d5b1df80" x="49.078125" y="168.39799" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4b9d2d8365" x="49.078125" y="168.39799" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1134,11 +1134,11 @@ L 637.2 168.39799
      <g id="line2d_53">
       <path d="M 49.078125 156.318951 
 L 637.2 156.318951 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#m65d5b1df80" x="49.078125" y="156.318951" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4b9d2d8365" x="49.078125" y="156.318951" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1146,11 +1146,11 @@ L 637.2 156.318951
      <g id="line2d_55">
       <path d="M 49.078125 146.449658 
 L 637.2 146.449658 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#m65d5b1df80" x="49.078125" y="146.449658" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4b9d2d8365" x="49.078125" y="146.449658" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1158,11 +1158,11 @@ L 637.2 146.449658
      <g id="line2d_57">
       <path d="M 49.078125 138.105289 
 L 637.2 138.105289 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#m65d5b1df80" x="49.078125" y="138.105289" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4b9d2d8365" x="49.078125" y="138.105289" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1170,11 +1170,11 @@ L 637.2 138.105289
      <g id="line2d_59">
       <path d="M 49.078125 130.877068 
 L 637.2 130.877068 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#m65d5b1df80" x="49.078125" y="130.877068" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4b9d2d8365" x="49.078125" y="130.877068" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1182,11 +1182,11 @@ L 637.2 130.877068
      <g id="line2d_61">
       <path d="M 49.078125 124.501326 
 L 637.2 124.501326 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#m65d5b1df80" x="49.078125" y="124.501326" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4b9d2d8365" x="49.078125" y="124.501326" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1194,11 +1194,11 @@ L 637.2 124.501326
      <g id="line2d_63">
       <path d="M 49.078125 81.277107 
 L 637.2 81.277107 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#m65d5b1df80" x="49.078125" y="81.277107" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4b9d2d8365" x="49.078125" y="81.277107" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1206,11 +1206,11 @@ L 637.2 81.277107
      <g id="line2d_65">
       <path d="M 49.078125 59.328775 
 L 637.2 59.328775 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#m65d5b1df80" x="49.078125" y="59.328775" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4b9d2d8365" x="49.078125" y="59.328775" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1332,7 +1332,7 @@ L 637.2 48.323125
    </g>
    <g id="text_13">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(324.643112 123.206672) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(324.643112 123.282456) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1364,7 +1364,7 @@ z
    </g>
    <g id="text_14">
     <!-- L10 -->
-    <g style="fill: #d62728" transform="translate(102.799363 312.435797) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(102.799363 312.940018) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1686,23 +1686,23 @@ z
    </g>
    <g id="line2d_67">
     <defs>
-     <path id="m98efb0f5ae" d="M -2.5 2.5 
+     <path id="ma1cf627ba0" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p6655eb9f26)">
-     <use xlink:href="#m98efb0f5ae" x="377.110281" y="104.685421" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m98efb0f5ae" x="323.801439" y="110.409833" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m98efb0f5ae" x="272.665744" y="126.308323" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m98efb0f5ae" x="235.168828" y="128.026741" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m98efb0f5ae" x="186.228265" y="149.377587" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m98efb0f5ae" x="158.303164" y="171.457731" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m98efb0f5ae" x="149.489547" y="182.192614" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m98efb0f5ae" x="140.563162" y="202.482797" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m98efb0f5ae" x="138.984853" y="209.328911" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p742c5d33d3)">
+     <use xlink:href="#ma1cf627ba0" x="377.110281" y="104.685421" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma1cf627ba0" x="323.801439" y="110.409833" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma1cf627ba0" x="272.665744" y="126.308323" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma1cf627ba0" x="235.168828" y="128.026741" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma1cf627ba0" x="186.228265" y="149.377587" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma1cf627ba0" x="158.303164" y="171.457731" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma1cf627ba0" x="149.489547" y="182.192614" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma1cf627ba0" x="140.563162" y="202.482797" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma1cf627ba0" x="138.984853" y="209.328911" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_68">
@@ -1755,7 +1755,7 @@ L 327.133241 110.069256
 L 326.02264 110.18302 
 L 324.91204 110.296545 
 L 323.801439 110.409833 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_69">
     <path d="M 323.801439 110.409833 
@@ -1807,7 +1807,7 @@ L 275.861725 125.44037
 L 274.796398 125.731236 
 L 273.731071 126.020548 
 L 272.665744 126.308323 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_70">
     <path d="M 272.665744 126.308323 
@@ -1859,7 +1859,7 @@ L 237.512385 127.920923
 L 236.7312 127.956219 
 L 235.950014 127.991491 
 L 235.168828 128.026741 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_71">
     <path d="M 235.168828 128.026741 
@@ -1911,7 +1911,7 @@ L 189.28705 148.263499
 L 188.267455 148.637415 
 L 187.24786 149.008766 
 L 186.228265 149.377587 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_72">
     <path d="M 186.228265 149.377587 
@@ -1963,7 +1963,7 @@ L 160.048483 170.312481
 L 159.46671 170.696929 
 L 158.884937 171.078667 
 L 158.303164 171.457731 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_73">
     <path d="M 158.303164 171.457731 
@@ -2015,7 +2015,7 @@ L 150.040398 181.580576
 L 149.856781 181.785359 
 L 149.673164 181.989369 
 L 149.489547 182.192614 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_74">
     <path d="M 149.489547 182.192614 
@@ -2067,7 +2067,7 @@ L 141.121061 201.414753
 L 140.935095 201.773114 
 L 140.749129 202.129119 
 L 140.563162 202.482797 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_75">
     <path d="M 140.563162 202.482797 
@@ -2119,26 +2119,26 @@ L 139.083497 208.925481
 L 139.050616 209.060292 
 L 139.017734 209.194768 
 L 138.984853 209.328911 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_76">
     <defs>
-     <path id="me038930ba1" d="M 0 -2.5 
+     <path id="m7d582679f5" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p6655eb9f26)">
-     <use xlink:href="#me038930ba1" x="610.467187" y="71.939349" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me038930ba1" x="319.880958" y="101.884157" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me038930ba1" x="210.281253" y="129.778154" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me038930ba1" x="196.287076" y="133.586625" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me038930ba1" x="176.054419" y="147.38645" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me038930ba1" x="152.161413" y="174.753272" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me038930ba1" x="146.720208" y="186.587648" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me038930ba1" x="143.994022" y="196.356323" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me038930ba1" x="142.666037" y="200.180971" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p742c5d33d3)">
+     <use xlink:href="#m7d582679f5" x="610.467187" y="71.939349" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7d582679f5" x="319.880958" y="101.884157" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7d582679f5" x="210.281253" y="129.778154" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7d582679f5" x="196.287076" y="133.586625" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7d582679f5" x="176.054419" y="147.38645" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7d582679f5" x="152.161413" y="174.753272" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7d582679f5" x="146.720208" y="186.587648" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7d582679f5" x="143.994022" y="196.356323" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7d582679f5" x="142.666037" y="200.180971" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_77">
@@ -2191,7 +2191,7 @@ L 338.042598 100.427247
 L 331.988718 100.917253 
 L 325.934838 101.402864 
 L 319.880958 101.884157 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_78">
     <path d="M 319.880958 101.884157 
@@ -2243,7 +2243,7 @@ L 217.131235 128.398367
 L 214.847908 128.862215 
 L 212.564581 129.322122 
 L 210.281253 129.778154 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_79">
     <path d="M 210.281253 129.778154 
@@ -2295,7 +2295,7 @@ L 197.161712 133.356286
 L 196.870166 133.433175 
 L 196.578621 133.509954 
 L 196.287076 133.586625 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_80">
     <path d="M 196.287076 133.586625 
@@ -2347,7 +2347,7 @@ L 177.31896 146.619719
 L 176.897447 146.876504 
 L 176.475933 147.132078 
 L 176.054419 147.38645 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_81">
     <path d="M 176.054419 147.38645 
@@ -2399,7 +2399,7 @@ L 153.654726 173.393769
 L 153.156955 173.850741 
 L 152.659184 174.303887 
 L 152.161413 174.753272 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_82">
     <path d="M 152.161413 174.753272 
@@ -2451,7 +2451,7 @@ L 147.060283 185.919158
 L 146.946925 186.142906 
 L 146.833566 186.365734 
 L 146.720208 186.587648 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_83">
     <path d="M 146.720208 186.587648 
@@ -2503,7 +2503,7 @@ L 144.164409 195.794799
 L 144.107613 195.982622 
 L 144.050817 196.169795 
 L 143.994022 196.356323 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_84">
     <path d="M 143.994022 196.356323 
@@ -2555,30 +2555,30 @@ L 142.749036 199.949687
 L 142.72137 200.026891 
 L 142.693704 200.103986 
 L 142.666037 200.180971 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_85">
     <defs>
-     <path id="m6e85406288" d="M -0 3.535534 
+     <path id="m96f07e8d5c" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p6655eb9f26)">
-     <use xlink:href="#m6e85406288" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6e85406288" x="242.839153" y="80.778898" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6e85406288" x="218.251194" y="86.377096" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6e85406288" x="197.814984" y="90.309617" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6e85406288" x="166.378359" y="99.066934" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6e85406288" x="145.830392" y="110.431955" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6e85406288" x="134.598477" y="126.026287" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6e85406288" x="124.077268" y="149.033155" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6e85406288" x="122.462976" y="157.476606" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6e85406288" x="81.012077" y="220.06889" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6e85406288" x="77.44276" y="239.652656" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6e85406288" x="76.953425" y="252.706566" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p742c5d33d3)">
+     <use xlink:href="#m96f07e8d5c" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m96f07e8d5c" x="242.839153" y="80.778898" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m96f07e8d5c" x="218.251194" y="86.377096" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m96f07e8d5c" x="197.814984" y="90.309617" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m96f07e8d5c" x="166.378359" y="99.066934" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m96f07e8d5c" x="145.830392" y="110.431955" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m96f07e8d5c" x="134.598477" y="126.026287" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m96f07e8d5c" x="124.077268" y="149.033155" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m96f07e8d5c" x="122.462976" y="157.476606" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m96f07e8d5c" x="81.012077" y="220.06889" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m96f07e8d5c" x="77.44276" y="239.652656" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m96f07e8d5c" x="76.953425" y="252.706566" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_86">
@@ -2631,7 +2631,7 @@ L 245.91379 79.91142
 L 244.888911 80.202126 
 L 243.864032 80.49128 
 L 242.839153 80.778898 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_87">
     <path d="M 242.839153 80.778898 
@@ -2683,7 +2683,7 @@ L 219.787941 86.043669
 L 219.275692 86.155039 
 L 218.763443 86.266182 
 L 218.251194 86.377096 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_88">
     <path d="M 218.251194 86.377096 
@@ -2735,7 +2735,7 @@ L 199.092247 90.072029
 L 198.666492 90.151341 
 L 198.240738 90.230537 
 L 197.814984 90.309617 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_89">
     <path d="M 197.814984 90.309617 
@@ -2787,7 +2787,7 @@ L 168.343148 98.559208
 L 167.688219 98.72898 
 L 167.033289 98.898221 
 L 166.378359 99.066934 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_90">
     <path d="M 166.378359 99.066934 
@@ -2839,7 +2839,7 @@ L 147.11464 109.78743
 L 146.686557 110.003126 
 L 146.258475 110.217965 
 L 145.830392 110.431955 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_91">
     <path d="M 145.830392 110.431955 
@@ -2891,7 +2891,7 @@ L 135.300472 125.172774
 L 135.066474 125.458776 
 L 134.832476 125.743276 
 L 134.598477 126.026287 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_92">
     <path d="M 134.598477 126.026287 
@@ -2943,7 +2943,7 @@ L 124.734843 147.848882
 L 124.515652 148.246526 
 L 124.29646 148.641269 
 L 124.077268 149.033155 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_93">
     <path d="M 124.077268 149.033155 
@@ -2995,7 +2995,7 @@ L 122.56387 156.985769
 L 122.530239 157.149876 
 L 122.496607 157.313488 
 L 122.462976 157.476606 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_94">
     <path d="M 122.462976 157.476606 
@@ -3047,7 +3047,7 @@ L 83.602758 217.699074
 L 82.739198 218.500595 
 L 81.875637 219.290422 
 L 81.012077 220.06889 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_95">
     <path d="M 81.012077 220.06889 
@@ -3099,7 +3099,7 @@ L 77.665842 238.615761
 L 77.591481 238.963605 
 L 77.517121 239.309227 
 L 77.44276 239.652656 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_96">
     <path d="M 77.44276 239.652656 
@@ -3151,23 +3151,23 @@ L 76.984008 251.97672
 L 76.973814 252.221097 
 L 76.96362 252.464376 
 L 76.953425 252.706566 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_97">
     <defs>
-     <path id="m59fb70793a" d="M -0 2.5 
+     <path id="m457dfffd5e" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p6655eb9f26)">
-     <use xlink:href="#m59fb70793a" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p742c5d33d3)">
+     <use xlink:href="#m457dfffd5e" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_98">
     <defs>
-     <path id="m8e1b4c9a64" d="M -0.833333 2.5 
+     <path id="m14ef7faacd" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -3182,16 +3182,16 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p6655eb9f26)">
-     <use xlink:href="#m8e1b4c9a64" x="432.495268" y="96.067622" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8e1b4c9a64" x="300.62247" y="112.493412" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8e1b4c9a64" x="266.967623" y="120.8136" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8e1b4c9a64" x="226.040946" y="122.099593" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8e1b4c9a64" x="180.985721" y="141.85872" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8e1b4c9a64" x="164.441833" y="156.106179" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8e1b4c9a64" x="157.761315" y="165.23787" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8e1b4c9a64" x="151.269082" y="178.700983" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8e1b4c9a64" x="150.327087" y="185.23695" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p742c5d33d3)">
+     <use xlink:href="#m14ef7faacd" x="432.495268" y="96.067622" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m14ef7faacd" x="300.62247" y="112.493412" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m14ef7faacd" x="266.967623" y="120.8136" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m14ef7faacd" x="226.040946" y="122.099593" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m14ef7faacd" x="180.985721" y="141.85872" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m14ef7faacd" x="164.441833" y="156.106179" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m14ef7faacd" x="157.761315" y="165.23787" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m14ef7faacd" x="151.269082" y="178.700983" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m14ef7faacd" x="150.327087" y="185.23695" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_99">
@@ -3244,7 +3244,7 @@ L 308.86452 111.600609
 L 306.11717 111.899849 
 L 303.36982 112.197444 
 L 300.62247 112.493412 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_100">
     <path d="M 300.62247 112.493412 
@@ -3296,7 +3296,7 @@ L 269.071051 120.329422
 L 268.369908 120.491297 
 L 267.668766 120.652688 
 L 266.967623 120.8136 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_101">
     <path d="M 266.967623 120.8136 
@@ -3348,7 +3348,7 @@ L 228.598863 122.020108
 L 227.746224 122.046616 
 L 226.893585 122.073111 
 L 226.040946 122.099593 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_102">
     <path d="M 226.040946 122.099593 
@@ -3400,7 +3400,7 @@ L 183.801673 140.814056
 L 182.863022 141.164522 
 L 181.924372 141.512734 
 L 180.985721 141.85872 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_103">
     <path d="M 180.985721 141.85872 
@@ -3452,7 +3452,7 @@ L 165.475826 155.317544
 L 165.131161 155.581701 
 L 164.786497 155.844575 
 L 164.441833 156.106179 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_104">
     <path d="M 164.441833 156.106179 
@@ -3504,7 +3504,7 @@ L 158.178848 164.710119
 L 158.03967 164.886608 
 L 157.900493 165.062524 
 L 157.761315 165.23787 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_105">
     <path d="M 157.761315 165.23787 
@@ -3556,7 +3556,7 @@ L 151.674847 177.950842
 L 151.539592 178.202046 
 L 151.404337 178.452089 
 L 151.269082 178.700983 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_106">
     <path d="M 151.269082 178.700983 
@@ -3608,11 +3608,11 @@ L 150.385962 184.850776
 L 150.366337 184.979807 
 L 150.346712 185.108531 
 L 150.327087 185.23695 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_107">
     <defs>
-     <path id="mef770a3dc4" d="M -1.25 2.5 
+     <path id="mc490e39ac2" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -3627,16 +3627,16 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p6655eb9f26)">
-     <use xlink:href="#mef770a3dc4" x="345.030867" y="136.859359" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mef770a3dc4" x="273.364924" y="143.571257" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mef770a3dc4" x="240.719951" y="149.310846" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mef770a3dc4" x="221.353978" y="154.160538" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mef770a3dc4" x="207.129625" y="156.092215" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mef770a3dc4" x="181.064802" y="166.758473" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mef770a3dc4" x="179.282169" y="170.289343" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mef770a3dc4" x="177.719335" y="175.489948" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mef770a3dc4" x="177.643939" y="181.552088" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p742c5d33d3)">
+     <use xlink:href="#mc490e39ac2" x="345.030867" y="136.859359" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc490e39ac2" x="273.364924" y="143.571257" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc490e39ac2" x="240.719951" y="149.310846" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc490e39ac2" x="221.353978" y="154.160538" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc490e39ac2" x="207.129625" y="156.092215" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc490e39ac2" x="181.064802" y="166.758473" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc490e39ac2" x="179.282169" y="170.289343" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc490e39ac2" x="177.719335" y="175.489948" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc490e39ac2" x="177.643939" y="181.552088" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_108">
@@ -3689,7 +3689,7 @@ L 277.844045 143.175283
 L 276.351005 143.307597 
 L 274.857964 143.439587 
 L 273.364924 143.571257 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_109">
     <path d="M 273.364924 143.571257 
@@ -3741,7 +3741,7 @@ L 242.760262 148.96941
 L 242.080158 149.083462 
 L 241.400055 149.197273 
 L 240.719951 149.310846 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_110">
     <path d="M 240.719951 149.310846 
@@ -3793,7 +3793,7 @@ L 222.564351 153.869835
 L 222.160893 153.966909 
 L 221.757435 154.06381 
 L 221.353978 154.160538 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_111">
     <path d="M 221.353978 154.160538 
@@ -3845,7 +3845,7 @@ L 208.018647 155.973483
 L 207.722306 156.013089 
 L 207.425965 156.052666 
 L 207.129625 156.092215 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_112">
     <path d="M 207.129625 156.092215 
@@ -3897,7 +3897,7 @@ L 182.693853 166.149994
 L 182.150836 166.353581 
 L 181.607819 166.556405 
 L 181.064802 166.758473 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_113">
     <path d="M 181.064802 166.758473 
@@ -3949,7 +3949,7 @@ L 179.393584 170.075284
 L 179.356445 170.146731 
 L 179.319307 170.218084 
 L 179.282169 170.289343 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_114">
     <path d="M 179.282169 170.289343 
@@ -4001,7 +4001,7 @@ L 177.817012 175.179146
 L 177.784453 175.282945 
 L 177.751894 175.386546 
 L 177.719335 175.489948 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_115">
     <path d="M 177.719335 175.489948 
@@ -4053,11 +4053,11 @@ L 177.648651 181.192458
 L 177.64708 181.3126 
 L 177.645509 181.432477 
 L 177.643939 181.552088 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_116">
     <defs>
-     <path id="mdb9bb12b4f" d="M 0 -2.5 
+     <path id="m874c9f298f" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -4070,16 +4070,16 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p6655eb9f26)">
-     <use xlink:href="#mdb9bb12b4f" x="226.871027" y="113.224491" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mdb9bb12b4f" x="226.871027" y="113.066324" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mdb9bb12b4f" x="226.871027" y="113.178221" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mdb9bb12b4f" x="226.871027" y="113.089884" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mdb9bb12b4f" x="177.768423" y="132.327899" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mdb9bb12b4f" x="160.37503" y="145.652356" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mdb9bb12b4f" x="153.995779" y="152.678629" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mdb9bb12b4f" x="147.106887" y="168.143801" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mdb9bb12b4f" x="145.871703" y="175.118358" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p742c5d33d3)">
+     <use xlink:href="#m874c9f298f" x="226.871027" y="113.224491" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m874c9f298f" x="226.871027" y="113.066324" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m874c9f298f" x="226.871027" y="113.178221" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m874c9f298f" x="226.871027" y="113.089884" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m874c9f298f" x="177.768423" y="132.327899" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m874c9f298f" x="160.37503" y="145.652356" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m874c9f298f" x="153.995779" y="152.678629" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m874c9f298f" x="147.106887" y="168.143801" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m874c9f298f" x="145.871703" y="175.118358" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_117">
@@ -4132,7 +4132,7 @@ L 226.871027 113.076223
 L 226.871027 113.072924 
 L 226.871027 113.069624 
 L 226.871027 113.066324 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_118">
     <path d="M 226.871027 113.066324 
@@ -4184,7 +4184,7 @@ L 226.871027 113.171234
 L 226.871027 113.173563 
 L 226.871027 113.175892 
 L 226.871027 113.178221 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_119">
     <path d="M 226.871027 113.178221 
@@ -4236,7 +4236,7 @@ L 226.871027 113.09541
 L 226.871027 113.093568 
 L 226.871027 113.091726 
 L 226.871027 113.089884 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_120">
     <path d="M 226.871027 113.089884 
@@ -4288,7 +4288,7 @@ L 180.837336 131.306392
 L 179.814365 131.649041 
 L 178.791394 131.989534 
 L 177.768423 132.327899 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_121">
     <path d="M 177.768423 132.327899 
@@ -4340,7 +4340,7 @@ L 161.462117 144.909076
 L 161.099755 145.157972 
 L 160.737393 145.405728 
 L 160.37503 145.652356 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_122">
     <path d="M 160.37503 145.652356 
@@ -4392,7 +4392,7 @@ L 154.394483 152.265218
 L 154.261581 152.403373 
 L 154.12868 152.541176 
 L 153.995779 152.678629 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_123">
     <path d="M 153.995779 152.678629 
@@ -4444,7 +4444,7 @@ L 147.537442 167.296442
 L 147.393924 167.580372 
 L 147.250405 167.862819 
 L 147.106887 168.143801 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_124">
     <path d="M 147.106887 168.143801 
@@ -4496,11 +4496,11 @@ L 145.948902 174.70781
 L 145.923169 174.845005 
 L 145.897436 174.981854 
 L 145.871703 175.118358 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_125">
     <defs>
-     <path id="m77047718ef" d="M 0 -2.5 
+     <path id="mb3359871ee" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -4509,16 +4509,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p6655eb9f26)">
-     <use xlink:href="#m77047718ef" x="585.66883" y="173.051371" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m77047718ef" x="527.144592" y="175.326465" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m77047718ef" x="457.339427" y="183.688849" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m77047718ef" x="292.124837" y="178.486631" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m77047718ef" x="243.129344" y="190.369032" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m77047718ef" x="213.541392" y="204.43395" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m77047718ef" x="204.551957" y="212.140784" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m77047718ef" x="195.860087" y="228.582256" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m77047718ef" x="194.019853" y="234.294862" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p742c5d33d3)">
+     <use xlink:href="#mb3359871ee" x="585.66883" y="173.051371" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb3359871ee" x="527.144592" y="175.326465" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb3359871ee" x="457.339427" y="183.688849" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb3359871ee" x="292.124837" y="178.486631" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb3359871ee" x="243.129344" y="190.369032" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb3359871ee" x="213.541392" y="204.43395" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb3359871ee" x="204.551957" y="212.140784" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb3359871ee" x="195.860087" y="228.582256" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb3359871ee" x="194.019853" y="234.294862" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_126">
@@ -4571,7 +4571,7 @@ L 530.802357 175.187039
 L 529.583102 175.233554 
 L 528.363847 175.28003 
 L 527.144592 175.326465 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_127">
     <path d="M 527.144592 175.326465 
@@ -4623,7 +4623,7 @@ L 461.70225 183.20239
 L 460.247976 183.36503 
 L 458.793701 183.527182 
 L 457.339427 183.688849 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_128">
     <path d="M 457.339427 183.688849 
@@ -4675,7 +4675,7 @@ L 302.450749 178.826834
 L 299.008779 178.713671 
 L 295.566808 178.60027 
 L 292.124837 178.486631 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_129">
     <path d="M 292.124837 178.486631 
@@ -4727,7 +4727,7 @@ L 246.191563 189.6981
 L 245.170823 189.922669 
 L 244.150084 190.146311 
 L 243.129344 190.369032 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_130">
     <path d="M 243.129344 190.369032 
@@ -4779,7 +4779,7 @@ L 215.390639 203.654226
 L 214.774224 203.915384 
 L 214.157808 204.175288 
 L 213.541392 204.43395 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_131">
     <path d="M 213.541392 204.43395 
@@ -4831,7 +4831,7 @@ L 205.113797 211.689953
 L 204.926517 211.840648 
 L 204.739237 211.990924 
 L 204.551957 212.140784 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_132">
     <path d="M 204.551957 212.140784 
@@ -4883,7 +4883,7 @@ L 196.403329 227.688717
 L 196.222248 227.988205 
 L 196.041168 228.286045 
 L 195.860087 228.582256 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_133">
     <path d="M 195.860087 228.582256 
@@ -4935,7 +4935,7 @@ L 194.134867 233.954953
 L 194.096529 234.068494 
 L 194.058191 234.181796 
 L 194.019853 234.294862 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="legend_1">
     <g id="patch_7">
@@ -4953,7 +4953,7 @@ z
     </g>
     <g id="line2d_134">
      <defs>
-      <path id="m6bd04fad8f" d="M 0 3.5 
+      <path id="ma723d285d8" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -4966,7 +4966,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m6bd04fad8f" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#ma723d285d8" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -5025,7 +5025,7 @@ z
     </g>
     <g id="line2d_135">
      <g>
-      <use xlink:href="#m98efb0f5ae" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#ma1cf627ba0" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -5039,7 +5039,7 @@ z
     </g>
     <g id="line2d_136">
      <g>
-      <use xlink:href="#me038930ba1" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m7d582679f5" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -5084,7 +5084,7 @@ z
     </g>
     <g id="line2d_137">
      <g>
-      <use xlink:href="#m6e85406288" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m96f07e8d5c" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -5127,7 +5127,7 @@ z
     </g>
     <g id="line2d_138">
      <g>
-      <use xlink:href="#m59fb70793a" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m457dfffd5e" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -5143,7 +5143,7 @@ z
     </g>
     <g id="line2d_139">
      <g>
-      <use xlink:href="#m8e1b4c9a64" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m14ef7faacd" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -5197,7 +5197,7 @@ z
     </g>
     <g id="line2d_140">
      <g>
-      <use xlink:href="#mef770a3dc4" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mc490e39ac2" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -5262,7 +5262,7 @@ z
     </g>
     <g id="line2d_141">
      <g>
-      <use xlink:href="#mdb9bb12b4f" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#m874c9f298f" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -5300,7 +5300,7 @@ z
     </g>
     <g id="line2d_142">
      <g>
-      <use xlink:href="#m77047718ef" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mb3359871ee" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -5370,486 +5370,486 @@ z
     </g>
    </g>
    <g id="line2d_143">
-    <g clip-path="url(#p6655eb9f26)">
-     <use xlink:href="#m6bd04fad8f" x="319.643112" y="128.206672" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m6bd04fad8f" x="269.129958" y="143.901385" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m6bd04fad8f" x="247.452898" y="149.033151" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m6bd04fad8f" x="192.820547" y="160.73925" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m6bd04fad8f" x="180.389901" y="170.787759" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m6bd04fad8f" x="156.350594" y="182.308316" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m6bd04fad8f" x="147.843012" y="190.985697" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m6bd04fad8f" x="146.231533" y="194.726733" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m6bd04fad8f" x="119.590386" y="289.537405" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m6bd04fad8f" x="97.799363" y="317.435797" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <g clip-path="url(#p742c5d33d3)">
+     <use xlink:href="#ma723d285d8" x="319.643112" y="128.282456" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma723d285d8" x="269.129958" y="143.692386" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma723d285d8" x="247.452898" y="149.000294" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma723d285d8" x="192.820547" y="160.764254" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma723d285d8" x="180.389901" y="171.025709" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma723d285d8" x="156.350594" y="180.873863" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma723d285d8" x="147.843012" y="189.683742" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma723d285d8" x="146.231533" y="194.452828" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma723d285d8" x="119.590386" y="289.17326" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma723d285d8" x="97.799363" y="317.940018" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
    <g id="line2d_144">
-    <path d="M 319.643112 128.206672 
-L 318.590755 128.584656 
-L 317.538397 128.96002 
-L 316.48604 129.332799 
-L 315.433682 129.703028 
-L 314.381325 130.070742 
-L 313.328968 130.435976 
-L 312.27661 130.798761 
-L 311.224253 131.159131 
-L 310.171896 131.517118 
-L 309.119538 131.872753 
-L 308.067181 132.226067 
-L 307.014823 132.577089 
-L 305.962466 132.92585 
-L 304.910109 133.272379 
-L 303.857751 133.616703 
-L 302.805394 133.958851 
-L 301.753037 134.298849 
-L 300.700679 134.636726 
-L 299.648322 134.972506 
-L 298.595965 135.306217 
-L 297.543607 135.637883 
-L 296.49125 135.967529 
-L 295.438892 136.29518 
-L 294.386535 136.620859 
-L 293.334178 136.944591 
-L 292.28182 137.266398 
-L 291.229463 137.586304 
-L 290.177106 137.904329 
-L 289.124748 138.220498 
-L 288.072391 138.53483 
-L 287.020033 138.847348 
-L 285.967676 139.158072 
-L 284.915319 139.467022 
-L 283.862961 139.774219 
-L 282.810604 140.079682 
-L 281.758247 140.383432 
-L 280.705889 140.685486 
-L 279.653532 140.985865 
-L 278.601175 141.284585 
-L 277.548817 141.581667 
-L 276.49646 141.877126 
-L 275.444102 142.170982 
-L 274.391745 142.463251 
-L 273.339388 142.753951 
-L 272.28703 143.043098 
-L 271.234673 143.330708 
-L 270.182316 143.616799 
-L 269.129958 143.901385 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 319.643112 128.282456 
+L 318.590755 128.652587 
+L 317.538397 129.020205 
+L 316.48604 129.385343 
+L 315.433682 129.748035 
+L 314.381325 130.108313 
+L 313.328968 130.466208 
+L 312.27661 130.821753 
+L 311.224253 131.174978 
+L 310.171896 131.525913 
+L 309.119538 131.874588 
+L 308.067181 132.22103 
+L 307.014823 132.56527 
+L 305.962466 132.907335 
+L 304.910109 133.247251 
+L 303.857751 133.585046 
+L 302.805394 133.920747 
+L 301.753037 134.254378 
+L 300.700679 134.585966 
+L 299.648322 134.915534 
+L 298.595965 135.243109 
+L 297.543607 135.568713 
+L 296.49125 135.89237 
+L 295.438892 136.214103 
+L 294.386535 136.533936 
+L 293.334178 136.85189 
+L 292.28182 137.167987 
+L 291.229463 137.482249 
+L 290.177106 137.794697 
+L 289.124748 138.105352 
+L 288.072391 138.414235 
+L 287.020033 138.721364 
+L 285.967676 139.026761 
+L 284.915319 139.330445 
+L 283.862961 139.632435 
+L 282.810604 139.932749 
+L 281.758247 140.231406 
+L 280.705889 140.528424 
+L 279.653532 140.823822 
+L 278.601175 141.117616 
+L 277.548817 141.409825 
+L 276.49646 141.700464 
+L 275.444102 141.989552 
+L 274.391745 142.277103 
+L 273.339388 142.563136 
+L 272.28703 142.847664 
+L 271.234673 143.130705 
+L 270.182316 143.412274 
+L 269.129958 143.692386 
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_145">
-    <path d="M 269.129958 143.901385 
-L 268.678353 144.013413 
-L 268.226747 144.125209 
-L 267.775142 144.236775 
-L 267.323537 144.348111 
-L 266.871931 144.459219 
-L 266.420326 144.570099 
-L 265.96872 144.680752 
-L 265.517115 144.79118 
-L 265.065509 144.901383 
-L 264.613904 145.011362 
-L 264.162299 145.121118 
-L 263.710693 145.230652 
-L 263.259088 145.339965 
-L 262.807482 145.449058 
-L 262.355877 145.557931 
-L 261.904271 145.666585 
-L 261.452666 145.775022 
-L 261.001061 145.883242 
-L 260.549455 145.991246 
-L 260.09785 146.099035 
-L 259.646244 146.20661 
-L 259.194639 146.313972 
-L 258.743034 146.421121 
-L 258.291428 146.528058 
-L 257.839823 146.634785 
-L 257.388217 146.741301 
-L 256.936612 146.847608 
-L 256.485006 146.953707 
-L 256.033401 147.059599 
-L 255.581796 147.165283 
-L 255.13019 147.270762 
-L 254.678585 147.376036 
-L 254.226979 147.481105 
-L 253.775374 147.58597 
-L 253.323769 147.690633 
-L 252.872163 147.795094 
-L 252.420558 147.899354 
-L 251.968952 148.003413 
-L 251.517347 148.107273 
-L 251.065741 148.210934 
-L 250.614136 148.314397 
-L 250.162531 148.417662 
-L 249.710925 148.520731 
-L 249.25932 148.623603 
-L 248.807714 148.726281 
-L 248.356109 148.828764 
-L 247.904503 148.931054 
-L 247.452898 149.033151 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 269.129958 143.692386 
+L 268.678353 143.808446 
+L 268.226747 143.924258 
+L 267.775142 144.039822 
+L 267.323537 144.155141 
+L 266.871931 144.270214 
+L 266.420326 144.385043 
+L 265.96872 144.499629 
+L 265.517115 144.613973 
+L 265.065509 144.728076 
+L 264.613904 144.841939 
+L 264.162299 144.955563 
+L 263.710693 145.068949 
+L 263.259088 145.182098 
+L 262.807482 145.295011 
+L 262.355877 145.407689 
+L 261.904271 145.520133 
+L 261.452666 145.632344 
+L 261.001061 145.744322 
+L 260.549455 145.85607 
+L 260.09785 145.967587 
+L 259.646244 146.078875 
+L 259.194639 146.189935 
+L 258.743034 146.300767 
+L 258.291428 146.411373 
+L 257.839823 146.521753 
+L 257.388217 146.631909 
+L 256.936612 146.741841 
+L 256.485006 146.85155 
+L 256.033401 146.961037 
+L 255.581796 147.070304 
+L 255.13019 147.17935 
+L 254.678585 147.288177 
+L 254.226979 147.396785 
+L 253.775374 147.505176 
+L 253.323769 147.613351 
+L 252.872163 147.72131 
+L 252.420558 147.829053 
+L 251.968952 147.936583 
+L 251.517347 148.0439 
+L 251.065741 148.151004 
+L 250.614136 148.257897 
+L 250.162531 148.364579 
+L 249.710925 148.471051 
+L 249.25932 148.577315 
+L 248.807714 148.68337 
+L 248.356109 148.789218 
+L 247.904503 148.894859 
+L 247.452898 149.000294 
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_146">
-    <path d="M 247.452898 149.033151 
-L 246.314724 149.304723 
-L 245.17655 149.57494 
-L 244.038376 149.843815 
-L 242.900202 150.111361 
-L 241.762028 150.377591 
-L 240.623854 150.642518 
-L 239.48568 150.906155 
-L 238.347506 151.168513 
-L 237.209332 151.429607 
-L 236.071158 151.689447 
-L 234.932984 151.948046 
-L 233.79481 152.205415 
-L 232.656636 152.461567 
-L 231.518462 152.716512 
-L 230.380288 152.970262 
-L 229.242114 153.222828 
-L 228.10394 153.474221 
-L 226.965766 153.724452 
-L 225.827592 153.973532 
-L 224.689418 154.22147 
-L 223.551244 154.468278 
-L 222.41307 154.713966 
-L 221.274896 154.958544 
-L 220.136722 155.202022 
-L 218.998548 155.44441 
-L 217.860374 155.685717 
-L 216.7222 155.925953 
-L 215.584026 156.165128 
-L 214.445852 156.40325 
-L 213.307678 156.64033 
-L 212.169505 156.876376 
-L 211.031331 157.111397 
-L 209.893157 157.345402 
-L 208.754983 157.578399 
-L 207.616809 157.810399 
-L 206.478635 158.041408 
-L 205.340461 158.271435 
-L 204.202287 158.500489 
-L 203.064113 158.728578 
-L 201.925939 158.95571 
-L 200.787765 159.181893 
-L 199.649591 159.407134 
-L 198.511417 159.631443 
-L 197.373243 159.854825 
-L 196.235069 160.07729 
-L 195.096895 160.298844 
-L 193.958721 160.519495 
-L 192.820547 160.73925 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 247.452898 149.000294 
+L 246.314724 149.273356 
+L 245.17655 149.545048 
+L 244.038376 149.815383 
+L 242.900202 150.084375 
+L 241.762028 150.352036 
+L 240.623854 150.618381 
+L 239.48568 150.883421 
+L 238.347506 151.14717 
+L 237.209332 151.40964 
+L 236.071158 151.670844 
+L 234.932984 151.930793 
+L 233.79481 152.1895 
+L 232.656636 152.446977 
+L 231.518462 152.703234 
+L 230.380288 152.958284 
+L 229.242114 153.212138 
+L 228.10394 153.464807 
+L 226.965766 153.716303 
+L 225.827592 153.966635 
+L 224.689418 154.215814 
+L 223.551244 154.463852 
+L 222.41307 154.710759 
+L 221.274896 154.956545 
+L 220.136722 155.201219 
+L 218.998548 155.444793 
+L 217.860374 155.687275 
+L 216.7222 155.928676 
+L 215.584026 156.169006 
+L 214.445852 156.408273 
+L 213.307678 156.646487 
+L 212.169505 156.883657 
+L 211.031331 157.119793 
+L 209.893157 157.354904 
+L 208.754983 157.588997 
+L 207.616809 157.822082 
+L 206.478635 158.054169 
+L 205.340461 158.285264 
+L 204.202287 158.515377 
+L 203.064113 158.744516 
+L 201.925939 158.972689 
+L 200.787765 159.199904 
+L 199.649591 159.426169 
+L 198.511417 159.651493 
+L 197.373243 159.875883 
+L 196.235069 160.099346 
+L 195.096895 160.32189 
+L 193.958721 160.543524 
+L 192.820547 160.764254 
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_147">
-    <path d="M 192.820547 160.73925 
-L 192.561575 160.968798 
-L 192.302603 161.197376 
-L 192.043631 161.424992 
-L 191.78466 161.651656 
-L 191.525688 161.877375 
-L 191.266716 162.102156 
-L 191.007744 162.326008 
-L 190.748773 162.548938 
-L 190.489801 162.770953 
-L 190.230829 162.992062 
-L 189.971857 163.212271 
-L 189.712885 163.431588 
-L 189.453914 163.65002 
-L 189.194942 163.867574 
-L 188.93597 164.084257 
-L 188.676998 164.300076 
-L 188.418027 164.515038 
-L 188.159055 164.72915 
-L 187.900083 164.942419 
-L 187.641111 165.15485 
-L 187.382139 165.366451 
-L 187.123168 165.577229 
-L 186.864196 165.787188 
-L 186.605224 165.996336 
-L 186.346252 166.20468 
-L 186.087281 166.412224 
-L 185.828309 166.618976 
-L 185.569337 166.824941 
-L 185.310365 167.030126 
-L 185.051393 167.234536 
-L 184.792422 167.438176 
-L 184.53345 167.641054 
-L 184.274478 167.843174 
-L 184.015506 168.044542 
-L 183.756535 168.245163 
-L 183.497563 168.445044 
-L 183.238591 168.64419 
-L 182.979619 168.842605 
-L 182.720647 169.040296 
-L 182.461676 169.237268 
-L 182.202704 169.433526 
-L 181.943732 169.629074 
-L 181.68476 169.823919 
-L 181.425789 170.018065 
-L 181.166817 170.211516 
-L 180.907845 170.40428 
-L 180.648873 170.596359 
-L 180.389901 170.787759 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 192.820547 160.764254 
+L 192.561575 160.99913 
+L 192.302603 161.232991 
+L 192.043631 161.465847 
+L 191.78466 161.697705 
+L 191.525688 161.928574 
+L 191.266716 162.158463 
+L 191.007744 162.387379 
+L 190.748773 162.615332 
+L 190.489801 162.842329 
+L 190.230829 163.068377 
+L 189.971857 163.293486 
+L 189.712885 163.517663 
+L 189.453914 163.740915 
+L 189.194942 163.963249 
+L 188.93597 164.184675 
+L 188.676998 164.405198 
+L 188.418027 164.624827 
+L 188.159055 164.843568 
+L 187.900083 165.061429 
+L 187.641111 165.278416 
+L 187.382139 165.494538 
+L 187.123168 165.709799 
+L 186.864196 165.924208 
+L 186.605224 166.137771 
+L 186.346252 166.350495 
+L 186.087281 166.562387 
+L 185.828309 166.773452 
+L 185.569337 166.983697 
+L 185.310365 167.193129 
+L 185.051393 167.401753 
+L 184.792422 167.609577 
+L 184.53345 167.816606 
+L 184.274478 168.022846 
+L 184.015506 168.228303 
+L 183.756535 168.432984 
+L 183.497563 168.636893 
+L 183.238591 168.840037 
+L 182.979619 169.042422 
+L 182.720647 169.244053 
+L 182.461676 169.444935 
+L 182.202704 169.645075 
+L 181.943732 169.844478 
+L 181.68476 170.043148 
+L 181.425789 170.241092 
+L 181.166817 170.438315 
+L 180.907845 170.634823 
+L 180.648873 170.830619 
+L 180.389901 171.025709 
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_148">
-    <path d="M 180.389901 170.787759 
-L 179.889083 171.054565 
-L 179.388264 171.320062 
-L 178.887445 171.584263 
-L 178.386626 171.847182 
-L 177.885807 172.108829 
-L 177.384988 172.369218 
-L 176.884169 172.62836 
-L 176.38335 172.886268 
-L 175.882531 173.142952 
-L 175.381713 173.398426 
-L 174.880894 173.652699 
-L 174.380075 173.905783 
-L 173.879256 174.15769 
-L 173.378437 174.408429 
-L 172.877618 174.658013 
-L 172.376799 174.906451 
-L 171.87598 175.153754 
-L 171.375161 175.399932 
-L 170.874342 175.644996 
-L 170.373524 175.888956 
-L 169.872705 176.131821 
-L 169.371886 176.373601 
-L 168.871067 176.614306 
-L 168.370248 176.853945 
-L 167.869429 177.092528 
-L 167.36861 177.330065 
-L 166.867791 177.566563 
-L 166.366972 177.802033 
-L 165.866154 178.036483 
-L 165.365335 178.269922 
-L 164.864516 178.502358 
-L 164.363697 178.733801 
-L 163.862878 178.964258 
-L 163.362059 179.193738 
-L 162.86124 179.42225 
-L 162.360421 179.649801 
-L 161.859602 179.876399 
-L 161.358783 180.102053 
-L 160.857965 180.32677 
-L 160.357146 180.550558 
-L 159.856327 180.773424 
-L 159.355508 180.995377 
-L 158.854689 181.216424 
-L 158.35387 181.436571 
-L 157.853051 181.655827 
-L 157.352232 181.874198 
-L 156.851413 182.091692 
-L 156.350594 182.308316 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 180.389901 171.025709 
+L 179.889083 171.250262 
+L 179.388264 171.473886 
+L 178.887445 171.69659 
+L 178.386626 171.918382 
+L 177.885807 172.139269 
+L 177.384988 172.359258 
+L 176.884169 172.578357 
+L 176.38335 172.796573 
+L 175.882531 173.013912 
+L 175.381713 173.230382 
+L 174.880894 173.44599 
+L 174.380075 173.660743 
+L 173.879256 173.874647 
+L 173.378437 174.087709 
+L 172.877618 174.299936 
+L 172.376799 174.511334 
+L 171.87598 174.721909 
+L 171.375161 174.931669 
+L 170.874342 175.140619 
+L 170.373524 175.348765 
+L 169.872705 175.556115 
+L 169.371886 175.762672 
+L 168.871067 175.968445 
+L 168.370248 176.173439 
+L 167.869429 176.377659 
+L 167.36861 176.581111 
+L 166.867791 176.783802 
+L 166.366972 176.985737 
+L 165.866154 177.186921 
+L 165.365335 177.38736 
+L 164.864516 177.58706 
+L 164.363697 177.786025 
+L 163.862878 177.984262 
+L 163.362059 178.181776 
+L 162.86124 178.378572 
+L 162.360421 178.574654 
+L 161.859602 178.770029 
+L 161.358783 178.964702 
+L 160.857965 179.158677 
+L 160.357146 179.351959 
+L 159.856327 179.544553 
+L 159.355508 179.736465 
+L 158.854689 179.927699 
+L 158.35387 180.118259 
+L 157.853051 180.308151 
+L 157.352232 180.49738 
+L 156.851413 180.685949 
+L 156.350594 180.873863 
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_149">
-    <path d="M 156.350594 182.308316 
-L 156.173353 182.504036 
-L 155.996112 182.699052 
-L 155.818871 182.893367 
-L 155.641629 183.086987 
-L 155.464388 183.279917 
-L 155.287147 183.472162 
-L 155.109905 183.663727 
-L 154.932664 183.854616 
-L 154.755423 184.044834 
-L 154.578182 184.234387 
-L 154.40094 184.423277 
-L 154.223699 184.611511 
-L 154.046458 184.799093 
-L 153.869216 184.986027 
-L 153.691975 185.172317 
-L 153.514734 185.357969 
-L 153.337492 185.542986 
-L 153.160251 185.727373 
-L 152.98301 185.911134 
-L 152.805769 186.094273 
-L 152.628527 186.276795 
-L 152.451286 186.458703 
-L 152.274045 186.640002 
-L 152.096803 186.820696 
-L 151.919562 187.000789 
-L 151.742321 187.180284 
-L 151.56508 187.359187 
-L 151.387838 187.5375 
-L 151.210597 187.715227 
-L 151.033356 187.892373 
-L 150.856114 188.068941 
-L 150.678873 188.244935 
-L 150.501632 188.420359 
-L 150.32439 188.595216 
-L 150.147149 188.76951 
-L 149.969908 188.943245 
-L 149.792667 189.116424 
-L 149.615425 189.28905 
-L 149.438184 189.461128 
-L 149.260943 189.63266 
-L 149.083701 189.803651 
-L 148.90646 189.974103 
-L 148.729219 190.14402 
-L 148.551977 190.313406 
-L 148.374736 190.482263 
-L 148.197495 190.650595 
-L 148.020254 190.818405 
-L 147.843012 190.985697 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 156.350594 180.873863 
+L 156.173353 181.072816 
+L 155.996112 181.27104 
+L 155.818871 181.468542 
+L 155.641629 181.665325 
+L 155.464388 181.861395 
+L 155.287147 182.056758 
+L 155.109905 182.251418 
+L 154.932664 182.445381 
+L 154.755423 182.638651 
+L 154.578182 182.831234 
+L 154.40094 183.023134 
+L 154.223699 183.214356 
+L 154.046458 183.404905 
+L 153.869216 183.594785 
+L 153.691975 183.784002 
+L 153.514734 183.972559 
+L 153.337492 184.160462 
+L 153.160251 184.347715 
+L 152.98301 184.534323 
+L 152.805769 184.72029 
+L 152.628527 184.905619 
+L 152.451286 185.090317 
+L 152.274045 185.274386 
+L 152.096803 185.457832 
+L 151.919562 185.640658 
+L 151.742321 185.822868 
+L 151.56508 186.004468 
+L 151.387838 186.18546 
+L 151.210597 186.365849 
+L 151.033356 186.545639 
+L 150.856114 186.724833 
+L 150.678873 186.903437 
+L 150.501632 187.081453 
+L 150.32439 187.258885 
+L 150.147149 187.435738 
+L 149.969908 187.612015 
+L 149.792667 187.78772 
+L 149.615425 187.962856 
+L 149.438184 188.137428 
+L 149.260943 188.311438 
+L 149.083701 188.484891 
+L 148.90646 188.657789 
+L 148.729219 188.830138 
+L 148.551977 189.001939 
+L 148.374736 189.173196 
+L 148.197495 189.343914 
+L 148.020254 189.514095 
+L 147.843012 189.683742 
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_150">
-    <path d="M 147.843012 190.985697 
-L 147.80944 191.066331 
-L 147.775867 191.146846 
-L 147.742295 191.227241 
-L 147.708722 191.307516 
-L 147.67515 191.387673 
-L 147.641577 191.467712 
-L 147.608005 191.547632 
-L 147.574432 191.627434 
-L 147.54086 191.707119 
-L 147.507287 191.786687 
-L 147.473715 191.866138 
-L 147.440142 191.945472 
-L 147.40657 192.024691 
-L 147.372997 192.103793 
-L 147.339425 192.182781 
-L 147.305852 192.261653 
-L 147.27228 192.34041 
-L 147.238707 192.419053 
-L 147.205135 192.497582 
-L 147.171562 192.575997 
-L 147.13799 192.654299 
-L 147.104417 192.732487 
-L 147.070845 192.810563 
-L 147.037273 192.888527 
-L 147.0037 192.966378 
-L 146.970128 193.044117 
-L 146.936555 193.121745 
-L 146.902983 193.199262 
-L 146.86941 193.276668 
-L 146.835838 193.353963 
-L 146.802265 193.431149 
-L 146.768693 193.508224 
-L 146.73512 193.58519 
-L 146.701548 193.662046 
-L 146.667975 193.738793 
-L 146.634403 193.815432 
-L 146.60083 193.891963 
-L 146.567258 193.968385 
-L 146.533685 194.0447 
-L 146.500113 194.120907 
-L 146.46654 194.197007 
-L 146.432968 194.273 
-L 146.399395 194.348887 
-L 146.365823 194.424668 
-L 146.33225 194.500342 
-L 146.298678 194.575911 
-L 146.265105 194.651375 
-L 146.231533 194.726733 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 147.843012 189.683742 
+L 147.80944 189.787507 
+L 147.775867 189.891073 
+L 147.742295 189.994441 
+L 147.708722 190.097613 
+L 147.67515 190.200588 
+L 147.641577 190.303367 
+L 147.608005 190.405952 
+L 147.574432 190.508343 
+L 147.54086 190.61054 
+L 147.507287 190.712545 
+L 147.473715 190.814358 
+L 147.440142 190.915979 
+L 147.40657 191.017411 
+L 147.372997 191.118652 
+L 147.339425 191.219705 
+L 147.305852 191.320569 
+L 147.27228 191.421246 
+L 147.238707 191.521736 
+L 147.205135 191.62204 
+L 147.171562 191.722158 
+L 147.13799 191.822091 
+L 147.104417 191.92184 
+L 147.070845 192.021406 
+L 147.037273 192.120789 
+L 147.0037 192.21999 
+L 146.970128 192.319009 
+L 146.936555 192.417848 
+L 146.902983 192.516506 
+L 146.86941 192.614985 
+L 146.835838 192.713285 
+L 146.802265 192.811407 
+L 146.768693 192.909351 
+L 146.73512 193.007119 
+L 146.701548 193.10471 
+L 146.667975 193.202125 
+L 146.634403 193.299366 
+L 146.60083 193.396432 
+L 146.567258 193.493325 
+L 146.533685 193.590044 
+L 146.500113 193.686591 
+L 146.46654 193.782966 
+L 146.432968 193.879169 
+L 146.399395 193.975202 
+L 146.365823 194.071065 
+L 146.33225 194.166758 
+L 146.298678 194.262283 
+L 146.265105 194.357639 
+L 146.231533 194.452828 
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_151">
-    <path d="M 146.231533 194.726733 
-L 145.676509 199.84827 
-L 145.121485 204.52685 
-L 144.566461 208.833032 
-L 144.011437 212.821753 
-L 143.456413 216.536624 
-L 142.901389 220.012844 
-L 142.346365 223.279235 
-L 141.791342 226.359691 
-L 141.236318 229.274246 
-L 140.681294 232.03986 
-L 140.12627 234.671017 
-L 139.571246 237.180188 
-L 139.016222 239.578185 
-L 138.461198 241.874443 
-L 137.906174 244.077243 
-L 137.35115 246.193898 
-L 136.796126 248.230892 
-L 136.241103 250.194005 
-L 135.686079 252.088408 
-L 135.131055 253.918749 
-L 134.576031 255.68922 
-L 134.021007 257.403613 
-L 133.465983 259.065373 
-L 132.910959 260.677634 
-L 132.355935 262.243261 
-L 131.800911 263.764875 
-L 131.245887 265.244884 
-L 130.690864 266.685503 
-L 130.13584 268.088774 
-L 129.580816 269.456584 
-L 129.025792 270.790682 
-L 128.470768 272.09269 
-L 127.915744 273.364114 
-L 127.36072 274.60636 
-L 126.805696 275.820737 
-L 126.250672 277.008466 
-L 125.695648 278.170694 
-L 125.140625 279.308492 
-L 124.585601 280.422865 
-L 124.030577 281.514759 
-L 123.475553 282.585063 
-L 122.920529 283.634615 
-L 122.365505 284.664203 
-L 121.810481 285.674573 
-L 121.255457 286.666429 
-L 120.700433 287.640438 
-L 120.145409 288.597231 
-L 119.590386 289.537405 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 146.231533 194.452828 
+L 145.676509 199.564516 
+L 145.121485 204.234876 
+L 144.566461 208.534094 
+L 144.011437 212.51684 
+L 143.456413 216.226528 
+L 142.901389 219.69821 
+L 142.346365 222.960593 
+L 141.791342 226.037485 
+L 141.236318 228.948849 
+L 140.681294 231.71159 
+L 140.12627 234.340147 
+L 139.571246 236.846953 
+L 139.016222 239.24279 
+L 138.461198 241.537066 
+L 137.906174 243.738044 
+L 137.35115 245.853016 
+L 136.796126 247.888451 
+L 136.241103 249.850115 
+L 135.686079 251.74317 
+L 135.131055 253.572253 
+L 134.576031 255.341546 
+L 134.021007 257.054835 
+L 133.465983 258.715556 
+L 132.910959 260.326841 
+L 132.355935 261.891547 
+L 131.800911 263.412291 
+L 131.245887 264.891477 
+L 130.690864 266.331316 
+L 130.13584 267.733847 
+L 129.580816 269.100954 
+L 129.025792 270.434383 
+L 128.470768 271.735754 
+L 127.915744 273.006572 
+L 127.36072 274.248238 
+L 126.805696 275.46206 
+L 126.250672 276.649259 
+L 125.695648 277.810979 
+L 125.140625 278.94829 
+L 124.585601 280.062197 
+L 124.030577 281.153643 
+L 123.475553 282.223517 
+L 122.920529 283.272654 
+L 122.365505 284.301844 
+L 121.810481 285.311831 
+L 121.255457 286.303317 
+L 120.700433 287.27697 
+L 120.145409 288.233418 
+L 119.590386 289.17326 
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_152">
-    <path d="M 119.590386 289.537405 
-L 119.136406 290.292524 
-L 118.682426 291.037254 
-L 118.228447 291.771878 
-L 117.774467 292.496664 
-L 117.320487 293.211875 
-L 116.866508 293.917759 
-L 116.412528 294.614556 
-L 115.958549 295.302498 
-L 115.504569 295.981806 
-L 115.050589 296.652695 
-L 114.59661 297.315371 
-L 114.14263 297.970033 
-L 113.68865 298.616871 
-L 113.234671 299.256072 
-L 112.780691 299.887812 
-L 112.326712 300.512265 
-L 111.872732 301.129596 
-L 111.418752 301.739966 
-L 110.964773 302.343531 
-L 110.510793 302.94044 
-L 110.056813 303.530838 
-L 109.602834 304.114867 
-L 109.148854 304.692661 
-L 108.694874 305.264354 
-L 108.240895 305.830071 
-L 107.786915 306.389938 
-L 107.332936 306.944073 
-L 106.878956 307.492593 
-L 106.424976 308.03561 
-L 105.970997 308.573234 
-L 105.517017 309.105572 
-L 105.063037 309.632724 
-L 104.609058 310.154793 
-L 104.155078 310.671875 
-L 103.701099 311.184064 
-L 103.247119 311.691452 
-L 102.793139 312.194128 
-L 102.33916 312.69218 
-L 101.88518 313.18569 
-L 101.4312 313.674742 
-L 100.977221 314.159415 
-L 100.523241 314.639787 
-L 100.069262 315.115933 
-L 99.615282 315.587928 
-L 99.161302 316.055843 
-L 98.707323 316.519747 
-L 98.253343 316.97971 
-L 97.799363 317.435797 
-" clip-path="url(#p6655eb9f26)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 119.590386 289.17326 
+L 119.136406 289.958481 
+L 118.682426 290.732475 
+L 118.228447 291.495558 
+L 117.774467 292.248033 
+L 117.320487 292.990191 
+L 116.866508 293.722311 
+L 116.412528 294.444662 
+L 115.958549 295.1575 
+L 115.504569 295.861072 
+L 115.050589 296.555617 
+L 114.59661 297.241364 
+L 114.14263 297.918532 
+L 113.68865 298.587333 
+L 113.234671 299.247971 
+L 112.780691 299.900645 
+L 112.326712 300.545542 
+L 111.872732 301.182847 
+L 111.418752 301.812735 
+L 110.964773 302.435379 
+L 110.510793 303.050942 
+L 110.056813 303.659583 
+L 109.602834 304.261457 
+L 109.148854 304.856712 
+L 108.694874 305.445493 
+L 108.240895 306.027939 
+L 107.786915 306.604184 
+L 107.332936 307.174359 
+L 106.878956 307.738592 
+L 106.424976 308.297003 
+L 105.970997 308.849713 
+L 105.517017 309.396836 
+L 105.063037 309.938485 
+L 104.609058 310.474767 
+L 104.155078 311.005789 
+L 103.701099 311.531652 
+L 103.247119 312.052455 
+L 102.793139 312.568296 
+L 102.33916 313.079267 
+L 101.88518 313.58546 
+L 101.4312 314.086963 
+L 100.977221 314.583863 
+L 100.523241 315.076242 
+L 100.069262 315.564184 
+L 99.615282 316.047766 
+L 99.161302 316.527066 
+L 98.707323 317.00216 
+L 98.253343 317.47312 
+L 97.799363 317.940018 
+" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
   </g>
   <g id="text_25">
@@ -6166,8 +6166,8 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-07-07T02:05:28Z  ·  Linux chungus2 x86_64  ·  commit 1a899305  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(43.462422 465.66) scale(0.07 -0.07)">
+   <!-- 2026-07-07T22:17:01Z  ·  Linux chungus2 x86_64  ·  commit dcf4b958  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(44.687422 465.66) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -6201,31 +6201,6 @@ L 1409 3309
 L 1409 2516 
 L 750 2516 
 L 750 3309 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-b7" d="M 684 2619 
@@ -6315,6 +6290,31 @@ Q 1038 2656 1286 2365
 Q 1534 2075 1959 2075 
 z
 " transform="scale(0.015625)"/>
+     <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
      <path id="DejaVuSans-3d" d="M 678 2906 
 L 4684 2906 
 L 4684 2381 
@@ -6355,14 +6355,14 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-37" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -6402,109 +6402,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3196.777344 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3260.400391 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3324.023438 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3387.646484 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3451.269531 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3514.892578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3578.515625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3610.302734 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3642.089844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3673.876953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3705.664062 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3737.451172 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3765.234375 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3826.757812 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3888.037109 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3951.416016 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4014.892578 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4053.755859 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4114.9375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4174.117188 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4235.640625 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4276.753906 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4310.445312 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4338.228516 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4399.751953 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4461.03125 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4524.410156 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4588.033203 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4621.724609 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4680.904297 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4744.527344 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4776.314453 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4839.9375 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4903.560547 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4935.347656 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4998.970703 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5035.054688 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5073.917969 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5128.898438 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5192.521484 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5224.308594 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5256.095703 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5287.882812 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5319.669922 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5351.457031 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5390.666016 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5454.044922 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5492.908203 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5554.089844 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5617.46875 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5680.945312 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5744.324219 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5807.800781 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5871.179688 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5910.388672 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5942.175781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6025.964844 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6057.751953 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6155.164062 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6216.6875 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6280.164062 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6307.947266 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6369.226562 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6432.605469 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6464.392578 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6516.492188 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6579.871094 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6641.150391 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6704.626953 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6756.726562 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6820.105469 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6881.287109 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6920.496094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6954.1875 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6985.974609 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7027.087891 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7088.367188 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7127.576172 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7155.359375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7216.541016 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7248.328125 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7276.111328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7328.210938 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7359.998047 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7423.474609 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7484.998047 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7524.207031 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7585.730469 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7625.09375 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7722.505859 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7750.289062 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7813.667969 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7841.451172 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7893.550781 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7932.759766 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7960.542969 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3135.351562 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3190.332031 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3225.537109 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3289.160156 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3352.636719 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3416.259766 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3479.882812 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3543.505859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3575.292969 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3607.080078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3638.867188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3670.654297 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3702.441406 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3730.224609 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3791.748047 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3853.027344 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3916.40625 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3979.882812 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4018.746094 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4079.927734 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4139.107422 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4200.630859 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4241.744141 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4275.435547 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4303.21875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4364.742188 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4426.021484 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4489.400391 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4553.023438 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4586.714844 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4645.894531 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4709.517578 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4741.304688 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4804.927734 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4868.550781 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4900.337891 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4963.960938 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5000.044922 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5038.908203 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5093.888672 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5157.511719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5189.298828 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5221.085938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5252.873047 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5284.660156 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5316.447266 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5355.65625 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5419.035156 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5457.898438 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5519.080078 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5582.458984 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5645.935547 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5709.314453 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5772.791016 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5836.169922 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5875.378906 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5907.166016 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5990.955078 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6022.742188 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6120.154297 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6181.677734 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6245.154297 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6272.9375 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6334.216797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6397.595703 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6429.382812 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6481.482422 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6544.861328 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6606.140625 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6669.617188 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6721.716797 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6785.095703 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6846.277344 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6885.486328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6919.177734 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6950.964844 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6992.078125 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7053.357422 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7092.566406 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7120.349609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7181.53125 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7213.318359 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7241.101562 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7293.201172 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7324.988281 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7388.464844 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7449.988281 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7489.197266 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7550.720703 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7590.083984 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7687.496094 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7715.279297 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7778.658203 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7806.441406 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7858.541016 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7897.75 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7925.533203 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p6655eb9f26">
+  <clipPath id="p742c5d33d3">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_decode_density.svg
+++ b/bench/graphs/silesia_decode_density.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 82.373685 412.80375 
 L 82.373685 47.3475 
-" clip-path="url(#p5a77d57261)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p7c4c6f9290)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m9fc22e82fc" d="M 0 0 
+       <path id="mba05d95da4" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m9fc22e82fc" x="82.373685" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mba05d95da4" x="82.373685" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -111,11 +111,11 @@ z
      <g id="line2d_3">
       <path d="M 165.44644 412.80375 
 L 165.44644 47.3475 
-" clip-path="url(#p5a77d57261)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p7c4c6f9290)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m9fc22e82fc" x="165.44644" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mba05d95da4" x="165.44644" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -157,11 +157,11 @@ z
      <g id="line2d_5">
       <path d="M 248.519195 412.80375 
 L 248.519195 47.3475 
-" clip-path="url(#p5a77d57261)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p7c4c6f9290)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m9fc22e82fc" x="248.519195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mba05d95da4" x="248.519195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -211,11 +211,11 @@ z
      <g id="line2d_7">
       <path d="M 331.59195 412.80375 
 L 331.59195 47.3475 
-" clip-path="url(#p5a77d57261)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p7c4c6f9290)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m9fc22e82fc" x="331.59195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mba05d95da4" x="331.59195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -252,11 +252,11 @@ z
      <g id="line2d_9">
       <path d="M 414.664704 412.80375 
 L 414.664704 47.3475 
-" clip-path="url(#p5a77d57261)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p7c4c6f9290)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m9fc22e82fc" x="414.664704" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mba05d95da4" x="414.664704" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -299,11 +299,11 @@ z
      <g id="line2d_11">
       <path d="M 497.737459 412.80375 
 L 497.737459 47.3475 
-" clip-path="url(#p5a77d57261)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p7c4c6f9290)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m9fc22e82fc" x="497.737459" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mba05d95da4" x="497.737459" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -351,11 +351,11 @@ z
      <g id="line2d_13">
       <path d="M 580.810214 412.80375 
 L 580.810214 47.3475 
-" clip-path="url(#p5a77d57261)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p7c4c6f9290)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m9fc22e82fc" x="580.810214" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mba05d95da4" x="580.810214" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -897,16 +897,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 391.82245 
 L 637.2 391.82245 
-" clip-path="url(#p5a77d57261)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p7c4c6f9290)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="mdd691718a6" d="M 0 0 
+       <path id="m81ab6ffa09" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mdd691718a6" x="49.078125" y="391.82245" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m81ab6ffa09" x="49.078125" y="391.82245" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -922,11 +922,11 @@ L -3.5 0
      <g id="line2d_17">
       <path d="M 49.078125 265.911133 
 L 637.2 265.911133 
-" clip-path="url(#p5a77d57261)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p7c4c6f9290)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mdd691718a6" x="49.078125" y="265.911133" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m81ab6ffa09" x="49.078125" y="265.911133" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -942,11 +942,11 @@ L 637.2 265.911133
      <g id="line2d_19">
       <path d="M 49.078125 139.999816 
 L 637.2 139.999816 
-" clip-path="url(#p5a77d57261)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p7c4c6f9290)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#mdd691718a6" x="49.078125" y="139.999816" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m81ab6ffa09" x="49.078125" y="139.999816" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -962,16 +962,16 @@ L 637.2 139.999816
      <g id="line2d_21">
       <path d="M 49.078125 411.32636 
 L 637.2 411.32636 
-" clip-path="url(#p5a77d57261)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p7c4c6f9290)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="mf3a6061827" d="M 0 0 
+       <path id="m60c8c8c61a" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#mf3a6061827" x="49.078125" y="411.32636" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m60c8c8c61a" x="49.078125" y="411.32636" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -979,11 +979,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 404.024518 
 L 637.2 404.024518 
-" clip-path="url(#p5a77d57261)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p7c4c6f9290)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mf3a6061827" x="49.078125" y="404.024518" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m60c8c8c61a" x="49.078125" y="404.024518" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -991,11 +991,11 @@ L 637.2 404.024518
      <g id="line2d_25">
       <path d="M 49.078125 397.583836 
 L 637.2 397.583836 
-" clip-path="url(#p5a77d57261)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p7c4c6f9290)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mf3a6061827" x="49.078125" y="397.583836" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m60c8c8c61a" x="49.078125" y="397.583836" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1003,11 +1003,11 @@ L 637.2 397.583836
      <g id="line2d_27">
       <path d="M 49.078125 353.919367 
 L 637.2 353.919367 
-" clip-path="url(#p5a77d57261)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p7c4c6f9290)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#mf3a6061827" x="49.078125" y="353.919367" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m60c8c8c61a" x="49.078125" y="353.919367" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1015,11 +1015,11 @@ L 637.2 353.919367
      <g id="line2d_29">
       <path d="M 49.078125 331.747485 
 L 637.2 331.747485 
-" clip-path="url(#p5a77d57261)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p7c4c6f9290)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#mf3a6061827" x="49.078125" y="331.747485" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m60c8c8c61a" x="49.078125" y="331.747485" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1027,11 +1027,11 @@ L 637.2 331.747485
      <g id="line2d_31">
       <path d="M 49.078125 316.016284 
 L 637.2 316.016284 
-" clip-path="url(#p5a77d57261)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p7c4c6f9290)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#mf3a6061827" x="49.078125" y="316.016284" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m60c8c8c61a" x="49.078125" y="316.016284" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1039,11 +1039,11 @@ L 637.2 316.016284
      <g id="line2d_33">
       <path d="M 49.078125 303.814216 
 L 637.2 303.814216 
-" clip-path="url(#p5a77d57261)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p7c4c6f9290)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#mf3a6061827" x="49.078125" y="303.814216" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m60c8c8c61a" x="49.078125" y="303.814216" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1051,11 +1051,11 @@ L 637.2 303.814216
      <g id="line2d_35">
       <path d="M 49.078125 293.844402 
 L 637.2 293.844402 
-" clip-path="url(#p5a77d57261)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p7c4c6f9290)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#mf3a6061827" x="49.078125" y="293.844402" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m60c8c8c61a" x="49.078125" y="293.844402" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1063,11 +1063,11 @@ L 637.2 293.844402
      <g id="line2d_37">
       <path d="M 49.078125 285.415043 
 L 637.2 285.415043 
-" clip-path="url(#p5a77d57261)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p7c4c6f9290)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#mf3a6061827" x="49.078125" y="285.415043" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m60c8c8c61a" x="49.078125" y="285.415043" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1075,11 +1075,11 @@ L 637.2 285.415043
      <g id="line2d_39">
       <path d="M 49.078125 278.113201 
 L 637.2 278.113201 
-" clip-path="url(#p5a77d57261)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p7c4c6f9290)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#mf3a6061827" x="49.078125" y="278.113201" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m60c8c8c61a" x="49.078125" y="278.113201" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1087,11 +1087,11 @@ L 637.2 278.113201
      <g id="line2d_41">
       <path d="M 49.078125 271.672519 
 L 637.2 271.672519 
-" clip-path="url(#p5a77d57261)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p7c4c6f9290)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#mf3a6061827" x="49.078125" y="271.672519" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m60c8c8c61a" x="49.078125" y="271.672519" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1099,11 +1099,11 @@ L 637.2 271.672519
      <g id="line2d_43">
       <path d="M 49.078125 228.00805 
 L 637.2 228.00805 
-" clip-path="url(#p5a77d57261)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p7c4c6f9290)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#mf3a6061827" x="49.078125" y="228.00805" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m60c8c8c61a" x="49.078125" y="228.00805" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1111,11 +1111,11 @@ L 637.2 228.00805
      <g id="line2d_45">
       <path d="M 49.078125 205.836168 
 L 637.2 205.836168 
-" clip-path="url(#p5a77d57261)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p7c4c6f9290)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#mf3a6061827" x="49.078125" y="205.836168" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m60c8c8c61a" x="49.078125" y="205.836168" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1123,11 +1123,11 @@ L 637.2 205.836168
      <g id="line2d_47">
       <path d="M 49.078125 190.104967 
 L 637.2 190.104967 
-" clip-path="url(#p5a77d57261)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p7c4c6f9290)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#mf3a6061827" x="49.078125" y="190.104967" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m60c8c8c61a" x="49.078125" y="190.104967" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1135,11 +1135,11 @@ L 637.2 190.104967
      <g id="line2d_49">
       <path d="M 49.078125 177.9029 
 L 637.2 177.9029 
-" clip-path="url(#p5a77d57261)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p7c4c6f9290)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#mf3a6061827" x="49.078125" y="177.9029" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m60c8c8c61a" x="49.078125" y="177.9029" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1147,11 +1147,11 @@ L 637.2 177.9029
      <g id="line2d_51">
       <path d="M 49.078125 167.933085 
 L 637.2 167.933085 
-" clip-path="url(#p5a77d57261)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p7c4c6f9290)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#mf3a6061827" x="49.078125" y="167.933085" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m60c8c8c61a" x="49.078125" y="167.933085" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1159,11 +1159,11 @@ L 637.2 167.933085
      <g id="line2d_53">
       <path d="M 49.078125 159.503726 
 L 637.2 159.503726 
-" clip-path="url(#p5a77d57261)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p7c4c6f9290)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#mf3a6061827" x="49.078125" y="159.503726" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m60c8c8c61a" x="49.078125" y="159.503726" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1171,11 +1171,11 @@ L 637.2 159.503726
      <g id="line2d_55">
       <path d="M 49.078125 152.201884 
 L 637.2 152.201884 
-" clip-path="url(#p5a77d57261)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p7c4c6f9290)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#mf3a6061827" x="49.078125" y="152.201884" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m60c8c8c61a" x="49.078125" y="152.201884" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1183,11 +1183,11 @@ L 637.2 152.201884
      <g id="line2d_57">
       <path d="M 49.078125 145.761202 
 L 637.2 145.761202 
-" clip-path="url(#p5a77d57261)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p7c4c6f9290)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#mf3a6061827" x="49.078125" y="145.761202" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m60c8c8c61a" x="49.078125" y="145.761202" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1195,11 +1195,11 @@ L 637.2 145.761202
      <g id="line2d_59">
       <path d="M 49.078125 102.096733 
 L 637.2 102.096733 
-" clip-path="url(#p5a77d57261)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p7c4c6f9290)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#mf3a6061827" x="49.078125" y="102.096733" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m60c8c8c61a" x="49.078125" y="102.096733" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1207,11 +1207,11 @@ L 637.2 102.096733
      <g id="line2d_61">
       <path d="M 49.078125 79.924851 
 L 637.2 79.924851 
-" clip-path="url(#p5a77d57261)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p7c4c6f9290)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#mf3a6061827" x="49.078125" y="79.924851" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m60c8c8c61a" x="49.078125" y="79.924851" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1219,11 +1219,11 @@ L 637.2 79.924851
      <g id="line2d_63">
       <path d="M 49.078125 64.19365 
 L 637.2 64.19365 
-" clip-path="url(#p5a77d57261)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p7c4c6f9290)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#mf3a6061827" x="49.078125" y="64.19365" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m60c8c8c61a" x="49.078125" y="64.19365" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1231,11 +1231,11 @@ L 637.2 64.19365
      <g id="line2d_65">
       <path d="M 49.078125 51.991583 
 L 637.2 51.991583 
-" clip-path="url(#p5a77d57261)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p7c4c6f9290)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#mf3a6061827" x="49.078125" y="51.991583" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m60c8c8c61a" x="49.078125" y="51.991583" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1398,7 +1398,7 @@ z
    <g id="line2d_67">
     <path d="M 49.078125 63.959148 
 L 637.2 63.959148 
-" clip-path="url(#p5a77d57261)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
+" clip-path="url(#p7c4c6f9290)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
    </g>
    <g id="patch_3">
     <path d="M 49.078125 412.80375 
@@ -1762,78 +1762,78 @@ z
    </g>
    <g id="line2d_68">
     <defs>
-     <path id="m89c9166434" d="M -2.5 2.5 
+     <path id="mc35b0b71a8" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p5a77d57261)">
-     <use xlink:href="#m89c9166434" x="75.810937" y="263.216607" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m89c9166434" x="105.634056" y="269.620798" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m89c9166434" x="204.490635" y="301.215031" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m89c9166434" x="234.479899" y="307.658059" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m89c9166434" x="242.537956" y="315.917944" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m89c9166434" x="300.771958" y="298.734802" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m89c9166434" x="303.26414" y="310.074879" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m89c9166434" x="304.261013" y="319.328576" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m89c9166434" x="313.897453" y="319.101018" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m89c9166434" x="414.166268" y="335.426532" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m89c9166434" x="587.289889" y="328.826648" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m89c9166434" x="610.467187" y="319.678275" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p7c4c6f9290)">
+     <use xlink:href="#mc35b0b71a8" x="75.810937" y="263.216607" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc35b0b71a8" x="105.634056" y="269.620798" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc35b0b71a8" x="204.490635" y="301.215031" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc35b0b71a8" x="234.479899" y="307.658059" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc35b0b71a8" x="242.537956" y="315.917944" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc35b0b71a8" x="300.771958" y="298.734802" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc35b0b71a8" x="303.26414" y="310.074879" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc35b0b71a8" x="304.261013" y="319.328576" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc35b0b71a8" x="313.897453" y="319.101018" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc35b0b71a8" x="414.166268" y="335.426532" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc35b0b71a8" x="587.289889" y="328.826648" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc35b0b71a8" x="610.467187" y="319.678275" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_69">
     <defs>
-     <path id="m8feb3d8607" d="M 0 -2.5 
+     <path id="ma5b4b61f77" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p5a77d57261)">
-     <use xlink:href="#m8feb3d8607" x="75.810937" y="262.505003" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8feb3d8607" x="105.634056" y="256.516219" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8feb3d8607" x="204.490635" y="300.455891" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8feb3d8607" x="234.479899" y="298.72384" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8feb3d8607" x="242.537956" y="307.046683" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8feb3d8607" x="300.771958" y="287.726284" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8feb3d8607" x="303.26414" y="300.256724" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8feb3d8607" x="304.261013" y="315.235818" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8feb3d8607" x="313.897453" y="307.4765" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8feb3d8607" x="414.166268" y="326.223389" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8feb3d8607" x="587.289889" y="329.609806" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8feb3d8607" x="610.467187" y="318.379704" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p7c4c6f9290)">
+     <use xlink:href="#ma5b4b61f77" x="75.810937" y="262.505003" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma5b4b61f77" x="105.634056" y="256.516219" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma5b4b61f77" x="204.490635" y="300.455891" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma5b4b61f77" x="234.479899" y="298.72384" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma5b4b61f77" x="242.537956" y="307.046683" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma5b4b61f77" x="300.771958" y="287.726284" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma5b4b61f77" x="303.26414" y="300.256724" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma5b4b61f77" x="304.261013" y="315.235818" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma5b4b61f77" x="313.897453" y="307.4765" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma5b4b61f77" x="414.166268" y="326.223389" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma5b4b61f77" x="587.289889" y="329.609806" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma5b4b61f77" x="610.467187" y="318.379704" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_70">
     <defs>
-     <path id="m6a57ba31c9" d="M -0 3.535534 
+     <path id="m941a5478ac" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p5a77d57261)">
-     <use xlink:href="#m6a57ba31c9" x="75.810937" y="231.044207" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a57ba31c9" x="105.634056" y="233.464672" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a57ba31c9" x="204.490635" y="259.725746" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a57ba31c9" x="234.479899" y="262.023129" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a57ba31c9" x="242.537956" y="273.368182" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a57ba31c9" x="300.771958" y="259.408271" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a57ba31c9" x="303.26414" y="270.926655" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a57ba31c9" x="304.261013" y="281.595692" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a57ba31c9" x="313.897453" y="277.309155" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a57ba31c9" x="414.166268" y="296.377475" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a57ba31c9" x="587.289889" y="301.735817" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a57ba31c9" x="610.467187" y="297.040139" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p7c4c6f9290)">
+     <use xlink:href="#m941a5478ac" x="75.810937" y="231.044207" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m941a5478ac" x="105.634056" y="233.464672" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m941a5478ac" x="204.490635" y="259.725746" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m941a5478ac" x="234.479899" y="262.023129" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m941a5478ac" x="242.537956" y="273.368182" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m941a5478ac" x="300.771958" y="259.408271" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m941a5478ac" x="303.26414" y="270.926655" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m941a5478ac" x="304.261013" y="281.595692" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m941a5478ac" x="313.897453" y="277.309155" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m941a5478ac" x="414.166268" y="296.377475" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m941a5478ac" x="587.289889" y="301.735817" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m941a5478ac" x="610.467187" y="297.040139" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_71">
     <defs>
-     <path id="m34151a164b" d="M -0.833333 2.5 
+     <path id="m7498fa8ab3" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -1848,24 +1848,24 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p5a77d57261)">
-     <use xlink:href="#m34151a164b" x="75.810937" y="286.910165" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m34151a164b" x="105.634056" y="294.974253" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m34151a164b" x="204.490635" y="327.107019" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m34151a164b" x="234.479899" y="335.778593" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m34151a164b" x="242.537956" y="341.647351" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m34151a164b" x="300.771958" y="337.663009" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m34151a164b" x="303.26414" y="345.502509" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m34151a164b" x="304.261013" y="345.645685" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m34151a164b" x="313.897453" y="351.930007" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m34151a164b" x="414.166268" y="363.456717" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m34151a164b" x="587.289889" y="368.243436" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m34151a164b" x="610.467187" y="356.848113" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p7c4c6f9290)">
+     <use xlink:href="#m7498fa8ab3" x="75.810937" y="286.910165" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7498fa8ab3" x="105.634056" y="294.974253" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7498fa8ab3" x="204.490635" y="327.107019" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7498fa8ab3" x="234.479899" y="335.778593" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7498fa8ab3" x="242.537956" y="341.647351" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7498fa8ab3" x="300.771958" y="337.663009" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7498fa8ab3" x="303.26414" y="345.502509" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7498fa8ab3" x="304.261013" y="345.645685" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7498fa8ab3" x="313.897453" y="351.930007" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7498fa8ab3" x="414.166268" y="363.456717" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7498fa8ab3" x="587.289889" y="368.243436" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7498fa8ab3" x="610.467187" y="356.848113" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_72">
     <defs>
-     <path id="m874c3963ea" d="M -1.25 2.5 
+     <path id="m0a9f961ba3" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -1880,24 +1880,24 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p5a77d57261)">
-     <use xlink:href="#m874c3963ea" x="75.810937" y="328.907922" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m874c3963ea" x="105.634056" y="342.121252" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m874c3963ea" x="204.490635" y="364.316276" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m874c3963ea" x="234.479899" y="371.357513" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m874c3963ea" x="242.537956" y="368.122771" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m874c3963ea" x="300.771958" y="365.072092" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m874c3963ea" x="303.26414" y="374.607784" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m874c3963ea" x="304.261013" y="366.131688" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m874c3963ea" x="313.897453" y="378.589014" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m874c3963ea" x="414.166268" y="386.15027" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m874c3963ea" x="587.289889" y="392.30027" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m874c3963ea" x="610.467187" y="391.11076" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p7c4c6f9290)">
+     <use xlink:href="#m0a9f961ba3" x="75.810937" y="328.907922" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0a9f961ba3" x="105.634056" y="342.121252" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0a9f961ba3" x="204.490635" y="364.316276" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0a9f961ba3" x="234.479899" y="371.357513" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0a9f961ba3" x="242.537956" y="368.122771" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0a9f961ba3" x="300.771958" y="365.072092" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0a9f961ba3" x="303.26414" y="374.607784" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0a9f961ba3" x="304.261013" y="366.131688" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0a9f961ba3" x="313.897453" y="378.589014" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0a9f961ba3" x="414.166268" y="386.15027" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0a9f961ba3" x="587.289889" y="392.30027" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0a9f961ba3" x="610.467187" y="391.11076" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_73">
     <defs>
-     <path id="mf13218babd" d="M 0 -2.5 
+     <path id="mf5545b46a6" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -1910,24 +1910,24 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p5a77d57261)">
-     <use xlink:href="#mf13218babd" x="75.810937" y="274.450514" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mf13218babd" x="105.634056" y="287.578172" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mf13218babd" x="204.490635" y="320.76932" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mf13218babd" x="234.479899" y="321.538199" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mf13218babd" x="242.537956" y="326.688339" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mf13218babd" x="300.771958" y="333.426229" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mf13218babd" x="303.26414" y="337.000867" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mf13218babd" x="304.261013" y="346.386297" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mf13218babd" x="313.897453" y="336.174424" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mf13218babd" x="414.166268" y="357.767316" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mf13218babd" x="587.289889" y="366.526213" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mf13218babd" x="610.467187" y="361.324423" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p7c4c6f9290)">
+     <use xlink:href="#mf5545b46a6" x="75.810937" y="274.450514" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf5545b46a6" x="105.634056" y="287.578172" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf5545b46a6" x="204.490635" y="320.76932" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf5545b46a6" x="234.479899" y="321.538199" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf5545b46a6" x="242.537956" y="326.688339" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf5545b46a6" x="300.771958" y="333.426229" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf5545b46a6" x="303.26414" y="337.000867" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf5545b46a6" x="304.261013" y="346.386297" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf5545b46a6" x="313.897453" y="336.174424" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf5545b46a6" x="414.166268" y="357.767316" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf5545b46a6" x="587.289889" y="366.526213" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf5545b46a6" x="610.467187" y="361.324423" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_74">
     <defs>
-     <path id="m370cc1c0f3" d="M 0 -2.5 
+     <path id="med96bdb3a1" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -1936,19 +1936,19 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p5a77d57261)">
-     <use xlink:href="#m370cc1c0f3" x="75.810937" y="345.30596" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m370cc1c0f3" x="105.634056" y="352.048776" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m370cc1c0f3" x="204.490635" y="367.386827" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m370cc1c0f3" x="234.479899" y="374.711659" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m370cc1c0f3" x="242.537956" y="380.187639" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m370cc1c0f3" x="300.771958" y="368.991079" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m370cc1c0f3" x="303.26414" y="375.43221" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m370cc1c0f3" x="304.261013" y="381.227374" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m370cc1c0f3" x="313.897453" y="385.221601" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m370cc1c0f3" x="414.166268" y="390.900659" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m370cc1c0f3" x="587.289889" y="396.192102" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m370cc1c0f3" x="610.467187" y="386.05669" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p7c4c6f9290)">
+     <use xlink:href="#med96bdb3a1" x="75.810937" y="345.30596" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#med96bdb3a1" x="105.634056" y="352.048776" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#med96bdb3a1" x="204.490635" y="367.386827" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#med96bdb3a1" x="234.479899" y="374.711659" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#med96bdb3a1" x="242.537956" y="380.187639" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#med96bdb3a1" x="300.771958" y="368.991079" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#med96bdb3a1" x="303.26414" y="375.43221" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#med96bdb3a1" x="304.261013" y="381.227374" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#med96bdb3a1" x="313.897453" y="385.221601" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#med96bdb3a1" x="414.166268" y="390.900659" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#med96bdb3a1" x="587.289889" y="396.192102" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#med96bdb3a1" x="610.467187" y="386.05669" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="legend_1">
@@ -1967,7 +1967,7 @@ z
     </g>
     <g id="line2d_75">
      <defs>
-      <path id="mce59d5e35d" d="M 0 3.5 
+      <path id="m8ae5d5f173" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -1980,7 +1980,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#mce59d5e35d" x="434.04625" y="211.758125" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m8ae5d5f173" x="434.04625" y="211.758125" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_15">
@@ -2039,7 +2039,7 @@ z
     </g>
     <g id="line2d_76">
      <g>
-      <use xlink:href="#m89c9166434" x="434.04625" y="223.500625" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mc35b0b71a8" x="434.04625" y="223.500625" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_16">
@@ -2053,7 +2053,7 @@ z
     </g>
     <g id="line2d_77">
      <g>
-      <use xlink:href="#m8feb3d8607" x="434.04625" y="235.243125" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#ma5b4b61f77" x="434.04625" y="235.243125" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -2098,7 +2098,7 @@ z
     </g>
     <g id="line2d_78">
      <g>
-      <use xlink:href="#m6a57ba31c9" x="434.04625" y="247.208125" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m941a5478ac" x="434.04625" y="247.208125" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -2118,7 +2118,7 @@ z
     </g>
     <g id="line2d_79">
      <g>
-      <use xlink:href="#m34151a164b" x="537.72375" y="211.758125" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m7498fa8ab3" x="537.72375" y="211.758125" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -2145,7 +2145,7 @@ z
     </g>
     <g id="line2d_80">
      <g>
-      <use xlink:href="#m874c3963ea" x="537.72375" y="223.500625" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m0a9f961ba3" x="537.72375" y="223.500625" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -2210,7 +2210,7 @@ z
     </g>
     <g id="line2d_81">
      <g>
-      <use xlink:href="#mf13218babd" x="537.72375" y="235.243125" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#mf5545b46a6" x="537.72375" y="235.243125" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_21">
@@ -2248,7 +2248,7 @@ z
     </g>
     <g id="line2d_82">
      <g>
-      <use xlink:href="#m370cc1c0f3" x="537.72375" y="246.985625" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#med96bdb3a1" x="537.72375" y="246.985625" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -2318,19 +2318,19 @@ z
     </g>
    </g>
    <g id="line2d_83">
-    <g clip-path="url(#p5a77d57261)">
-     <use xlink:href="#mce59d5e35d" x="75.810937" y="298.510024" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mce59d5e35d" x="105.634056" y="315.672864" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mce59d5e35d" x="204.490635" y="347.595466" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mce59d5e35d" x="234.479899" y="355.186159" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mce59d5e35d" x="242.537956" y="354.419257" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mce59d5e35d" x="300.771958" y="342.079401" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mce59d5e35d" x="303.26414" y="366.152202" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mce59d5e35d" x="304.261013" y="375.092892" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mce59d5e35d" x="313.897453" y="369.574066" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mce59d5e35d" x="414.166268" y="382.204646" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mce59d5e35d" x="587.289889" y="393.510593" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mce59d5e35d" x="610.467187" y="371.196024" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <g clip-path="url(#p7c4c6f9290)">
+     <use xlink:href="#m8ae5d5f173" x="75.810937" y="298.510024" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m8ae5d5f173" x="105.634056" y="315.672864" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m8ae5d5f173" x="204.490635" y="347.595466" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m8ae5d5f173" x="234.479899" y="355.186159" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m8ae5d5f173" x="242.537956" y="354.419257" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m8ae5d5f173" x="300.771958" y="342.079401" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m8ae5d5f173" x="303.26414" y="366.152202" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m8ae5d5f173" x="304.261013" y="375.092892" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m8ae5d5f173" x="313.897453" y="369.574066" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m8ae5d5f173" x="414.166268" y="382.204646" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m8ae5d5f173" x="587.289889" y="393.510593" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m8ae5d5f173" x="610.467187" y="371.196024" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
   </g>
@@ -3184,7 +3184,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p5a77d57261">
+  <clipPath id="p7c4c6f9290">
    <rect x="49.078125" y="47.3475" width="588.121875" height="365.45625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_decode_ranking.svg
+++ b/bench/graphs/silesia_decode_ranking.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 290.788615 308.04375 
 L 290.788615 56.7075 
-" clip-path="url(#p9492024f93)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pad8457e370)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m1aefb0db73" d="M 0 0 
+       <path id="md1cfdf40ec" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m1aefb0db73" x="290.788615" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md1cfdf40ec" x="290.788615" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -136,11 +136,11 @@ z
      <g id="line2d_3">
       <path d="M 447.590599 308.04375 
 L 447.590599 56.7075 
-" clip-path="url(#p9492024f93)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pad8457e370)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m1aefb0db73" x="447.590599" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md1cfdf40ec" x="447.590599" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -177,16 +177,16 @@ z
      <g id="line2d_5">
       <path d="M 181.188732 308.04375 
 L 181.188732 56.7075 
-" clip-path="url(#p9492024f93)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pad8457e370)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <defs>
-       <path id="ma5c57bd3bf" d="M 0 0 
+       <path id="md305e1d50d" d="M 0 0 
 L 0 2 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#ma5c57bd3bf" x="181.188732" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md305e1d50d" x="181.188732" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -194,11 +194,11 @@ L 0 2
      <g id="line2d_7">
       <path d="M 208.800191 308.04375 
 L 208.800191 56.7075 
-" clip-path="url(#p9492024f93)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pad8457e370)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#ma5c57bd3bf" x="208.800191" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md305e1d50d" x="208.800191" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -206,11 +206,11 @@ L 208.800191 56.7075
      <g id="line2d_9">
       <path d="M 228.390833 308.04375 
 L 228.390833 56.7075 
-" clip-path="url(#p9492024f93)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pad8457e370)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#ma5c57bd3bf" x="228.390833" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md305e1d50d" x="228.390833" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -218,11 +218,11 @@ L 228.390833 56.7075
      <g id="line2d_11">
       <path d="M 243.586515 308.04375 
 L 243.586515 56.7075 
-" clip-path="url(#p9492024f93)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pad8457e370)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#ma5c57bd3bf" x="243.586515" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md305e1d50d" x="243.586515" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -230,11 +230,11 @@ L 243.586515 56.7075
      <g id="line2d_13">
       <path d="M 256.002291 308.04375 
 L 256.002291 56.7075 
-" clip-path="url(#p9492024f93)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pad8457e370)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#ma5c57bd3bf" x="256.002291" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md305e1d50d" x="256.002291" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -242,11 +242,11 @@ L 256.002291 56.7075
      <g id="line2d_15">
       <path d="M 266.499681 308.04375 
 L 266.499681 56.7075 
-" clip-path="url(#p9492024f93)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pad8457e370)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <g>
-       <use xlink:href="#ma5c57bd3bf" x="266.499681" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md305e1d50d" x="266.499681" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -254,11 +254,11 @@ L 266.499681 56.7075
      <g id="line2d_17">
       <path d="M 275.592933 308.04375 
 L 275.592933 56.7075 
-" clip-path="url(#p9492024f93)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pad8457e370)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#ma5c57bd3bf" x="275.592933" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md305e1d50d" x="275.592933" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -266,11 +266,11 @@ L 275.592933 56.7075
      <g id="line2d_19">
       <path d="M 283.61375 308.04375 
 L 283.61375 56.7075 
-" clip-path="url(#p9492024f93)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pad8457e370)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#ma5c57bd3bf" x="283.61375" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md305e1d50d" x="283.61375" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -278,11 +278,11 @@ L 283.61375 56.7075
      <g id="line2d_21">
       <path d="M 337.990716 308.04375 
 L 337.990716 56.7075 
-" clip-path="url(#p9492024f93)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pad8457e370)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#ma5c57bd3bf" x="337.990716" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md305e1d50d" x="337.990716" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -290,11 +290,11 @@ L 337.990716 56.7075
      <g id="line2d_23">
       <path d="M 365.602174 308.04375 
 L 365.602174 56.7075 
-" clip-path="url(#p9492024f93)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pad8457e370)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#ma5c57bd3bf" x="365.602174" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md305e1d50d" x="365.602174" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -302,11 +302,11 @@ L 365.602174 56.7075
      <g id="line2d_25">
       <path d="M 385.192816 308.04375 
 L 385.192816 56.7075 
-" clip-path="url(#p9492024f93)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pad8457e370)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#ma5c57bd3bf" x="385.192816" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md305e1d50d" x="385.192816" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -314,11 +314,11 @@ L 385.192816 56.7075
      <g id="line2d_27">
       <path d="M 400.388498 308.04375 
 L 400.388498 56.7075 
-" clip-path="url(#p9492024f93)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pad8457e370)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#ma5c57bd3bf" x="400.388498" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md305e1d50d" x="400.388498" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -326,11 +326,11 @@ L 400.388498 56.7075
      <g id="line2d_29">
       <path d="M 412.804275 308.04375 
 L 412.804275 56.7075 
-" clip-path="url(#p9492024f93)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pad8457e370)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#ma5c57bd3bf" x="412.804275" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md305e1d50d" x="412.804275" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -338,11 +338,11 @@ L 412.804275 56.7075
      <g id="line2d_31">
       <path d="M 423.301664 308.04375 
 L 423.301664 56.7075 
-" clip-path="url(#p9492024f93)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pad8457e370)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#ma5c57bd3bf" x="423.301664" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md305e1d50d" x="423.301664" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -350,11 +350,11 @@ L 423.301664 56.7075
      <g id="line2d_33">
       <path d="M 432.394917 308.04375 
 L 432.394917 56.7075 
-" clip-path="url(#p9492024f93)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pad8457e370)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#ma5c57bd3bf" x="432.394917" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md305e1d50d" x="432.394917" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -362,11 +362,11 @@ L 432.394917 56.7075
      <g id="line2d_35">
       <path d="M 440.415734 308.04375 
 L 440.415734 56.7075 
-" clip-path="url(#p9492024f93)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pad8457e370)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#ma5c57bd3bf" x="440.415734" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md305e1d50d" x="440.415734" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -374,11 +374,11 @@ L 440.415734 56.7075
      <g id="line2d_37">
       <path d="M 494.792699 308.04375 
 L 494.792699 56.7075 
-" clip-path="url(#p9492024f93)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pad8457e370)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#ma5c57bd3bf" x="494.792699" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md305e1d50d" x="494.792699" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -386,11 +386,11 @@ L 494.792699 56.7075
      <g id="line2d_39">
       <path d="M 522.404158 308.04375 
 L 522.404158 56.7075 
-" clip-path="url(#p9492024f93)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pad8457e370)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#ma5c57bd3bf" x="522.404158" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md305e1d50d" x="522.404158" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -398,11 +398,11 @@ L 522.404158 56.7075
      <g id="line2d_41">
       <path d="M 541.9948 308.04375 
 L 541.9948 56.7075 
-" clip-path="url(#p9492024f93)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pad8457e370)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#ma5c57bd3bf" x="541.9948" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md305e1d50d" x="541.9948" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -410,11 +410,11 @@ L 541.9948 56.7075
      <g id="line2d_43">
       <path d="M 557.190482 308.04375 
 L 557.190482 56.7075 
-" clip-path="url(#p9492024f93)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pad8457e370)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#ma5c57bd3bf" x="557.190482" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md305e1d50d" x="557.190482" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -985,12 +985,12 @@ z
     <g id="ytick_1">
      <g id="line2d_45">
       <defs>
-       <path id="m3930b8e024" d="M 0 0 
+       <path id="m846275b4b7" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m3930b8e024" x="139.360469" y="296.619375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m846275b4b7" x="139.360469" y="296.619375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -1062,7 +1062,7 @@ z
     <g id="ytick_2">
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m3930b8e024" x="139.360469" y="263.978304" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m846275b4b7" x="139.360469" y="263.978304" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -1129,7 +1129,7 @@ z
     <g id="ytick_3">
      <g id="line2d_47">
       <g>
-       <use xlink:href="#m3930b8e024" x="139.360469" y="231.337232" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m846275b4b7" x="139.360469" y="231.337232" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -1242,7 +1242,7 @@ z
     <g id="ytick_4">
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m3930b8e024" x="139.360469" y="198.696161" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m846275b4b7" x="139.360469" y="198.696161" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -1298,7 +1298,7 @@ z
     <g id="ytick_5">
      <g id="line2d_49">
       <g>
-       <use xlink:href="#m3930b8e024" x="139.360469" y="166.055089" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m846275b4b7" x="139.360469" y="166.055089" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -1345,7 +1345,7 @@ z
     <g id="ytick_6">
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m3930b8e024" x="139.360469" y="133.414018" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m846275b4b7" x="139.360469" y="133.414018" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -1361,7 +1361,7 @@ z
     <g id="ytick_7">
      <g id="line2d_51">
       <g>
-       <use xlink:href="#m3930b8e024" x="139.360469" y="100.772946" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m846275b4b7" x="139.360469" y="100.772946" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -1408,7 +1408,7 @@ z
     <g id="ytick_8">
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m3930b8e024" x="139.360469" y="68.131875" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m846275b4b7" x="139.360469" y="68.131875" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -1431,47 +1431,47 @@ z
    <g id="LineCollection_1">
     <path d="M 139.360469 296.619375 
 L 154.556151 296.619375 
-" clip-path="url(#p9492024f93)" style="fill: none; stroke: #17becf; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#pad8457e370)" style="fill: none; stroke: #17becf; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_2">
     <path d="M 139.360469 263.978304 
 L 162.32653 263.978304 
-" clip-path="url(#p9492024f93)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#pad8457e370)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_3">
     <path d="M 139.360469 231.337232 
 L 178.681331 231.337232 
-" clip-path="url(#p9492024f93)" style="fill: none; stroke: #d62728; stroke-opacity: 0.9; stroke-width: 2.4"/>
+" clip-path="url(#pad8457e370)" style="fill: none; stroke: #d62728; stroke-opacity: 0.9; stroke-width: 2.4"/>
    </g>
    <g id="LineCollection_4">
     <path d="M 139.360469 198.696161 
 L 201.044126 198.696161 
-" clip-path="url(#p9492024f93)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#pad8457e370)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_5">
     <path d="M 139.360469 166.055089 
 L 209.976983 166.055089 
-" clip-path="url(#p9492024f93)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#pad8457e370)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_6">
     <path d="M 139.360469 133.414018 
 L 239.121093 133.414018 
-" clip-path="url(#p9492024f93)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#pad8457e370)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_7">
     <path d="M 139.360469 100.772946 
 L 247.282543 100.772946 
-" clip-path="url(#p9492024f93)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#pad8457e370)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_8">
     <path d="M 139.360469 68.131875 
 L 285.279501 68.131875 
-" clip-path="url(#p9492024f93)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#pad8457e370)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="line2d_53">
     <path d="M 542.286834 308.04375 
 L 542.286834 56.7075 
-" clip-path="url(#p9492024f93)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
+" clip-path="url(#pad8457e370)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
    </g>
    <g id="patch_3">
     <path d="M 139.360469 308.04375 
@@ -1875,7 +1875,7 @@ z
    </g>
    <g id="line2d_54">
     <defs>
-     <path id="m8a0de763ec" d="M 0 3 
+     <path id="m132ce2a851" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1887,13 +1887,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #17becf"/>
     </defs>
-    <g clip-path="url(#p9492024f93)">
-     <use xlink:href="#m8a0de763ec" x="154.556151" y="296.619375" style="fill: #17becf; stroke: #17becf"/>
+    <g clip-path="url(#pad8457e370)">
+     <use xlink:href="#m132ce2a851" x="154.556151" y="296.619375" style="fill: #17becf; stroke: #17becf"/>
     </g>
    </g>
    <g id="line2d_55">
     <defs>
-     <path id="me608b17f9e" d="M 0 3 
+     <path id="meab2220eb7" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1905,13 +1905,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #e377c2"/>
     </defs>
-    <g clip-path="url(#p9492024f93)">
-     <use xlink:href="#me608b17f9e" x="162.32653" y="263.978304" style="fill: #e377c2; stroke: #e377c2"/>
+    <g clip-path="url(#pad8457e370)">
+     <use xlink:href="#meab2220eb7" x="162.32653" y="263.978304" style="fill: #e377c2; stroke: #e377c2"/>
     </g>
    </g>
    <g id="line2d_56">
     <defs>
-     <path id="m0403e17e87" d="M 0 5 
+     <path id="mfc4c4956a5" d="M 0 5 
 C 1.326016 5 2.597899 4.473168 3.535534 3.535534 
 C 4.473168 2.597899 5 1.326016 5 0 
 C 5 -1.326016 4.473168 -2.597899 3.535534 -3.535534 
@@ -1923,13 +1923,13 @@ C -2.597899 4.473168 -1.326016 5 0 5
 z
 " style="stroke: #d62728"/>
     </defs>
-    <g clip-path="url(#p9492024f93)">
-     <use xlink:href="#m0403e17e87" x="178.681331" y="231.337232" style="fill: #d62728; stroke: #d62728"/>
+    <g clip-path="url(#pad8457e370)">
+     <use xlink:href="#mfc4c4956a5" x="178.681331" y="231.337232" style="fill: #d62728; stroke: #d62728"/>
     </g>
    </g>
    <g id="line2d_57">
     <defs>
-     <path id="m44c8552612" d="M 0 3 
+     <path id="m3247c2044c" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1941,13 +1941,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #8c564b"/>
     </defs>
-    <g clip-path="url(#p9492024f93)">
-     <use xlink:href="#m44c8552612" x="201.044126" y="198.696161" style="fill: #8c564b; stroke: #8c564b"/>
+    <g clip-path="url(#pad8457e370)">
+     <use xlink:href="#m3247c2044c" x="201.044126" y="198.696161" style="fill: #8c564b; stroke: #8c564b"/>
     </g>
    </g>
    <g id="line2d_58">
     <defs>
-     <path id="mfd32cc826c" d="M 0 3 
+     <path id="mf12cb4b7ad" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1959,13 +1959,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #bcbd22"/>
     </defs>
-    <g clip-path="url(#p9492024f93)">
-     <use xlink:href="#mfd32cc826c" x="209.976983" y="166.055089" style="fill: #bcbd22; stroke: #bcbd22"/>
+    <g clip-path="url(#pad8457e370)">
+     <use xlink:href="#mf12cb4b7ad" x="209.976983" y="166.055089" style="fill: #bcbd22; stroke: #bcbd22"/>
     </g>
    </g>
    <g id="line2d_59">
     <defs>
-     <path id="m2a5c9c0a25" d="M 0 3 
+     <path id="m90b232df21" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1977,13 +1977,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #1f77b4"/>
     </defs>
-    <g clip-path="url(#p9492024f93)">
-     <use xlink:href="#m2a5c9c0a25" x="239.121093" y="133.414018" style="fill: #1f77b4; stroke: #1f77b4"/>
+    <g clip-path="url(#pad8457e370)">
+     <use xlink:href="#m90b232df21" x="239.121093" y="133.414018" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_60">
     <defs>
-     <path id="m9f530d1a0f" d="M 0 3 
+     <path id="me6a6dc1d06" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1995,13 +1995,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #2ca02c"/>
     </defs>
-    <g clip-path="url(#p9492024f93)">
-     <use xlink:href="#m9f530d1a0f" x="247.282543" y="100.772946" style="fill: #2ca02c; stroke: #2ca02c"/>
+    <g clip-path="url(#pad8457e370)">
+     <use xlink:href="#me6a6dc1d06" x="247.282543" y="100.772946" style="fill: #2ca02c; stroke: #2ca02c"/>
     </g>
    </g>
    <g id="line2d_61">
     <defs>
-     <path id="md52c44bc45" d="M 0 3 
+     <path id="mea3f864004" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -2013,8 +2013,8 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #9467bd"/>
     </defs>
-    <g clip-path="url(#p9492024f93)">
-     <use xlink:href="#md52c44bc45" x="285.279501" y="68.131875" style="fill: #9467bd; stroke: #9467bd"/>
+    <g clip-path="url(#pad8457e370)">
+     <use xlink:href="#mea3f864004" x="285.279501" y="68.131875" style="fill: #9467bd; stroke: #9467bd"/>
     </g>
    </g>
   </g>
@@ -2869,7 +2869,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p9492024f93">
+  <clipPath id="pad8457e370">
    <rect x="139.360469" y="56.7075" width="425.839531" height="251.33625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_ratio_heatmap.svg
+++ b/bench/graphs/silesia_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.34175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p00b904c5ea)">
+   <g clip-path="url(#p15995ccbd3)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAosAAAGaCAYAAABniAm0AAAJ/klEQVR4nO3Yu45eVx2H4ZnM+IDHmbEtSCLCQcJRQAqBEoWCKhWCgmvgCmioqBB3QMUN0KGI0k1KpACBEAogSkIQB1lDjB1jGXs8Mx9X8BYoWvqjT89zBT9pb6397rV7fvsnm50tdPLTW9MTlrjw6svTE5bZfebT0xOW2Lz1u+kJS+x+5aXpCUtsHt6fnrDM8fdfm56wxDM/+tb0hCV2bzw7PWGNk4fTC5Y5/+V2nvdPTQ8AAOD/l1gEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACDt/vvktc30iBUO/nU8PWGJDw+vTE9Y5j+nD6YnLPHZj06mJyzx0aeem56wxPnmfHrCMtf3b0xPWOPOB9MLlrh/fTuf19N//tP0hGU2L35tesISbhYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEj7B3duT29Y48q16QVLbDYn0xOW+czrv56esMar35xesMTRh/+YnrDG+en0gnUOtvT8uHR1esESh//czu/z3c/fnJ6wzPW/vj09YQk3iwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEDafXJ2azM9YoW94/enJyxx++mL0xOWefDk3vSEJW7+5d70hCVOv/z16QlLPDy9Pz1hmaO9a9MTlti896vpCUs8+sLL0xOWuPz2G9MTlnn81VemJyzhZhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIuz9/73ub6REr3Lh8MD1hiXfu3ZmesMx3f/yb6QlL/PaH356esMTRpaPpCUv84BdvTk9Y5hvPX56esMR3br4yPWGJ1//2xvSEJa5e2M73cGdnZ+dn796dnrCEm0UAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAg7T45u7WZHrHC3cfH0xOWONg/nJ6wzDv3fj89YYkXrr00PWGJzeZ8esISV0+39x/67+fbeS4+f/DC9IQlHp09nJ6wxLaeHTs7Ozt7T+1PT1hie09FAAA+NrEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAApP293f3pDUt8cu/G9IQ19i5OL1jm6NLR9IQlDvYPpycscbY5nZ6wxPmF7f2Hfm5zZXoC/4Nt/T6fbB5NT1jm/uPj6QlLbO+pCADAxyYWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBI+4/OHk5vWOLy7v70hCU+ePDH6QnLnJ6fTE9Y4/jd6QVL3D86nJ6wxOHFG9MTljk5ezQ9YYlP3H5/esISj5/93PSEJQ7+8Nb0hGUef/FL0xOWcLMIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAApP8Cc6OciHDVLsgAAAAASUVORK5CYII=" id="imagebf4923a7d4" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="468.72" height="295.2"/>
+iVBORw0KGgoAAAANSUhEUgAAAosAAAGaCAYAAABniAm0AAAJ/klEQVR4nO3Yu45eVx2H4ZnM+IDHmbEtSCLCQcJRQAqBEoWCKhWCgmvgCmioqBB3QMUN0KGI0k1KpACBEAogSkIQB1lDjB1jGXs8Mx9X8BYoWvqjT89zBT9pb6397rV7fvsnm50tdPLTW9MTlrjw6svTE5bZfebT0xOW2Lz1u+kJS+x+5aXpCUtsHt6fnrDM8fdfm56wxDM/+tb0hCV2bzw7PWGNk4fTC5Y5/+V2nvdPTQ8AAOD/l1gEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACDt/vvktc30iBUO/nU8PWGJDw+vTE9Y5j+nD6YnLPHZj06mJyzx0aeem56wxPnmfHrCMtf3b0xPWOPOB9MLlrh/fTuf19N//tP0hGU2L35tesISbhYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEj7B3duT29Y48q16QVLbDYn0xOW+czrv56esMar35xesMTRh/+YnrDG+en0gnUOtvT8uHR1esESh//czu/z3c/fnJ6wzPW/vj09YQk3iwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEDafXJ2azM9YoW94/enJyxx++mL0xOWefDk3vSEJW7+5d70hCVOv/z16QlLPDy9Pz1hmaO9a9MTlti896vpCUs8+sLL0xOWuPz2G9MTlnn81VemJyzhZhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIuz9/73ub6REr3Lh8MD1hiXfu3ZmesMx3f/yb6QlL/PaH356esMTRpaPpCUv84BdvTk9Y5hvPX56esMR3br4yPWGJ1//2xvSEJa5e2M73cGdnZ+dn796dnrCEm0UAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAg7T45u7WZHrHC3cfH0xOWONg/nJ6wzDv3fj89YYkXrr00PWGJzeZ8esISV0+39x/67+fbeS4+f/DC9IQlHp09nJ6wxLaeHTs7Ozt7T+1PT1hie09FAAA+NrEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAApP293f3pDUt8cu/G9IQ19i5OL1jm6NLR9IQlDvYPpycscbY5nZ6wxPmF7f2Hfm5zZXoC/4Nt/T6fbB5NT1jm/uPj6QlLbO+pCADAxyYWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBI+4/OHk5vWOLy7v70hCU+ePDH6QnLnJ6fTE9Y4/jd6QVL3D86nJ6wxOHFG9MTljk5ezQ9YYlP3H5/esISj5/93PSEJQ7+8Nb0hGUef/FL0xOWcLMIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAApP8Cc6OciHDVLsgAAAAASUVORK5CYII=" id="imaged420a3313d" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="468.72" height="295.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m7d744fcc73" d="M 0 0 
+       <path id="m9a3625595e" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m7d744fcc73" x="115.182137" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9a3625595e" x="115.182137" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m7d744fcc73" x="154.193912" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9a3625595e" x="154.193912" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m7d744fcc73" x="193.205687" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9a3625595e" x="193.205687" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m7d744fcc73" x="232.217462" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9a3625595e" x="232.217462" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m7d744fcc73" x="271.229237" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9a3625595e" x="271.229237" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m7d744fcc73" x="310.241012" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9a3625595e" x="310.241012" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m7d744fcc73" x="349.252787" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9a3625595e" x="349.252787" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m7d744fcc73" x="388.264562" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9a3625595e" x="388.264562" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m7d744fcc73" x="427.276336" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9a3625595e" x="427.276336" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m7d744fcc73" x="466.288111" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9a3625595e" x="466.288111" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m7d744fcc73" x="505.299886" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9a3625595e" x="505.299886" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m7d744fcc73" x="544.311661" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9a3625595e" x="544.311661" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="m71ed69b621" d="M 0 0 
+       <path id="me22f5a0b56" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m71ed69b621" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me22f5a0b56" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m71ed69b621" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me22f5a0b56" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m71ed69b621" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me22f5a0b56" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m71ed69b621" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me22f5a0b56" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -836,7 +836,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m71ed69b621" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me22f5a0b56" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -899,7 +899,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m71ed69b621" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me22f5a0b56" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -966,7 +966,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m71ed69b621" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me22f5a0b56" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1047,7 +1047,7 @@ z
     <g id="ytick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m71ed69b621" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me22f5a0b56" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -2060,18 +2060,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABEAAAFUCAYAAADCj9eRAAAB2ElEQVR4nO2aQY7EIAwEIeFP+6X9/33C3MPcKKSS1TygZRftNlLS2//fbJtn9KvvajAi17ZCM7Uzeg+TEyJhsh4TE8D25ZhYRMJkPSYmmZ0zIhfQEMPkJq74JpgQlUBMABkIrOV2KLMRItXMhrQjqcQUSszsbGuomFSbHULEAlblE0klor1zMaG0XwnDBDAsBVY0O4CIBizlE4ntEbCijK3mE8vKUPkEEIF8YslYje2RZFP5BJkdCxOonf1i6jEhRICOyjEBzFaPiWd2iChoYbKKhMkqgmSsh4kkHkU+6UyeACJEJaLZ6QQTzy7WtGPyicX2Kp/c+yKaATTliSWoTXsnPllEEtTLGX37f+7WRpuPQ4RhomlntCdMTohATIDbKceEaGfOD1BJZueIiImJZQBNTCxgw2Q91N7Zf7RBsxMmR0TqMdmvxPRmI0TmDJNVJExWkTBZRcJkFSnFZH6Q5aVhQrQzkYUOVEIxIXxSjAnRDjQ7mndsZud9VEwsPtFcsWjvaNZofHKoEpFPELCPJmORdqblMWxiYjEbw+QJk/dR+SQD+BbROFbEJAP4Q4RgQpiNCupKIhAT4gewakws7YTJIREoY4FPeNWYaNoJk18iQNqXY1LKJ1/07Ct/l+QCQgAAAABJRU5ErkJggg==" id="imaged6e0973c46" transform="scale(1 -1) translate(0 -244.8)" x="573.84" y="-74.16" width="12.24" height="244.8"/>
+iVBORw0KGgoAAAANSUhEUgAAABEAAAFUCAYAAADCj9eRAAAB2ElEQVR4nO2aQY7EIAwEIeFP+6X9/33C3MPcKKSS1TygZRftNlLS2//fbJtn9KvvajAi17ZCM7Uzeg+TEyJhsh4TE8D25ZhYRMJkPSYmmZ0zIhfQEMPkJq74JpgQlUBMABkIrOV2KLMRItXMhrQjqcQUSszsbGuomFSbHULEAlblE0klor1zMaG0XwnDBDAsBVY0O4CIBizlE4ntEbCijK3mE8vKUPkEEIF8YslYje2RZFP5BJkdCxOonf1i6jEhRICOyjEBzFaPiWd2iChoYbKKhMkqgmSsh4kkHkU+6UyeACJEJaLZ6QQTzy7WtGPyicX2Kp/c+yKaATTliSWoTXsnPllEEtTLGX37f+7WRpuPQ4RhomlntCdMTohATIDbKceEaGfOD1BJZueIiImJZQBNTCxgw2Q91N7Zf7RBsxMmR0TqMdmvxPRmI0TmDJNVJExWkTBZRcJkFSnFZH6Q5aVhQrQzkYUOVEIxIXxSjAnRDjQ7mndsZud9VEwsPtFcsWjvaNZofHKoEpFPELCPJmORdqblMWxiYjEbw+QJk/dR+SQD+BbROFbEJAP4Q4RgQpiNCupKIhAT4gewakws7YTJIREoY4FPeNWYaNoJk18iQNqXY1LKJ1/07Ct/l+QCQgAAAABJRU5ErkJggg==" id="image745ca6cab4" transform="scale(1 -1) translate(0 -244.8)" x="573.84" y="-74.16" width="12.24" height="244.8"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_21">
       <defs>
-       <path id="m494aba25a1" d="M 0 0 
+       <path id="m292dde7fd2" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m494aba25a1" x="585.876562" y="282.022672" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m292dde7fd2" x="585.876562" y="282.022672" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_117">
@@ -2097,7 +2097,7 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m494aba25a1" x="585.876562" y="239.353777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m292dde7fd2" x="585.876562" y="239.353777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_118">
@@ -2114,7 +2114,7 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m494aba25a1" x="585.876562" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m292dde7fd2" x="585.876562" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_119">
@@ -2130,7 +2130,7 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m494aba25a1" x="585.876562" y="154.015985" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m292dde7fd2" x="585.876562" y="154.015985" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_120">
@@ -2146,7 +2146,7 @@ z
     <g id="ytick_13">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m494aba25a1" x="585.876562" y="111.347089" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m292dde7fd2" x="585.876562" y="111.347089" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_121">
@@ -2739,8 +2739,8 @@ z
    </g>
   </g>
   <g id="text_124">
-   <!-- 2026-07-07T02:05:28Z  ·  Linux chungus2 x86_64  ·  commit 1a899305  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(43.462422 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-07T22:17:01Z  ·  Linux chungus2 x86_64  ·  commit dcf4b958  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(44.687422 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2764,6 +2764,44 @@ L 1409 3309
 L 1409 2516 
 L 750 2516 
 L 750 3309 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-b7" d="M 684 2619 
+L 1344 2619 
+L 1344 1825 
+L 684 1825 
+L 684 2619 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-4c" d="M 628 4666 
+L 1259 4666 
+L 1259 531 
+L 3531 531 
+L 3531 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-75" d="M 544 1381 
+L 544 3500 
+L 1119 3500 
+L 1119 1403 
+Q 1119 906 1312 657 
+Q 1506 409 1894 409 
+Q 2359 409 2629 706 
+Q 2900 1003 2900 1516 
+L 2900 3500 
+L 3475 3500 
+L 3475 0 
+L 2900 0 
+L 2900 538 
+Q 2691 219 2414 64 
+Q 2138 -91 1772 -91 
+Q 1169 -91 856 284 
+Q 544 659 544 1381 
+z
+M 1991 3584 
+L 1991 3584 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-38" d="M 2034 2216 
@@ -2805,44 +2843,6 @@ Q 1625 4250 1398 4047
 Q 1172 3844 1172 3481 
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-b7" d="M 684 2619 
-L 1344 2619 
-L 1344 1825 
-L 684 1825 
-L 684 2619 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-4c" d="M 628 4666 
-L 1259 4666 
-L 1259 531 
-L 3531 531 
-L 3531 0 
-L 628 0 
-L 628 4666 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-75" d="M 544 1381 
-L 544 3500 
-L 1119 3500 
-L 1119 1403 
-Q 1119 906 1312 657 
-Q 1506 409 1894 409 
-Q 2359 409 2629 706 
-Q 2900 1003 2900 1516 
-L 2900 3500 
-L 3475 3500 
-L 3475 0 
-L 2900 0 
-L 2900 538 
-Q 2691 219 2414 64 
-Q 2138 -91 1772 -91 
-Q 1169 -91 856 284 
-Q 544 659 544 1381 
-z
-M 1991 3584 
-L 1991 3584 
-z
-" transform="scale(0.015625)"/>
      <path id="DejaVuSans-3b" d="M 750 3309 
 L 1409 3309 
 L 1409 2516 
@@ -2870,14 +2870,14 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-37" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2917,109 +2917,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3196.777344 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3260.400391 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3324.023438 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3387.646484 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3451.269531 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3514.892578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3578.515625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3610.302734 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3642.089844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3673.876953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3705.664062 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3737.451172 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3765.234375 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3826.757812 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3888.037109 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3951.416016 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4014.892578 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4053.755859 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4114.9375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4174.117188 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4235.640625 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4276.753906 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4310.445312 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4338.228516 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4399.751953 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4461.03125 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4524.410156 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4588.033203 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4621.724609 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4680.904297 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4744.527344 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4776.314453 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4839.9375 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4903.560547 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4935.347656 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4998.970703 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5035.054688 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5073.917969 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5128.898438 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5192.521484 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5224.308594 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5256.095703 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5287.882812 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5319.669922 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5351.457031 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5390.666016 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5454.044922 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5492.908203 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5554.089844 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5617.46875 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5680.945312 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5744.324219 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5807.800781 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5871.179688 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5910.388672 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5942.175781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6025.964844 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6057.751953 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6155.164062 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6216.6875 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6280.164062 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6307.947266 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6369.226562 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6432.605469 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6464.392578 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6516.492188 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6579.871094 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6641.150391 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6704.626953 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6756.726562 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6820.105469 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6881.287109 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6920.496094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6954.1875 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6985.974609 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7027.087891 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7088.367188 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7127.576172 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7155.359375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7216.541016 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7248.328125 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7276.111328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7328.210938 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7359.998047 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7423.474609 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7484.998047 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7524.207031 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7585.730469 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7625.09375 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7722.505859 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7750.289062 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7813.667969 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7841.451172 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7893.550781 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7932.759766 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7960.542969 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3135.351562 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3190.332031 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3225.537109 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3289.160156 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3352.636719 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3416.259766 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3479.882812 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3543.505859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3575.292969 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3607.080078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3638.867188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3670.654297 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3702.441406 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3730.224609 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3791.748047 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3853.027344 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3916.40625 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3979.882812 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4018.746094 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4079.927734 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4139.107422 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4200.630859 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4241.744141 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4275.435547 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4303.21875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4364.742188 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4426.021484 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4489.400391 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4553.023438 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4586.714844 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4645.894531 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4709.517578 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4741.304688 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4804.927734 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4868.550781 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4900.337891 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4963.960938 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5000.044922 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5038.908203 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5093.888672 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5157.511719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5189.298828 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5221.085938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5252.873047 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5284.660156 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5316.447266 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5355.65625 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5419.035156 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5457.898438 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5519.080078 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5582.458984 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5645.935547 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5709.314453 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5772.791016 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5836.169922 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5875.378906 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5907.166016 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5990.955078 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6022.742188 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6120.154297 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6181.677734 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6245.154297 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6272.9375 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6334.216797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6397.595703 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6429.382812 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6481.482422 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6544.861328 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6606.140625 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6669.617188 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6721.716797 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6785.095703 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6846.277344 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6885.486328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6919.177734 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6950.964844 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6992.078125 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7053.357422 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7092.566406 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7120.349609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7181.53125 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7213.318359 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7241.101562 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7293.201172 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7324.988281 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7388.464844 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7449.988281 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7489.197266 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7550.720703 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7590.083984 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7687.496094 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7715.279297 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7778.658203 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7806.441406 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7858.541016 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7897.75 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7925.533203 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p00b904c5ea">
+  <clipPath id="p15995ccbd3">
    <rect x="95.67625" y="49.34175" width="468.141298" height="294.686261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_summary.svg
+++ b/bench/graphs/silesia_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="575.475156pt" height="386.202469pt" viewBox="0 0 575.475156 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="573.025156pt" height="386.202469pt" viewBox="0 0 573.025156 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,232 +22,232 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 386.202469 
-L 575.475156 386.202469 
-L 575.475156 0 
+L 573.025156 386.202469 
+L 573.025156 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 189.862578 104.1264 
-L 294.487578 104.1264 
-L 294.487578 74.7432 
-L 189.862578 74.7432 
+    <path d="M 188.637578 104.1264 
+L 293.262578 104.1264 
+L 293.262578 74.7432 
+L 188.637578 74.7432 
 z
-" clip-path="url(#pc239fd0050)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p3031c1b8b3)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 294.487578 104.1264 
-L 399.112578 104.1264 
-L 399.112578 74.7432 
-L 294.487578 74.7432 
+    <path d="M 293.262578 104.1264 
+L 397.887578 104.1264 
+L 397.887578 74.7432 
+L 293.262578 74.7432 
 z
-" clip-path="url(#pc239fd0050)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p3031c1b8b3)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 399.112578 104.1264 
-L 503.737578 104.1264 
-L 503.737578 74.7432 
-L 399.112578 74.7432 
+    <path d="M 397.887578 104.1264 
+L 502.512578 104.1264 
+L 502.512578 74.7432 
+L 397.887578 74.7432 
 z
-" clip-path="url(#pc239fd0050)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p3031c1b8b3)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 189.862578 133.5096 
-L 294.487578 133.5096 
-L 294.487578 104.1264 
-L 189.862578 104.1264 
+    <path d="M 188.637578 133.5096 
+L 293.262578 133.5096 
+L 293.262578 104.1264 
+L 188.637578 104.1264 
 z
-" clip-path="url(#pc239fd0050)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p3031c1b8b3)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 294.487578 133.5096 
-L 399.112578 133.5096 
-L 399.112578 104.1264 
-L 294.487578 104.1264 
+    <path d="M 293.262578 133.5096 
+L 397.887578 133.5096 
+L 397.887578 104.1264 
+L 293.262578 104.1264 
 z
-" clip-path="url(#pc239fd0050)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p3031c1b8b3)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 399.112578 133.5096 
-L 503.737578 133.5096 
-L 503.737578 104.1264 
-L 399.112578 104.1264 
+    <path d="M 397.887578 133.5096 
+L 502.512578 133.5096 
+L 502.512578 104.1264 
+L 397.887578 104.1264 
 z
-" clip-path="url(#pc239fd0050)" style="fill: #fece7c; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p3031c1b8b3)" style="fill: #fece7c; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 189.862578 162.8928 
-L 294.487578 162.8928 
-L 294.487578 133.5096 
-L 189.862578 133.5096 
+    <path d="M 188.637578 162.8928 
+L 293.262578 162.8928 
+L 293.262578 133.5096 
+L 188.637578 133.5096 
 z
-" clip-path="url(#pc239fd0050)" style="fill: #fee08b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p3031c1b8b3)" style="fill: #fee08b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 294.487578 162.8928 
-L 399.112578 162.8928 
-L 399.112578 133.5096 
-L 294.487578 133.5096 
+    <path d="M 293.262578 162.8928 
+L 397.887578 162.8928 
+L 397.887578 133.5096 
+L 293.262578 133.5096 
 z
-" clip-path="url(#pc239fd0050)" style="fill: #feefa3; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p3031c1b8b3)" style="fill: #feefa3; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 399.112578 162.8928 
-L 503.737578 162.8928 
-L 503.737578 133.5096 
-L 399.112578 133.5096 
+    <path d="M 397.887578 162.8928 
+L 502.512578 162.8928 
+L 502.512578 133.5096 
+L 397.887578 133.5096 
 z
-" clip-path="url(#pc239fd0050)" style="fill: #fdbf6f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p3031c1b8b3)" style="fill: #fdbf6f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 189.862578 192.276 
-L 294.487578 192.276 
-L 294.487578 162.8928 
-L 189.862578 162.8928 
+    <path d="M 188.637578 192.276 
+L 293.262578 192.276 
+L 293.262578 162.8928 
+L 188.637578 162.8928 
 z
-" clip-path="url(#pc239fd0050)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p3031c1b8b3)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 294.487578 192.276 
-L 399.112578 192.276 
-L 399.112578 162.8928 
-L 294.487578 162.8928 
+    <path d="M 293.262578 192.276 
+L 397.887578 192.276 
+L 397.887578 162.8928 
+L 293.262578 162.8928 
 z
-" clip-path="url(#pc239fd0050)" style="fill: #fede89; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p3031c1b8b3)" style="fill: #fede89; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 399.112578 192.276 
-L 503.737578 192.276 
-L 503.737578 162.8928 
-L 399.112578 162.8928 
+    <path d="M 397.887578 192.276 
+L 502.512578 192.276 
+L 502.512578 162.8928 
+L 397.887578 162.8928 
 z
-" clip-path="url(#pc239fd0050)" style="fill: #f7814c; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p3031c1b8b3)" style="fill: #f7814c; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 189.862578 221.6592 
-L 294.487578 221.6592 
-L 294.487578 192.276 
-L 189.862578 192.276 
+    <path d="M 188.637578 221.6592 
+L 293.262578 221.6592 
+L 293.262578 192.276 
+L 188.637578 192.276 
 z
-" clip-path="url(#pc239fd0050)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p3031c1b8b3)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 294.487578 221.6592 
-L 399.112578 221.6592 
-L 399.112578 192.276 
-L 294.487578 192.276 
+    <path d="M 293.262578 221.6592 
+L 397.887578 221.6592 
+L 397.887578 192.276 
+L 293.262578 192.276 
 z
-" clip-path="url(#pc239fd0050)" style="fill: #fed27f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p3031c1b8b3)" style="fill: #fed27f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 399.112578 221.6592 
-L 503.737578 221.6592 
-L 503.737578 192.276 
-L 399.112578 192.276 
+    <path d="M 397.887578 221.6592 
+L 502.512578 221.6592 
+L 502.512578 192.276 
+L 397.887578 192.276 
 z
-" clip-path="url(#pc239fd0050)" style="fill: #fffcba; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p3031c1b8b3)" style="fill: #fffcba; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 189.862578 251.0424 
-L 294.487578 251.0424 
-L 294.487578 221.6592 
-L 189.862578 221.6592 
+    <path d="M 188.637578 251.0424 
+L 293.262578 251.0424 
+L 293.262578 221.6592 
+L 188.637578 221.6592 
 z
-" clip-path="url(#pc239fd0050)" style="fill: #fff3ac; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p3031c1b8b3)" style="fill: #fff3ac; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 294.487578 251.0424 
-L 399.112578 251.0424 
-L 399.112578 221.6592 
-L 294.487578 221.6592 
+    <path d="M 293.262578 251.0424 
+L 397.887578 251.0424 
+L 397.887578 221.6592 
+L 293.262578 221.6592 
 z
-" clip-path="url(#pc239fd0050)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p3031c1b8b3)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 399.112578 251.0424 
-L 503.737578 251.0424 
-L 503.737578 221.6592 
-L 399.112578 221.6592 
+    <path d="M 397.887578 251.0424 
+L 502.512578 251.0424 
+L 502.512578 221.6592 
+L 397.887578 221.6592 
 z
-" clip-path="url(#pc239fd0050)" style="fill: #e8f59f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p3031c1b8b3)" style="fill: #e8f59f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 189.862578 280.4256 
-L 294.487578 280.4256 
-L 294.487578 251.0424 
-L 189.862578 251.0424 
+    <path d="M 188.637578 280.4256 
+L 293.262578 280.4256 
+L 293.262578 251.0424 
+L 188.637578 251.0424 
 z
-" clip-path="url(#pc239fd0050)" style="fill: #feec9f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p3031c1b8b3)" style="fill: #feec9f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 294.487578 280.4256 
-L 399.112578 280.4256 
-L 399.112578 251.0424 
-L 294.487578 251.0424 
+    <path d="M 293.262578 280.4256 
+L 397.887578 280.4256 
+L 397.887578 251.0424 
+L 293.262578 251.0424 
 z
-" clip-path="url(#pc239fd0050)" style="fill: #fdbf6f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p3031c1b8b3)" style="fill: #fdc171; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 399.112578 280.4256 
-L 503.737578 280.4256 
-L 503.737578 251.0424 
-L 399.112578 251.0424 
+    <path d="M 397.887578 280.4256 
+L 502.512578 280.4256 
+L 502.512578 251.0424 
+L 397.887578 251.0424 
 z
-" clip-path="url(#pc239fd0050)" style="fill: #f88950; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p3031c1b8b3)" style="fill: #f88c51; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 189.862578 309.8088 
-L 294.487578 309.8088 
-L 294.487578 280.4256 
-L 189.862578 280.4256 
+    <path d="M 188.637578 309.8088 
+L 293.262578 309.8088 
+L 293.262578 280.4256 
+L 188.637578 280.4256 
 z
-" clip-path="url(#pc239fd0050)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p3031c1b8b3)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 294.487578 309.8088 
-L 399.112578 309.8088 
-L 399.112578 280.4256 
-L 294.487578 280.4256 
+    <path d="M 293.262578 309.8088 
+L 397.887578 309.8088 
+L 397.887578 280.4256 
+L 293.262578 280.4256 
 z
-" clip-path="url(#pc239fd0050)" style="fill: #fa9b58; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p3031c1b8b3)" style="fill: #fa9b58; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 399.112578 309.8088 
-L 503.737578 309.8088 
-L 503.737578 280.4256 
-L 399.112578 280.4256 
+    <path d="M 397.887578 309.8088 
+L 502.512578 309.8088 
+L 502.512578 280.4256 
+L 397.887578 280.4256 
 z
-" clip-path="url(#pc239fd0050)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p3031c1b8b3)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 189.862578 339.192 
-L 294.487578 339.192 
-L 294.487578 309.8088 
-L 189.862578 309.8088 
+    <path d="M 188.637578 339.192 
+L 293.262578 339.192 
+L 293.262578 309.8088 
+L 188.637578 309.8088 
 z
-" clip-path="url(#pc239fd0050)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p3031c1b8b3)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 294.487578 339.192 
-L 399.112578 339.192 
-L 399.112578 309.8088 
-L 294.487578 309.8088 
+    <path d="M 293.262578 339.192 
+L 397.887578 339.192 
+L 397.887578 309.8088 
+L 293.262578 309.8088 
 z
-" clip-path="url(#pc239fd0050)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p3031c1b8b3)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 399.112578 339.192 
-L 503.737578 339.192 
-L 503.737578 309.8088 
-L 399.112578 309.8088 
+    <path d="M 397.887578 339.192 
+L 502.512578 339.192 
+L 502.512578 309.8088 
+L 397.887578 309.8088 
 z
-" clip-path="url(#pc239fd0050)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p3031c1b8b3)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(122.849844 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(121.624844 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(230.134063 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(228.909063 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(308.706172 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(307.481172 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(407.057891 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(405.832891 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(118.787578 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(117.562578 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.320 -->
-    <g transform="translate(230.723828 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(229.498828 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -918,7 +918,7 @@ z
    </g>
    <g id="text_7">
     <!-- 117 -->
-    <g transform="translate(339.165078 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(337.940078 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -952,7 +952,7 @@ z
    </g>
    <g id="text_8">
     <!-- 852 -->
-    <g transform="translate(443.790078 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(442.565078 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -1026,7 +1026,7 @@ z
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(113.425703 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(112.200703 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1125,7 +1125,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.324 -->
-    <g transform="translate(230.723828 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(229.498828 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1156,7 +1156,7 @@ z
    </g>
    <g id="text_11">
     <!-- 61 -->
-    <g transform="translate(341.710078 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(340.485078 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -1195,7 +1195,7 @@ z
    </g>
    <g id="text_12">
     <!-- 312 -->
-    <g transform="translate(443.790078 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(442.565078 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
@@ -1203,7 +1203,7 @@ z
    </g>
    <g id="text_13">
     <!-- Go compress/flate -->
-    <g transform="translate(101.118828 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(99.893828 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -1374,7 +1374,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.325 -->
-    <g transform="translate(230.723828 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(229.498828 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1384,14 +1384,14 @@ z
    </g>
    <g id="text_15">
     <!-- 50 -->
-    <g transform="translate(341.710078 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(340.485078 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
     <!-- 275 -->
-    <g transform="translate(443.790078 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(442.565078 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
@@ -1399,7 +1399,7 @@ z
    </g>
    <g id="text_17">
     <!-- JS fflate -->
-    <g transform="translate(122.151328 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(120.926328 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1459,7 +1459,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.329 -->
-    <g transform="translate(230.723828 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(229.498828 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-39" d="M 703 97 
 L 703 672 
@@ -1501,14 +1501,14 @@ z
    </g>
    <g id="text_19">
     <!-- 41 -->
-    <g transform="translate(341.710078 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(340.485078 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
     <!-- 160 -->
-    <g transform="translate(443.790078 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(442.565078 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -1516,7 +1516,7 @@ z
    </g>
    <g id="text_21">
     <!-- zlib -->
-    <g transform="translate(130.688828 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(129.463828 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1540,7 +1540,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.323 -->
-    <g transform="translate(230.723828 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(229.498828 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1550,14 +1550,14 @@ z
    </g>
    <g id="text_23">
     <!-- 38 -->
-    <g transform="translate(341.710078 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(340.485078 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_24">
     <!-- 448 -->
-    <g transform="translate(443.790078 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(442.565078 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(127.246094 0)"/>
@@ -1565,7 +1565,7 @@ z
    </g>
    <g id="text_25">
     <!-- miniz_oxide -->
-    <g transform="translate(113.995078 238.44705) scale(0.08 -0.08)">
+    <g transform="translate(112.770078 238.44705) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6e" d="M 3513 2113 
 L 3513 0 
@@ -1624,7 +1624,7 @@ z
    </g>
    <g id="text_26">
     <!-- 0.322 -->
-    <g transform="translate(230.723828 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(229.498828 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1634,14 +1634,14 @@ z
    </g>
    <g id="text_27">
     <!-- 36 -->
-    <g transform="translate(341.710078 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(340.485078 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_28">
     <!-- 527 -->
-    <g transform="translate(443.790078 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(442.565078 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
@@ -1649,7 +1649,7 @@ z
    </g>
    <g id="text_29">
     <!-- lean-zip (native) -->
-    <g transform="translate(100.496953 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(99.271953 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1758,7 +1758,7 @@ z
    </g>
    <g id="text_30">
     <!-- 0.323 -->
-    <g transform="translate(229.523203 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(228.298203 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1851,8 +1851,15 @@ z
     </g>
    </g>
    <g id="text_31">
-    <!-- 31 -->
-    <g transform="translate(341.233828 267.9415) scale(0.08 -0.08)">
+    <!-- 32 -->
+    <g transform="translate(340.008828 267.9415) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-Bold-33"/>
+     <use xlink:href="#DejaVuSans-Bold-32" transform="translate(69.580078 0)"/>
+    </g>
+   </g>
+   <g id="text_32">
+    <!-- 178 -->
+    <g transform="translate(441.850703 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-31" d="M 750 831 
 L 1813 831 
@@ -1868,15 +1875,6 @@ L 750 0
 L 750 831 
 z
 " transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-Bold-33"/>
-     <use xlink:href="#DejaVuSans-Bold-31" transform="translate(69.580078 0)"/>
-    </g>
-   </g>
-   <g id="text_32">
-    <!-- 176 -->
-    <g transform="translate(443.075703 267.9415) scale(0.08 -0.08)">
-     <defs>
       <path id="DejaVuSans-Bold-37" d="M 428 4666 
 L 3944 4666 
 L 3944 3988 
@@ -1887,45 +1885,54 @@ L 428 3781
 L 428 4666 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-36" d="M 2316 2303 
-Q 2000 2303 1842 2098 
-Q 1684 1894 1684 1484 
-Q 1684 1075 1842 870 
-Q 2000 666 2316 666 
-Q 2634 666 2792 870 
-Q 2950 1075 2950 1484 
-Q 2950 1894 2792 2098 
-Q 2634 2303 2316 2303 
+      <path id="DejaVuSans-Bold-38" d="M 2228 2088 
+Q 1891 2088 1709 1903 
+Q 1528 1719 1528 1375 
+Q 1528 1031 1709 848 
+Q 1891 666 2228 666 
+Q 2563 666 2741 848 
+Q 2919 1031 2919 1375 
+Q 2919 1722 2741 1905 
+Q 2563 2088 2228 2088 
 z
-M 3803 4544 
-L 3803 3681 
-Q 3506 3822 3243 3889 
-Q 2981 3956 2731 3956 
-Q 2194 3956 1894 3657 
-Q 1594 3359 1544 2772 
-Q 1750 2925 1990 3001 
-Q 2231 3078 2516 3078 
-Q 3231 3078 3670 2659 
-Q 4109 2241 4109 1563 
-Q 4109 813 3618 361 
-Q 3128 -91 2303 -91 
-Q 1394 -91 895 523 
-Q 397 1138 397 2266 
-Q 397 3422 980 4083 
-Q 1563 4744 2578 4744 
-Q 2900 4744 3203 4694 
-Q 3506 4644 3803 4544 
+M 1350 2484 
+Q 925 2613 709 2878 
+Q 494 3144 494 3541 
+Q 494 4131 934 4440 
+Q 1375 4750 2228 4750 
+Q 3075 4750 3515 4442 
+Q 3956 4134 3956 3541 
+Q 3956 3144 3739 2878 
+Q 3522 2613 3097 2484 
+Q 3572 2353 3814 2058 
+Q 4056 1763 4056 1313 
+Q 4056 619 3595 264 
+Q 3134 -91 2228 -91 
+Q 1319 -91 855 264 
+Q 391 619 391 1313 
+Q 391 1763 633 2058 
+Q 875 2353 1350 2484 
+z
+M 1631 3419 
+Q 1631 3141 1786 2991 
+Q 1941 2841 2228 2841 
+Q 2509 2841 2662 2991 
+Q 2816 3141 2816 3419 
+Q 2816 3697 2662 3845 
+Q 2509 3994 2228 3994 
+Q 1941 3994 1786 3844 
+Q 1631 3694 1631 3419 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-Bold-31"/>
      <use xlink:href="#DejaVuSans-Bold-37" transform="translate(69.580078 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-36" transform="translate(139.160156 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-38" transform="translate(139.160156 0)"/>
     </g>
    </g>
    <g id="text_33">
     <!-- OCaml decompress -->
-    <g transform="translate(98.611953 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(97.386953 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -1990,7 +1997,7 @@ z
    </g>
    <g id="text_34">
     <!-- 0.336 -->
-    <g transform="translate(230.723828 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(229.498828 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -2000,21 +2007,21 @@ z
    </g>
    <g id="text_35">
     <!-- 21 -->
-    <g transform="translate(341.710078 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(340.485078 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_36">
     <!-- 69 -->
-    <g transform="translate(446.335078 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(445.110078 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-36"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(126.833203 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(125.608203 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -2025,7 +2032,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.303 -->
-    <g transform="translate(230.723828 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(229.498828 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -2035,13 +2042,13 @@ z
    </g>
    <g id="text_39">
     <!-- 1 -->
-    <g transform="translate(344.255078 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(343.030078 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(447.425078 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(446.200078 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2057,7 +2064,7 @@ z
   </g>
   <g id="text_41">
    <!-- silesia — geomean over files, level 6 -->
-   <g transform="translate(154.339297 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(153.114297 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-2014" d="M 344 2156 
 L 6056 2156 
@@ -2130,6 +2137,36 @@ L 653 256
 L 653 1209 
 z
 " transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-36" d="M 2316 2303 
+Q 2000 2303 1842 2098 
+Q 1684 1894 1684 1484 
+Q 1684 1075 1842 870 
+Q 2000 666 2316 666 
+Q 2634 666 2792 870 
+Q 2950 1075 2950 1484 
+Q 2950 1894 2792 2098 
+Q 2634 2303 2316 2303 
+z
+M 3803 4544 
+L 3803 3681 
+Q 3506 3822 3243 3889 
+Q 2981 3956 2731 3956 
+Q 2194 3956 1894 3657 
+Q 1594 3359 1544 2772 
+Q 1750 2925 1990 3001 
+Q 2231 3078 2516 3078 
+Q 3231 3078 3670 2659 
+Q 4109 2241 4109 1563 
+Q 4109 813 3618 361 
+Q 3128 -91 2303 -91 
+Q 1394 -91 895 523 
+Q 397 1138 397 2266 
+Q 397 3422 980 4083 
+Q 1563 4744 2578 4744 
+Q 2900 4744 3203 4694 
+Q 3506 4644 3803 4544 
+z
+" transform="scale(0.015625)"/>
     </defs>
     <use xlink:href="#DejaVuSans-Bold-73"/>
     <use xlink:href="#DejaVuSans-Bold-69" transform="translate(59.521484 0)"/>
@@ -2171,7 +2208,7 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-07-07T02:05:28Z  ·  Linux chungus2 x86_64  ·  commit 1a899305  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-07-07T22:17:01Z  ·  Linux chungus2 x86_64  ·  commit dcf4b958  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2312,14 +2349,14 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-37" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2359,110 +2396,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3196.777344 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3260.400391 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3324.023438 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3387.646484 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3451.269531 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3514.892578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3578.515625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3610.302734 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3642.089844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3673.876953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3705.664062 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3737.451172 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3765.234375 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3826.757812 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3888.037109 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3951.416016 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4014.892578 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4053.755859 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4114.9375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4174.117188 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4235.640625 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4276.753906 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4310.445312 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4338.228516 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4399.751953 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4461.03125 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4524.410156 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4588.033203 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4621.724609 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4680.904297 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4744.527344 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4776.314453 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4839.9375 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4903.560547 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4935.347656 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4998.970703 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5035.054688 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5073.917969 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5128.898438 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5192.521484 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5224.308594 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5256.095703 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5287.882812 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5319.669922 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5351.457031 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5390.666016 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5454.044922 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5492.908203 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5554.089844 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5617.46875 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5680.945312 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5744.324219 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5807.800781 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5871.179688 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5910.388672 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5942.175781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6025.964844 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6057.751953 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6155.164062 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6216.6875 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6280.164062 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6307.947266 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6369.226562 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6432.605469 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6464.392578 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6516.492188 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6579.871094 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6641.150391 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6704.626953 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6756.726562 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6820.105469 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6881.287109 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6920.496094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6954.1875 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6985.974609 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7027.087891 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7088.367188 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7127.576172 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7155.359375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7216.541016 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7248.328125 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7276.111328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7328.210938 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7359.998047 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7423.474609 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7484.998047 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7524.207031 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7585.730469 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7625.09375 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7722.505859 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7750.289062 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7813.667969 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7841.451172 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7893.550781 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7932.759766 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7960.542969 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3135.351562 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3190.332031 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3225.537109 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3289.160156 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3352.636719 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3416.259766 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3479.882812 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3543.505859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3575.292969 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3607.080078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3638.867188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3670.654297 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3702.441406 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3730.224609 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3791.748047 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3853.027344 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3916.40625 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3979.882812 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4018.746094 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4079.927734 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4139.107422 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4200.630859 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4241.744141 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4275.435547 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4303.21875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4364.742188 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4426.021484 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4489.400391 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4553.023438 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4586.714844 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4645.894531 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4709.517578 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4741.304688 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4804.927734 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4868.550781 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4900.337891 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4963.960938 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5000.044922 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5038.908203 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5093.888672 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5157.511719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5189.298828 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5221.085938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5252.873047 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5284.660156 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5316.447266 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5355.65625 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5419.035156 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5457.898438 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5519.080078 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5582.458984 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5645.935547 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5709.314453 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5772.791016 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5836.169922 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5875.378906 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5907.166016 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5990.955078 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6022.742188 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6120.154297 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6181.677734 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6245.154297 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6272.9375 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6334.216797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6397.595703 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6429.382812 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6481.482422 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6544.861328 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6606.140625 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6669.617188 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6721.716797 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6785.095703 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6846.277344 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6885.486328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6919.177734 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6950.964844 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6992.078125 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7053.357422 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7092.566406 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7120.349609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7181.53125 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7213.318359 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7241.101562 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7293.201172 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7324.988281 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7388.464844 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7449.988281 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7489.197266 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7550.720703 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7590.083984 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7687.496094 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7715.279297 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7778.658203 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7806.441406 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7858.541016 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7897.75 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7925.533203 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pc239fd0050">
-   <rect x="85.237578" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="p3031c1b8b3">
+   <rect x="84.012578" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/results/latest.json
+++ b/bench/results/latest.json
@@ -1,8 +1,8 @@
 {
  "meta": {
-  "date": "2026-07-07T02:05:28Z",
+  "date": "2026-07-07T22:17:01Z",
   "machine": "Linux chungus2 x86_64",
-  "git_commit": "1a899305",
+  "git_commit": "dcf4b958",
   "toolchain": "leanprover/lean4:v4.30.0-rc2",
   "note": "compress_mbps/decompress_mbps are a median-of-5 snapshot on the machine above; ratio is deterministic"
  },
@@ -14,8 +14,8 @@
    "level": 1,
    "out_size": 60455,
    "ratio": 0.3975,
-   "compress_mbps": 67.22,
-   "decompress_mbps": 109.18
+   "compress_mbps": 66.86,
+   "decompress_mbps": 109.65
   },
   {
    "compressor": "native",
@@ -24,8 +24,8 @@
    "level": 2,
    "out_size": 56316,
    "ratio": 0.3703,
-   "compress_mbps": 48.8,
-   "decompress_mbps": 120.91
+   "compress_mbps": 48.87,
+   "decompress_mbps": 121.62
   },
   {
    "compressor": "native",
@@ -34,8 +34,8 @@
    "level": 3,
    "out_size": 55646,
    "ratio": 0.3659,
-   "compress_mbps": 42.97,
-   "decompress_mbps": 131.75
+   "compress_mbps": 43.64,
+   "decompress_mbps": 132.82
   },
   {
    "compressor": "native",
@@ -44,8 +44,8 @@
    "level": 4,
    "out_size": 54357,
    "ratio": 0.3574,
-   "compress_mbps": 34.2,
-   "decompress_mbps": 135.12
+   "compress_mbps": 34.15,
+   "decompress_mbps": 136.22
   },
   {
    "compressor": "native",
@@ -54,8 +54,8 @@
    "level": 5,
    "out_size": 54078,
    "ratio": 0.3556,
-   "compress_mbps": 27.67,
-   "decompress_mbps": 142.1
+   "compress_mbps": 27.59,
+   "decompress_mbps": 143.63
   },
   {
    "compressor": "native",
@@ -64,8 +64,8 @@
    "level": 6,
    "out_size": 54013,
    "ratio": 0.3551,
-   "compress_mbps": 26.29,
-   "decompress_mbps": 146.61
+   "compress_mbps": 26.89,
+   "decompress_mbps": 148.13
   },
   {
    "compressor": "native",
@@ -74,8 +74,8 @@
    "level": 7,
    "out_size": 53772,
    "ratio": 0.3536,
-   "compress_mbps": 22.24,
-   "decompress_mbps": 147.94
+   "compress_mbps": 22.67,
+   "decompress_mbps": 148.55
   },
   {
    "compressor": "native",
@@ -84,8 +84,8 @@
    "level": 8,
    "out_size": 53753,
    "ratio": 0.3534,
-   "compress_mbps": 21.33,
-   "decompress_mbps": 148.36
+   "compress_mbps": 21.73,
+   "decompress_mbps": 149.0
   },
   {
    "compressor": "native",
@@ -94,8 +94,8 @@
    "level": 9,
    "out_size": 52732,
    "ratio": 0.3467,
-   "compress_mbps": 4.11,
-   "decompress_mbps": 148.06
+   "compress_mbps": 4.16,
+   "decompress_mbps": 148.97
   },
   {
    "compressor": "native",
@@ -104,7 +104,7 @@
    "level": 10,
    "out_size": 52078,
    "ratio": 0.3424,
-   "compress_mbps": 2.29,
+   "compress_mbps": 2.28,
    "decompress_mbps": null
   },
   {
@@ -114,8 +114,8 @@
    "level": 1,
    "out_size": 53135,
    "ratio": 0.4245,
-   "compress_mbps": 61.58,
-   "decompress_mbps": 103.34
+   "compress_mbps": 61.38,
+   "decompress_mbps": 103.52
   },
   {
    "compressor": "native",
@@ -124,8 +124,8 @@
    "level": 2,
    "out_size": 50187,
    "ratio": 0.4009,
-   "compress_mbps": 45.75,
-   "decompress_mbps": 110.86
+   "compress_mbps": 45.9,
+   "decompress_mbps": 111.06
   },
   {
    "compressor": "native",
@@ -134,8 +134,8 @@
    "level": 3,
    "out_size": 49810,
    "ratio": 0.3979,
-   "compress_mbps": 41.35,
-   "decompress_mbps": 120.03
+   "compress_mbps": 41.56,
+   "decompress_mbps": 120.26
   },
   {
    "compressor": "native",
@@ -144,8 +144,8 @@
    "level": 4,
    "out_size": 48687,
    "ratio": 0.3889,
-   "compress_mbps": 32.23,
-   "decompress_mbps": 124.37
+   "compress_mbps": 32.4,
+   "decompress_mbps": 125.19
   },
   {
    "compressor": "native",
@@ -154,8 +154,8 @@
    "level": 5,
    "out_size": 48586,
    "ratio": 0.3881,
-   "compress_mbps": 27.91,
-   "decompress_mbps": 130.39
+   "compress_mbps": 27.97,
+   "decompress_mbps": 130.9
   },
   {
    "compressor": "native",
@@ -164,8 +164,8 @@
    "level": 6,
    "out_size": 48373,
    "ratio": 0.3864,
-   "compress_mbps": 25.14,
-   "decompress_mbps": 133.16
+   "compress_mbps": 25.93,
+   "decompress_mbps": 133.91
   },
   {
    "compressor": "native",
@@ -174,8 +174,8 @@
    "level": 7,
    "out_size": 48288,
    "ratio": 0.3858,
-   "compress_mbps": 22.99,
-   "decompress_mbps": 133.13
+   "compress_mbps": 23.62,
+   "decompress_mbps": 134.16
   },
   {
    "compressor": "native",
@@ -184,8 +184,8 @@
    "level": 8,
    "out_size": 48284,
    "ratio": 0.3857,
-   "compress_mbps": 22.76,
-   "decompress_mbps": 133.62
+   "compress_mbps": 23.3,
+   "decompress_mbps": 134.3
   },
   {
    "compressor": "native",
@@ -194,8 +194,8 @@
    "level": 9,
    "out_size": 47430,
    "ratio": 0.3789,
-   "compress_mbps": 4.47,
-   "decompress_mbps": 133.68
+   "compress_mbps": 4.48,
+   "decompress_mbps": 134.46
   },
   {
    "compressor": "native",
@@ -214,8 +214,8 @@
    "level": 1,
    "out_size": 8476,
    "ratio": 0.3445,
-   "compress_mbps": 61.26,
-   "decompress_mbps": 123.0
+   "compress_mbps": 60.18,
+   "decompress_mbps": 122.19
   },
   {
    "compressor": "native",
@@ -224,8 +224,8 @@
    "level": 2,
    "out_size": 8271,
    "ratio": 0.3362,
-   "compress_mbps": 49.86,
-   "decompress_mbps": 126.95
+   "compress_mbps": 50.4,
+   "decompress_mbps": 127.03
   },
   {
    "compressor": "native",
@@ -234,8 +234,8 @@
    "level": 3,
    "out_size": 8158,
    "ratio": 0.3316,
-   "compress_mbps": 48.13,
-   "decompress_mbps": 130.01
+   "compress_mbps": 48.63,
+   "decompress_mbps": 129.5
   },
   {
    "compressor": "native",
@@ -244,8 +244,8 @@
    "level": 4,
    "out_size": 7948,
    "ratio": 0.3231,
-   "compress_mbps": 43.22,
-   "decompress_mbps": 136.0
+   "compress_mbps": 43.46,
+   "decompress_mbps": 135.42
   },
   {
    "compressor": "native",
@@ -254,8 +254,8 @@
    "level": 5,
    "out_size": 7899,
    "ratio": 0.3211,
-   "compress_mbps": 37.04,
-   "decompress_mbps": 140.25
+   "compress_mbps": 37.02,
+   "decompress_mbps": 139.78
   },
   {
    "compressor": "native",
@@ -264,8 +264,8 @@
    "level": 6,
    "out_size": 7912,
    "ratio": 0.3216,
-   "compress_mbps": 36.45,
-   "decompress_mbps": 141.59
+   "compress_mbps": 36.46,
+   "decompress_mbps": 140.28
   },
   {
    "compressor": "native",
@@ -274,8 +274,8 @@
    "level": 7,
    "out_size": 7897,
    "ratio": 0.321,
-   "compress_mbps": 33.25,
-   "decompress_mbps": 143.05
+   "compress_mbps": 33.28,
+   "decompress_mbps": 141.44
   },
   {
    "compressor": "native",
@@ -284,8 +284,8 @@
    "level": 8,
    "out_size": 7897,
    "ratio": 0.321,
-   "compress_mbps": 33.33,
-   "decompress_mbps": 141.37
+   "compress_mbps": 32.95,
+   "decompress_mbps": 141.87
   },
   {
    "compressor": "native",
@@ -294,8 +294,8 @@
    "level": 9,
    "out_size": 7803,
    "ratio": 0.3172,
-   "compress_mbps": 4.64,
-   "decompress_mbps": 141.62
+   "compress_mbps": 4.74,
+   "decompress_mbps": 141.72
   },
   {
    "compressor": "native",
@@ -314,8 +314,8 @@
    "level": 1,
    "out_size": 3509,
    "ratio": 0.3147,
-   "compress_mbps": 46.78,
-   "decompress_mbps": 98.8
+   "compress_mbps": 45.66,
+   "decompress_mbps": 98.83
   },
   {
    "compressor": "native",
@@ -324,8 +324,8 @@
    "level": 2,
    "out_size": 3269,
    "ratio": 0.2932,
-   "compress_mbps": 40.66,
-   "decompress_mbps": 100.97
+   "compress_mbps": 39.96,
+   "decompress_mbps": 101.51
   },
   {
    "compressor": "native",
@@ -334,8 +334,8 @@
    "level": 3,
    "out_size": 3208,
    "ratio": 0.2877,
-   "compress_mbps": 39.53,
-   "decompress_mbps": 105.6
+   "compress_mbps": 38.9,
+   "decompress_mbps": 104.97
   },
   {
    "compressor": "native",
@@ -344,8 +344,8 @@
    "level": 4,
    "out_size": 3128,
    "ratio": 0.2805,
-   "compress_mbps": 36.69,
-   "decompress_mbps": 107.41
+   "compress_mbps": 36.06,
+   "decompress_mbps": 107.64
   },
   {
    "compressor": "native",
@@ -354,8 +354,8 @@
    "level": 5,
    "out_size": 3111,
    "ratio": 0.279,
-   "compress_mbps": 32.93,
-   "decompress_mbps": 109.54
+   "compress_mbps": 32.18,
+   "decompress_mbps": 109.48
   },
   {
    "compressor": "native",
@@ -364,8 +364,8 @@
    "level": 6,
    "out_size": 3119,
    "ratio": 0.2797,
-   "compress_mbps": 33.17,
-   "decompress_mbps": 110.51
+   "compress_mbps": 32.46,
+   "decompress_mbps": 110.26
   },
   {
    "compressor": "native",
@@ -374,8 +374,8 @@
    "level": 7,
    "out_size": 3111,
    "ratio": 0.279,
-   "compress_mbps": 31.13,
-   "decompress_mbps": 110.96
+   "compress_mbps": 30.63,
+   "decompress_mbps": 110.31
   },
   {
    "compressor": "native",
@@ -384,8 +384,8 @@
    "level": 8,
    "out_size": 3111,
    "ratio": 0.279,
-   "compress_mbps": 31.06,
-   "decompress_mbps": 110.86
+   "compress_mbps": 30.54,
+   "decompress_mbps": 110.29
   },
   {
    "compressor": "native",
@@ -394,8 +394,8 @@
    "level": 9,
    "out_size": 3056,
    "ratio": 0.2741,
-   "compress_mbps": 5.2,
-   "decompress_mbps": 110.52
+   "compress_mbps": 5.22,
+   "decompress_mbps": 110.44
   },
   {
    "compressor": "native",
@@ -404,7 +404,7 @@
    "level": 10,
    "out_size": 3032,
    "ratio": 0.2719,
-   "compress_mbps": 2.9,
+   "compress_mbps": 2.91,
    "decompress_mbps": null
   },
   {
@@ -414,8 +414,8 @@
    "level": 1,
    "out_size": 1282,
    "ratio": 0.3445,
-   "compress_mbps": 24.34,
-   "decompress_mbps": 56.31
+   "compress_mbps": 23.66,
+   "decompress_mbps": 55.63
   },
   {
    "compressor": "native",
@@ -424,8 +424,8 @@
    "level": 2,
    "out_size": 1225,
    "ratio": 0.3292,
-   "compress_mbps": 22.93,
-   "decompress_mbps": 57.01
+   "compress_mbps": 22.4,
+   "decompress_mbps": 56.62
   },
   {
    "compressor": "native",
@@ -434,8 +434,8 @@
    "level": 3,
    "out_size": 1220,
    "ratio": 0.3279,
-   "compress_mbps": 22.62,
-   "decompress_mbps": 56.87
+   "compress_mbps": 22.13,
+   "decompress_mbps": 56.59
   },
   {
    "compressor": "native",
@@ -444,8 +444,8 @@
    "level": 4,
    "out_size": 1213,
    "ratio": 0.326,
-   "compress_mbps": 22.21,
-   "decompress_mbps": 58.11
+   "compress_mbps": 21.62,
+   "decompress_mbps": 57.51
   },
   {
    "compressor": "native",
@@ -454,8 +454,8 @@
    "level": 5,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 21.33,
-   "decompress_mbps": 58.8
+   "compress_mbps": 20.82,
+   "decompress_mbps": 58.15
   },
   {
    "compressor": "native",
@@ -464,8 +464,8 @@
    "level": 6,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 21.06,
-   "decompress_mbps": 58.77
+   "compress_mbps": 20.43,
+   "decompress_mbps": 58.24
   },
   {
    "compressor": "native",
@@ -474,8 +474,8 @@
    "level": 7,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 20.84,
-   "decompress_mbps": 58.9
+   "compress_mbps": 20.26,
+   "decompress_mbps": 57.99
   },
   {
    "compressor": "native",
@@ -484,8 +484,8 @@
    "level": 8,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 20.87,
-   "decompress_mbps": 58.8
+   "compress_mbps": 20.25,
+   "decompress_mbps": 58.33
   },
   {
    "compressor": "native",
@@ -495,7 +495,7 @@
    "out_size": 1205,
    "ratio": 0.3238,
    "compress_mbps": 4.75,
-   "decompress_mbps": 58.76
+   "decompress_mbps": 58.27
   },
   {
    "compressor": "native",
@@ -514,8 +514,8 @@
    "level": 1,
    "out_size": 251793,
    "ratio": 0.2445,
-   "compress_mbps": 129.53,
-   "decompress_mbps": 203.89
+   "compress_mbps": 127.8,
+   "decompress_mbps": 206.06
   },
   {
    "compressor": "native",
@@ -524,8 +524,8 @@
    "level": 2,
    "out_size": 242565,
    "ratio": 0.2356,
-   "compress_mbps": 89.75,
-   "decompress_mbps": 218.38
+   "compress_mbps": 88.97,
+   "decompress_mbps": 220.59
   },
   {
    "compressor": "native",
@@ -534,8 +534,8 @@
    "level": 3,
    "out_size": 242532,
    "ratio": 0.2355,
-   "compress_mbps": 76.33,
-   "decompress_mbps": 226.74
+   "compress_mbps": 75.91,
+   "decompress_mbps": 229.51
   },
   {
    "compressor": "native",
@@ -544,8 +544,8 @@
    "level": 4,
    "out_size": 239953,
    "ratio": 0.233,
-   "compress_mbps": 73.66,
-   "decompress_mbps": 233.53
+   "compress_mbps": 73.85,
+   "decompress_mbps": 236.28
   },
   {
    "compressor": "native",
@@ -554,8 +554,8 @@
    "level": 5,
    "out_size": 218565,
    "ratio": 0.2123,
-   "compress_mbps": 49.77,
-   "decompress_mbps": 231.63
+   "compress_mbps": 49.86,
+   "decompress_mbps": 232.2
   },
   {
    "compressor": "native",
@@ -564,8 +564,8 @@
    "level": 6,
    "out_size": 202676,
    "ratio": 0.1968,
-   "compress_mbps": 37.12,
-   "decompress_mbps": 237.54
+   "compress_mbps": 37.69,
+   "decompress_mbps": 238.56
   },
   {
    "compressor": "native",
@@ -574,8 +574,8 @@
    "level": 7,
    "out_size": 201403,
    "ratio": 0.1956,
-   "compress_mbps": 27.5,
-   "decompress_mbps": 239.92
+   "compress_mbps": 28.01,
+   "decompress_mbps": 241.08
   },
   {
    "compressor": "native",
@@ -584,8 +584,8 @@
    "level": 8,
    "out_size": 200798,
    "ratio": 0.195,
-   "compress_mbps": 20.99,
-   "decompress_mbps": 242.41
+   "compress_mbps": 21.14,
+   "decompress_mbps": 243.51
   },
   {
    "compressor": "native",
@@ -594,8 +594,8 @@
    "level": 9,
    "out_size": 182508,
    "ratio": 0.1772,
-   "compress_mbps": 3.31,
-   "decompress_mbps": 243.82
+   "compress_mbps": 3.36,
+   "decompress_mbps": 244.31
   },
   {
    "compressor": "native",
@@ -604,7 +604,7 @@
    "level": 10,
    "out_size": 178067,
    "ratio": 0.1729,
-   "compress_mbps": 1.4,
+   "compress_mbps": 1.41,
    "decompress_mbps": null
   },
   {
@@ -614,8 +614,8 @@
    "level": 1,
    "out_size": 160674,
    "ratio": 0.3765,
-   "compress_mbps": 73.24,
-   "decompress_mbps": 116.61
+   "compress_mbps": 72.97,
+   "decompress_mbps": 117.65
   },
   {
    "compressor": "native",
@@ -624,8 +624,8 @@
    "level": 2,
    "out_size": 149787,
    "ratio": 0.351,
-   "compress_mbps": 51.47,
-   "decompress_mbps": 125.79
+   "compress_mbps": 52.46,
+   "decompress_mbps": 126.41
   },
   {
    "compressor": "native",
@@ -634,8 +634,8 @@
    "level": 3,
    "out_size": 148055,
    "ratio": 0.3469,
-   "compress_mbps": 45.44,
-   "decompress_mbps": 138.43
+   "compress_mbps": 46.56,
+   "decompress_mbps": 139.13
   },
   {
    "compressor": "native",
@@ -644,8 +644,8 @@
    "level": 4,
    "out_size": 144750,
    "ratio": 0.3392,
-   "compress_mbps": 36.75,
-   "decompress_mbps": 142.63
+   "compress_mbps": 36.69,
+   "decompress_mbps": 144.01
   },
   {
    "compressor": "native",
@@ -655,7 +655,7 @@
    "out_size": 144408,
    "ratio": 0.3384,
    "compress_mbps": 29.71,
-   "decompress_mbps": 150.03
+   "decompress_mbps": 151.45
   },
   {
    "compressor": "native",
@@ -664,8 +664,8 @@
    "level": 6,
    "out_size": 144070,
    "ratio": 0.3376,
-   "compress_mbps": 27.98,
-   "decompress_mbps": 153.71
+   "compress_mbps": 28.4,
+   "decompress_mbps": 154.78
   },
   {
    "compressor": "native",
@@ -674,8 +674,8 @@
    "level": 7,
    "out_size": 143628,
    "ratio": 0.3366,
-   "compress_mbps": 23.81,
-   "decompress_mbps": 154.4
+   "compress_mbps": 24.33,
+   "decompress_mbps": 155.66
   },
   {
    "compressor": "native",
@@ -684,8 +684,8 @@
    "level": 8,
    "out_size": 143569,
    "ratio": 0.3364,
-   "compress_mbps": 23.11,
-   "decompress_mbps": 154.16
+   "compress_mbps": 23.49,
+   "decompress_mbps": 155.78
   },
   {
    "compressor": "native",
@@ -694,8 +694,8 @@
    "level": 9,
    "out_size": 140322,
    "ratio": 0.3288,
-   "compress_mbps": 4.08,
-   "decompress_mbps": 155.28
+   "compress_mbps": 4.12,
+   "decompress_mbps": 155.58
   },
   {
    "compressor": "native",
@@ -704,7 +704,7 @@
    "level": 10,
    "out_size": 138830,
    "ratio": 0.3253,
-   "compress_mbps": 2.38,
+   "compress_mbps": 2.42,
    "decompress_mbps": null
   },
   {
@@ -714,8 +714,8 @@
    "level": 1,
    "out_size": 212588,
    "ratio": 0.4412,
-   "compress_mbps": 62.42,
-   "decompress_mbps": 97.01
+   "compress_mbps": 61.98,
+   "decompress_mbps": 98.41
   },
   {
    "compressor": "native",
@@ -724,8 +724,8 @@
    "level": 2,
    "out_size": 199981,
    "ratio": 0.415,
-   "compress_mbps": 44.2,
-   "decompress_mbps": 105.76
+   "compress_mbps": 44.57,
+   "decompress_mbps": 107.07
   },
   {
    "compressor": "native",
@@ -734,8 +734,8 @@
    "level": 3,
    "out_size": 198551,
    "ratio": 0.4121,
-   "compress_mbps": 38.94,
-   "decompress_mbps": 115.1
+   "compress_mbps": 39.73,
+   "decompress_mbps": 117.19
   },
   {
    "compressor": "native",
@@ -744,8 +744,8 @@
    "level": 4,
    "out_size": 193783,
    "ratio": 0.4022,
-   "compress_mbps": 29.28,
-   "decompress_mbps": 119.1
+   "compress_mbps": 29.14,
+   "decompress_mbps": 121.01
   },
   {
    "compressor": "native",
@@ -754,8 +754,8 @@
    "level": 5,
    "out_size": 193223,
    "ratio": 0.401,
-   "compress_mbps": 24.6,
-   "decompress_mbps": 125.4
+   "compress_mbps": 24.47,
+   "decompress_mbps": 127.1
   },
   {
    "compressor": "native",
@@ -764,8 +764,8 @@
    "level": 6,
    "out_size": 193416,
    "ratio": 0.4014,
-   "compress_mbps": 23.88,
-   "decompress_mbps": 128.73
+   "compress_mbps": 24.56,
+   "decompress_mbps": 130.54
   },
   {
    "compressor": "native",
@@ -774,8 +774,8 @@
    "level": 7,
    "out_size": 192664,
    "ratio": 0.3998,
-   "compress_mbps": 20.28,
-   "decompress_mbps": 128.97
+   "compress_mbps": 20.51,
+   "decompress_mbps": 130.68
   },
   {
    "compressor": "native",
@@ -784,8 +784,8 @@
    "level": 8,
    "out_size": 192638,
    "ratio": 0.3998,
-   "compress_mbps": 19.65,
-   "decompress_mbps": 129.82
+   "compress_mbps": 19.69,
+   "decompress_mbps": 131.14
   },
   {
    "compressor": "native",
@@ -794,8 +794,8 @@
    "level": 9,
    "out_size": 189365,
    "ratio": 0.393,
-   "compress_mbps": 3.9,
-   "decompress_mbps": 129.92
+   "compress_mbps": 3.88,
+   "decompress_mbps": 131.46
   },
   {
    "compressor": "native",
@@ -814,8 +814,8 @@
    "level": 1,
    "out_size": 60161,
    "ratio": 0.1172,
-   "compress_mbps": 206.75,
-   "decompress_mbps": 336.1
+   "compress_mbps": 206.72,
+   "decompress_mbps": 343.32
   },
   {
    "compressor": "native",
@@ -824,8 +824,8 @@
    "level": 2,
    "out_size": 58873,
    "ratio": 0.1147,
-   "compress_mbps": 149.3,
-   "decompress_mbps": 351.42
+   "compress_mbps": 153.38,
+   "decompress_mbps": 359.42
   },
   {
    "compressor": "native",
@@ -834,8 +834,8 @@
    "level": 3,
    "out_size": 58327,
    "ratio": 0.1137,
-   "compress_mbps": 130.13,
-   "decompress_mbps": 373.66
+   "compress_mbps": 133.21,
+   "decompress_mbps": 382.0
   },
   {
    "compressor": "native",
@@ -844,8 +844,8 @@
    "level": 4,
    "out_size": 55588,
    "ratio": 0.1083,
-   "compress_mbps": 90.15,
-   "decompress_mbps": 344.76
+   "compress_mbps": 89.71,
+   "decompress_mbps": 355.0
   },
   {
    "compressor": "native",
@@ -854,8 +854,8 @@
    "level": 5,
    "out_size": 55097,
    "ratio": 0.1074,
-   "compress_mbps": 68.18,
-   "decompress_mbps": 367.52
+   "compress_mbps": 67.78,
+   "decompress_mbps": 378.1
   },
   {
    "compressor": "native",
@@ -864,8 +864,8 @@
    "level": 6,
    "out_size": 55195,
    "ratio": 0.1075,
-   "compress_mbps": 55.01,
-   "decompress_mbps": 400.1
+   "compress_mbps": 55.89,
+   "decompress_mbps": 404.07
   },
   {
    "compressor": "native",
@@ -874,8 +874,8 @@
    "level": 7,
    "out_size": 54316,
    "ratio": 0.1058,
-   "compress_mbps": 43.1,
-   "decompress_mbps": 422.91
+   "compress_mbps": 43.71,
+   "decompress_mbps": 423.41
   },
   {
    "compressor": "native",
@@ -884,8 +884,8 @@
    "level": 8,
    "out_size": 53091,
    "ratio": 0.1034,
-   "compress_mbps": 34.69,
-   "decompress_mbps": 450.67
+   "compress_mbps": 35.1,
+   "decompress_mbps": 456.62
   },
   {
    "compressor": "native",
@@ -894,8 +894,8 @@
    "level": 9,
    "out_size": 52605,
    "ratio": 0.1025,
-   "compress_mbps": 5.37,
-   "decompress_mbps": 465.54
+   "compress_mbps": 5.44,
+   "decompress_mbps": 463.22
   },
   {
    "compressor": "native",
@@ -904,7 +904,7 @@
    "level": 10,
    "out_size": 52234,
    "ratio": 0.1018,
-   "compress_mbps": 3.53,
+   "compress_mbps": 3.54,
    "decompress_mbps": null
   },
   {
@@ -914,8 +914,8 @@
    "level": 1,
    "out_size": 14249,
    "ratio": 0.3726,
-   "compress_mbps": 51.89,
-   "decompress_mbps": 112.36
+   "compress_mbps": 51.7,
+   "decompress_mbps": 112.65
   },
   {
    "compressor": "native",
@@ -924,8 +924,8 @@
    "level": 2,
    "out_size": 13825,
    "ratio": 0.3615,
-   "compress_mbps": 45.03,
-   "decompress_mbps": 114.75
+   "compress_mbps": 44.96,
+   "decompress_mbps": 115.26
   },
   {
    "compressor": "native",
@@ -934,8 +934,8 @@
    "level": 3,
    "out_size": 13751,
    "ratio": 0.3596,
-   "compress_mbps": 43.35,
-   "decompress_mbps": 116.05
+   "compress_mbps": 43.1,
+   "decompress_mbps": 116.87
   },
   {
    "compressor": "native",
@@ -944,8 +944,8 @@
    "level": 4,
    "out_size": 13287,
    "ratio": 0.3475,
-   "compress_mbps": 38.98,
-   "decompress_mbps": 122.33
+   "compress_mbps": 38.62,
+   "decompress_mbps": 122.72
   },
   {
    "compressor": "native",
@@ -954,8 +954,8 @@
    "level": 5,
    "out_size": 13240,
    "ratio": 0.3462,
-   "compress_mbps": 34.56,
-   "decompress_mbps": 128.87
+   "compress_mbps": 34.25,
+   "decompress_mbps": 128.84
   },
   {
    "compressor": "native",
@@ -964,8 +964,8 @@
    "level": 6,
    "out_size": 12944,
    "ratio": 0.3385,
-   "compress_mbps": 18.33,
-   "decompress_mbps": 131.05
+   "compress_mbps": 18.77,
+   "decompress_mbps": 131.45
   },
   {
    "compressor": "native",
@@ -974,8 +974,8 @@
    "level": 7,
    "out_size": 12929,
    "ratio": 0.3381,
-   "compress_mbps": 16.91,
-   "decompress_mbps": 131.45
+   "compress_mbps": 17.39,
+   "decompress_mbps": 132.08
   },
   {
    "compressor": "native",
@@ -984,8 +984,8 @@
    "level": 8,
    "out_size": 12921,
    "ratio": 0.3379,
-   "compress_mbps": 15.72,
-   "decompress_mbps": 133.52
+   "compress_mbps": 16.14,
+   "decompress_mbps": 133.69
   },
   {
    "compressor": "native",
@@ -994,8 +994,8 @@
    "level": 9,
    "out_size": 12427,
    "ratio": 0.325,
-   "compress_mbps": 5.15,
-   "decompress_mbps": 135.01
+   "compress_mbps": 5.17,
+   "decompress_mbps": 135.14
   },
   {
    "compressor": "native",
@@ -1014,8 +1014,8 @@
    "level": 1,
    "out_size": 1800,
    "ratio": 0.4258,
-   "compress_mbps": 25.2,
-   "decompress_mbps": 58.06
+   "compress_mbps": 24.85,
+   "decompress_mbps": 57.19
   },
   {
    "compressor": "native",
@@ -1024,8 +1024,8 @@
    "level": 2,
    "out_size": 1750,
    "ratio": 0.414,
-   "compress_mbps": 23.61,
-   "decompress_mbps": 58.62
+   "compress_mbps": 23.47,
+   "decompress_mbps": 57.84
   },
   {
    "compressor": "native",
@@ -1034,8 +1034,8 @@
    "level": 3,
    "out_size": 1742,
    "ratio": 0.4121,
-   "compress_mbps": 23.63,
-   "decompress_mbps": 58.64
+   "compress_mbps": 23.3,
+   "decompress_mbps": 58.03
   },
   {
    "compressor": "native",
@@ -1044,8 +1044,8 @@
    "level": 4,
    "out_size": 1726,
    "ratio": 0.4083,
-   "compress_mbps": 23.27,
-   "decompress_mbps": 60.09
+   "compress_mbps": 22.99,
+   "decompress_mbps": 59.22
   },
   {
    "compressor": "native",
@@ -1054,8 +1054,8 @@
    "level": 5,
    "out_size": 1722,
    "ratio": 0.4074,
-   "compress_mbps": 22.82,
-   "decompress_mbps": 60.26
+   "compress_mbps": 22.58,
+   "decompress_mbps": 59.44
   },
   {
    "compressor": "native",
@@ -1064,8 +1064,8 @@
    "level": 6,
    "out_size": 1722,
    "ratio": 0.4074,
-   "compress_mbps": 21.82,
-   "decompress_mbps": 60.3
+   "compress_mbps": 21.67,
+   "decompress_mbps": 59.35
   },
   {
    "compressor": "native",
@@ -1074,8 +1074,8 @@
    "level": 7,
    "out_size": 1722,
    "ratio": 0.4074,
-   "compress_mbps": 21.89,
-   "decompress_mbps": 60.27
+   "compress_mbps": 21.71,
+   "decompress_mbps": 59.38
   },
   {
    "compressor": "native",
@@ -1084,8 +1084,8 @@
    "level": 8,
    "out_size": 1722,
    "ratio": 0.4074,
-   "compress_mbps": 21.9,
-   "decompress_mbps": 60.25
+   "compress_mbps": 21.74,
+   "decompress_mbps": 59.51
   },
   {
    "compressor": "native",
@@ -1094,8 +1094,8 @@
    "level": 9,
    "out_size": 1708,
    "ratio": 0.4041,
-   "compress_mbps": 5.22,
-   "decompress_mbps": 59.94
+   "compress_mbps": 5.23,
+   "decompress_mbps": 59.52
   },
   {
    "compressor": "native",
@@ -1104,7 +1104,7 @@
    "level": 10,
    "out_size": 1693,
    "ratio": 0.4005,
-   "compress_mbps": 3.14,
+   "compress_mbps": 3.12,
    "decompress_mbps": null
   },
   {
@@ -4414,8 +4414,8 @@
    "level": 1,
    "out_size": 4259644,
    "ratio": 0.4179,
-   "compress_mbps": 64.94,
-   "decompress_mbps": 102.31
+   "compress_mbps": 64.23,
+   "decompress_mbps": 103.46
   },
   {
    "compressor": "native",
@@ -4424,8 +4424,8 @@
    "level": 2,
    "out_size": 3977395,
    "ratio": 0.3902,
-   "compress_mbps": 46.35,
-   "decompress_mbps": 110.74
+   "compress_mbps": 46.36,
+   "decompress_mbps": 111.59
   },
   {
    "compressor": "native",
@@ -4434,8 +4434,8 @@
    "level": 3,
    "out_size": 3945296,
    "ratio": 0.3871,
-   "compress_mbps": 40.51,
-   "decompress_mbps": 121.9
+   "compress_mbps": 40.94,
+   "decompress_mbps": 121.93
   },
   {
    "compressor": "native",
@@ -4444,8 +4444,8 @@
    "level": 4,
    "out_size": 3851998,
    "ratio": 0.3779,
-   "compress_mbps": 31.08,
-   "decompress_mbps": 124.15
+   "compress_mbps": 31.24,
+   "decompress_mbps": 125.55
   },
   {
    "compressor": "native",
@@ -4454,8 +4454,8 @@
    "level": 5,
    "out_size": 3840481,
    "ratio": 0.3768,
-   "compress_mbps": 26.33,
-   "decompress_mbps": 130.58
+   "compress_mbps": 26.32,
+   "decompress_mbps": 131.73
   },
   {
    "compressor": "native",
@@ -4464,8 +4464,8 @@
    "level": 6,
    "out_size": 3847941,
    "ratio": 0.3775,
-   "compress_mbps": 25.57,
-   "decompress_mbps": 134.95
+   "compress_mbps": 26.51,
+   "decompress_mbps": 136.03
   },
   {
    "compressor": "native",
@@ -4474,8 +4474,8 @@
    "level": 7,
    "out_size": 3834802,
    "ratio": 0.3762,
-   "compress_mbps": 21.56,
-   "decompress_mbps": 135.41
+   "compress_mbps": 22.23,
+   "decompress_mbps": 136.55
   },
   {
    "compressor": "native",
@@ -4484,8 +4484,8 @@
    "level": 8,
    "out_size": 3833946,
    "ratio": 0.3762,
-   "compress_mbps": 21.04,
-   "decompress_mbps": 135.04
+   "compress_mbps": 21.45,
+   "decompress_mbps": 136.56
   },
   {
    "compressor": "native",
@@ -4494,8 +4494,8 @@
    "level": 9,
    "out_size": 3766584,
    "ratio": 0.3695,
-   "compress_mbps": 4.03,
-   "decompress_mbps": 137.78
+   "compress_mbps": 4.0,
+   "decompress_mbps": 139.1
   },
   {
    "compressor": "native",
@@ -4504,7 +4504,7 @@
    "level": 10,
    "out_size": 3711172,
    "ratio": 0.3641,
-   "compress_mbps": 2.33,
+   "compress_mbps": 2.36,
    "decompress_mbps": null
   },
   {
@@ -4514,8 +4514,8 @@
    "level": 1,
    "out_size": 21267086,
    "ratio": 0.4152,
-   "compress_mbps": 80.64,
-   "decompress_mbps": 131.27
+   "compress_mbps": 78.9,
+   "decompress_mbps": 131.77
   },
   {
    "compressor": "native",
@@ -4524,8 +4524,8 @@
    "level": 2,
    "out_size": 20802983,
    "ratio": 0.4061,
-   "compress_mbps": 62.91,
-   "decompress_mbps": 138.11
+   "compress_mbps": 63.24,
+   "decompress_mbps": 138.99
   },
   {
    "compressor": "native",
@@ -4534,8 +4534,8 @@
    "level": 3,
    "out_size": 20665485,
    "ratio": 0.4035,
-   "compress_mbps": 58.69,
-   "decompress_mbps": 142.03
+   "compress_mbps": 58.81,
+   "decompress_mbps": 142.71
   },
   {
    "compressor": "native",
@@ -4544,8 +4544,8 @@
    "level": 4,
    "out_size": 20356893,
    "ratio": 0.3974,
-   "compress_mbps": 47.87,
-   "decompress_mbps": 145.76
+   "compress_mbps": 48.64,
+   "decompress_mbps": 145.81
   },
   {
    "compressor": "native",
@@ -4554,8 +4554,8 @@
    "level": 5,
    "out_size": 20209289,
    "ratio": 0.3946,
-   "compress_mbps": 38.45,
-   "decompress_mbps": 157.29
+   "compress_mbps": 38.41,
+   "decompress_mbps": 157.36
   },
   {
    "compressor": "native",
@@ -4564,8 +4564,8 @@
    "level": 6,
    "out_size": 19174181,
    "ratio": 0.3743,
-   "compress_mbps": 25.93,
-   "decompress_mbps": 160.6
+   "compress_mbps": 26.13,
+   "decompress_mbps": 161.08
   },
   {
    "compressor": "native",
@@ -4574,8 +4574,8 @@
    "level": 7,
    "out_size": 19127630,
    "ratio": 0.3734,
-   "compress_mbps": 21.43,
-   "decompress_mbps": 161.53
+   "compress_mbps": 21.52,
+   "decompress_mbps": 161.44
   },
   {
    "compressor": "native",
@@ -4584,8 +4584,8 @@
    "level": 8,
    "out_size": 19117840,
    "ratio": 0.3732,
-   "compress_mbps": 18.56,
-   "decompress_mbps": 162.63
+   "compress_mbps": 18.67,
+   "decompress_mbps": 163.06
   },
   {
    "compressor": "native",
@@ -4594,8 +4594,8 @@
    "level": 9,
    "out_size": 18686872,
    "ratio": 0.3648,
-   "compress_mbps": 4.17,
-   "decompress_mbps": 157.85
+   "compress_mbps": 4.18,
+   "decompress_mbps": 158.87
   },
   {
    "compressor": "native",
@@ -4604,7 +4604,7 @@
    "level": 10,
    "out_size": 18539905,
    "ratio": 0.362,
-   "compress_mbps": 2.2,
+   "compress_mbps": 1.82,
    "decompress_mbps": null
   },
   {
@@ -4614,8 +4614,8 @@
    "level": 1,
    "out_size": 3864163,
    "ratio": 0.3876,
-   "compress_mbps": 78.65,
-   "decompress_mbps": 118.16
+   "compress_mbps": 78.37,
+   "decompress_mbps": 120.98
   },
   {
    "compressor": "native",
@@ -4624,8 +4624,8 @@
    "level": 2,
    "out_size": 3734957,
    "ratio": 0.3746,
-   "compress_mbps": 60.59,
-   "decompress_mbps": 125.61
+   "compress_mbps": 60.61,
+   "decompress_mbps": 126.38
   },
   {
    "compressor": "native",
@@ -4634,8 +4634,8 @@
    "level": 3,
    "out_size": 3708443,
    "ratio": 0.3719,
-   "compress_mbps": 51.48,
-   "decompress_mbps": 134.18
+   "compress_mbps": 51.98,
+   "decompress_mbps": 135.59
   },
   {
    "compressor": "native",
@@ -4644,8 +4644,8 @@
    "level": 4,
    "out_size": 3683603,
    "ratio": 0.3694,
-   "compress_mbps": 37.31,
-   "decompress_mbps": 129.15
+   "compress_mbps": 37.27,
+   "decompress_mbps": 130.12
   },
   {
    "compressor": "native",
@@ -4654,8 +4654,8 @@
    "level": 5,
    "out_size": 3677014,
    "ratio": 0.3688,
-   "compress_mbps": 30.29,
-   "decompress_mbps": 134.4
+   "compress_mbps": 30.22,
+   "decompress_mbps": 136.28
   },
   {
    "compressor": "native",
@@ -4664,8 +4664,8 @@
    "level": 6,
    "out_size": 3588221,
    "ratio": 0.3599,
-   "compress_mbps": 26.95,
-   "decompress_mbps": 140.5
+   "compress_mbps": 27.71,
+   "decompress_mbps": 141.5
   },
   {
    "compressor": "native",
@@ -4674,8 +4674,8 @@
    "level": 7,
    "out_size": 3581006,
    "ratio": 0.3592,
-   "compress_mbps": 22.14,
-   "decompress_mbps": 141.9
+   "compress_mbps": 22.57,
+   "decompress_mbps": 143.39
   },
   {
    "compressor": "native",
@@ -4684,8 +4684,8 @@
    "level": 8,
    "out_size": 3580944,
    "ratio": 0.3592,
-   "compress_mbps": 19.95,
-   "decompress_mbps": 144.82
+   "compress_mbps": 20.43,
+   "decompress_mbps": 145.92
   },
   {
    "compressor": "native",
@@ -4694,8 +4694,8 @@
    "level": 9,
    "out_size": 3581441,
    "ratio": 0.3592,
-   "compress_mbps": 4.46,
-   "decompress_mbps": 148.79
+   "compress_mbps": 4.54,
+   "decompress_mbps": 150.67
   },
   {
    "compressor": "native",
@@ -4714,8 +4714,8 @@
    "level": 1,
    "out_size": 3785443,
    "ratio": 0.1128,
-   "compress_mbps": 230.59,
-   "decompress_mbps": 354.43
+   "compress_mbps": 230.34,
+   "decompress_mbps": 358.02
   },
   {
    "compressor": "native",
@@ -4724,8 +4724,8 @@
    "level": 2,
    "out_size": 3761560,
    "ratio": 0.1121,
-   "compress_mbps": 144.78,
-   "decompress_mbps": 399.28
+   "compress_mbps": 146.79,
+   "decompress_mbps": 401.47
   },
   {
    "compressor": "native",
@@ -4734,8 +4734,8 @@
    "level": 3,
    "out_size": 3606997,
    "ratio": 0.1075,
-   "compress_mbps": 124.78,
-   "decompress_mbps": 444.74
+   "compress_mbps": 125.51,
+   "decompress_mbps": 448.53
   },
   {
    "compressor": "native",
@@ -4744,8 +4744,8 @@
    "level": 4,
    "out_size": 3201209,
    "ratio": 0.0954,
-   "compress_mbps": 96.25,
-   "decompress_mbps": 458.4
+   "compress_mbps": 96.02,
+   "decompress_mbps": 461.8
   },
   {
    "compressor": "native",
@@ -4754,8 +4754,8 @@
    "level": 5,
    "out_size": 3091564,
    "ratio": 0.0921,
-   "compress_mbps": 73.6,
-   "decompress_mbps": 520.74
+   "compress_mbps": 73.13,
+   "decompress_mbps": 525.58
   },
   {
    "compressor": "native",
@@ -4764,8 +4764,8 @@
    "level": 6,
    "out_size": 3112756,
    "ratio": 0.0928,
-   "compress_mbps": 70.93,
-   "decompress_mbps": 561.53
+   "compress_mbps": 71.57,
+   "decompress_mbps": 563.64
   },
   {
    "compressor": "native",
@@ -4774,8 +4774,8 @@
    "level": 7,
    "out_size": 3062314,
    "ratio": 0.0913,
-   "compress_mbps": 54.61,
-   "decompress_mbps": 571.55
+   "compress_mbps": 55.5,
+   "decompress_mbps": 576.8
   },
   {
    "compressor": "native",
@@ -4784,8 +4784,8 @@
    "level": 8,
    "out_size": 3045348,
    "ratio": 0.0908,
-   "compress_mbps": 46.32,
-   "decompress_mbps": 593.54
+   "compress_mbps": 46.91,
+   "decompress_mbps": 599.55
   },
   {
    "compressor": "native",
@@ -4794,8 +4794,8 @@
    "level": 9,
    "out_size": 3031645,
    "ratio": 0.0904,
-   "compress_mbps": 3.11,
-   "decompress_mbps": 596.7
+   "compress_mbps": 3.17,
+   "decompress_mbps": 601.36
   },
   {
    "compressor": "native",
@@ -4804,7 +4804,7 @@
    "level": 10,
    "out_size": 2902186,
    "ratio": 0.0865,
-   "compress_mbps": 1.84,
+   "compress_mbps": 1.85,
    "decompress_mbps": null
   },
   {
@@ -4814,8 +4814,8 @@
    "level": 1,
    "out_size": 3357083,
    "ratio": 0.5457,
-   "compress_mbps": 55.2,
-   "decompress_mbps": 90.49
+   "compress_mbps": 56.24,
+   "decompress_mbps": 92.0
   },
   {
    "compressor": "native",
@@ -4824,8 +4824,8 @@
    "level": 2,
    "out_size": 3285077,
    "ratio": 0.534,
-   "compress_mbps": 46.8,
-   "decompress_mbps": 92.59
+   "compress_mbps": 46.35,
+   "decompress_mbps": 92.68
   },
   {
    "compressor": "native",
@@ -4834,8 +4834,8 @@
    "level": 3,
    "out_size": 3272746,
    "ratio": 0.532,
-   "compress_mbps": 45.17,
-   "decompress_mbps": 97.03
+   "compress_mbps": 45.0,
+   "decompress_mbps": 95.23
   },
   {
    "compressor": "native",
@@ -4844,8 +4844,8 @@
    "level": 4,
    "out_size": 3228052,
    "ratio": 0.5247,
-   "compress_mbps": 38.09,
-   "decompress_mbps": 102.79
+   "compress_mbps": 38.1,
+   "decompress_mbps": 103.31
   },
   {
    "compressor": "native",
@@ -4854,8 +4854,8 @@
    "level": 5,
    "out_size": 3223415,
    "ratio": 0.5239,
-   "compress_mbps": 34.46,
-   "decompress_mbps": 107.74
+   "compress_mbps": 34.4,
+   "decompress_mbps": 107.25
   },
   {
    "compressor": "native",
@@ -4864,8 +4864,8 @@
    "level": 6,
    "out_size": 3159522,
    "ratio": 0.5136,
-   "compress_mbps": 23.29,
-   "decompress_mbps": 108.08
+   "compress_mbps": 23.94,
+   "decompress_mbps": 108.81
   },
   {
    "compressor": "native",
@@ -4874,8 +4874,8 @@
    "level": 7,
    "out_size": 3156358,
    "ratio": 0.513,
-   "compress_mbps": 21.57,
-   "decompress_mbps": 109.4
+   "compress_mbps": 22.4,
+   "decompress_mbps": 109.6
   },
   {
    "compressor": "native",
@@ -4884,8 +4884,8 @@
    "level": 8,
    "out_size": 3155368,
    "ratio": 0.5129,
-   "compress_mbps": 20.98,
-   "decompress_mbps": 109.91
+   "compress_mbps": 21.32,
+   "decompress_mbps": 109.86
   },
   {
    "compressor": "native",
@@ -4894,8 +4894,8 @@
    "level": 9,
    "out_size": 3048772,
    "ratio": 0.4956,
-   "compress_mbps": 4.88,
-   "decompress_mbps": 111.92
+   "compress_mbps": 4.87,
+   "decompress_mbps": 109.2
   },
   {
    "compressor": "native",
@@ -4904,7 +4904,7 @@
    "level": 10,
    "out_size": 3021986,
    "ratio": 0.4912,
-   "compress_mbps": 3.04,
+   "compress_mbps": 3.06,
    "decompress_mbps": null
   },
   {
@@ -4914,8 +4914,8 @@
    "level": 1,
    "out_size": 3838828,
    "ratio": 0.3806,
-   "compress_mbps": 90.14,
-   "decompress_mbps": 151.02
+   "compress_mbps": 89.33,
+   "decompress_mbps": 156.27
   },
   {
    "compressor": "native",
@@ -4924,8 +4924,8 @@
    "level": 2,
    "out_size": 3792520,
    "ratio": 0.376,
-   "compress_mbps": 66.44,
-   "decompress_mbps": 155.98
+   "compress_mbps": 66.59,
+   "decompress_mbps": 161.7
   },
   {
    "compressor": "native",
@@ -4934,8 +4934,8 @@
    "level": 3,
    "out_size": 3783171,
    "ratio": 0.3751,
-   "compress_mbps": 64.19,
-   "decompress_mbps": 159.66
+   "compress_mbps": 64.53,
+   "decompress_mbps": 165.55
   },
   {
    "compressor": "native",
@@ -4944,8 +4944,8 @@
    "level": 4,
    "out_size": 3648458,
    "ratio": 0.3617,
-   "compress_mbps": 57.77,
-   "decompress_mbps": 169.9
+   "compress_mbps": 57.75,
+   "decompress_mbps": 176.79
   },
   {
    "compressor": "native",
@@ -4954,8 +4954,8 @@
    "level": 5,
    "out_size": 3648472,
    "ratio": 0.3617,
-   "compress_mbps": 54.0,
-   "decompress_mbps": 182.89
+   "compress_mbps": 53.53,
+   "decompress_mbps": 183.0
   },
   {
    "compressor": "native",
@@ -4964,8 +4964,8 @@
    "level": 6,
    "out_size": 3648595,
    "ratio": 0.3618,
-   "compress_mbps": 42.32,
-   "decompress_mbps": 185.99
+   "compress_mbps": 43.69,
+   "decompress_mbps": 184.18
   },
   {
    "compressor": "native",
@@ -4974,8 +4974,8 @@
    "level": 7,
    "out_size": 3648160,
    "ratio": 0.3617,
-   "compress_mbps": 42.57,
-   "decompress_mbps": 187.68
+   "compress_mbps": 43.5,
+   "decompress_mbps": 187.01
   },
   {
    "compressor": "native",
@@ -4984,8 +4984,8 @@
    "level": 8,
    "out_size": 3648156,
    "ratio": 0.3617,
-   "compress_mbps": 42.29,
-   "decompress_mbps": 189.18
+   "compress_mbps": 43.27,
+   "decompress_mbps": 188.07
   },
   {
    "compressor": "native",
@@ -4994,8 +4994,8 @@
    "level": 9,
    "out_size": 3648156,
    "ratio": 0.3617,
-   "compress_mbps": 5.75,
-   "decompress_mbps": 194.56
+   "compress_mbps": 5.71,
+   "decompress_mbps": 191.93
   },
   {
    "compressor": "native",
@@ -5004,7 +5004,7 @@
    "level": 10,
    "out_size": 3647321,
    "ratio": 0.3616,
-   "compress_mbps": 3.21,
+   "compress_mbps": 3.26,
    "decompress_mbps": null
   },
   {
@@ -5014,8 +5014,8 @@
    "level": 1,
    "out_size": 2254442,
    "ratio": 0.3402,
-   "compress_mbps": 82.61,
-   "decompress_mbps": 128.38
+   "compress_mbps": 82.52,
+   "decompress_mbps": 124.77
   },
   {
    "compressor": "native",
@@ -5024,8 +5024,8 @@
    "level": 2,
    "out_size": 2044843,
    "ratio": 0.3086,
-   "compress_mbps": 55.81,
-   "decompress_mbps": 137.79
+   "compress_mbps": 55.86,
+   "decompress_mbps": 140.79
   },
   {
    "compressor": "native",
@@ -5034,8 +5034,8 @@
    "level": 3,
    "out_size": 1992105,
    "ratio": 0.3006,
-   "compress_mbps": 45.1,
-   "decompress_mbps": 151.13
+   "compress_mbps": 43.0,
+   "decompress_mbps": 156.45
   },
   {
    "compressor": "native",
@@ -5044,8 +5044,8 @@
    "level": 4,
    "out_size": 1890729,
    "ratio": 0.2853,
-   "compress_mbps": 32.32,
-   "decompress_mbps": 155.14
+   "compress_mbps": 32.1,
+   "decompress_mbps": 159.15
   },
   {
    "compressor": "native",
@@ -5054,8 +5054,8 @@
    "level": 5,
    "out_size": 1858234,
    "ratio": 0.2804,
-   "compress_mbps": 21.31,
-   "decompress_mbps": 168.97
+   "compress_mbps": 21.09,
+   "decompress_mbps": 171.37
   },
   {
    "compressor": "native",
@@ -5064,8 +5064,8 @@
    "level": 6,
    "out_size": 1856235,
    "ratio": 0.2801,
-   "compress_mbps": 25.06,
-   "decompress_mbps": 180.37
+   "compress_mbps": 25.32,
+   "decompress_mbps": 185.73
   },
   {
    "compressor": "native",
@@ -5074,8 +5074,8 @@
    "level": 7,
    "out_size": 1823963,
    "ratio": 0.2752,
-   "compress_mbps": 16.32,
-   "decompress_mbps": 183.56
+   "compress_mbps": 16.37,
+   "decompress_mbps": 185.59
   },
   {
    "compressor": "native",
@@ -5084,8 +5084,8 @@
    "level": 8,
    "out_size": 1820112,
    "ratio": 0.2746,
-   "compress_mbps": 14.25,
-   "decompress_mbps": 186.04
+   "compress_mbps": 14.29,
+   "decompress_mbps": 192.09
   },
   {
    "compressor": "native",
@@ -5094,8 +5094,8 @@
    "level": 9,
    "out_size": 1773447,
    "ratio": 0.2676,
-   "compress_mbps": 2.82,
-   "decompress_mbps": 190.62
+   "compress_mbps": 2.87,
+   "decompress_mbps": 191.95
   },
   {
    "compressor": "native",
@@ -5104,7 +5104,7 @@
    "level": 10,
    "out_size": 1718500,
    "ratio": 0.2593,
-   "compress_mbps": 1.51,
+   "compress_mbps": 1.52,
    "decompress_mbps": null
   },
   {
@@ -5114,8 +5114,8 @@
    "level": 1,
    "out_size": 6406301,
    "ratio": 0.2965,
-   "compress_mbps": 110.25,
-   "decompress_mbps": 193.61
+   "compress_mbps": 109.31,
+   "decompress_mbps": 195.21
   },
   {
    "compressor": "native",
@@ -5124,8 +5124,8 @@
    "level": 2,
    "out_size": 6102377,
    "ratio": 0.2824,
-   "compress_mbps": 81.09,
-   "decompress_mbps": 204.9
+   "compress_mbps": 80.54,
+   "decompress_mbps": 206.7
   },
   {
    "compressor": "native",
@@ -5134,8 +5134,8 @@
    "level": 3,
    "out_size": 6022184,
    "ratio": 0.2787,
-   "compress_mbps": 72.2,
-   "decompress_mbps": 214.14
+   "compress_mbps": 73.49,
+   "decompress_mbps": 215.64
   },
   {
    "compressor": "native",
@@ -5144,8 +5144,8 @@
    "level": 4,
    "out_size": 5880892,
    "ratio": 0.2722,
-   "compress_mbps": 57.58,
-   "decompress_mbps": 224.59
+   "compress_mbps": 57.23,
+   "decompress_mbps": 225.43
   },
   {
    "compressor": "native",
@@ -5154,8 +5154,8 @@
    "level": 5,
    "out_size": 5834363,
    "ratio": 0.27,
-   "compress_mbps": 45.47,
-   "decompress_mbps": 235.79
+   "compress_mbps": 45.3,
+   "decompress_mbps": 237.39
   },
   {
    "compressor": "native",
@@ -5164,8 +5164,8 @@
    "level": 6,
    "out_size": 5409792,
    "ratio": 0.2504,
-   "compress_mbps": 36.9,
-   "decompress_mbps": 239.4
+   "compress_mbps": 38.01,
+   "decompress_mbps": 242.08
   },
   {
    "compressor": "native",
@@ -5174,8 +5174,8 @@
    "level": 7,
    "out_size": 5393735,
    "ratio": 0.2496,
-   "compress_mbps": 31.93,
-   "decompress_mbps": 244.38
+   "compress_mbps": 32.64,
+   "decompress_mbps": 244.99
   },
   {
    "compressor": "native",
@@ -5184,8 +5184,8 @@
    "level": 8,
    "out_size": 5389952,
    "ratio": 0.2495,
-   "compress_mbps": 30.28,
-   "decompress_mbps": 246.16
+   "compress_mbps": 30.52,
+   "decompress_mbps": 246.15
   },
   {
    "compressor": "native",
@@ -5195,7 +5195,7 @@
    "out_size": 5235865,
    "ratio": 0.2423,
    "compress_mbps": 4.52,
-   "decompress_mbps": 244.53
+   "decompress_mbps": 246.53
   },
   {
    "compressor": "native",
@@ -5204,7 +5204,7 @@
    "level": 10,
    "out_size": 5177560,
    "ratio": 0.2396,
-   "compress_mbps": 2.45,
+   "compress_mbps": 2.48,
    "decompress_mbps": null
   },
   {
@@ -5214,8 +5214,8 @@
    "level": 1,
    "out_size": 5612204,
    "ratio": 0.7739,
-   "compress_mbps": 46.49,
-   "decompress_mbps": 92.07
+   "compress_mbps": 46.68,
+   "decompress_mbps": 91.69
   },
   {
    "compressor": "native",
@@ -5224,8 +5224,8 @@
    "level": 2,
    "out_size": 5533875,
    "ratio": 0.7631,
-   "compress_mbps": 38.96,
-   "decompress_mbps": 94.03
+   "compress_mbps": 38.99,
+   "decompress_mbps": 93.38
   },
   {
    "compressor": "native",
@@ -5234,8 +5234,8 @@
    "level": 3,
    "out_size": 5522436,
    "ratio": 0.7615,
-   "compress_mbps": 36.7,
-   "decompress_mbps": 96.4
+   "compress_mbps": 36.79,
+   "decompress_mbps": 97.13
   },
   {
    "compressor": "native",
@@ -5244,8 +5244,8 @@
    "level": 4,
    "out_size": 5494383,
    "ratio": 0.7576,
-   "compress_mbps": 31.94,
-   "decompress_mbps": 99.51
+   "compress_mbps": 31.74,
+   "decompress_mbps": 100.46
   },
   {
    "compressor": "native",
@@ -5254,8 +5254,8 @@
    "level": 5,
    "out_size": 5489807,
    "ratio": 0.757,
-   "compress_mbps": 30.29,
-   "decompress_mbps": 102.45
+   "compress_mbps": 30.06,
+   "decompress_mbps": 103.92
   },
   {
    "compressor": "native",
@@ -5264,8 +5264,8 @@
    "level": 6,
    "out_size": 5470520,
    "ratio": 0.7544,
-   "compress_mbps": 21.91,
-   "decompress_mbps": 104.05
+   "compress_mbps": 22.8,
+   "decompress_mbps": 104.41
   },
   {
    "compressor": "native",
@@ -5274,8 +5274,8 @@
    "level": 7,
    "out_size": 5463682,
    "ratio": 0.7534,
-   "compress_mbps": 20.91,
-   "decompress_mbps": 103.84
+   "compress_mbps": 21.89,
+   "decompress_mbps": 104.98
   },
   {
    "compressor": "native",
@@ -5284,8 +5284,8 @@
    "level": 8,
    "out_size": 5463761,
    "ratio": 0.7534,
-   "compress_mbps": 20.8,
-   "decompress_mbps": 104.97
+   "compress_mbps": 21.33,
+   "decompress_mbps": 104.82
   },
   {
    "compressor": "native",
@@ -5294,8 +5294,8 @@
    "level": 9,
    "out_size": 5284536,
    "ratio": 0.7287,
-   "compress_mbps": 4.88,
-   "decompress_mbps": 104.82
+   "compress_mbps": 4.92,
+   "decompress_mbps": 104.71
   },
   {
    "compressor": "native",
@@ -5304,7 +5304,7 @@
    "level": 10,
    "out_size": 5262319,
    "ratio": 0.7256,
-   "compress_mbps": 3.46,
+   "compress_mbps": 3.4,
    "decompress_mbps": null
   },
   {
@@ -5314,8 +5314,8 @@
    "level": 1,
    "out_size": 13727247,
    "ratio": 0.3311,
-   "compress_mbps": 82.93,
-   "decompress_mbps": 130.87
+   "compress_mbps": 82.87,
+   "decompress_mbps": 135.52
   },
   {
    "compressor": "native",
@@ -5324,8 +5324,8 @@
    "level": 2,
    "out_size": 12940398,
    "ratio": 0.3121,
-   "compress_mbps": 60.74,
-   "decompress_mbps": 145.78
+   "compress_mbps": 60.83,
+   "decompress_mbps": 145.83
   },
   {
    "compressor": "native",
@@ -5334,8 +5334,8 @@
    "level": 3,
    "out_size": 12703756,
    "ratio": 0.3064,
-   "compress_mbps": 55.81,
-   "decompress_mbps": 157.32
+   "compress_mbps": 55.32,
+   "decompress_mbps": 158.9
   },
   {
    "compressor": "native",
@@ -5344,8 +5344,8 @@
    "level": 4,
    "out_size": 12177338,
    "ratio": 0.2937,
-   "compress_mbps": 43.18,
-   "decompress_mbps": 164.35
+   "compress_mbps": 43.13,
+   "decompress_mbps": 165.37
   },
   {
    "compressor": "native",
@@ -5354,8 +5354,8 @@
    "level": 5,
    "out_size": 12051075,
    "ratio": 0.2907,
-   "compress_mbps": 33.63,
-   "decompress_mbps": 173.44
+   "compress_mbps": 33.35,
+   "decompress_mbps": 174.01
   },
   {
    "compressor": "native",
@@ -5364,8 +5364,8 @@
    "level": 6,
    "out_size": 12103573,
    "ratio": 0.2919,
-   "compress_mbps": 33.72,
-   "decompress_mbps": 178.34
+   "compress_mbps": 34.7,
+   "decompress_mbps": 179.27
   },
   {
    "compressor": "native",
@@ -5374,8 +5374,8 @@
    "level": 7,
    "out_size": 12027976,
    "ratio": 0.2901,
-   "compress_mbps": 27.32,
-   "decompress_mbps": 179.18
+   "compress_mbps": 27.78,
+   "decompress_mbps": 180.01
   },
   {
    "compressor": "native",
@@ -5384,8 +5384,8 @@
    "level": 8,
    "out_size": 12019953,
    "ratio": 0.2899,
-   "compress_mbps": 25.89,
-   "decompress_mbps": 180.35
+   "compress_mbps": 21.7,
+   "decompress_mbps": 132.44
   },
   {
    "compressor": "native",
@@ -5394,8 +5394,8 @@
    "level": 9,
    "out_size": 11806466,
    "ratio": 0.2848,
-   "compress_mbps": 3.69,
-   "decompress_mbps": 179.47
+   "compress_mbps": 3.68,
+   "decompress_mbps": 179.99
   },
   {
    "compressor": "native",
@@ -5404,7 +5404,7 @@
    "level": 10,
    "out_size": 11636727,
    "ratio": 0.2807,
-   "compress_mbps": 1.92,
+   "compress_mbps": 1.94,
    "decompress_mbps": null
   },
   {
@@ -5414,8 +5414,8 @@
    "level": 1,
    "out_size": 6438176,
    "ratio": 0.7597,
-   "compress_mbps": 42.8,
-   "decompress_mbps": 75.91
+   "compress_mbps": 43.68,
+   "decompress_mbps": 77.76
   },
   {
    "compressor": "native",
@@ -5424,8 +5424,8 @@
    "level": 2,
    "out_size": 6392101,
    "ratio": 0.7543,
-   "compress_mbps": 41.43,
-   "decompress_mbps": 77.01
+   "compress_mbps": 41.52,
+   "decompress_mbps": 78.07
   },
   {
    "compressor": "native",
@@ -5434,8 +5434,8 @@
    "level": 3,
    "out_size": 6392124,
    "ratio": 0.7543,
-   "compress_mbps": 41.49,
-   "decompress_mbps": 78.66
+   "compress_mbps": 40.88,
+   "decompress_mbps": 80.53
   },
   {
    "compressor": "native",
@@ -5444,8 +5444,8 @@
    "level": 4,
    "out_size": 6360604,
    "ratio": 0.7506,
-   "compress_mbps": 39.13,
-   "decompress_mbps": 78.5
+   "compress_mbps": 39.16,
+   "decompress_mbps": 79.68
   },
   {
    "compressor": "native",
@@ -5454,8 +5454,8 @@
    "level": 5,
    "out_size": 6360567,
    "ratio": 0.7506,
-   "compress_mbps": 39.01,
-   "decompress_mbps": 80.7
+   "compress_mbps": 39.04,
+   "decompress_mbps": 82.97
   },
   {
    "compressor": "native",
@@ -5464,8 +5464,8 @@
    "level": 6,
    "out_size": 6271453,
    "ratio": 0.7401,
-   "compress_mbps": 15.98,
-   "decompress_mbps": 81.34
+   "compress_mbps": 16.59,
+   "decompress_mbps": 82.89
   },
   {
    "compressor": "native",
@@ -5474,8 +5474,8 @@
    "level": 7,
    "out_size": 6271447,
    "ratio": 0.7401,
-   "compress_mbps": 15.98,
-   "decompress_mbps": 81.61
+   "compress_mbps": 16.76,
+   "decompress_mbps": 82.27
   },
   {
    "compressor": "native",
@@ -5484,8 +5484,8 @@
    "level": 8,
    "out_size": 6271447,
    "ratio": 0.7401,
-   "compress_mbps": 16.03,
-   "decompress_mbps": 81.41
+   "compress_mbps": 17.42,
+   "decompress_mbps": 82.78
   },
   {
    "compressor": "native",
@@ -5494,8 +5494,8 @@
    "level": 9,
    "out_size": 5952505,
    "ratio": 0.7024,
-   "compress_mbps": 5.77,
-   "decompress_mbps": 82.45
+   "compress_mbps": 5.85,
+   "decompress_mbps": 82.83
   },
   {
    "compressor": "native",
@@ -5504,7 +5504,7 @@
    "level": 10,
    "out_size": 5848663,
    "ratio": 0.6902,
-   "compress_mbps": 4.18,
+   "compress_mbps": 4.29,
    "decompress_mbps": null
   },
   {
@@ -5514,8 +5514,8 @@
    "level": 1,
    "out_size": 858525,
    "ratio": 0.1606,
-   "compress_mbps": 174.9,
-   "decompress_mbps": 261.94
+   "compress_mbps": 174.37,
+   "decompress_mbps": 265.62
   },
   {
    "compressor": "native",
@@ -5524,8 +5524,8 @@
    "level": 2,
    "out_size": 846807,
    "ratio": 0.1584,
-   "compress_mbps": 108.52,
-   "decompress_mbps": 297.15
+   "compress_mbps": 112.46,
+   "decompress_mbps": 300.43
   },
   {
    "compressor": "native",
@@ -5534,8 +5534,8 @@
    "level": 3,
    "out_size": 806798,
    "ratio": 0.1509,
-   "compress_mbps": 100.19,
-   "decompress_mbps": 344.89
+   "compress_mbps": 103.12,
+   "decompress_mbps": 350.6
   },
   {
    "compressor": "native",
@@ -5544,8 +5544,8 @@
    "level": 4,
    "out_size": 717301,
    "ratio": 0.1342,
-   "compress_mbps": 77.61,
-   "decompress_mbps": 324.45
+   "compress_mbps": 77.34,
+   "decompress_mbps": 332.55
   },
   {
    "compressor": "native",
@@ -5554,8 +5554,8 @@
    "level": 5,
    "out_size": 701552,
    "ratio": 0.1312,
-   "compress_mbps": 61.08,
-   "decompress_mbps": 385.5
+   "compress_mbps": 60.91,
+   "decompress_mbps": 391.92
   },
   {
    "compressor": "native",
@@ -5564,8 +5564,8 @@
    "level": 6,
    "out_size": 678544,
    "ratio": 0.1269,
-   "compress_mbps": 56.33,
-   "decompress_mbps": 393.31
+   "compress_mbps": 58.17,
+   "decompress_mbps": 403.14
   },
   {
    "compressor": "native",
@@ -5574,8 +5574,8 @@
    "level": 7,
    "out_size": 663716,
    "ratio": 0.1242,
-   "compress_mbps": 45.99,
-   "decompress_mbps": 425.05
+   "compress_mbps": 47.1,
+   "decompress_mbps": 402.26
   },
   {
    "compressor": "native",
@@ -5584,8 +5584,8 @@
    "level": 8,
    "out_size": 660481,
    "ratio": 0.1236,
-   "compress_mbps": 41.06,
-   "decompress_mbps": 407.07
+   "compress_mbps": 41.79,
+   "decompress_mbps": 415.15
   },
   {
    "compressor": "native",
@@ -5594,8 +5594,8 @@
    "level": 9,
    "out_size": 659417,
    "ratio": 0.1234,
-   "compress_mbps": 4.21,
-   "decompress_mbps": 438.96
+   "compress_mbps": 4.3,
+   "decompress_mbps": 439.25
   },
   {
    "compressor": "native",


### PR DESCRIPTION
This PR derives the whole-stream frequencies the levels-6–8 base candidate needs by summing the per-block frequencies the split-sizing pass already computes, instead of a second whole-stream `tokenFreqsP` walk. `tokenFreqsP` costs 4.7% of compress at L6 dickens / 3.0% at L6 mozilla; on inputs with cuts the base candidate no longer pays for it a second time — one per-block pass plus a cheap ~316-entry summation replaces the second full walk. Output is byte-identical and the verified roundtrip/padding specs are preserved.

The base candidate feeds the verified specs (`inflate_deflateRaw`, `deflateRaw_pad`), so this needs a proven equality rather than a conformance pin. `Zip/Spec/DeflateFreqsAdditive.lean` proves `tokenFreqsP` additivity over concatenation:

    tokenFreqsP (a ++ b) = mergeEOBFreqsP (tokenFreqsP a) (tokenFreqsP b)

where `mergeEOBFreqsP` is element-wise addition with a `−1` correction at the end-of-block symbol (256), which every per-block histogram pre-counts once. The proof characterizes each histogram entry as its initial value plus the number of processed words that bump it (`litDeltaP`/`distDeltaP`), and those bump-counts are additive over `++`; the only shared over-count is EOB, which no word ever bumps.

`sharedPartitionSizedFreqsP` fuses the frequency summation into the existing clamped-partition sizing recursion: it reuses the same per-block `tokenFreqsP` array `sizedTrees` already consumes, folding it into the whole-stream histogram with `mergeEOBFreqsP`. `Zip/Spec/DeflateBaseFreqsReuse.lean` proves its first component is definitionally `sharedPartitionSizedP` (so every sizing/emit theorem transfers unchanged) and its second component is `tokenFreqsP toks` (via the additivity theorem over the clamped cuts). The levels-6–8 dispatch, when the split has cuts, feeds those frequencies to a freq-taking `deflateRawBasePPrepF` whose emit theorem stays definitionally clean (`deflateRawBasePPrepF_obsFreqs` recovers `deflateRawBasePPrep`); when the split has no cuts the base still walks the whole stream, unchanged.

Follow-up to items 1–3 (https://github.com/kim-em/lean-zip/pull/2771). Closes https://github.com/kim-em/lean-zip/issues/2772.

🤖 Prepared with Claude Code
