### PR TITLE
perf(decode): cheapen the per-block table build (shift-based powers, constant fixed tables, unchecked fillSlots)

### DIFF
--- a/Zip/Native/Inflate.lean
+++ b/Zip/Native/Inflate.lean
@@ -292,6 +292,31 @@ def fillSlots (packed : Array UInt32) (base stride count : Nat) (entry : UInt32)
   else fillSlots (packed.set! base entry) (base + stride) stride (count - 1) entry
 termination_by count
 
+/-- Unchecked variant of `fillSlots`: writes each slot with the proof-carrying
+    `Array.set` (compiles to an unchecked store, no per-slot bounds branch) rather
+    than the checked `set!`. The precondition
+    `0 < count → base + (count-1)·stride < packed.size` states the last slot the
+    fill touches is in range; it is preserved by the recursion because the last
+    slot never moves as `base` advances by `stride` and `count` shrinks. Equal to
+    `fillSlots` (`HuffTree.fillSlotsU_eq` in `Zip.Spec.InflateCanonical`), so
+    `buildCanonicalLoop` can call it behind a single per-codeword bounds guard
+    instead of paying a bounds check on every one of a codeword's `2^(fastBits-len)`
+    slot writes. -/
+def fillSlotsU (packed : Array UInt32) (base stride count : Nat) (entry : UInt32)
+    (hb : 0 < count → base + (count - 1) * stride < packed.size) : Array UInt32 :=
+  if h : count = 0 then packed
+  else
+    have hbase : base < packed.size :=
+      Nat.lt_of_le_of_lt (Nat.le_add_right _ _) (hb (Nat.pos_of_ne_zero h))
+    fillSlotsU (packed.set base entry hbase) (base + stride) stride (count - 1) entry (by
+      intro _
+      rw [Array.size_set]
+      have hlt := hb (by omega)
+      have hmul : (count - 1 - 1) * stride = (count - 1) * stride - stride := Nat.sub_one_mul _ _
+      have hge : stride ≤ (count - 1) * stride := Nat.le_mul_of_pos_left stride (by omega)
+      omega)
+termination_by count
+
 /-- The canonical table-fill loop: for each symbol from `start`, look up its
     canonical code `c = nextCode[len]` (advancing `nextCode[len]`, exactly as
     `HuffTree.insertLoop` does), and — for codes that fit the `fastBits` window —
@@ -307,8 +332,13 @@ def buildCanonicalLoop (lengths : Array UInt8) (nextCode : Array UInt32)
       let nextCode' := nextCode.set! len.toNat (c + 1)
       if len.toNat ≤ fastBits then
         let base := bitReverse c.toNat len.toNat 0
-        let packed' := fillSlots packed base (2 ^ len.toNat)
-          (2 ^ (fastBits - len.toNat)) (packEntry start.toUInt16 len)
+        let stride := 1 <<< len.toNat
+        let count := 1 <<< (fastBits - len.toNat)
+        let entry := packEntry start.toUInt16 len
+        let packed' :=
+          if hb : base + (count - 1) * stride < packed.size then
+            fillSlotsU packed base stride count entry (fun _ => hb)
+          else fillSlots packed base stride count entry
         buildCanonicalLoop lengths nextCode' (start + 1) packed'
       else
         buildCanonicalLoop lengths nextCode' (start + 1) packed
@@ -369,7 +399,7 @@ def kraftSumFast (count : Array Nat) (maxBits : Nat) : Nat :=
 where
   go (count : Array Nat) (maxBits b acc : Nat) : Nat :=
     if h : b ≤ maxBits then
-      go count maxBits (b + 1) (acc + count[b]! * 2 ^ (maxBits - b))
+      go count maxBits (b + 1) (acc + count[b]! * (1 <<< (maxBits - b)))
     else acc
   termination_by maxBits + 1 - b
 
@@ -388,7 +418,7 @@ def validateLengths (lengths : Array UInt8) (maxBits : Nat := 15) :
     Except String Unit :=
   if lengths.any (fun l => l.toNat > maxBits) then
     .error "Inflate: code length exceeds maximum"
-  else if kraftSumFast (countLengthsFast lengths maxBits) maxBits > 2 ^ maxBits then
+  else if kraftSumFast (countLengthsFast lengths maxBits) maxBits > 1 <<< maxBits then
     .error "Inflate: oversubscribed Huffman code"
   else
     .ok ()

--- a/Zip/Native/InflateTreeFree.lean
+++ b/Zip/Native/InflateTreeFree.lean
@@ -312,19 +312,15 @@ def goTreeFreeU (litTable distTable : DecodeTable) (litLD distLD : LongDecode)
       have hb : cnt4.toUSize.toNat = cnt4 := toUSize_toNat_of_lt (by omega)
       rw [hb]; omega
 
-/-- Tree-free wide-buffer block decode: builds the fast tables canonically and
-    the long-code tables, then runs the tree-free loop (no Huffman tree). Runs the
-    unboxed `goTreeFreeU` when the input is addressable, else the boxed
-    `goTreeFree` — mirroring `goFusedPDispatch`. -/
-def decodeHuffmanFastBufTreeFree (br : BitReader) (output : ByteArray)
-    (litLengths distLengths : Array UInt8) (maxOut : Nat) :
+/-- Tree-free wide-buffer block decode from prebuilt tables: runs the tree-free
+    loop (no Huffman tree) over the already-constructed fast/long decode tables.
+    Runs the unboxed `goTreeFreeU` when the input is addressable, else the boxed
+    `goTreeFree` — mirroring `goFusedPDispatch`. Factored out of
+    `decodeHuffmanFastBufTreeFree` so the fixed-Huffman path can pass the
+    compile-time-constant fixed tables instead of rebuilding them every block. -/
+def decodeHuffmanFastBufTables (br : BitReader) (output : ByteArray)
+    (litTable distTable : DecodeTable) (litLD distLD : LongDecode) (maxOut : Nat) :
     Except String (ByteArray × BitReader) := do
-  let litCount := HuffTree.countLengthsFast litLengths 15
-  let distCount := HuffTree.countLengthsFast distLengths 15
-  let litTable := HuffTree.buildTableCanonicalFastWithCount litLengths litCount 15
-  let distTable := HuffTree.buildTableCanonicalFastWithCount distLengths distCount 15
-  let litLD := HuffTree.buildLongDecodeWithCount litLengths litCount 15
-  let distLD := HuffTree.buildLongDecodeWithCount distLengths distCount 15
   let (pos, bitBuf, cnt) := refill br.data br.pos 0 0
   let bitBuf := bitBuf >>> br.bitOff.toUInt64
   let cnt := cnt - br.bitOff
@@ -339,9 +335,65 @@ def decodeHuffmanFastBufTreeFree (br : BitReader) (output : ByteArray)
   let endbit := pos' * 8 - cnt'
   .ok (out, { data := br.data, pos := endbit / 8, bitOff := endbit % 8 })
 
+/-- Tree-free wide-buffer block decode: builds the fast tables canonically and
+    the long-code tables, then runs the tree-free loop (no Huffman tree) via
+    `decodeHuffmanFastBufTables`. -/
+def decodeHuffmanFastBufTreeFree (br : BitReader) (output : ByteArray)
+    (litLengths distLengths : Array UInt8) (maxOut : Nat) :
+    Except String (ByteArray × BitReader) :=
+  let litCount := HuffTree.countLengthsFast litLengths 15
+  let distCount := HuffTree.countLengthsFast distLengths 15
+  let litTable := HuffTree.buildTableCanonicalFastWithCount litLengths litCount 15
+  let distTable := HuffTree.buildTableCanonicalFastWithCount distLengths distCount 15
+  let litLD := HuffTree.buildLongDecodeWithCount litLengths litCount 15
+  let distLD := HuffTree.buildLongDecodeWithCount distLengths distCount 15
+  decodeHuffmanFastBufTables br output litTable distTable litLD distLD maxOut
+
 end InflateBuf
 
 namespace Inflate
+
+open Zip.Native.HuffTree (DecodeTable LongDecode)
+
+/-! ### Fixed-Huffman decode tables as compile-time constants
+
+RFC 1951 §3.2.6 fixes the lit/length and distance code lengths, so their canonical
+decode tables and long-code tables are the same for *every* fixed block. As nullary
+`def`s these are closed terms: the Lean runtime computes each exactly once (via a
+`lean_once_cell_t`) and caches it, so the fixed-Huffman decode path never rebuilds a
+table. `decodeHuffmanFastBufFixed` runs `decodeHuffmanFastBufTables` over these
+constants, and is proven equal to the per-block build
+(`Zip.Spec.InflateTreeFreeCorrect.decodeHuffmanFastBufFixed_eq`). -/
+
+/-- Per-length histogram for `fixedLitLengths` (shared by the fixed lit table and
+    long-decode table). -/
+def fixedLitCount : Array Nat := HuffTree.countLengthsFast fixedLitLengths 15
+
+/-- Per-length histogram for `fixedDistLengths`. -/
+def fixedDistCount : Array Nat := HuffTree.countLengthsFast fixedDistLengths 15
+
+/-- The fixed lit/length canonical fast decode table (RFC 1951 §3.2.6), built once. -/
+def fixedLitTable : DecodeTable :=
+  HuffTree.buildTableCanonicalFastWithCount fixedLitLengths fixedLitCount 15
+
+/-- The fixed distance canonical fast decode table (RFC 1951 §3.2.6), built once. -/
+def fixedDistTable : DecodeTable :=
+  HuffTree.buildTableCanonicalFastWithCount fixedDistLengths fixedDistCount 15
+
+/-- The fixed lit/length long-code decode table, built once. -/
+def fixedLitLD : LongDecode := HuffTree.buildLongDecodeWithCount fixedLitLengths fixedLitCount 15
+
+/-- The fixed distance long-code decode table, built once. -/
+def fixedDistLD : LongDecode := HuffTree.buildLongDecodeWithCount fixedDistLengths fixedDistCount 15
+
+/-- Fixed-Huffman block decode over the compile-time-constant fixed tables — no
+    per-block table build. Equal to
+    `decodeHuffmanFastBufTreeFree br output fixedLitLengths fixedDistLengths maxOut`
+    (`decodeHuffmanFastBufFixed_eq`). -/
+def decodeHuffmanFastBufFixed (br : BitReader) (output : ByteArray) (maxOut : Nat) :
+    Except String (ByteArray × BitReader) :=
+  InflateBuf.decodeHuffmanFastBufTables br output fixedLitTable fixedDistTable
+    fixedLitLD fixedDistLD maxOut
 
 /-- Like `decodeDynamicTrees`, but returns only the code-length vectors — it never
     builds the lit/dist Huffman trees (the whole point of the tree-free path). The
@@ -383,7 +435,7 @@ def inflateLoopTreeFree (br : BitReader) (output : ByteArray) (maxOut dataSize :
   let (btype, br₂) ← br₁.readBits 2
   let (output', br') ← match btype with
     | 0 => Inflate.decodeStored br₂ output maxOut
-    | 1 => InflateBuf.decodeHuffmanFastBufTreeFree br₂ output fixedLitLengths fixedDistLengths maxOut
+    | 1 => decodeHuffmanFastBufFixed br₂ output maxOut
     | 2 => do
       let (litLens, distLens, br₃) ← decodeDynamicLengthsOnly br₂
       InflateBuf.decodeHuffmanFastBufTreeFree br₃ output litLens distLens maxOut

--- a/Zip/Spec/InflateCanonical.lean
+++ b/Zip/Spec/InflateCanonical.lean
@@ -165,6 +165,25 @@ theorem cwOf_eq_iff_mod (idx c len : Nat) :
     rw [ih (packed.set! base entry) (base + stride)]
     simp
 
+/-- A proof-carrying `Array.set` in bounds is the checked `set!`. -/
+private theorem set_eq_set! {α : Type _} {a : Array α} {i : Nat} {v : α} (h : i < a.size) :
+    a.set i v h = a.set! i v := by
+  rw [Array.set!_eq_setIfInBounds, Array.setIfInBounds_def, dif_pos h]
+
+/-- The unchecked fill `fillSlotsU` (used on the decode path behind a single
+    per-codeword bounds guard) equals the checked `fillSlots`: each proof-carrying
+    `Array.set` in bounds is the corresponding `set!`. -/
+theorem fillSlotsU_eq (packed : Array UInt32) (base stride count : Nat) (entry : UInt32)
+    (hb : 0 < count → base + (count - 1) * stride < packed.size) :
+    fillSlotsU packed base stride count entry hb = fillSlots packed base stride count entry := by
+  rw [fillSlotsU, fillSlots]
+  by_cases hc : count = 0
+  · rw [dif_pos hc, if_pos hc]
+  · rw [dif_neg hc, if_neg hc]
+    simp only [set_eq_set!]
+    exact fillSlotsU_eq (packed.set! base entry) (base + stride) stride (count - 1) entry _
+termination_by count
+
 /-- A slot not on the fill's arithmetic progression `{base + j·stride : j < count}`
     keeps its old value. -/
 theorem fillSlots_getElem_ne (packed : Array UInt32) (base stride count idx : Nat)
@@ -440,7 +459,10 @@ theorem buildCanonicalLoop_size (lengths : Array UInt8) (nextCode : Array UInt32
   · dsimp only []
     split
     · split
-      · rw [buildCanonicalLoop_size, fillSlots_size]
+      · rw [buildCanonicalLoop_size]
+        split
+        · rw [fillSlotsU_eq, fillSlots_size]
+        · rw [fillSlots_size]
       · rw [buildCanonicalLoop_size]
     · rw [buildCanonicalLoop_size]
   · rfl
@@ -564,7 +586,7 @@ theorem buildCanonicalLoop_spec
       split
       · -- len ≤ fastBits: fill this code's slots
         rename_i hfast
-        simp only [hc!]
+        simp only [hc!, Nat.shiftLeft_eq, Nat.one_mul, fillSlotsU_eq, dite_eq_ite, ite_self]
         refine buildCanonicalLoop_spec lengths _ (start + 1) _ lsList hlsList maxBits hmb
           blCount hblCount ncSpec hncSpec hv hncSize' (by rw [fillSlots_size]; exact hpsize)
           idx hidx hnc' ?_ ?_

--- a/Zip/Spec/InflateTreeFreeCorrect.lean
+++ b/Zip/Spec/InflateTreeFreeCorrect.lean
@@ -1695,7 +1695,7 @@ theorem decodeHuffmanFastBufTreeFree_ok_iff (br : BitReader) (output : ByteArray
     · have hs := hbc1.span; rw [hpe] at hs; omega
   have hbc2 : BufCorr br.data br.bitPos pos0 (bitBuf0 >>> br.bitOff.toUInt64) (cnt0 - br.bitOff) :=
     consume_corr hbc1 hboff (by omega)
-  unfold decodeHuffmanFastBufTreeFree decodeHuffmanFastBuf
+  unfold decodeHuffmanFastBufTreeFree decodeHuffmanFastBufTables decodeHuffmanFastBuf
   rw [hrf]
   dsimp only []
   rw [htlit, htdist,
@@ -1743,6 +1743,17 @@ private theorem bindOk {α β : Type} {e : Except String α} {f : α → Except 
   cases e with
   | error e => simp [bind, Except.bind] at he
   | ok a => exact ⟨a, rfl, by simpa only [bind, Except.bind] using he⟩
+
+/-- The constant-table fixed-Huffman decode is the per-block build specialised to
+    the fixed code lengths: `decodeHuffmanFastBufFixed` runs
+    `decodeHuffmanFastBufTables` over the compile-time fixed tables, which are by
+    definition the tables `decodeHuffmanFastBufTreeFree` builds from
+    `fixedLitLengths`/`fixedDistLengths`. Definitionally equal, so every fixed-block
+    correctness step goes through `decodeHuffmanFastBufTreeFree_ok_iff` unchanged. -/
+theorem decodeHuffmanFastBufFixed_eq (br : BitReader) (output : ByteArray) (maxOut : Nat) :
+    decodeHuffmanFastBufFixed br output maxOut
+      = InflateBuf.decodeHuffmanFastBufTreeFree br output fixedLitLengths fixedDistLengths maxOut :=
+  rfl
 
 /-- A single `readBit` yields a value `< 2` (it is `(…) &&& 1`). -/
 theorem readBit_lt {br br' : BitReader} {bit : UInt32} (h : br.readBit = .ok (bit, br')) :
@@ -1962,7 +1973,7 @@ theorem inflateLoopTreeFree_of_inflateLoop (data : ByteArray)
           (HuffTree.fromLengthsTree fixedDistLengths 15) maxOut = .ok (output', br') := by
         rw [← decodeHuffmanFast_eq br₂ output _ _ maxOut hldep hddep hbo₂ hwf₂]; exact hblock
       obtain ⟨hd', hp', hl'⟩ := Zip.Native.decodeHuffman_inv _ _ br₂ br' output output' maxOut hhf' hp₂ hl₂
-      rw [htf]; dsimp only [bind, Except.bind]
+      rw [decodeHuffmanFastBufFixed_eq, htf]; dsimp only [bind, Except.bind]
       exact tailfwd output' br' hp' hl' (by rw [hd']; exact hdata₂) htail
     · -- dynamic Huffman block
       obtain ⟨pdt, hdt, h⟩ := bindOk h; obtain ⟨lt, dt, br₃⟩ := pdt; simp only [] at h
@@ -2071,6 +2082,7 @@ theorem inflateLoop_of_inflateLoopTreeFree (data : ByteArray)
       exact tailbwd output' br' hp' hl' (by rw [hd']; exact hdata₂) htail
     · -- fixed Huffman block
       obtain ⟨pb, hblock, htail⟩ := bindOk h; obtain ⟨output', br'⟩ := pb
+      rw [decodeHuffmanFastBufFixed_eq] at hblock
       have hbuf := (decodeHuffmanFastBufTreeFree_ok_iff br₂ output fixedLitLengths fixedDistLengths
         hflv hflb hfdv hfdb maxOut hbo₂ hwf₂ (output', br')).mp hblock
       have hfast : Inflate.decodeHuffmanFast br₂ output (HuffTree.fromLengthsTree fixedLitLengths 15)

--- a/Zip/Spec/InflateTreeFreeCorrect.lean
+++ b/Zip/Spec/InflateTreeFreeCorrect.lean
@@ -68,6 +68,7 @@ theorem kraftSumFast_go_eq (count : Array Nat) (maxBits b acc : Nat) :
   if h : b ≤ maxBits then
     rw [dif_pos h, kraftSumFast_go_eq count maxBits (b + 1) _,
         Huffman.Spec.kraftSumFrom_unfold count maxBits b h]
+    simp only [Nat.shiftLeft_eq, Nat.one_mul]
     omega
   else
     rw [dif_neg h, Huffman.Spec.kraftSumFrom_gt count maxBits b (by omega), Nat.add_zero]
@@ -104,6 +105,7 @@ theorem fromLengths_eq_validate (lengths : Array UInt8) (maxBits : Nat) :
     fromLengths lengths maxBits
       = (validateLengths lengths maxBits).map (fun _ => fromLengthsTree lengths maxBits) := by
   unfold fromLengths validateLengths
+  simp only [Nat.shiftLeft_eq, Nat.one_mul]
   by_cases h1 : lengths.any (fun l => l.toNat > maxBits) = true
   · rw [if_pos h1, if_pos h1]; rfl
   · rw [if_neg h1, if_neg h1, validate_kraft_eq lengths maxBits h1]

--- a/bench/graphs/canterbury_compress_heatmap.svg
+++ b/bench/graphs/canterbury_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#pfa937b0076)">
+   <g clip-path="url(#p06ea0e31fb)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJB0lEQVR4nO3YvYpdVQCG4TmZM5qYMQyCMRgIgjaCYKWN9vZeiFdg4zV4ByLYi2BhbWMpNgqCRAmKkmh+ZiaT82Mh2AvvYpnN81zBt1nsfd6zVru/Ptsf8HQ5fzh7wTiPl/ls+4vz2ROGWV27PnvCGM8+N3vBOKtLsxeM8WS579lSz2x/95fZE4ZZ5okBAEwksAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYuvbq7uzNwxxsT2fPWGYGyevzJ4wzPHu+uwJQ6zO7s+eMMzXZ9/PnjDEy8+8OHvCMNvdZvaEIR5sTmdPGGaz386eMMRbz9+cPWEYN1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQWx8fnczeMMRuvZs9YZjjg8uzJ4zz5+3ZC4bYn92fPWGYt2+9M3vCEKeb5Z7Zo4U+22vHb8yeMMzFajN7whD7n76dPWEYN1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQW185PJ69YYjz7ensCeOsFtzFl6/NXjDEasFndrTZzJ4wxJLP7Op6me/Zbxd3Zk8YZrO7mD1hiJtXT2ZPGGa5XxAAgEkEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMRW2+8+2s8eAf/a7WYvgH9c8v/zqeP7wf+ILwgAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDE1h/8fnv2hiHuP97OnjDMN3cezJ4wzBfvvzt7whAvXbk1e8Iwb37y6ewJQ7z36guzJwzz472z2ROGuLI+nD1hmM+//GH2hCFOP/5w9oRh3GABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBAbLXZfbWfPWKE7W4ze8Iwl1bL7eLD89PZE8Y4XM9eMM6ju7MXDLE9uTF7wjC7/W72hCGOVst9z57sl/mbdrRZ5nMdHLjBAgDICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgNh69oBR9ge72ROGObz36+wJ4zz8Y/aCIfYXT2ZPGGZ18/XZE/iPHm9PZ08Y4mi5r9nB0cUyz2z/x8+zJwzjBgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABifwNgWILmYcDVwgAAAABJRU5ErkJggg==" id="image0de40c5a5b" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJCUlEQVR4nO3YvYpdVQCG4TmZM5qYMQTBGBIIgoKNYKWN9vZeiFdg4zV4ByLYi2BhbWMpNgqCBA2Kmmh+ZiaT82Mh2AvvYpnN81zBt1mz93lnrXZ/fbo/4Oly9nD2gnEeL/PZ9udnsycMs7pybfaEMZ59bvaCcVYXZi8Y48ly37Olntn+7k+zJwyzzBMDAJhIYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxNa3V3dnbxjifHs2e8Iw16++PHvCMMe7a7MnDLE6vT97wjBfnX43e8IQN555cfaEYba7zewJQzzYnMyeMMxmv509YYg3n785e8IwbrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgtj4+ujp7wxC79W72hGGODy7OnjDOn7dnLxhif3p/9oRh3rr19uwJQ5xslntmjxb6bK8evz57wjDnq83sCUPsf/xm9oRh3GABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBAbH3p8Hj2hiHOtiezJ4yzWnAXX7wye8EQqwWf2dFmM3vCEEs+s8vrZb5nv57fmT1hmM3ufPaEIW5evjp7wjDL/YIAAEwisAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACC22n774X72CPjXbjd7Afzjgv8/nzq+H/yP+IIAAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBAbP3+b7dnbxji/uPt7AnDfH3nwewJw3z+3juzJwzx0qVbsycM88bHn8yeMMS7r7wwe8IwP9w7nT1hiEvrw9kThvnsi+9nTxji5KMPZk8Yxg0WAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxFab3Zf72SNG2O42sycMc2G13C4+PDuZPWGMw/XsBeM8ujt7wRDbq9dnTxhmt9/NnjDE0Wq579mT/TJ/0442y3yugwM3WAAAOYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABBbzx4wyv5gN3vCMIf3fpk9YZyHv89eMMT+/MnsCcOsbrw2ewL/0en24ewJQxw9We6dwdHjZZ7Z/o+fZ08YZrl/jQAAkwgsAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAIDY33qKguFB58SoAAAAAElFTkSuQmCC" id="imageae5a4feb2a" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m9d3b5b1483" d="M 0 0 
+       <path id="m71846296da" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m9d3b5b1483" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m71846296da" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m9d3b5b1483" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m71846296da" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m9d3b5b1483" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m71846296da" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m9d3b5b1483" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m71846296da" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m9d3b5b1483" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m71846296da" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m9d3b5b1483" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m71846296da" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m9d3b5b1483" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m71846296da" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m9d3b5b1483" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m71846296da" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m9d3b5b1483" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m71846296da" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m9d3b5b1483" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m71846296da" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m9d3b5b1483" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m71846296da" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="md92ec006b4" d="M 0 0 
+       <path id="m0f68a0fb03" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#md92ec006b4" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0f68a0fb03" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#md92ec006b4" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0f68a0fb03" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#md92ec006b4" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0f68a0fb03" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#md92ec006b4" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0f68a0fb03" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#md92ec006b4" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0f68a0fb03" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#md92ec006b4" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0f68a0fb03" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#md92ec006b4" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0f68a0fb03" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#md92ec006b4" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0f68a0fb03" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1384,7 +1384,7 @@ z
     </g>
    </g>
    <g id="text_24">
-    <!-- -89 -->
+    <!-- -88 -->
     <g transform="translate(266.996679 68.904519) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
@@ -1429,7 +1429,7 @@ z
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_25">
@@ -1441,18 +1441,18 @@ z
     </g>
    </g>
    <g id="text_26">
-    <!-- +8 -->
+    <!-- +9 -->
     <g transform="translate(346.015229 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_27">
-    <!-- +27 -->
+    <!-- +28 -->
     <g transform="translate(383.198215 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_28">
@@ -1464,45 +1464,11 @@ z
     </g>
    </g>
    <g id="text_29">
-    <!-- -43 -->
+    <!-- -44 -->
     <g transform="translate(463.250671 68.904519) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-33" d="M 2597 2516 
-Q 3050 2419 3304 2112 
-Q 3559 1806 3559 1356 
-Q 3559 666 3084 287 
-Q 2609 -91 1734 -91 
-Q 1441 -91 1130 -33 
-Q 819 25 488 141 
-L 488 750 
-Q 750 597 1062 519 
-Q 1375 441 1716 441 
-Q 2309 441 2620 675 
-Q 2931 909 2931 1356 
-Q 2931 1769 2642 2001 
-Q 2353 2234 1838 2234 
-L 1294 2234 
-L 1294 2753 
-L 1863 2753 
-Q 2328 2753 2575 2939 
-Q 2822 3125 2822 3475 
-Q 2822 3834 2567 4026 
-Q 2313 4219 1838 4219 
-Q 1578 4219 1281 4162 
-Q 984 4106 628 3988 
-L 628 4550 
-Q 988 4650 1302 4700 
-Q 1616 4750 1894 4750 
-Q 2613 4750 3031 4423 
-Q 3450 4097 3450 3541 
-Q 3450 3153 3228 2886 
-Q 3006 2619 2597 2516 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_30">
@@ -1577,6 +1543,40 @@ z
    <g id="text_39">
     <!-- -3 -->
     <g transform="translate(426.067685 104.25537) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
     </g>
@@ -2181,18 +2181,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="image8b2f6524f8" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
+iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="imagef5c9d00830" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="mef04d20138" d="M 0 0 
+       <path id="md5258ea213" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mef04d20138" x="547.779688" y="276.293905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md5258ea213" x="547.779688" y="276.293905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
@@ -2215,7 +2215,7 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#mef04d20138" x="547.779688" y="247.808905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md5258ea213" x="547.779688" y="247.808905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
@@ -2229,7 +2229,7 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#mef04d20138" x="547.779688" y="219.323905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md5258ea213" x="547.779688" y="219.323905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
@@ -2243,7 +2243,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#mef04d20138" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md5258ea213" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
@@ -2256,7 +2256,7 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mef04d20138" x="547.779688" y="162.353904" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md5258ea213" x="547.779688" y="162.353904" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_112">
@@ -2269,7 +2269,7 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#mef04d20138" x="547.779688" y="133.868904" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md5258ea213" x="547.779688" y="133.868904" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
@@ -2282,7 +2282,7 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mef04d20138" x="547.779688" y="105.383904" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md5258ea213" x="547.779688" y="105.383904" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
@@ -2943,8 +2943,8 @@ z
    </g>
   </g>
   <g id="text_117">
-   <!-- 2026-07-07T22:17:01Z  ·  Linux chungus2 x86_64  ·  commit dcf4b958  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(17.687422 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-08T05:15:03Z  ·  Linux chungus2 x86_64  ·  commit cf8297c9  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(17.98 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -3011,16 +3011,16 @@ z
     <use xlink:href="#DejaVuSans-37" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
     <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3060,109 +3060,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3135.351562 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3190.332031 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3225.537109 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3289.160156 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3352.636719 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3416.259766 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3479.882812 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3543.505859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3575.292969 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3607.080078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3638.867188 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3670.654297 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3702.441406 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3730.224609 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3791.748047 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3853.027344 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3916.40625 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3979.882812 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4018.746094 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4079.927734 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4139.107422 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4200.630859 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4241.744141 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4275.435547 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4303.21875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4364.742188 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4426.021484 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4489.400391 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4553.023438 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4586.714844 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4645.894531 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4709.517578 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4741.304688 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4804.927734 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4868.550781 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4900.337891 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4963.960938 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5000.044922 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5038.908203 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5093.888672 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5157.511719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5189.298828 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5221.085938 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5252.873047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5284.660156 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5316.447266 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5355.65625 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5419.035156 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5457.898438 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5519.080078 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5582.458984 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5645.935547 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5709.314453 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5772.791016 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5836.169922 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5875.378906 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5907.166016 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5990.955078 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6022.742188 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6120.154297 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6181.677734 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6245.154297 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6272.9375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6334.216797 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6397.595703 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6429.382812 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6481.482422 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6544.861328 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6606.140625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6669.617188 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6721.716797 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6785.095703 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6846.277344 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6885.486328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6919.177734 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6950.964844 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6992.078125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7053.357422 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7092.566406 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7120.349609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7181.53125 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7213.318359 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7241.101562 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7293.201172 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7324.988281 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7388.464844 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7449.988281 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7489.197266 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7550.720703 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7590.083984 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7687.496094 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7715.279297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7778.658203 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7806.441406 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7858.541016 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7897.75 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7925.533203 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3126.855469 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3162.060547 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3225.683594 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3289.306641 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3352.929688 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3416.552734 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3471.533203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3535.15625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3566.943359 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3598.730469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3630.517578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3662.304688 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3694.091797 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3721.875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3783.398438 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3844.677734 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3908.056641 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3971.533203 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4010.396484 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4071.578125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4130.757812 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4192.28125 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4233.394531 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4267.085938 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4294.869141 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4356.392578 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4417.671875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4481.050781 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4544.673828 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4578.365234 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4637.544922 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4701.167969 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4732.955078 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4796.578125 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4860.201172 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4891.988281 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4955.611328 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4991.695312 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5030.558594 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5085.539062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5149.162109 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5180.949219 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5212.736328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5244.523438 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5276.310547 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5308.097656 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5347.306641 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5410.685547 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5449.548828 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5510.730469 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5574.109375 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5637.585938 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5700.964844 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5764.441406 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5827.820312 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5867.029297 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5898.816406 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5982.605469 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6014.392578 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6111.804688 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6173.328125 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6236.804688 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6264.587891 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6325.867188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6389.246094 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6421.033203 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6473.132812 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6536.511719 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6597.791016 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6661.267578 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6713.367188 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6776.746094 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6837.927734 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6877.136719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6910.828125 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6942.615234 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6983.728516 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7045.007812 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7084.216797 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7112 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7173.181641 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7204.96875 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7232.751953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7284.851562 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7316.638672 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7380.115234 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7441.638672 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7480.847656 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7542.371094 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7581.734375 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7679.146484 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7706.929688 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7770.308594 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7798.091797 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7850.191406 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7889.400391 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7917.183594 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pfa937b0076">
+  <clipPath id="p06ea0e31fb">
    <rect x="95.67625" y="49.4355" width="431.758783" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_compress_pareto.svg
+++ b/bench/graphs/canterbury_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 79.118387 412.80375 
 L 79.118387 48.323125 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m72909e15f7" d="M 0 0 
+       <path id="m6b81c17efc" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m72909e15f7" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6b81c17efc" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -161,11 +161,11 @@ z
      <g id="line2d_3">
       <path d="M 166.481434 412.80375 
 L 166.481434 48.323125 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m72909e15f7" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6b81c17efc" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -216,11 +216,11 @@ z
      <g id="line2d_5">
       <path d="M 253.844481 412.80375 
 L 253.844481 48.323125 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m72909e15f7" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6b81c17efc" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -237,11 +237,11 @@ L 253.844481 48.323125
      <g id="line2d_7">
       <path d="M 341.207528 412.80375 
 L 341.207528 48.323125 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m72909e15f7" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6b81c17efc" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -279,11 +279,11 @@ z
      <g id="line2d_9">
       <path d="M 428.570575 412.80375 
 L 428.570575 48.323125 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m72909e15f7" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6b81c17efc" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -332,11 +332,11 @@ z
      <g id="line2d_11">
       <path d="M 515.933622 412.80375 
 L 515.933622 48.323125 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m72909e15f7" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6b81c17efc" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -353,11 +353,11 @@ L 515.933622 48.323125
      <g id="line2d_13">
       <path d="M 603.296669 412.80375 
 L 603.296669 48.323125 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m72909e15f7" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6b81c17efc" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -854,16 +854,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 347.786382 
 L 637.2 347.786382 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="m82a5852e3c" d="M 0 0 
+       <path id="md88a702d1f" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m82a5852e3c" x="49.078125" y="347.786382" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md88a702d1f" x="49.078125" y="347.786382" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -895,11 +895,11 @@ z
      <g id="line2d_17">
       <path d="M 49.078125 238.646289 
 L 637.2 238.646289 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m82a5852e3c" x="49.078125" y="238.646289" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md88a702d1f" x="49.078125" y="238.646289" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -915,11 +915,11 @@ L 637.2 238.646289
      <g id="line2d_19">
       <path d="M 49.078125 129.506196 
 L 637.2 129.506196 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m82a5852e3c" x="49.078125" y="129.506196" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md88a702d1f" x="49.078125" y="129.506196" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -935,16 +935,16 @@ L 637.2 129.506196
      <g id="line2d_21">
       <path d="M 49.078125 404.853417 
 L 637.2 404.853417 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="m2ac1984819" d="M 0 0 
+       <path id="m805efe0d62" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m2ac1984819" x="49.078125" y="404.853417" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m805efe0d62" x="49.078125" y="404.853417" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -952,11 +952,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 391.217592 
 L 637.2 391.217592 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m2ac1984819" x="49.078125" y="391.217592" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m805efe0d62" x="49.078125" y="391.217592" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -964,11 +964,11 @@ L 637.2 391.217592
      <g id="line2d_25">
       <path d="M 49.078125 380.640824 
 L 637.2 380.640824 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m2ac1984819" x="49.078125" y="380.640824" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m805efe0d62" x="49.078125" y="380.640824" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -976,11 +976,11 @@ L 637.2 380.640824
      <g id="line2d_27">
       <path d="M 49.078125 371.998975 
 L 637.2 371.998975 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m2ac1984819" x="49.078125" y="371.998975" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m805efe0d62" x="49.078125" y="371.998975" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -988,11 +988,11 @@ L 637.2 371.998975
      <g id="line2d_29">
       <path d="M 49.078125 364.692396 
 L 637.2 364.692396 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m2ac1984819" x="49.078125" y="364.692396" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m805efe0d62" x="49.078125" y="364.692396" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1000,11 +1000,11 @@ L 637.2 364.692396
      <g id="line2d_31">
       <path d="M 49.078125 358.36315 
 L 637.2 358.36315 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m2ac1984819" x="49.078125" y="358.36315" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m805efe0d62" x="49.078125" y="358.36315" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1012,11 +1012,11 @@ L 637.2 358.36315
      <g id="line2d_33">
       <path d="M 49.078125 352.780359 
 L 637.2 352.780359 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m2ac1984819" x="49.078125" y="352.780359" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m805efe0d62" x="49.078125" y="352.780359" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1024,11 +1024,11 @@ L 637.2 352.780359
      <g id="line2d_35">
       <path d="M 49.078125 314.93194 
 L 637.2 314.93194 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m2ac1984819" x="49.078125" y="314.93194" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m805efe0d62" x="49.078125" y="314.93194" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1036,11 +1036,11 @@ L 637.2 314.93194
      <g id="line2d_37">
       <path d="M 49.078125 295.713324 
 L 637.2 295.713324 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m2ac1984819" x="49.078125" y="295.713324" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m805efe0d62" x="49.078125" y="295.713324" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1048,11 +1048,11 @@ L 637.2 295.713324
      <g id="line2d_39">
       <path d="M 49.078125 282.077499 
 L 637.2 282.077499 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m2ac1984819" x="49.078125" y="282.077499" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m805efe0d62" x="49.078125" y="282.077499" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1060,11 +1060,11 @@ L 637.2 282.077499
      <g id="line2d_41">
       <path d="M 49.078125 271.500731 
 L 637.2 271.500731 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m2ac1984819" x="49.078125" y="271.500731" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m805efe0d62" x="49.078125" y="271.500731" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1072,11 +1072,11 @@ L 637.2 271.500731
      <g id="line2d_43">
       <path d="M 49.078125 262.858882 
 L 637.2 262.858882 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m2ac1984819" x="49.078125" y="262.858882" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m805efe0d62" x="49.078125" y="262.858882" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1084,11 +1084,11 @@ L 637.2 262.858882
      <g id="line2d_45">
       <path d="M 49.078125 255.552304 
 L 637.2 255.552304 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m2ac1984819" x="49.078125" y="255.552304" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m805efe0d62" x="49.078125" y="255.552304" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1096,11 +1096,11 @@ L 637.2 255.552304
      <g id="line2d_47">
       <path d="M 49.078125 249.223057 
 L 637.2 249.223057 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m2ac1984819" x="49.078125" y="249.223057" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m805efe0d62" x="49.078125" y="249.223057" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1108,11 +1108,11 @@ L 637.2 249.223057
      <g id="line2d_49">
       <path d="M 49.078125 243.640266 
 L 637.2 243.640266 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m2ac1984819" x="49.078125" y="243.640266" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m805efe0d62" x="49.078125" y="243.640266" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1120,11 +1120,11 @@ L 637.2 243.640266
      <g id="line2d_51">
       <path d="M 49.078125 205.791848 
 L 637.2 205.791848 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m2ac1984819" x="49.078125" y="205.791848" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m805efe0d62" x="49.078125" y="205.791848" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1132,11 +1132,11 @@ L 637.2 205.791848
      <g id="line2d_53">
       <path d="M 49.078125 186.573231 
 L 637.2 186.573231 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#m2ac1984819" x="49.078125" y="186.573231" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m805efe0d62" x="49.078125" y="186.573231" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1144,11 +1144,11 @@ L 637.2 186.573231
      <g id="line2d_55">
       <path d="M 49.078125 172.937406 
 L 637.2 172.937406 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#m2ac1984819" x="49.078125" y="172.937406" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m805efe0d62" x="49.078125" y="172.937406" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1156,11 +1156,11 @@ L 637.2 172.937406
      <g id="line2d_57">
       <path d="M 49.078125 162.360638 
 L 637.2 162.360638 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#m2ac1984819" x="49.078125" y="162.360638" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m805efe0d62" x="49.078125" y="162.360638" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1168,11 +1168,11 @@ L 637.2 162.360638
      <g id="line2d_59">
       <path d="M 49.078125 153.71879 
 L 637.2 153.71879 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#m2ac1984819" x="49.078125" y="153.71879" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m805efe0d62" x="49.078125" y="153.71879" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1180,11 +1180,11 @@ L 637.2 153.71879
      <g id="line2d_61">
       <path d="M 49.078125 146.412211 
 L 637.2 146.412211 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#m2ac1984819" x="49.078125" y="146.412211" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m805efe0d62" x="49.078125" y="146.412211" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1192,11 +1192,11 @@ L 637.2 146.412211
      <g id="line2d_63">
       <path d="M 49.078125 140.082964 
 L 637.2 140.082964 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#m2ac1984819" x="49.078125" y="140.082964" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m805efe0d62" x="49.078125" y="140.082964" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1204,11 +1204,11 @@ L 637.2 140.082964
      <g id="line2d_65">
       <path d="M 49.078125 134.500173 
 L 637.2 134.500173 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#m2ac1984819" x="49.078125" y="134.500173" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m805efe0d62" x="49.078125" y="134.500173" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1216,11 +1216,11 @@ L 637.2 134.500173
      <g id="line2d_67">
       <path d="M 49.078125 96.651755 
 L 637.2 96.651755 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_68">
       <g>
-       <use xlink:href="#m2ac1984819" x="49.078125" y="96.651755" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m805efe0d62" x="49.078125" y="96.651755" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1228,11 +1228,11 @@ L 637.2 96.651755
      <g id="line2d_69">
       <path d="M 49.078125 77.433138 
 L 637.2 77.433138 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_70">
       <g>
-       <use xlink:href="#m2ac1984819" x="49.078125" y="77.433138" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m805efe0d62" x="49.078125" y="77.433138" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1240,11 +1240,11 @@ L 637.2 77.433138
      <g id="line2d_71">
       <path d="M 49.078125 63.797313 
 L 637.2 63.797313 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_72">
       <g>
-       <use xlink:href="#m2ac1984819" x="49.078125" y="63.797313" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m805efe0d62" x="49.078125" y="63.797313" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1252,11 +1252,11 @@ L 637.2 63.797313
      <g id="line2d_73">
       <path d="M 49.078125 53.220545 
 L 637.2 53.220545 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_74">
       <g>
-       <use xlink:href="#m2ac1984819" x="49.078125" y="53.220545" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m805efe0d62" x="49.078125" y="53.220545" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1378,7 +1378,7 @@ L 637.2 48.323125
    </g>
    <g id="text_13">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(294.669676 148.196321) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(294.669676 149.450186) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1410,7 +1410,7 @@ z
    </g>
    <g id="text_14">
     <!-- L10 -->
-    <g style="fill: #d62728" transform="translate(104.852312 297.578113) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(104.852312 297.96803) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1732,23 +1732,23 @@ z
    </g>
    <g id="line2d_75">
     <defs>
-     <path id="m002f6c963e" d="M -2.5 2.5 
+     <path id="m75294422a3" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pc8796b989c)">
-     <use xlink:href="#m002f6c963e" x="355.479835" y="95.382063" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m002f6c963e" x="308.273931" y="102.754513" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m002f6c963e" x="271.230161" y="116.528062" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m002f6c963e" x="217.83458" y="120.013651" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m002f6c963e" x="177.077692" y="138.43462" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m002f6c963e" x="162.880539" y="157.778627" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m002f6c963e" x="160.741445" y="165.196647" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m002f6c963e" x="153.966678" y="183.405761" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m002f6c963e" x="151.589614" y="194.488118" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pb4032dd086)">
+     <use xlink:href="#m75294422a3" x="355.479835" y="95.382063" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m75294422a3" x="308.273931" y="102.754513" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m75294422a3" x="271.230161" y="116.528062" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m75294422a3" x="217.83458" y="120.013651" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m75294422a3" x="177.077692" y="138.43462" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m75294422a3" x="162.880539" y="157.778627" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m75294422a3" x="160.741445" y="165.196647" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m75294422a3" x="153.966678" y="183.405761" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m75294422a3" x="151.589614" y="194.488118" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_76">
@@ -1801,7 +1801,7 @@ L 311.2243 102.325849
 L 310.240844 102.469168 
 L 309.257387 102.612055 
 L 308.273931 102.754513 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_77">
     <path d="M 308.273931 102.754513 
@@ -1853,7 +1853,7 @@ L 273.545396 115.775058
 L 272.773651 116.027391 
 L 272.001906 116.278388 
 L 271.230161 116.528062 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_78">
     <path d="M 271.230161 116.528062 
@@ -1905,7 +1905,7 @@ L 221.171803 119.803152
 L 220.059395 119.873422 
 L 218.946988 119.943588 
 L 217.83458 120.013651 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_79">
     <path d="M 217.83458 120.013651 
@@ -1957,7 +1957,7 @@ L 179.624997 137.470928
 L 178.775895 137.79434 
 L 177.926794 138.115561 
 L 177.077692 138.43462 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_80">
     <path d="M 177.077692 138.43462 
@@ -2009,7 +2009,7 @@ L 163.767861 156.775388
 L 163.472087 157.112166 
 L 163.176313 157.446568 
 L 162.880539 157.778627 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_81">
     <path d="M 162.880539 157.778627 
@@ -2061,7 +2061,7 @@ L 160.875139 164.765525
 L 160.830574 164.909668 
 L 160.78601 165.053375 
 L 160.741445 165.196647 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_82">
     <path d="M 160.741445 165.196647 
@@ -2113,7 +2113,7 @@ L 154.390101 182.45125
 L 154.24896 182.771561 
 L 154.107819 183.089721 
 L 153.966678 183.405761 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_83">
     <path d="M 153.966678 183.405761 
@@ -2165,26 +2165,26 @@ L 151.73818 193.866427
 L 151.688658 194.074564 
 L 151.639136 194.281792 
 L 151.589614 194.488118 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_84">
     <defs>
-     <path id="m808296bf2f" d="M 0 -2.5 
+     <path id="mb20dc0d780" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pc8796b989c)">
-     <use xlink:href="#m808296bf2f" x="531.649087" y="75.963093" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m808296bf2f" x="283.721324" y="99.020035" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m808296bf2f" x="218.882044" y="121.069315" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m808296bf2f" x="187.447228" y="127.10685" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m808296bf2f" x="176.342474" y="138.36311" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m808296bf2f" x="163.054314" y="161.312135" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m808296bf2f" x="162.210539" y="168.753955" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m808296bf2f" x="159.303811" y="175.753345" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m808296bf2f" x="157.793928" y="179.494802" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pb4032dd086)">
+     <use xlink:href="#mb20dc0d780" x="531.649087" y="75.963093" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb20dc0d780" x="283.721324" y="99.020035" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb20dc0d780" x="218.882044" y="121.069315" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb20dc0d780" x="187.447228" y="127.10685" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb20dc0d780" x="176.342474" y="138.36311" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb20dc0d780" x="163.054314" y="161.312135" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb20dc0d780" x="162.210539" y="168.753955" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb20dc0d780" x="159.303811" y="175.753345" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb20dc0d780" x="157.793928" y="179.494802" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_85">
@@ -2237,7 +2237,7 @@ L 299.21681 97.864971
 L 294.051648 98.253128 
 L 288.886486 98.638133 
 L 283.721324 99.020035 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_86">
     <path d="M 283.721324 99.020035 
@@ -2289,7 +2289,7 @@ L 222.934499 119.954333
 L 221.583681 120.328916 
 L 220.232863 120.700561 
 L 218.882044 121.069315 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_87">
     <path d="M 218.882044 121.069315 
@@ -2341,7 +2341,7 @@ L 189.411904 126.751217
 L 188.757012 126.870058 
 L 188.10212 126.988602 
 L 187.447228 127.10685 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_88">
     <path d="M 187.447228 127.10685 
@@ -2393,7 +2393,7 @@ L 177.036521 137.732718
 L 176.805172 137.943781 
 L 176.573823 138.153909 
 L 176.342474 138.36311 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_89">
     <path d="M 176.342474 138.36311 
@@ -2445,7 +2445,7 @@ L 163.884824 160.161325
 L 163.607987 160.548041 
 L 163.33115 160.931628 
 L 163.054314 161.312135 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_90">
     <path d="M 163.054314 161.312135 
@@ -2497,7 +2497,7 @@ L 162.263275 168.321549
 L 162.245696 168.466124 
 L 162.228118 168.610258 
 L 162.210539 168.753955 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_91">
     <path d="M 162.210539 168.753955 
@@ -2549,7 +2549,7 @@ L 159.485481 175.344896
 L 159.424925 175.481437 
 L 159.364368 175.617586 
 L 159.303811 175.753345 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_92">
     <path d="M 159.303811 175.753345 
@@ -2601,30 +2601,30 @@ L 157.888296 179.269417
 L 157.85684 179.344665 
 L 157.825384 179.419793 
 L 157.793928 179.494802 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_93">
     <defs>
-     <path id="ma8bc97674d" d="M -0 3.535534 
+     <path id="mbef3a8d526" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pc8796b989c)">
-     <use xlink:href="#ma8bc97674d" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma8bc97674d" x="203.775848" y="81.750179" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma8bc97674d" x="186.982691" y="88.344921" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma8bc97674d" x="179.779306" y="91.045312" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma8bc97674d" x="157.610419" y="99.395085" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma8bc97674d" x="148.722526" y="107.864022" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma8bc97674d" x="144.388162" y="121.237794" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma8bc97674d" x="127.071247" y="144.560664" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma8bc97674d" x="124.491988" y="152.083585" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma8bc97674d" x="92.613662" y="207.637263" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma8bc97674d" x="87.348715" y="225.457654" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma8bc97674d" x="86.053433" y="242.017529" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pb4032dd086)">
+     <use xlink:href="#mbef3a8d526" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbef3a8d526" x="203.775848" y="81.750179" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbef3a8d526" x="186.982691" y="88.344921" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbef3a8d526" x="179.779306" y="91.045312" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbef3a8d526" x="157.610419" y="99.395085" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbef3a8d526" x="148.722526" y="107.864022" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbef3a8d526" x="144.388162" y="121.237794" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbef3a8d526" x="127.071247" y="144.560664" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbef3a8d526" x="124.491988" y="152.083585" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbef3a8d526" x="92.613662" y="207.637263" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbef3a8d526" x="87.348715" y="225.457654" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbef3a8d526" x="86.053433" y="242.017529" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_94">
@@ -2677,7 +2677,7 @@ L 206.762331 80.855075
 L 205.766837 81.155325 
 L 204.771342 81.453685 
 L 203.775848 81.750179 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_95">
     <path d="M 203.775848 81.750179 
@@ -2729,7 +2729,7 @@ L 188.032264 87.958568
 L 187.682406 88.087703 
 L 187.332549 88.216487 
 L 186.982691 88.344921 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_96">
     <path d="M 186.982691 88.344921 
@@ -2781,7 +2781,7 @@ L 180.229518 90.88097
 L 180.079447 90.935814 
 L 179.929376 90.990595 
 L 179.779306 91.045312 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_97">
     <path d="M 179.779306 91.045312 
@@ -2833,7 +2833,7 @@ L 158.995974 98.914174
 L 158.534122 99.075021 
 L 158.07227 99.235323 
 L 157.610419 99.395085 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_98">
     <path d="M 157.610419 99.395085 
@@ -2885,7 +2885,7 @@ L 149.27802 107.37681
 L 149.092855 107.539771 
 L 148.907691 107.702174 
 L 148.722526 107.864022 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_99">
     <path d="M 148.722526 107.864022 
@@ -2937,7 +2937,7 @@ L 144.65906 120.50385
 L 144.568761 120.749763 
 L 144.478462 120.994407 
 L 144.388162 121.237794 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_100">
     <path d="M 144.388162 121.237794 
@@ -2989,7 +2989,7 @@ L 128.153555 143.395158
 L 127.792786 143.786853 
 L 127.432016 144.175338 
 L 127.071247 144.560664 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_101">
     <path d="M 127.071247 144.560664 
@@ -3041,7 +3041,7 @@ L 124.653192 151.646811
 L 124.599457 151.79285 
 L 124.545723 151.93844 
 L 124.491988 152.083585 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_102">
     <path d="M 124.491988 152.083585 
@@ -3093,7 +3093,7 @@ L 94.606058 205.546972
 L 93.941926 206.254028 
 L 93.277794 206.950691 
 L 92.613662 207.637263 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_103">
     <path d="M 92.613662 207.637263 
@@ -3145,7 +3145,7 @@ L 87.677774 224.520091
 L 87.568088 224.834677 
 L 87.458402 225.147189 
 L 87.348715 225.457654 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_104">
     <path d="M 87.348715 225.457654 
@@ -3197,23 +3197,23 @@ L 86.134388 241.135848
 L 86.107403 241.431568 
 L 86.080418 241.725454 
 L 86.053433 242.017529 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_105">
     <defs>
-     <path id="me0a934e4a4" d="M -0 2.5 
+     <path id="m14daf4e2f2" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pc8796b989c)">
-     <use xlink:href="#me0a934e4a4" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pb4032dd086)">
+     <use xlink:href="#m14daf4e2f2" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_106">
     <defs>
-     <path id="m012bf5a8af" d="M -0.833333 2.5 
+     <path id="m2e872db069" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -3228,16 +3228,16 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pc8796b989c)">
-     <use xlink:href="#m012bf5a8af" x="362.865999" y="115.428618" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m012bf5a8af" x="278.798176" y="122.858526" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m012bf5a8af" x="251.17632" y="128.261574" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m012bf5a8af" x="200.806828" y="131.522849" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m012bf5a8af" x="169.803221" y="147.931404" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m012bf5a8af" x="161.916638" y="160.718659" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m012bf5a8af" x="158.697104" y="167.705569" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m012bf5a8af" x="154.26679" y="181.026105" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m012bf5a8af" x="153.096464" y="191.924265" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pb4032dd086)">
+     <use xlink:href="#m2e872db069" x="362.865999" y="115.428618" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2e872db069" x="278.798176" y="122.858526" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2e872db069" x="251.17632" y="128.261574" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2e872db069" x="200.806828" y="131.522849" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2e872db069" x="169.803221" y="147.931404" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2e872db069" x="161.916638" y="160.718659" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2e872db069" x="158.697104" y="167.705569" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2e872db069" x="154.26679" y="181.026105" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2e872db069" x="153.096464" y="191.924265" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_107">
@@ -3290,7 +3290,7 @@ L 284.052415 122.426763
 L 282.301002 122.571121 
 L 280.549589 122.715042 
 L 278.798176 122.858526 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_108">
     <path d="M 278.798176 122.858526 
@@ -3342,7 +3342,7 @@ L 252.902686 127.94134
 L 252.327231 128.048325 
 L 251.751776 128.155069 
 L 251.17632 128.261574 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_109">
     <path d="M 251.17632 128.261574 
@@ -3394,7 +3394,7 @@ L 203.954921 131.325463
 L 202.905557 131.39135 
 L 201.856192 131.457145 
 L 200.806828 131.522849 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_110">
     <path d="M 200.806828 131.522849 
@@ -3446,7 +3446,7 @@ L 171.740947 147.056528
 L 171.095038 147.349951 
 L 170.44913 147.64157 
 L 169.803221 147.931404 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_111">
     <path d="M 169.803221 147.931404 
@@ -3498,7 +3498,7 @@ L 162.409549 160.012958
 L 162.245246 160.249361 
 L 162.080942 160.484591 
 L 161.916638 160.718659 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_112">
     <path d="M 161.916638 160.718659 
@@ -3550,7 +3550,7 @@ L 158.898325 167.297798
 L 158.831251 167.434112 
 L 158.764178 167.570034 
 L 158.697104 167.705569 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_113">
     <path d="M 158.697104 167.705569 
@@ -3602,7 +3602,7 @@ L 154.543684 180.294711
 L 154.451386 180.539765 
 L 154.359088 180.783558 
 L 154.26679 181.026105 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_114">
     <path d="M 154.26679 181.026105 
@@ -3654,11 +3654,11 @@ L 153.16961 191.311823
 L 153.145228 191.516851 
 L 153.120846 191.720996 
 L 153.096464 191.924265 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_115">
     <defs>
-     <path id="mee9f8fe1ab" d="M -1.25 2.5 
+     <path id="mdbbd9ec472" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -3673,16 +3673,16 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pc8796b989c)">
-     <use xlink:href="#mee9f8fe1ab" x="301.619021" y="150.561849" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mee9f8fe1ab" x="250.236474" y="156.671134" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mee9f8fe1ab" x="225.418659" y="160.842551" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mee9f8fe1ab" x="212.328936" y="161.382211" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mee9f8fe1ab" x="209.030149" y="166.25091" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mee9f8fe1ab" x="197.547749" y="171.432451" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mee9f8fe1ab" x="194.819287" y="175.129495" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mee9f8fe1ab" x="193.12279" y="181.606362" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mee9f8fe1ab" x="192.79794" y="189.451167" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pb4032dd086)">
+     <use xlink:href="#mdbbd9ec472" x="301.619021" y="150.561849" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdbbd9ec472" x="250.236474" y="156.671134" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdbbd9ec472" x="225.418659" y="160.842551" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdbbd9ec472" x="212.328936" y="161.382211" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdbbd9ec472" x="209.030149" y="166.25091" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdbbd9ec472" x="197.547749" y="171.432451" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdbbd9ec472" x="194.819287" y="175.129495" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdbbd9ec472" x="193.12279" y="181.606362" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdbbd9ec472" x="192.79794" y="189.451167" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_116">
@@ -3735,7 +3735,7 @@ L 253.447883 156.311526
 L 252.377414 156.431699 
 L 251.306944 156.551567 
 L 250.236474 156.671134 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_117">
     <path d="M 250.236474 156.671134 
@@ -3787,7 +3787,7 @@ L 226.969772 160.592321
 L 226.452735 160.675878 
 L 225.935697 160.759287 
 L 225.418659 160.842551 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_118">
     <path d="M 225.418659 160.842551 
@@ -3839,7 +3839,7 @@ L 213.147044 161.348661
 L 212.874341 161.359847 
 L 212.601639 161.37103 
 L 212.328936 161.382211 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_119">
     <path d="M 212.328936 161.382211 
@@ -3891,7 +3891,7 @@ L 209.236323 165.960837
 L 209.167599 166.057725 
 L 209.098874 166.154416 
 L 209.030149 166.25091 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_120">
     <path d="M 209.030149 166.25091 
@@ -3943,7 +3943,7 @@ L 198.265399 171.124681
 L 198.026182 171.227493 
 L 197.786966 171.330083 
 L 197.547749 171.432451 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_121">
     <path d="M 197.547749 171.432451 
@@ -3995,7 +3995,7 @@ L 194.989815 174.906688
 L 194.932972 174.981074 
 L 194.876129 175.055342 
 L 194.819287 175.129495 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_122">
     <path d="M 194.819287 175.129495 
@@ -4047,7 +4047,7 @@ L 193.228821 181.226479
 L 193.193478 181.353445 
 L 193.158134 181.480072 
 L 193.12279 181.606362 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_123">
     <path d="M 193.12279 181.606362 
@@ -4099,11 +4099,11 @@ L 192.818243 188.997124
 L 192.811475 189.148955 
 L 192.804707 189.300302 
 L 192.79794 189.451167 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_124">
     <defs>
-     <path id="m851cf456c6" d="M 0 -2.5 
+     <path id="m98f2ebf328" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -4116,16 +4116,16 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#pc8796b989c)">
-     <use xlink:href="#m851cf456c6" x="206.45578" y="118.584066" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m851cf456c6" x="206.45578" y="118.258949" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m851cf456c6" x="206.45578" y="118.759361" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m851cf456c6" x="206.45578" y="118.234957" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m851cf456c6" x="171.767499" y="134.097889" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m851cf456c6" x="163.54283" y="144.663903" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m851cf456c6" x="160.174881" y="151.505345" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m851cf456c6" x="154.179217" y="169.303726" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m851cf456c6" x="152.4406" y="178.584542" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#pb4032dd086)">
+     <use xlink:href="#m98f2ebf328" x="206.45578" y="118.584066" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m98f2ebf328" x="206.45578" y="118.258949" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m98f2ebf328" x="206.45578" y="118.759361" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m98f2ebf328" x="206.45578" y="118.234957" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m98f2ebf328" x="171.767499" y="134.097889" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m98f2ebf328" x="163.54283" y="144.663903" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m98f2ebf328" x="160.174881" y="151.505345" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m98f2ebf328" x="154.179217" y="169.303726" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m98f2ebf328" x="152.4406" y="178.584542" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_125">
@@ -4178,7 +4178,7 @@ L 206.45578 118.279335
 L 206.45578 118.27254 
 L 206.45578 118.265745 
 L 206.45578 118.258949 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_126">
     <path d="M 206.45578 118.258949 
@@ -4230,7 +4230,7 @@ L 206.45578 118.728239
 L 206.45578 118.738615 
 L 206.45578 118.748989 
 L 206.45578 118.759361 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_127">
     <path d="M 206.45578 118.759361 
@@ -4282,7 +4282,7 @@ L 206.45578 118.267903
 L 206.45578 118.256924 
 L 206.45578 118.245942 
 L 206.45578 118.234957 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_128">
     <path d="M 206.45578 118.234957 
@@ -4334,7 +4334,7 @@ L 173.935517 133.247721
 L 173.212844 133.532808 
 L 172.490172 133.816191 
 L 171.767499 134.097889 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_129">
     <path d="M 171.767499 134.097889 
@@ -4386,7 +4386,7 @@ L 164.056872 144.068227
 L 163.885524 144.267619 
 L 163.714177 144.466175 
 L 163.54283 144.663903 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_130">
     <path d="M 163.54283 144.663903 
@@ -4438,7 +4438,7 @@ L 160.385378 151.105499
 L 160.315212 151.239156 
 L 160.245047 151.372438 
 L 160.174881 151.505345 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_131">
     <path d="M 160.174881 151.505345 
@@ -4490,7 +4490,7 @@ L 154.553946 168.367127
 L 154.429036 168.681387 
 L 154.304126 168.993578 
 L 154.179217 169.303726 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_132">
     <path d="M 154.179217 169.303726 
@@ -4542,11 +4542,11 @@ L 152.549264 178.054798
 L 152.513043 178.232038 
 L 152.476822 178.408618 
 L 152.4406 178.584542 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_133">
     <defs>
-     <path id="ma40c13d693" d="M 0 -2.5 
+     <path id="m4ab1f91aed" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -4555,16 +4555,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pc8796b989c)">
-     <use xlink:href="#ma40c13d693" x="610.467188" y="172.829682" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma40c13d693" x="592.067397" y="173.763838" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma40c13d693" x="534.807821" y="180.385179" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma40c13d693" x="327.802209" y="176.172104" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma40c13d693" x="275.83761" y="186.734601" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma40c13d693" x="258.25125" y="198.783148" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma40c13d693" x="256.777056" y="203.737732" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma40c13d693" x="248.769854" y="217.74136" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma40c13d693" x="246.264594" y="227.740017" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pb4032dd086)">
+     <use xlink:href="#m4ab1f91aed" x="610.467188" y="172.829682" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4ab1f91aed" x="592.067397" y="173.763838" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4ab1f91aed" x="534.807821" y="180.385179" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4ab1f91aed" x="327.802209" y="176.172104" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4ab1f91aed" x="275.83761" y="186.734601" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4ab1f91aed" x="258.25125" y="198.783148" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4ab1f91aed" x="256.777056" y="203.737732" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4ab1f91aed" x="248.769854" y="217.74136" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4ab1f91aed" x="246.264594" y="227.740017" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_134">
@@ -4617,7 +4617,7 @@ L 593.217384 173.705989
 L 592.834055 173.72528 
 L 592.450726 173.744563 
 L 592.067397 173.763838 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_135">
     <path d="M 592.067397 173.763838 
@@ -4669,7 +4669,7 @@ L 538.386544 179.997367
 L 537.193636 180.126991 
 L 536.000728 180.25626 
 L 534.807821 180.385179 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_136">
     <path d="M 534.807821 180.385179 
@@ -4721,7 +4721,7 @@ L 340.74006 176.446681
 L 336.427443 176.355332 
 L 332.114826 176.263806 
 L 327.802209 176.172104 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_137">
     <path d="M 327.802209 176.172104 
@@ -4773,7 +4773,7 @@ L 279.085397 186.139102
 L 278.002801 186.338434 
 L 276.920205 186.536931 
 L 275.83761 186.734601 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_138">
     <path d="M 275.83761 186.734601 
@@ -4825,7 +4825,7 @@ L 259.350398 198.113494
 L 258.984015 198.337765 
 L 258.617633 198.560979 
 L 258.25125 198.783148 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_139">
     <path d="M 258.25125 198.783148 
@@ -4877,7 +4877,7 @@ L 256.869193 203.442789
 L 256.838481 203.541307 
 L 256.807768 203.639621 
 L 256.777056 203.737732 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_140">
     <path d="M 256.777056 203.737732 
@@ -4929,7 +4929,7 @@ L 249.270304 216.977455
 L 249.103487 217.23346 
 L 248.93667 217.48809 
 L 248.769854 217.74136 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_141">
     <path d="M 248.769854 217.74136 
@@ -4981,7 +4981,7 @@ L 246.421172 227.173237
 L 246.368979 227.362918 
 L 246.316786 227.551842 
 L 246.264594 227.740017 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="legend_1">
     <g id="patch_7">
@@ -4999,7 +4999,7 @@ z
     </g>
     <g id="line2d_142">
      <defs>
-      <path id="m61a32e56df" d="M 0 3.5 
+      <path id="m7f74749afc" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -5012,7 +5012,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m61a32e56df" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m7f74749afc" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -5071,7 +5071,7 @@ z
     </g>
     <g id="line2d_143">
      <g>
-      <use xlink:href="#m002f6c963e" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m75294422a3" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -5085,7 +5085,7 @@ z
     </g>
     <g id="line2d_144">
      <g>
-      <use xlink:href="#m808296bf2f" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mb20dc0d780" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -5130,7 +5130,7 @@ z
     </g>
     <g id="line2d_145">
      <g>
-      <use xlink:href="#ma8bc97674d" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mbef3a8d526" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -5173,7 +5173,7 @@ z
     </g>
     <g id="line2d_146">
      <g>
-      <use xlink:href="#me0a934e4a4" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m14daf4e2f2" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -5189,7 +5189,7 @@ z
     </g>
     <g id="line2d_147">
      <g>
-      <use xlink:href="#m012bf5a8af" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m2e872db069" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -5243,7 +5243,7 @@ z
     </g>
     <g id="line2d_148">
      <g>
-      <use xlink:href="#mee9f8fe1ab" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mdbbd9ec472" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -5308,7 +5308,7 @@ z
     </g>
     <g id="line2d_149">
      <g>
-      <use xlink:href="#m851cf456c6" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#m98f2ebf328" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -5346,7 +5346,7 @@ z
     </g>
     <g id="line2d_150">
      <g>
-      <use xlink:href="#ma40c13d693" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m4ab1f91aed" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -5416,486 +5416,486 @@ z
     </g>
    </g>
    <g id="line2d_151">
-    <g clip-path="url(#pc8796b989c)">
-     <use xlink:href="#m61a32e56df" x="289.669676" y="153.196321" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m61a32e56df" x="223.847406" y="163.911304" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m61a32e56df" x="212.215046" y="167.663596" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m61a32e56df" x="181.367844" y="175.419581" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m61a32e56df" x="165.231972" y="183.473767" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m61a32e56df" x="153.327587" y="189.004841" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m61a32e56df" x="148.576453" y="194.92415" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m61a32e56df" x="145.287154" y="198.023662" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m61a32e56df" x="115.00257" y="275.970483" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m61a32e56df" x="99.852312" y="302.578113" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <g clip-path="url(#pb4032dd086)">
+     <use xlink:href="#m7f74749afc" x="289.669676" y="154.450186" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m7f74749afc" x="223.847406" y="163.880971" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m7f74749afc" x="212.215046" y="167.652193" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m7f74749afc" x="181.367844" y="175.346471" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m7f74749afc" x="165.231972" y="183.532075" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m7f74749afc" x="153.327587" y="188.734987" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m7f74749afc" x="148.576453" y="194.774246" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m7f74749afc" x="145.287154" y="197.774656" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m7f74749afc" x="115.00257" y="276.539352" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m7f74749afc" x="99.852312" y="302.96803" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
    <g id="line2d_152">
-    <path d="M 289.669676 153.196321 
-L 288.298379 153.446135 
-L 286.927082 153.69464 
-L 285.555784 153.941849 
-L 284.184487 154.187775 
-L 282.81319 154.432432 
-L 281.441892 154.675832 
-L 280.070595 154.917989 
-L 278.699298 155.158915 
-L 277.328 155.398623 
-L 275.956703 155.637124 
-L 274.585406 155.874432 
-L 273.214109 156.110557 
-L 271.842811 156.345512 
-L 270.471514 156.579308 
-L 269.100217 156.811956 
-L 267.728919 157.043468 
-L 266.357622 157.273854 
-L 264.986325 157.503127 
-L 263.615028 157.731295 
-L 262.24373 157.958371 
-L 260.872433 158.184364 
-L 259.501136 158.409284 
-L 258.129838 158.633142 
-L 256.758541 158.855948 
-L 255.387244 159.077711 
-L 254.015947 159.298442 
-L 252.644649 159.51815 
-L 251.273352 159.736843 
-L 249.902055 159.954533 
-L 248.530757 160.171227 
-L 247.15946 160.386935 
-L 245.788163 160.601666 
-L 244.416866 160.815429 
-L 243.045568 161.028231 
-L 241.674271 161.240083 
-L 240.302974 161.450992 
-L 238.931676 161.660966 
-L 237.560379 161.870015 
-L 236.189082 162.078146 
-L 234.817784 162.285366 
-L 233.446487 162.491685 
-L 232.07519 162.697109 
-L 230.703893 162.901647 
-L 229.332595 163.105307 
-L 227.961298 163.308095 
-L 226.590001 163.510019 
-L 225.218703 163.711086 
-L 223.847406 163.911304 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 289.669676 154.450186 
+L 288.298379 154.667073 
+L 286.927082 154.882972 
+L 285.555784 155.097893 
+L 284.184487 155.311843 
+L 282.81319 155.524831 
+L 281.441892 155.736867 
+L 280.070595 155.947959 
+L 278.699298 156.158115 
+L 277.328 156.367343 
+L 275.956703 156.575651 
+L 274.585406 156.783048 
+L 273.214109 156.989542 
+L 271.842811 157.19514 
+L 270.471514 157.399849 
+L 269.100217 157.603679 
+L 267.728919 157.806636 
+L 266.357622 158.008727 
+L 264.986325 158.209961 
+L 263.615028 158.410343 
+L 262.24373 158.609883 
+L 260.872433 158.808585 
+L 259.501136 159.006458 
+L 258.129838 159.203509 
+L 256.758541 159.399744 
+L 255.387244 159.595169 
+L 254.015947 159.789793 
+L 252.644649 159.98362 
+L 251.273352 160.176658 
+L 249.902055 160.368913 
+L 248.530757 160.560391 
+L 247.15946 160.751099 
+L 245.788163 160.941043 
+L 244.416866 161.130228 
+L 243.045568 161.318662 
+L 241.674271 161.506349 
+L 240.302974 161.693296 
+L 238.931676 161.879509 
+L 237.560379 162.064993 
+L 236.189082 162.249754 
+L 234.817784 162.433797 
+L 233.446487 162.617129 
+L 232.07519 162.799754 
+L 230.703893 162.981678 
+L 229.332595 163.162907 
+L 227.961298 163.343446 
+L 226.590001 163.523299 
+L 225.218703 163.702472 
+L 223.847406 163.880971 
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_153">
-    <path d="M 223.847406 163.911304 
-L 223.605065 163.992585 
-L 223.362724 164.073726 
-L 223.120384 164.154729 
-L 222.878043 164.235593 
-L 222.635702 164.31632 
-L 222.393361 164.39691 
-L 222.15102 164.477362 
-L 221.908679 164.557679 
-L 221.666339 164.637859 
-L 221.423998 164.717905 
-L 221.181657 164.797815 
-L 220.939316 164.877591 
-L 220.696975 164.957232 
-L 220.454635 165.03674 
-L 220.212294 165.116115 
-L 219.969953 165.195358 
-L 219.727612 165.274468 
-L 219.485271 165.353446 
-L 219.24293 165.432293 
-L 219.00059 165.511008 
-L 218.758249 165.589594 
-L 218.515908 165.668049 
-L 218.273567 165.746375 
-L 218.031226 165.824571 
-L 217.788885 165.902639 
-L 217.546545 165.980578 
-L 217.304204 166.058389 
-L 217.061863 166.136073 
-L 216.819522 166.21363 
-L 216.577181 166.29106 
-L 216.33484 166.368363 
-L 216.0925 166.445541 
-L 215.850159 166.522594 
-L 215.607818 166.599521 
-L 215.365477 166.676324 
-L 215.123136 166.753002 
-L 214.880795 166.829556 
-L 214.638455 166.905988 
-L 214.396114 166.982296 
-L 214.153773 167.058481 
-L 213.911432 167.134544 
-L 213.669091 167.210486 
-L 213.42675 167.286305 
-L 213.18441 167.362004 
-L 212.942069 167.437582 
-L 212.699728 167.51304 
-L 212.457387 167.588378 
-L 212.215046 167.663596 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 223.847406 163.880971 
+L 223.605065 163.962678 
+L 223.362724 164.044244 
+L 223.120384 164.12567 
+L 222.878043 164.206957 
+L 222.635702 164.288104 
+L 222.393361 164.369112 
+L 222.15102 164.449983 
+L 221.908679 164.530715 
+L 221.666339 164.61131 
+L 221.423998 164.691769 
+L 221.181657 164.772091 
+L 220.939316 164.852277 
+L 220.696975 164.932328 
+L 220.454635 165.012244 
+L 220.212294 165.092025 
+L 219.969953 165.171673 
+L 219.727612 165.251186 
+L 219.485271 165.330567 
+L 219.24293 165.409815 
+L 219.00059 165.48893 
+L 218.758249 165.567914 
+L 218.515908 165.646766 
+L 218.273567 165.725488 
+L 218.031226 165.804078 
+L 217.788885 165.882539 
+L 217.546545 165.96087 
+L 217.304204 166.039072 
+L 217.061863 166.117145 
+L 216.819522 166.19509 
+L 216.577181 166.272906 
+L 216.33484 166.350595 
+L 216.0925 166.428157 
+L 215.850159 166.505593 
+L 215.607818 166.582902 
+L 215.365477 166.660085 
+L 215.123136 166.737142 
+L 214.880795 166.814075 
+L 214.638455 166.890883 
+L 214.396114 166.967566 
+L 214.153773 167.044126 
+L 213.911432 167.120562 
+L 213.669091 167.196876 
+L 213.42675 167.273066 
+L 213.18441 167.349134 
+L 212.942069 167.425081 
+L 212.699728 167.500906 
+L 212.457387 167.57661 
+L 212.215046 167.652193 
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_154">
-    <path d="M 212.215046 167.663596 
-L 211.572396 167.838826 
-L 210.929746 168.013411 
-L 210.287096 168.187355 
-L 209.644446 168.360664 
-L 209.001796 168.533341 
-L 208.359146 168.705391 
-L 207.716496 168.876818 
-L 207.073846 169.047628 
-L 206.431196 169.217825 
-L 205.788546 169.387413 
-L 205.145896 169.556396 
-L 204.503246 169.724779 
-L 203.860596 169.892566 
-L 203.217946 170.059761 
-L 202.575296 170.226368 
-L 201.932645 170.392392 
-L 201.289995 170.557836 
-L 200.647345 170.722705 
-L 200.004695 170.887002 
-L 199.362045 171.050732 
-L 198.719395 171.213898 
-L 198.076745 171.376504 
-L 197.434095 171.538554 
-L 196.791445 171.700053 
-L 196.148795 171.861003 
-L 195.506145 172.021408 
-L 194.863495 172.181272 
-L 194.220845 172.340599 
-L 193.578195 172.499392 
-L 192.935545 172.657655 
-L 192.292895 172.815391 
-L 191.650245 172.972604 
-L 191.007595 173.129297 
-L 190.364945 173.285474 
-L 189.722294 173.441138 
-L 189.079644 173.596293 
-L 188.436994 173.750941 
-L 187.794344 173.905086 
-L 187.151694 174.058732 
-L 186.509044 174.211881 
-L 185.866394 174.364537 
-L 185.223744 174.516703 
-L 184.581094 174.668382 
-L 183.938444 174.819578 
-L 183.295794 174.970292 
-L 182.653144 175.120529 
-L 182.010494 175.270291 
-L 181.367844 175.419581 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 212.215046 167.652193 
+L 211.572396 167.825915 
+L 210.929746 167.999004 
+L 210.287096 168.171462 
+L 209.644446 168.343296 
+L 209.001796 168.514509 
+L 208.359146 168.685105 
+L 207.716496 168.85509 
+L 207.073846 169.024467 
+L 206.431196 169.193241 
+L 205.788546 169.361417 
+L 205.145896 169.528997 
+L 204.503246 169.695988 
+L 203.860596 169.862392 
+L 203.217946 170.028214 
+L 202.575296 170.193458 
+L 201.932645 170.358127 
+L 201.289995 170.522227 
+L 200.647345 170.685761 
+L 200.004695 170.848732 
+L 199.362045 171.011145 
+L 198.719395 171.173003 
+L 198.076745 171.33431 
+L 197.434095 171.495071 
+L 196.791445 171.655287 
+L 196.148795 171.814965 
+L 195.506145 171.974106 
+L 194.863495 172.132714 
+L 194.220845 172.290794 
+L 193.578195 172.448348 
+L 192.935545 172.60538 
+L 192.292895 172.761893 
+L 191.650245 172.917892 
+L 191.007595 173.073378 
+L 190.364945 173.228357 
+L 189.722294 173.38283 
+L 189.079644 173.536801 
+L 188.436994 173.690274 
+L 187.794344 173.843252 
+L 187.151694 173.995737 
+L 186.509044 174.147734 
+L 185.866394 174.299244 
+L 185.223744 174.450272 
+L 184.581094 174.60082 
+L 183.938444 174.750892 
+L 183.295794 174.90049 
+L 182.653144 175.049617 
+L 182.010494 175.198276 
+L 181.367844 175.346471 
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_155">
-    <path d="M 181.367844 175.419581 
-L 181.03168 175.602124 
-L 180.695516 175.783966 
-L 180.359352 175.965114 
-L 180.023188 176.145572 
-L 179.687024 176.325345 
-L 179.35086 176.504439 
-L 179.014696 176.682859 
-L 178.678532 176.86061 
-L 178.342368 177.037697 
-L 178.006204 177.214124 
-L 177.67004 177.389898 
-L 177.333876 177.565022 
-L 176.997712 177.739501 
-L 176.661548 177.91334 
-L 176.325384 178.086544 
-L 175.98922 178.259118 
-L 175.653056 178.431065 
-L 175.316892 178.602391 
-L 174.980728 178.7731 
-L 174.644564 178.943197 
-L 174.3084 179.112685 
-L 173.972236 179.281569 
-L 173.636072 179.449853 
-L 173.299908 179.617543 
-L 172.963744 179.784641 
-L 172.62758 179.951152 
-L 172.291416 180.11708 
-L 171.955252 180.282429 
-L 171.619088 180.447204 
-L 171.282924 180.611407 
-L 170.94676 180.775044 
-L 170.610596 180.938118 
-L 170.274432 181.100633 
-L 169.938268 181.262592 
-L 169.602104 181.424 
-L 169.26594 181.58486 
-L 168.929776 181.745176 
-L 168.593612 181.904952 
-L 168.257448 182.06419 
-L 167.921284 182.222896 
-L 167.58512 182.381072 
-L 167.248956 182.538722 
-L 166.912792 182.695849 
-L 166.576628 182.852458 
-L 166.240464 183.00855 
-L 165.9043 183.16413 
-L 165.568136 183.319201 
-L 165.231972 183.473767 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 181.367844 175.346471 
+L 181.03168 175.532251 
+L 180.695516 175.717305 
+L 180.359352 175.90164 
+L 180.023188 176.08526 
+L 179.687024 176.268172 
+L 179.35086 176.450381 
+L 179.014696 176.631892 
+L 178.678532 176.812711 
+L 178.342368 176.992842 
+L 178.006204 177.172292 
+L 177.67004 177.351064 
+L 177.333876 177.529165 
+L 176.997712 177.706599 
+L 176.661548 177.883372 
+L 176.325384 178.059487 
+L 175.98922 178.234951 
+L 175.653056 178.409768 
+L 175.316892 178.583942 
+L 174.980728 178.757478 
+L 174.644564 178.930382 
+L 174.3084 179.102657 
+L 173.972236 179.274308 
+L 173.636072 179.44534 
+L 173.299908 179.615757 
+L 172.963744 179.785563 
+L 172.62758 179.954763 
+L 172.291416 180.123361 
+L 171.955252 180.291362 
+L 171.619088 180.45877 
+L 171.282924 180.625588 
+L 170.94676 180.791821 
+L 170.610596 180.957473 
+L 170.274432 181.122548 
+L 169.938268 181.287051 
+L 169.602104 181.450984 
+L 169.26594 181.614353 
+L 168.929776 181.77716 
+L 168.593612 181.93941 
+L 168.257448 182.101106 
+L 167.921284 182.262253 
+L 167.58512 182.422854 
+L 167.248956 182.582912 
+L 166.912792 182.742432 
+L 166.576628 182.901416 
+L 166.240464 183.05987 
+L 165.9043 183.217795 
+L 165.568136 183.375196 
+L 165.231972 183.532075 
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_156">
-    <path d="M 165.231972 183.473767 
-L 164.983964 183.595833 
-L 164.735956 183.717585 
-L 164.487948 183.839025 
-L 164.23994 183.960156 
-L 163.991932 184.080977 
-L 163.743924 184.201491 
-L 163.495916 184.3217 
-L 163.247908 184.441604 
-L 162.9999 184.561206 
-L 162.751892 184.680507 
-L 162.503884 184.799508 
-L 162.255876 184.918212 
-L 162.007868 185.036618 
-L 161.75986 185.15473 
-L 161.511852 185.272548 
-L 161.263844 185.390074 
-L 161.015836 185.50731 
-L 160.767828 185.624256 
-L 160.51982 185.740914 
-L 160.271812 185.857286 
-L 160.023804 185.973373 
-L 159.775796 186.089176 
-L 159.527788 186.204697 
-L 159.27978 186.319937 
-L 159.031772 186.434898 
-L 158.783764 186.54958 
-L 158.535756 186.663986 
-L 158.287748 186.778116 
-L 158.03974 186.891972 
-L 157.791732 187.005555 
-L 157.543724 187.118867 
-L 157.295716 187.231908 
-L 157.047708 187.344681 
-L 156.7997 187.457185 
-L 156.551691 187.569424 
-L 156.303683 187.681397 
-L 156.055675 187.793106 
-L 155.807667 187.904553 
-L 155.559659 188.015738 
-L 155.311651 188.126663 
-L 155.063643 188.23733 
-L 154.815635 188.347738 
-L 154.567627 188.45789 
-L 154.319619 188.567786 
-L 154.071611 188.677428 
-L 153.823603 188.786817 
-L 153.575595 188.895954 
-L 153.327587 189.004841 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 165.231972 183.532075 
+L 164.983964 183.646504 
+L 164.735956 183.760657 
+L 164.487948 183.874536 
+L 164.23994 183.988142 
+L 163.991932 184.101476 
+L 163.743924 184.21454 
+L 163.495916 184.327335 
+L 163.247908 184.439862 
+L 162.9999 184.552122 
+L 162.751892 184.664118 
+L 162.503884 184.775849 
+L 162.255876 184.887318 
+L 162.007868 184.998525 
+L 161.75986 185.109471 
+L 161.511852 185.220159 
+L 161.263844 185.330589 
+L 161.015836 185.440762 
+L 160.767828 185.550679 
+L 160.51982 185.660343 
+L 160.271812 185.769753 
+L 160.023804 185.878911 
+L 159.775796 185.987818 
+L 159.527788 186.096476 
+L 159.27978 186.204885 
+L 159.031772 186.313047 
+L 158.783764 186.420962 
+L 158.535756 186.528633 
+L 158.287748 186.636059 
+L 158.03974 186.743243 
+L 157.791732 186.850184 
+L 157.543724 186.956885 
+L 157.295716 187.063346 
+L 157.047708 187.169569 
+L 156.7997 187.275554 
+L 156.551691 187.381303 
+L 156.303683 187.486816 
+L 156.055675 187.592095 
+L 155.807667 187.69714 
+L 155.559659 187.801954 
+L 155.311651 187.906536 
+L 155.063643 188.010888 
+L 154.815635 188.11501 
+L 154.567627 188.218904 
+L 154.319619 188.322571 
+L 154.071611 188.426012 
+L 153.823603 188.529228 
+L 153.575595 188.632219 
+L 153.327587 188.734987 
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_157">
-    <path d="M 153.327587 189.004841 
-L 153.228605 189.136009 
-L 153.129623 189.266815 
-L 153.030641 189.397262 
-L 152.931659 189.52735 
-L 152.832678 189.657082 
-L 152.733696 189.78646 
-L 152.634714 189.915486 
-L 152.535732 190.044162 
-L 152.43675 190.172489 
-L 152.337768 190.30047 
-L 152.238786 190.428106 
-L 152.139804 190.5554 
-L 152.040822 190.682352 
-L 151.94184 190.808966 
-L 151.842858 190.935242 
-L 151.743876 191.061182 
-L 151.644894 191.186789 
-L 151.545912 191.312064 
-L 151.44693 191.437008 
-L 151.347948 191.561624 
-L 151.248966 191.685914 
-L 151.149984 191.809878 
-L 151.051002 191.933519 
-L 150.95202 192.056838 
-L 150.853038 192.179837 
-L 150.754056 192.302518 
-L 150.655074 192.424882 
-L 150.556093 192.546931 
-L 150.457111 192.668667 
-L 150.358129 192.790091 
-L 150.259147 192.911204 
-L 150.160165 193.032009 
-L 150.061183 193.152507 
-L 149.962201 193.272699 
-L 149.863219 193.392587 
-L 149.764237 193.512173 
-L 149.665255 193.631457 
-L 149.566273 193.750442 
-L 149.467291 193.86913 
-L 149.368309 193.987521 
-L 149.269327 194.105617 
-L 149.170345 194.223419 
-L 149.071363 194.340929 
-L 148.972381 194.458149 
-L 148.873399 194.57508 
-L 148.774417 194.691722 
-L 148.675435 194.808079 
-L 148.576453 194.92415 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 153.327587 188.734987 
+L 153.228605 188.868983 
+L 153.129623 189.0026 
+L 153.030641 189.135842 
+L 152.931659 189.268711 
+L 152.832678 189.401208 
+L 152.733696 189.533335 
+L 152.634714 189.665096 
+L 152.535732 189.796491 
+L 152.43675 189.927523 
+L 152.337768 190.058193 
+L 152.238786 190.188505 
+L 152.139804 190.318459 
+L 152.040822 190.448058 
+L 151.94184 190.577303 
+L 151.842858 190.706197 
+L 151.743876 190.834742 
+L 151.644894 190.962939 
+L 151.545912 191.090789 
+L 151.44693 191.218297 
+L 151.347948 191.345462 
+L 151.248966 191.472286 
+L 151.149984 191.598772 
+L 151.051002 191.724922 
+L 150.95202 191.850737 
+L 150.853038 191.976219 
+L 150.754056 192.101369 
+L 150.655074 192.22619 
+L 150.556093 192.350683 
+L 150.457111 192.47485 
+L 150.358129 192.598692 
+L 150.259147 192.722212 
+L 150.160165 192.84541 
+L 150.061183 192.96829 
+L 149.962201 193.090851 
+L 149.863219 193.213097 
+L 149.764237 193.335028 
+L 149.665255 193.456646 
+L 149.566273 193.577953 
+L 149.467291 193.69895 
+L 149.368309 193.819639 
+L 149.269327 193.940021 
+L 149.170345 194.060099 
+L 149.071363 194.179873 
+L 148.972381 194.299346 
+L 148.873399 194.418517 
+L 148.774417 194.53739 
+L 148.675435 194.655966 
+L 148.576453 194.774246 
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_158">
-    <path d="M 148.576453 194.92415 
-L 148.507926 194.990835 
-L 148.439399 195.057425 
-L 148.370872 195.123922 
-L 148.302345 195.190326 
-L 148.233818 195.256638 
-L 148.165291 195.322856 
-L 148.096764 195.388982 
-L 148.028237 195.455016 
-L 147.95971 195.520958 
-L 147.891183 195.586809 
-L 147.822656 195.652568 
-L 147.754129 195.718236 
-L 147.685602 195.783813 
-L 147.617074 195.8493 
-L 147.548547 195.914696 
-L 147.48002 195.980002 
-L 147.411493 196.045218 
-L 147.342966 196.110345 
-L 147.274439 196.175382 
-L 147.205912 196.240331 
-L 147.137385 196.30519 
-L 147.068858 196.369961 
-L 147.000331 196.434643 
-L 146.931804 196.499237 
-L 146.863277 196.563743 
-L 146.79475 196.628162 
-L 146.726223 196.692493 
-L 146.657696 196.756737 
-L 146.589169 196.820894 
-L 146.520641 196.884964 
-L 146.452114 196.948948 
-L 146.383587 197.012845 
-L 146.31506 197.076657 
-L 146.246533 197.140383 
-L 146.178006 197.204023 
-L 146.109479 197.267578 
-L 146.040952 197.331047 
-L 145.972425 197.394432 
-L 145.903898 197.457732 
-L 145.835371 197.520948 
-L 145.766844 197.58408 
-L 145.698317 197.647127 
-L 145.62979 197.710091 
-L 145.561263 197.772971 
-L 145.492735 197.835768 
-L 145.424208 197.898482 
-L 145.355681 197.961113 
-L 145.287154 198.023662 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 148.576453 194.774246 
+L 148.507926 194.838731 
+L 148.439399 194.903129 
+L 148.370872 194.96744 
+L 148.302345 195.031663 
+L 148.233818 195.0958 
+L 148.165291 195.159849 
+L 148.096764 195.223813 
+L 148.028237 195.28769 
+L 147.95971 195.351481 
+L 147.891183 195.415187 
+L 147.822656 195.478807 
+L 147.754129 195.542341 
+L 147.685602 195.605791 
+L 147.617074 195.669156 
+L 147.548547 195.732436 
+L 147.48002 195.795632 
+L 147.411493 195.858744 
+L 147.342966 195.921771 
+L 147.274439 195.984716 
+L 147.205912 196.047576 
+L 147.137385 196.110353 
+L 147.068858 196.173048 
+L 147.000331 196.235659 
+L 146.931804 196.298188 
+L 146.863277 196.360635 
+L 146.79475 196.422999 
+L 146.726223 196.485282 
+L 146.657696 196.547482 
+L 146.589169 196.609601 
+L 146.520641 196.671639 
+L 146.452114 196.733596 
+L 146.383587 196.795472 
+L 146.31506 196.857267 
+L 146.246533 196.918982 
+L 146.178006 196.980616 
+L 146.109479 197.042171 
+L 146.040952 197.103645 
+L 145.972425 197.165041 
+L 145.903898 197.226356 
+L 145.835371 197.287592 
+L 145.766844 197.34875 
+L 145.698317 197.409828 
+L 145.62979 197.470828 
+L 145.561263 197.53175 
+L 145.492735 197.592593 
+L 145.424208 197.653359 
+L 145.355681 197.714046 
+L 145.287154 197.774656 
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_159">
-    <path d="M 145.287154 198.023662 
-L 144.656225 201.979883 
-L 144.025297 205.63118 
-L 143.394368 209.021212 
-L 142.763439 212.184884 
-L 142.13251 215.150542 
-L 141.501581 217.941521 
-L 140.870652 220.577258 
-L 140.239723 223.074117 
-L 139.608795 225.446003 
-L 138.977866 227.704833 
-L 138.346937 229.860896 
-L 137.716008 231.923137 
-L 137.085079 233.899382 
-L 136.45415 235.796517 
-L 135.823222 237.620633 
-L 135.192293 239.377143 
-L 134.561364 241.07088 
-L 133.930435 242.706175 
-L 133.299506 244.286928 
-L 132.668577 245.81666 
-L 132.037648 247.298562 
-L 131.40672 248.735534 
-L 130.775791 250.130221 
-L 130.144862 251.48504 
-L 129.513933 252.802207 
-L 128.883004 254.08376 
-L 128.252075 255.331573 
-L 127.621147 256.547376 
-L 126.990218 257.732773 
-L 126.359289 258.889245 
-L 125.72836 260.018173 
-L 125.097431 261.120836 
-L 124.466502 262.198429 
-L 123.835573 263.252067 
-L 123.204645 264.282793 
-L 122.573716 265.29158 
-L 121.942787 266.279345 
-L 121.311858 267.246944 
-L 120.680929 268.195186 
-L 120.05 269.124829 
-L 119.419071 270.036588 
-L 118.788143 270.93114 
-L 118.157214 271.809122 
-L 117.526285 272.671135 
-L 116.895356 273.517751 
-L 116.264427 274.349511 
-L 115.633498 275.166926 
-L 115.00257 275.970483 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 145.287154 197.774656 
+L 144.656225 201.812679 
+L 144.025297 205.533538 
+L 143.394368 208.983446 
+L 142.763439 212.199201 
+L 142.13251 215.210577 
+L 141.501581 218.042009 
+L 140.870652 220.713793 
+L 140.239723 223.242977 
+L 139.608795 225.644014 
+L 138.977866 227.929265 
+L 138.346937 230.109387 
+L 137.716008 232.193627 
+L 137.085079 234.190066 
+L 136.45415 236.105803 
+L 135.823222 237.94711 
+L 135.192293 239.719554 
+L 134.561364 241.428101 
+L 133.930435 243.077198 
+L 133.299506 244.670844 
+L 132.668577 246.212647 
+L 132.037648 247.705874 
+L 131.40672 249.153492 
+L 130.775791 250.558205 
+L 130.144862 251.922484 
+L 129.513933 253.248591 
+L 128.883004 254.538605 
+L 128.252075 255.794437 
+L 127.621147 257.017853 
+L 126.990218 258.210485 
+L 126.359289 259.373843 
+L 125.72836 260.50933 
+L 125.097431 261.618251 
+L 124.466502 262.70182 
+L 123.835573 263.761171 
+L 123.204645 264.797362 
+L 122.573716 265.811385 
+L 121.942787 266.804168 
+L 121.311858 267.776583 
+L 120.680929 268.729448 
+L 120.05 269.663535 
+L 119.419071 270.579569 
+L 118.788143 271.478235 
+L 118.157214 272.360179 
+L 117.526285 273.226012 
+L 116.895356 274.076313 
+L 116.264427 274.911628 
+L 115.633498 275.732477 
+L 115.00257 276.539352 
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_160">
-    <path d="M 115.00257 275.970483 
-L 114.686939 276.708327 
-L 114.371309 277.434861 
-L 114.055678 278.150426 
-L 113.740048 278.855349 
-L 113.424418 279.549942 
-L 113.108787 280.234503 
-L 112.793157 280.909318 
-L 112.477527 281.57466 
-L 112.161896 282.230792 
-L 111.846266 282.877965 
-L 111.530636 283.516421 
-L 111.215005 284.146391 
-L 110.899375 284.768097 
-L 110.583745 285.381755 
-L 110.268114 285.98757 
-L 109.952484 286.585738 
-L 109.636853 287.176453 
-L 109.321223 287.759895 
-L 109.005593 288.336244 
-L 108.689962 288.905668 
-L 108.374332 289.468333 
-L 108.058702 290.024396 
-L 107.743071 290.574012 
-L 107.427441 291.117328 
-L 107.111811 291.654486 
-L 106.79618 292.185625 
-L 106.48055 292.710878 
-L 106.16492 293.230374 
-L 105.849289 293.744239 
-L 105.533659 294.252592 
-L 105.218028 294.75555 
-L 104.902398 295.253228 
-L 104.586768 295.745735 
-L 104.271137 296.233176 
-L 103.955507 296.715656 
-L 103.639877 297.193274 
-L 103.324246 297.666127 
-L 103.008616 298.13431 
-L 102.692986 298.597913 
-L 102.377355 299.057026 
-L 102.061725 299.511734 
-L 101.746095 299.962122 
-L 101.430464 300.40827 
-L 101.114834 300.850258 
-L 100.799203 301.288163 
-L 100.483573 301.722059 
-L 100.167943 302.152019 
-L 99.852312 302.578113 
-" clip-path="url(#pc8796b989c)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 115.00257 276.539352 
+L 114.686939 277.270772 
+L 114.371309 277.991078 
+L 114.055678 278.700601 
+L 113.740048 279.399659 
+L 113.424418 280.088557 
+L 113.108787 280.767585 
+L 112.793157 281.437024 
+L 112.477527 282.097139 
+L 112.161896 282.748187 
+L 111.846266 283.390413 
+L 111.530636 284.024054 
+L 111.215005 284.649336 
+L 110.899375 285.266476 
+L 110.583745 285.875684 
+L 110.268114 286.477162 
+L 109.952484 287.071103 
+L 109.636853 287.657693 
+L 109.321223 288.237112 
+L 109.005593 288.809534 
+L 108.689962 289.375125 
+L 108.374332 289.934047 
+L 108.058702 290.486455 
+L 107.743071 291.032499 
+L 107.427441 291.572324 
+L 107.111811 292.10607 
+L 106.79618 292.633872 
+L 106.48055 293.155862 
+L 106.16492 293.672166 
+L 105.849289 294.182907 
+L 105.533659 294.688203 
+L 105.218028 295.188169 
+L 104.902398 295.682916 
+L 104.586768 296.172553 
+L 104.271137 296.657183 
+L 103.955507 297.136908 
+L 103.639877 297.611826 
+L 103.324246 298.082033 
+L 103.008616 298.547621 
+L 102.692986 299.008681 
+L 102.377355 299.465299 
+L 102.061725 299.917559 
+L 101.746095 300.365546 
+L 101.430464 300.809338 
+L 101.114834 301.249013 
+L 100.799203 301.684647 
+L 100.483573 302.116314 
+L 100.167943 302.544085 
+L 99.852312 302.96803 
+" clip-path="url(#pb4032dd086)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
   </g>
   <g id="text_25">
@@ -6254,8 +6254,8 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-07-07T22:17:01Z  ·  Linux chungus2 x86_64  ·  commit dcf4b958  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(44.687422 465.66) scale(0.07 -0.07)">
+   <!-- 2026-07-08T05:15:03Z  ·  Linux chungus2 x86_64  ·  commit cf8297c9  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(44.98 465.66) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -6276,6 +6276,31 @@ L 1638 0
 L 1638 4134 
 L -19 4134 
 L -19 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-3a" d="M 750 794 
@@ -6378,31 +6403,6 @@ Q 1038 2656 1286 2365
 Q 1534 2075 1959 2075 
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
-z
-" transform="scale(0.015625)"/>
      <path id="DejaVuSans-3d" d="M 678 2906 
 L 4684 2906 
 L 4684 2381 
@@ -6441,16 +6441,16 @@ z
     <use xlink:href="#DejaVuSans-37" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
     <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -6490,109 +6490,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3135.351562 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3190.332031 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3225.537109 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3289.160156 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3352.636719 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3416.259766 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3479.882812 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3543.505859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3575.292969 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3607.080078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3638.867188 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3670.654297 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3702.441406 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3730.224609 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3791.748047 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3853.027344 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3916.40625 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3979.882812 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4018.746094 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4079.927734 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4139.107422 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4200.630859 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4241.744141 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4275.435547 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4303.21875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4364.742188 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4426.021484 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4489.400391 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4553.023438 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4586.714844 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4645.894531 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4709.517578 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4741.304688 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4804.927734 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4868.550781 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4900.337891 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4963.960938 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5000.044922 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5038.908203 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5093.888672 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5157.511719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5189.298828 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5221.085938 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5252.873047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5284.660156 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5316.447266 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5355.65625 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5419.035156 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5457.898438 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5519.080078 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5582.458984 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5645.935547 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5709.314453 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5772.791016 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5836.169922 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5875.378906 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5907.166016 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5990.955078 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6022.742188 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6120.154297 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6181.677734 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6245.154297 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6272.9375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6334.216797 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6397.595703 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6429.382812 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6481.482422 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6544.861328 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6606.140625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6669.617188 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6721.716797 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6785.095703 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6846.277344 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6885.486328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6919.177734 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6950.964844 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6992.078125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7053.357422 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7092.566406 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7120.349609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7181.53125 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7213.318359 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7241.101562 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7293.201172 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7324.988281 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7388.464844 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7449.988281 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7489.197266 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7550.720703 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7590.083984 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7687.496094 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7715.279297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7778.658203 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7806.441406 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7858.541016 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7897.75 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7925.533203 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3126.855469 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3162.060547 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3225.683594 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3289.306641 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3352.929688 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3416.552734 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3471.533203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3535.15625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3566.943359 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3598.730469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3630.517578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3662.304688 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3694.091797 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3721.875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3783.398438 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3844.677734 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3908.056641 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3971.533203 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4010.396484 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4071.578125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4130.757812 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4192.28125 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4233.394531 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4267.085938 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4294.869141 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4356.392578 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4417.671875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4481.050781 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4544.673828 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4578.365234 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4637.544922 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4701.167969 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4732.955078 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4796.578125 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4860.201172 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4891.988281 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4955.611328 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4991.695312 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5030.558594 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5085.539062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5149.162109 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5180.949219 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5212.736328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5244.523438 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5276.310547 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5308.097656 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5347.306641 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5410.685547 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5449.548828 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5510.730469 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5574.109375 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5637.585938 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5700.964844 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5764.441406 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5827.820312 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5867.029297 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5898.816406 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5982.605469 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6014.392578 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6111.804688 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6173.328125 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6236.804688 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6264.587891 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6325.867188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6389.246094 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6421.033203 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6473.132812 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6536.511719 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6597.791016 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6661.267578 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6713.367188 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6776.746094 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6837.927734 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6877.136719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6910.828125 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6942.615234 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6983.728516 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7045.007812 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7084.216797 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7112 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7173.181641 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7204.96875 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7232.751953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7284.851562 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7316.638672 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7380.115234 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7441.638672 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7480.847656 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7542.371094 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7581.734375 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7679.146484 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7706.929688 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7770.308594 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7798.091797 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7850.191406 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7889.400391 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7917.183594 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pc8796b989c">
+  <clipPath id="pb4032dd086">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_ratio_heatmap.svg
+++ b/bench/graphs/canterbury_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#pd25df8895c)">
+   <g clip-path="url(#pdc9b517830)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAI/UlEQVR4nO3YwYqkVx2H4aqe7qYn4oAyashScCfBhRtn49o7yRW4DNl7HcYbEEQk2Yjixo24E3ciISRjnMyE7p7q78sljMKRv9T7PFfwO3zUqZdz3P71y/1wbl5+Nr1gqf3z8zrP4XA4/OPnv56esNTf//JqesJyP/3wZ9MTljv+6MfTE9Y6XkwvWO/FJ9ML1rt5Mr1gqV997xfTE5Y7w18SAMB/TgwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKQd706/2adHrLYftukJSx3PsFmvLq6nJyx1v91OT1ju6q9/mp6w3OmHz6YnLHXa7qcnLPfq9GJ6wnJPz+x6eP3k6fSE5c7vXxYA4L8ghgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0i6vXn0xvWG9u6+mF6y1b9ML1nv8ZHrBUtfTA/4H9hevpicsd/Xl8+kJS11tp+kJyz0+x/vu9uX0gqWuLs/vxvMyBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgLTjafvdPj1itX3fpicstZ3ZeQ6Hw+Hq4np6wlIP+2l6wnKPXj6fnrDeN787vWCp19v99ITlPr/95/SE5d6+u5yesNT2rXemJyznZQgASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASLv886d/mN6w3MXhOD1hqe+89XR6wnIP22l6wlLXj26mJyz33se/n56w3Ac/+cH0hKVO+zY9Ybn3//i36QnLPXvnG9MTlnrv3WfTE5bzMgQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIC04+uH3+7TI1a7f7idnrDU4+PN9ATe4P54mp6w3L/vPpuesNy3b96enrDUtm/TE5b74u7T6QnLPb/7ZHrCUt9/8u70hOW8DAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACDtuG0f7dMjgP9Dp/vpBetdXk8v4A1uH76anrDczaO3pifwBl6GAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkHZ5v91Ob1juYTtNT1jq8uJ6esJyV2d2ptfb/fSE5faLbXrCcscz+04P+3nddYfD4fDl/fPpCctdP76ZnrDUvp/f3eBlCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGlfA43TkfjdNPLgAAAAAElFTkSuQmCC" id="imagef17821226e" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAI/UlEQVR4nO3YwYqkVx2H4aqe7qYn4oAyashScCfBhRtn49o7yRW4DNl7HcYbEEQk2Yjixo24E3ciISRjnMyE7p7q78sljMKRv9T7PFfwO3zUqZdz3P71y/1wbl5+Nr1gqf3z8zrP4XA4/OPnv56esNTf//JqesJyP/3wZ9MTljv+6MfTE9Y6XkwvWO/FJ9ML1rt5Mr1gqV997xfTE5Y7w18SAMB/TgwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKQd706/2adHrLYftukJSx3PsFmvLq6nJyx1v91OT1ju6q9/mp6w3OmHz6YnLHXa7qcnLPfq9GJ6wnJPz+x6eP3k6fSE5c7vXxYA4L8ghgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0i6vXn0xvWG9u6+mF6y1b9ML1nv8ZHrBUtfTA/4H9hevpicsd/Xl8+kJS11tp+kJyz0+x/vu9uX0gqWuLs/vxvMyBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgLTjafvdPj1itX3fpicstZ3ZeQ6Hw+Hq4np6wlIP+2l6wnKPXj6fnrDeN787vWCp19v99ITlPr/95/SE5d6+u5yesNT2rXemJyznZQgASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASLv886d/mN6w3MXhOD1hqe+89XR6wnIP22l6wlLXj26mJyz33se/n56w3Ac/+cH0hKVO+zY9Ybn3//i36QnLPXvnG9MTlnrv3WfTE5bzMgQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIC04+uH3+7TI1a7f7idnrDU4+PN9ATe4P54mp6w3L/vPpuesNy3b96enrDUtm/TE5b74u7T6QnLPb/7ZHrCUt9/8u70hOW8DAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACDtuG0f7dMjgP9Dp/vpBetdXk8v4A1uH76anrDczaO3pifwBl6GAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkHZ5v91Ob1juYTtNT1jq8uJ6esJyV2d2ptfb/fSE5faLbXrCcscz+04P+3nddYfD4fDl/fPpCctdP76ZnrDUvp/f3eBlCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGlfA43TkfjdNPLgAAAAAElFTkSuQmCC" id="image133cbb4394" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m4cc6495e57" d="M 0 0 
+       <path id="mfd9a7503eb" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m4cc6495e57" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfd9a7503eb" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m4cc6495e57" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfd9a7503eb" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m4cc6495e57" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfd9a7503eb" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m4cc6495e57" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfd9a7503eb" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m4cc6495e57" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfd9a7503eb" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m4cc6495e57" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfd9a7503eb" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m4cc6495e57" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfd9a7503eb" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m4cc6495e57" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfd9a7503eb" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m4cc6495e57" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfd9a7503eb" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m4cc6495e57" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfd9a7503eb" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m4cc6495e57" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfd9a7503eb" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="m34d63f1e7b" d="M 0 0 
+       <path id="m69b59f64cc" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m34d63f1e7b" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m69b59f64cc" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m34d63f1e7b" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m69b59f64cc" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m34d63f1e7b" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m69b59f64cc" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m34d63f1e7b" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m69b59f64cc" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m34d63f1e7b" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m69b59f64cc" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m34d63f1e7b" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m69b59f64cc" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m34d63f1e7b" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m69b59f64cc" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m34d63f1e7b" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m69b59f64cc" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -2092,18 +2092,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="image18d5c169cd" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
+iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="image539c6a8dca" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="mdb404abca3" d="M 0 0 
+       <path id="m1e06fc6e16" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mdb404abca3" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1e06fc6e16" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
@@ -2129,7 +2129,7 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#mdb404abca3" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1e06fc6e16" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
@@ -2146,7 +2146,7 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#mdb404abca3" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1e06fc6e16" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
@@ -2163,7 +2163,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#mdb404abca3" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1e06fc6e16" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
@@ -2180,7 +2180,7 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mdb404abca3" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1e06fc6e16" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_112">
@@ -2196,7 +2196,7 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#mdb404abca3" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1e06fc6e16" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
@@ -2212,7 +2212,7 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mdb404abca3" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1e06fc6e16" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
@@ -2228,7 +2228,7 @@ z
     <g id="ytick_16">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#mdb404abca3" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1e06fc6e16" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_115">
@@ -2244,7 +2244,7 @@ z
     <g id="ytick_17">
      <g id="line2d_28">
       <g>
-       <use xlink:href="#mdb404abca3" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1e06fc6e16" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_116">
@@ -2882,8 +2882,8 @@ z
    </g>
   </g>
   <g id="text_119">
-   <!-- 2026-07-07T22:17:01Z  ·  Linux chungus2 x86_64  ·  commit dcf4b958  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(17.687422 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-08T05:15:03Z  ·  Linux chungus2 x86_64  ·  commit cf8297c9  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(17.98 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2950,16 +2950,16 @@ z
     <use xlink:href="#DejaVuSans-37" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
     <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2999,109 +2999,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3135.351562 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3190.332031 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3225.537109 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3289.160156 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3352.636719 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3416.259766 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3479.882812 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3543.505859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3575.292969 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3607.080078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3638.867188 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3670.654297 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3702.441406 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3730.224609 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3791.748047 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3853.027344 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3916.40625 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3979.882812 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4018.746094 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4079.927734 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4139.107422 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4200.630859 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4241.744141 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4275.435547 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4303.21875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4364.742188 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4426.021484 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4489.400391 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4553.023438 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4586.714844 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4645.894531 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4709.517578 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4741.304688 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4804.927734 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4868.550781 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4900.337891 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4963.960938 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5000.044922 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5038.908203 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5093.888672 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5157.511719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5189.298828 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5221.085938 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5252.873047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5284.660156 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5316.447266 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5355.65625 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5419.035156 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5457.898438 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5519.080078 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5582.458984 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5645.935547 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5709.314453 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5772.791016 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5836.169922 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5875.378906 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5907.166016 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5990.955078 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6022.742188 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6120.154297 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6181.677734 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6245.154297 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6272.9375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6334.216797 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6397.595703 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6429.382812 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6481.482422 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6544.861328 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6606.140625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6669.617188 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6721.716797 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6785.095703 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6846.277344 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6885.486328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6919.177734 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6950.964844 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6992.078125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7053.357422 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7092.566406 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7120.349609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7181.53125 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7213.318359 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7241.101562 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7293.201172 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7324.988281 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7388.464844 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7449.988281 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7489.197266 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7550.720703 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7590.083984 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7687.496094 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7715.279297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7778.658203 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7806.441406 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7858.541016 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7897.75 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7925.533203 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3126.855469 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3162.060547 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3225.683594 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3289.306641 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3352.929688 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3416.552734 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3471.533203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3535.15625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3566.943359 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3598.730469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3630.517578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3662.304688 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3694.091797 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3721.875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3783.398438 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3844.677734 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3908.056641 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3971.533203 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4010.396484 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4071.578125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4130.757812 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4192.28125 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4233.394531 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4267.085938 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4294.869141 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4356.392578 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4417.671875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4481.050781 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4544.673828 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4578.365234 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4637.544922 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4701.167969 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4732.955078 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4796.578125 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4860.201172 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4891.988281 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4955.611328 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4991.695312 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5030.558594 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5085.539062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5149.162109 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5180.949219 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5212.736328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5244.523438 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5276.310547 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5308.097656 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5347.306641 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5410.685547 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5449.548828 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5510.730469 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5574.109375 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5637.585938 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5700.964844 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5764.441406 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5827.820312 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5867.029297 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5898.816406 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5982.605469 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6014.392578 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6111.804688 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6173.328125 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6236.804688 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6264.587891 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6325.867188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6389.246094 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6421.033203 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6473.132812 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6536.511719 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6597.791016 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6661.267578 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6713.367188 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6776.746094 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6837.927734 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6877.136719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6910.828125 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6942.615234 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6983.728516 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7045.007812 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7084.216797 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7112 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7173.181641 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7204.96875 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7232.751953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7284.851562 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7316.638672 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7380.115234 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7441.638672 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7480.847656 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7542.371094 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7581.734375 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7679.146484 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7706.929688 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7770.308594 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7798.091797 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7850.191406 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7889.400391 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7917.183594 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pd25df8895c">
+  <clipPath id="pdc9b517830">
    <rect x="95.67625" y="49.4355" width="416.571298" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_summary.svg
+++ b/bench/graphs/canterbury_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="573.025156pt" height="386.202469pt" viewBox="0 0 573.025156 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="572.44pt" height="386.202469pt" viewBox="0 0 572.44 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,232 +22,232 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 386.202469 
-L 573.025156 386.202469 
-L 573.025156 0 
+L 572.44 386.202469 
+L 572.44 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 188.637578 104.1264 
-L 293.262578 104.1264 
-L 293.262578 74.7432 
-L 188.637578 74.7432 
+    <path d="M 188.345 104.1264 
+L 292.97 104.1264 
+L 292.97 74.7432 
+L 188.345 74.7432 
 z
-" clip-path="url(#p85cb60a729)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9fe91b6117)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 293.262578 104.1264 
-L 397.887578 104.1264 
-L 397.887578 74.7432 
-L 293.262578 74.7432 
+    <path d="M 292.97 104.1264 
+L 397.595 104.1264 
+L 397.595 74.7432 
+L 292.97 74.7432 
 z
-" clip-path="url(#p85cb60a729)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9fe91b6117)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 397.887578 104.1264 
-L 502.512578 104.1264 
-L 502.512578 74.7432 
-L 397.887578 74.7432 
+    <path d="M 397.595 104.1264 
+L 502.22 104.1264 
+L 502.22 74.7432 
+L 397.595 74.7432 
 z
-" clip-path="url(#p85cb60a729)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9fe91b6117)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 188.637578 133.5096 
-L 293.262578 133.5096 
-L 293.262578 104.1264 
-L 188.637578 104.1264 
+    <path d="M 188.345 133.5096 
+L 292.97 133.5096 
+L 292.97 104.1264 
+L 188.345 104.1264 
 z
-" clip-path="url(#p85cb60a729)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9fe91b6117)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 293.262578 133.5096 
-L 397.887578 133.5096 
-L 397.887578 104.1264 
-L 293.262578 104.1264 
+    <path d="M 292.97 133.5096 
+L 397.595 133.5096 
+L 397.595 104.1264 
+L 292.97 104.1264 
 z
-" clip-path="url(#p85cb60a729)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9fe91b6117)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 397.887578 133.5096 
-L 502.512578 133.5096 
-L 502.512578 104.1264 
-L 397.887578 104.1264 
+    <path d="M 397.595 133.5096 
+L 502.22 133.5096 
+L 502.22 104.1264 
+L 397.595 104.1264 
 z
-" clip-path="url(#p85cb60a729)" style="fill: #fdb768; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9fe91b6117)" style="fill: #fdb768; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 188.637578 162.8928 
-L 293.262578 162.8928 
-L 293.262578 133.5096 
-L 188.637578 133.5096 
+    <path d="M 188.345 162.8928 
+L 292.97 162.8928 
+L 292.97 133.5096 
+L 188.345 133.5096 
 z
-" clip-path="url(#p85cb60a729)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9fe91b6117)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 293.262578 162.8928 
-L 397.887578 162.8928 
-L 397.887578 133.5096 
-L 293.262578 133.5096 
+    <path d="M 292.97 162.8928 
+L 397.595 162.8928 
+L 397.595 133.5096 
+L 292.97 133.5096 
 z
-" clip-path="url(#p85cb60a729)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9fe91b6117)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 397.887578 162.8928 
-L 502.512578 162.8928 
-L 502.512578 133.5096 
-L 397.887578 133.5096 
+    <path d="M 397.595 162.8928 
+L 502.22 162.8928 
+L 502.22 133.5096 
+L 397.595 133.5096 
 z
-" clip-path="url(#p85cb60a729)" style="fill: #bbe278; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9fe91b6117)" style="fill: #bbe278; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 188.637578 192.276 
-L 293.262578 192.276 
-L 293.262578 162.8928 
-L 188.637578 162.8928 
+    <path d="M 188.345 192.276 
+L 292.97 192.276 
+L 292.97 162.8928 
+L 188.345 162.8928 
 z
-" clip-path="url(#p85cb60a729)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9fe91b6117)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 293.262578 192.276 
-L 397.887578 192.276 
-L 397.887578 162.8928 
-L 293.262578 162.8928 
+    <path d="M 292.97 192.276 
+L 397.595 192.276 
+L 397.595 162.8928 
+L 292.97 162.8928 
 z
-" clip-path="url(#p85cb60a729)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9fe91b6117)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 397.887578 192.276 
-L 502.512578 192.276 
-L 502.512578 162.8928 
-L 397.887578 162.8928 
+    <path d="M 397.595 192.276 
+L 502.22 192.276 
+L 502.22 162.8928 
+L 397.595 162.8928 
 z
-" clip-path="url(#p85cb60a729)" style="fill: #fdc776; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9fe91b6117)" style="fill: #fdc776; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 188.637578 221.6592 
-L 293.262578 221.6592 
-L 293.262578 192.276 
-L 188.637578 192.276 
+    <path d="M 188.345 221.6592 
+L 292.97 221.6592 
+L 292.97 192.276 
+L 188.345 192.276 
 z
-" clip-path="url(#p85cb60a729)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9fe91b6117)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 293.262578 221.6592 
-L 397.887578 221.6592 
-L 397.887578 192.276 
-L 293.262578 192.276 
+    <path d="M 292.97 221.6592 
+L 397.595 221.6592 
+L 397.595 192.276 
+L 292.97 192.276 
 z
-" clip-path="url(#p85cb60a729)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9fe91b6117)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 397.887578 221.6592 
-L 502.512578 221.6592 
-L 502.512578 192.276 
-L 397.887578 192.276 
+    <path d="M 397.595 221.6592 
+L 502.22 221.6592 
+L 502.22 192.276 
+L 397.595 192.276 
 z
-" clip-path="url(#p85cb60a729)" style="fill: #addc6f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9fe91b6117)" style="fill: #addc6f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 188.637578 251.0424 
-L 293.262578 251.0424 
-L 293.262578 221.6592 
-L 188.637578 221.6592 
+    <path d="M 188.345 251.0424 
+L 292.97 251.0424 
+L 292.97 221.6592 
+L 188.345 221.6592 
 z
-" clip-path="url(#p85cb60a729)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9fe91b6117)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 293.262578 251.0424 
-L 397.887578 251.0424 
-L 397.887578 221.6592 
-L 293.262578 221.6592 
+    <path d="M 292.97 251.0424 
+L 397.595 251.0424 
+L 397.595 221.6592 
+L 292.97 221.6592 
 z
-" clip-path="url(#p85cb60a729)" style="fill: #fdbd6d; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9fe91b6117)" style="fill: #fdbd6d; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 397.887578 251.0424 
-L 502.512578 251.0424 
-L 502.512578 221.6592 
-L 397.887578 221.6592 
+    <path d="M 397.595 251.0424 
+L 502.22 251.0424 
+L 502.22 221.6592 
+L 397.595 221.6592 
 z
-" clip-path="url(#p85cb60a729)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9fe91b6117)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 188.637578 280.4256 
-L 293.262578 280.4256 
-L 293.262578 251.0424 
-L 188.637578 251.0424 
+    <path d="M 188.345 280.4256 
+L 292.97 280.4256 
+L 292.97 251.0424 
+L 188.345 251.0424 
 z
-" clip-path="url(#p85cb60a729)" style="fill: #ebf7a3; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9fe91b6117)" style="fill: #ebf7a3; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 293.262578 280.4256 
-L 397.887578 280.4256 
-L 397.887578 251.0424 
-L 293.262578 251.0424 
+    <path d="M 292.97 280.4256 
+L 397.595 280.4256 
+L 397.595 251.0424 
+L 292.97 251.0424 
 z
-" clip-path="url(#p85cb60a729)" style="fill: #fb9d59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9fe91b6117)" style="fill: #fb9d59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 397.887578 280.4256 
-L 502.512578 280.4256 
-L 502.512578 251.0424 
-L 397.887578 251.0424 
+    <path d="M 397.595 280.4256 
+L 502.22 280.4256 
+L 502.22 251.0424 
+L 397.595 251.0424 
 z
-" clip-path="url(#p85cb60a729)" style="fill: #f36b42; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9fe91b6117)" style="fill: #f47044; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 188.637578 309.8088 
-L 293.262578 309.8088 
-L 293.262578 280.4256 
-L 188.637578 280.4256 
+    <path d="M 188.345 309.8088 
+L 292.97 309.8088 
+L 292.97 280.4256 
+L 188.345 280.4256 
 z
-" clip-path="url(#p85cb60a729)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9fe91b6117)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 293.262578 309.8088 
-L 397.887578 309.8088 
-L 397.887578 280.4256 
-L 293.262578 280.4256 
+    <path d="M 292.97 309.8088 
+L 397.595 309.8088 
+L 397.595 280.4256 
+L 292.97 280.4256 
 z
-" clip-path="url(#p85cb60a729)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9fe91b6117)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 397.887578 309.8088 
-L 502.512578 309.8088 
-L 502.512578 280.4256 
-L 397.887578 280.4256 
+    <path d="M 397.595 309.8088 
+L 502.22 309.8088 
+L 502.22 280.4256 
+L 397.595 280.4256 
 z
-" clip-path="url(#p85cb60a729)" style="fill: #ee613e; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9fe91b6117)" style="fill: #ee613e; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 188.637578 339.192 
-L 293.262578 339.192 
-L 293.262578 309.8088 
-L 188.637578 309.8088 
+    <path d="M 188.345 339.192 
+L 292.97 339.192 
+L 292.97 309.8088 
+L 188.345 309.8088 
 z
-" clip-path="url(#p85cb60a729)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9fe91b6117)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 293.262578 339.192 
-L 397.887578 339.192 
-L 397.887578 309.8088 
-L 293.262578 309.8088 
+    <path d="M 292.97 339.192 
+L 397.595 339.192 
+L 397.595 309.8088 
+L 292.97 309.8088 
 z
-" clip-path="url(#p85cb60a729)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9fe91b6117)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 397.887578 339.192 
-L 502.512578 339.192 
-L 502.512578 309.8088 
-L 397.887578 309.8088 
+    <path d="M 397.595 339.192 
+L 502.22 339.192 
+L 502.22 309.8088 
+L 397.595 309.8088 
 z
-" clip-path="url(#p85cb60a729)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9fe91b6117)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(121.624844 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(121.332266 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(228.909063 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(228.616484 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(307.481172 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(307.188594 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(405.832891 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(405.540313 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(117.562578 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(117.27 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.296 -->
-    <g transform="translate(229.498828 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(229.20625 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -946,7 +946,7 @@ z
    </g>
    <g id="text_7">
     <!-- 158 -->
-    <g transform="translate(337.940078 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(337.6475 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -1034,7 +1034,7 @@ z
    </g>
    <g id="text_8">
     <!-- 925 -->
-    <g transform="translate(442.565078 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(442.2725 91.6423) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-39"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
@@ -1042,7 +1042,7 @@ z
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(112.200703 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(111.908125 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1141,7 +1141,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.299 -->
-    <g transform="translate(229.498828 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(229.20625 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1151,7 +1151,7 @@ z
    </g>
    <g id="text_11">
     <!-- 73 -->
-    <g transform="translate(340.485078 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(340.1925 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -1202,7 +1202,7 @@ z
    </g>
    <g id="text_12">
     <!-- 283 -->
-    <g transform="translate(442.565078 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(442.2725 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(127.246094 0)"/>
@@ -1210,7 +1210,7 @@ z
    </g>
    <g id="text_13">
     <!-- zlib -->
-    <g transform="translate(129.463828 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(129.17125 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1234,7 +1234,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.299 -->
-    <g transform="translate(229.498828 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(229.20625 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1244,14 +1244,14 @@ z
    </g>
    <g id="text_15">
     <!-- 55 -->
-    <g transform="translate(340.485078 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(340.1925 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
     <!-- 692 -->
-    <g transform="translate(442.565078 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(442.2725 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-36"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
@@ -1259,7 +1259,7 @@ z
    </g>
    <g id="text_17">
     <!-- Go compress/flate -->
-    <g transform="translate(99.893828 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(99.60125 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -1430,7 +1430,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.299 -->
-    <g transform="translate(229.498828 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(229.20625 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1440,14 +1440,14 @@ z
    </g>
    <g id="text_19">
     <!-- 52 -->
-    <g transform="translate(340.485078 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(340.1925 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
     <!-- 323 -->
-    <g transform="translate(442.565078 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(442.2725 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(127.246094 0)"/>
@@ -1455,7 +1455,7 @@ z
    </g>
    <g id="text_21">
     <!-- miniz_oxide -->
-    <g transform="translate(112.770078 209.06385) scale(0.08 -0.08)">
+    <g transform="translate(112.4775 209.06385) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6e" d="M 3513 2113 
 L 3513 0 
@@ -1514,7 +1514,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.299 -->
-    <g transform="translate(229.498828 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(229.20625 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1524,14 +1524,14 @@ z
    </g>
    <g id="text_23">
     <!-- 51 -->
-    <g transform="translate(340.485078 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(340.1925 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_24">
     <!-- 729 -->
-    <g transform="translate(442.565078 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(442.2725 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-37"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(127.246094 0)"/>
@@ -1539,7 +1539,7 @@ z
    </g>
    <g id="text_25">
     <!-- JS fflate -->
-    <g transform="translate(120.926328 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(120.63375 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1599,7 +1599,7 @@ z
    </g>
    <g id="text_26">
     <!-- 0.307 -->
-    <g transform="translate(229.498828 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(229.20625 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1609,7 +1609,7 @@ z
    </g>
    <g id="text_27">
     <!-- 41 -->
-    <g transform="translate(340.485078 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(340.1925 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1637,14 +1637,14 @@ z
    </g>
    <g id="text_28">
     <!-- 80 -->
-    <g transform="translate(445.110078 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(444.8175 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-38"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_29">
     <!-- lean-zip (native) -->
-    <g transform="translate(99.271953 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(98.979375 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1753,7 +1753,7 @@ z
    </g>
    <g id="text_30">
     <!-- 0.297 -->
-    <g transform="translate(228.298203 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(228.005625 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1854,56 +1854,15 @@ z
     </g>
    </g>
    <g id="text_31">
-    <!-- 28 -->
-    <g transform="translate(340.008828 267.9415) scale(0.08 -0.08)">
-     <defs>
-      <path id="DejaVuSans-Bold-38" d="M 2228 2088 
-Q 1891 2088 1709 1903 
-Q 1528 1719 1528 1375 
-Q 1528 1031 1709 848 
-Q 1891 666 2228 666 
-Q 2563 666 2741 848 
-Q 2919 1031 2919 1375 
-Q 2919 1722 2741 1905 
-Q 2563 2088 2228 2088 
-z
-M 1350 2484 
-Q 925 2613 709 2878 
-Q 494 3144 494 3541 
-Q 494 4131 934 4440 
-Q 1375 4750 2228 4750 
-Q 3075 4750 3515 4442 
-Q 3956 4134 3956 3541 
-Q 3956 3144 3739 2878 
-Q 3522 2613 3097 2484 
-Q 3572 2353 3814 2058 
-Q 4056 1763 4056 1313 
-Q 4056 619 3595 264 
-Q 3134 -91 2228 -91 
-Q 1319 -91 855 264 
-Q 391 619 391 1313 
-Q 391 1763 633 2058 
-Q 875 2353 1350 2484 
-z
-M 1631 3419 
-Q 1631 3141 1786 2991 
-Q 1941 2841 2228 2841 
-Q 2509 2841 2662 2991 
-Q 2816 3141 2816 3419 
-Q 2816 3697 2662 3845 
-Q 2509 3994 2228 3994 
-Q 1941 3994 1786 3844 
-Q 1631 3694 1631 3419 
-z
-" transform="scale(0.015625)"/>
-     </defs>
+    <!-- 29 -->
+    <g transform="translate(339.71625 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-Bold-32"/>
-     <use xlink:href="#DejaVuSans-Bold-38" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-39" transform="translate(69.580078 0)"/>
     </g>
    </g>
    <g id="text_32">
-    <!-- 135 -->
-    <g transform="translate(441.850703 267.9415) scale(0.08 -0.08)">
+    <!-- 145 -->
+    <g transform="translate(441.558125 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-31" d="M 750 831 
 L 1813 831 
@@ -1919,36 +1878,23 @@ L 750 0
 L 750 831 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-33" d="M 2981 2516 
-Q 3453 2394 3698 2092 
-Q 3944 1791 3944 1325 
-Q 3944 631 3412 270 
-Q 2881 -91 1863 -91 
-Q 1503 -91 1142 -33 
-Q 781 25 428 141 
-L 428 1069 
-Q 766 900 1098 814 
-Q 1431 728 1753 728 
-Q 2231 728 2486 893 
-Q 2741 1059 2741 1369 
-Q 2741 1688 2480 1852 
-Q 2219 2016 1709 2016 
-L 1228 2016 
-L 1228 2791 
-L 1734 2791 
-Q 2188 2791 2409 2933 
-Q 2631 3075 2631 3366 
-Q 2631 3634 2415 3781 
-Q 2200 3928 1806 3928 
-Q 1516 3928 1219 3862 
-Q 922 3797 628 3669 
-L 628 4550 
-Q 984 4650 1334 4700 
-Q 1684 4750 2022 4750 
-Q 2931 4750 3382 4451 
-Q 3834 4153 3834 3553 
-Q 3834 3144 3618 2883 
-Q 3403 2622 2981 2516 
+      <path id="DejaVuSans-Bold-34" d="M 2356 3675 
+L 1038 1722 
+L 2356 1722 
+L 2356 3675 
+z
+M 2156 4666 
+L 3494 4666 
+L 3494 1722 
+L 4159 1722 
+L 4159 850 
+L 3494 850 
+L 3494 0 
+L 2356 0 
+L 2356 850 
+L 288 850 
+L 288 1881 
+L 2156 4666 
 z
 " transform="scale(0.015625)"/>
       <path id="DejaVuSans-Bold-35" d="M 678 4666 
@@ -1978,13 +1924,13 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-Bold-31"/>
-     <use xlink:href="#DejaVuSans-Bold-33" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-34" transform="translate(69.580078 0)"/>
      <use xlink:href="#DejaVuSans-Bold-35" transform="translate(139.160156 0)"/>
     </g>
    </g>
    <g id="text_33">
     <!-- OCaml decompress -->
-    <g transform="translate(97.386953 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(97.094375 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -2049,7 +1995,7 @@ z
    </g>
    <g id="text_34">
     <!-- 0.321 -->
-    <g transform="translate(229.498828 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(229.20625 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -2059,14 +2005,14 @@ z
    </g>
    <g id="text_35">
     <!-- 23 -->
-    <g transform="translate(340.485078 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(340.1925 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_36">
     <!-- 117 -->
-    <g transform="translate(442.565078 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(442.2725 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
@@ -2074,7 +2020,7 @@ z
    </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(125.608203 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(125.315625 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -2085,7 +2031,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.279 -->
-    <g transform="translate(229.498828 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(229.20625 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -2095,13 +2041,13 @@ z
    </g>
    <g id="text_39">
     <!-- 0 -->
-    <g transform="translate(343.030078 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(342.7375 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(446.200078 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(445.9075 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2117,7 +2063,7 @@ z
   </g>
   <g id="text_41">
    <!-- canterbury — geomean over files, level 6 -->
-   <g transform="translate(136.021328 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(135.72875 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-62" d="M 2400 722 
 Q 2759 722 2948 984 
@@ -2330,7 +2276,7 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-07-07T22:17:01Z  ·  Linux chungus2 x86_64  ·  commit dcf4b958  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-07-08T05:15:03Z  ·  Linux chungus2 x86_64  ·  commit cf8297c9  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2469,16 +2415,16 @@ z
     <use xlink:href="#DejaVuSans-37" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
     <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2518,110 +2464,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3135.351562 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3190.332031 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3225.537109 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3289.160156 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3352.636719 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3416.259766 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3479.882812 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3543.505859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3575.292969 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3607.080078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3638.867188 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3670.654297 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3702.441406 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3730.224609 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3791.748047 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3853.027344 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3916.40625 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3979.882812 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4018.746094 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4079.927734 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4139.107422 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4200.630859 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4241.744141 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4275.435547 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4303.21875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4364.742188 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4426.021484 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4489.400391 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4553.023438 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4586.714844 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4645.894531 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4709.517578 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4741.304688 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4804.927734 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4868.550781 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4900.337891 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4963.960938 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5000.044922 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5038.908203 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5093.888672 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5157.511719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5189.298828 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5221.085938 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5252.873047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5284.660156 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5316.447266 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5355.65625 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5419.035156 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5457.898438 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5519.080078 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5582.458984 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5645.935547 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5709.314453 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5772.791016 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5836.169922 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5875.378906 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5907.166016 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5990.955078 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6022.742188 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6120.154297 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6181.677734 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6245.154297 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6272.9375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6334.216797 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6397.595703 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6429.382812 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6481.482422 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6544.861328 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6606.140625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6669.617188 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6721.716797 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6785.095703 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6846.277344 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6885.486328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6919.177734 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6950.964844 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6992.078125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7053.357422 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7092.566406 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7120.349609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7181.53125 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7213.318359 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7241.101562 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7293.201172 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7324.988281 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7388.464844 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7449.988281 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7489.197266 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7550.720703 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7590.083984 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7687.496094 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7715.279297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7778.658203 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7806.441406 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7858.541016 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7897.75 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7925.533203 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3126.855469 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3162.060547 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3225.683594 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3289.306641 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3352.929688 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3416.552734 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3471.533203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3535.15625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3566.943359 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3598.730469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3630.517578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3662.304688 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3694.091797 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3721.875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3783.398438 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3844.677734 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3908.056641 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3971.533203 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4010.396484 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4071.578125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4130.757812 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4192.28125 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4233.394531 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4267.085938 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4294.869141 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4356.392578 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4417.671875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4481.050781 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4544.673828 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4578.365234 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4637.544922 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4701.167969 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4732.955078 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4796.578125 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4860.201172 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4891.988281 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4955.611328 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4991.695312 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5030.558594 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5085.539062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5149.162109 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5180.949219 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5212.736328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5244.523438 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5276.310547 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5308.097656 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5347.306641 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5410.685547 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5449.548828 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5510.730469 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5574.109375 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5637.585938 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5700.964844 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5764.441406 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5827.820312 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5867.029297 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5898.816406 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5982.605469 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6014.392578 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6111.804688 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6173.328125 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6236.804688 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6264.587891 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6325.867188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6389.246094 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6421.033203 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6473.132812 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6536.511719 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6597.791016 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6661.267578 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6713.367188 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6776.746094 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6837.927734 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6877.136719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6910.828125 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6942.615234 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6983.728516 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7045.007812 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7084.216797 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7112 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7173.181641 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7204.96875 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7232.751953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7284.851562 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7316.638672 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7380.115234 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7441.638672 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7480.847656 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7542.371094 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7581.734375 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7679.146484 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7706.929688 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7770.308594 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7798.091797 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7850.191406 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7889.400391 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7917.183594 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p85cb60a729">
-   <rect x="84.012578" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="p9fe91b6117">
+   <rect x="83.72" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/graphs/silesia_compress_heatmap.svg
+++ b/bench/graphs/silesia_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.34175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#pa081a4fe07)">
+   <g clip-path="url(#p22e929e887)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAqAAAAGaCAYAAADQNfGTAAAJ+UlEQVR4nO3YsW6k1R2HYeyZNd5FchYQFotokiaKUkREQojbyHVQ0XIN3AAdZS4gRRoKikikoSRNkIAkQkRZbdBiHHtscxHovH/n0/NcwW905sy833d0+5+P717YsquL6QVrHR1PL1jr9jC9YK2tn9/hanrBWo8eTy9Y63/Ppxfwc+xOphestfXv54PT6QVLbfzfDwCA+0aAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQ2n9++Hp6w1InD/bTE5a6PFxNT1jqydkb0xOW+ur7b6YnLHU4upmesNRvHr4yPWGpw4un0xOW+ufzf0xPWOr84fn0hKUuTw7TE5Y6euFiesJS3oACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAACp/fmj8+kNSz156VfTE5b67uLr6QlLvX657Weks1d/Nz1hqZPd6fSEpW5uD9MTltr6+W3+8x1v+/Ptj9+cnrDU6eXl9ISltv3vDgDAvSNAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBI7V/cPZresNTTy2+nJyy19fO7efmV6QlLffPs8+kJSz2/vpyesNTbL789PWGpq7vD9ISlvvr+y+kJS/321d9PT1jqs2//Mj1hqbde2/b5eQMKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkDq6+fT9u+kRS93eTi/g59j6+R17BoQxW79/fj//vx0O0wuW2vjpAQBw3whQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABS+/PPvpjesNTuZDc9Yanvvvj39ISlPnrvrekJS334122f37tvnk1PWOqPn3w5PWGpD/7w6+kJS/3p7/+dnrDULx8/nJ6w1NMfr6cnLPXOk0fTE5byBhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgdXd/8+W56xEq766vpCWvtTqYXrHW4nF6w1v50esFau/30grXubqcXrHW98ft3tPF3MMfbvn/XR9u+fw8Oh+kJS2389gEAcN8IUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUvvn18+mNyz1i6vpBWvdvHQyPWGp3Q9Ppyesdfb69IK1ri6mFyx1td/2M/zJxbPpCWs9fmN6wVp3t9MLlnrwr79NT1jr7Hx6wVLb/vUEAODeEaAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKR+AtAie82hecYiAAAAAElFTkSuQmCC" id="image9f23102d8a" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="483.84" height="295.2"/>
+iVBORw0KGgoAAAANSUhEUgAAAqAAAAGaCAYAAADQNfGTAAAJ90lEQVR4nO3YsY6cVx2H4ezOeL22pSWOxSpGbkKDUAoUpAjlNrgOKlqugRugo+QCKGgoKJCcJmVosOQEUJQIK0SOWXZnd7mI6Lz/zafnuYLf6MyZeb/v6Obfv799a8su30wvWOvoeHrBWjeH6QVrbf38DpfTC9Z6+Pb0grX+93p6Ad/F7mR6wVpb/37eO51esNTG//0AALhrBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAAKn9J4fPpjcsdXJvPz1hqYvD5fSEpZ6e/Wh6wlIvv/l8esJSh6Pr6QlL/fTBO9MTljrcP52esNQ/X/9jesJS5w/OpycsdXFymJ6w1NFbb6YnLOUNKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkNqfPzyf3rDU00c/np6w1JdvPpuesNS7F9t+Rjp78rPpCUud7E6nJyx1fXOYnrDU1s9v85/veNufb3/8bHrCUqcXF9MTltr2vzsAAHeOAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAILW/v3s4vWGpVxdfTE9Yauvnd/34nekJS33+9SfTE5Z6fXUxPWGpDx9/OD1hqcvbw/SEpV5+82J6wlLvP/n59ISlnn/x1+kJS33ww22fnzegAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAAKmj67/8+nZ6xFI3N9ML+C62fn7HngFhzNbvn9/P77fDYXrBUhs/PQAA7hoBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBAan/+/NPpDUvtTnbTE5b68tOvpics9btffTA9Yanffrzt8/vo2dn0hKX+8OcX0xOW+s0vfzI9Yak//v0/0xOWeu/tB9MTlnr136vpCUv94unD6QlLeQMKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkjq6u/3Q7PWKl3dXl9IS1difTC9Y6XEwvWGt/Or1grd1+esFatzfTC9a62vj9O9r4O5jjbd+/q6Nt3797h8P0hKU2fvsAALhrBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAAKn966uvpzcs9YPL6QVrXT86mZ6w1O7bV9MT1jp7d3rBWpdvphcsdbnf9jP8ydbv3+Nn0wvWur2ZXrDUvX/9bXrCWmfn0wuW2vavJwAAd44ABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAg9X/NgnvNEP3WtQAAAABJRU5ErkJggg==" id="image9bb3ebf120" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="483.84" height="295.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m04360577bb" d="M 0 0 
+       <path id="m4721f65817" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m04360577bb" x="115.814949" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4721f65817" x="115.814949" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m04360577bb" x="156.092348" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4721f65817" x="156.092348" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m04360577bb" x="196.369746" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4721f65817" x="196.369746" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m04360577bb" x="236.647145" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4721f65817" x="236.647145" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m04360577bb" x="276.924544" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4721f65817" x="276.924544" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m04360577bb" x="317.201942" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4721f65817" x="317.201942" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m04360577bb" x="357.479341" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4721f65817" x="357.479341" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m04360577bb" x="397.756739" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4721f65817" x="397.756739" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m04360577bb" x="438.034138" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4721f65817" x="438.034138" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m04360577bb" x="478.311536" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4721f65817" x="478.311536" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m04360577bb" x="518.588935" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4721f65817" x="518.588935" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m04360577bb" x="558.866334" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4721f65817" x="558.866334" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="m26c50d0627" d="M 0 0 
+       <path id="mb0c4171904" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m26c50d0627" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb0c4171904" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m26c50d0627" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb0c4171904" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m26c50d0627" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb0c4171904" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m26c50d0627" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb0c4171904" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -836,7 +836,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m26c50d0627" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb0c4171904" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -899,7 +899,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m26c50d0627" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb0c4171904" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -966,7 +966,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m26c50d0627" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb0c4171904" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1047,7 +1047,7 @@ z
     <g id="ytick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m26c50d0627" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb0c4171904" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -1241,42 +1241,10 @@ z
     </g>
    </g>
    <g id="text_23">
-    <!-- +6 -->
+    <!-- +5 -->
     <g transform="translate(191.578535 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-36" d="M 2113 2584 
-Q 1688 2584 1439 2293 
-Q 1191 2003 1191 1497 
-Q 1191 994 1439 701 
-Q 1688 409 2113 409 
-Q 2538 409 2786 701 
-Q 3034 994 3034 1497 
-Q 3034 2003 2786 2293 
-Q 2538 2584 2113 2584 
-z
-M 3366 4563 
-L 3366 3988 
-Q 3128 4100 2886 4159 
-Q 2644 4219 2406 4219 
-Q 1781 4219 1451 3797 
-Q 1122 3375 1075 2522 
-Q 1259 2794 1537 2939 
-Q 1816 3084 2150 3084 
-Q 2853 3084 3261 2657 
-Q 3669 2231 3669 1497 
-Q 3669 778 3244 343 
-Q 2819 -91 2113 -91 
-Q 1303 -91 875 529 
-Q 447 1150 447 2328 
-Q 447 3434 972 4092 
-Q 1497 4750 2381 4750 
-Q 2619 4750 2861 4703 
-Q 3103 4656 3366 4563 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_24">
@@ -1332,46 +1300,55 @@ z
     </g>
    </g>
    <g id="text_25">
-    <!-- -9 -->
+    <!-- -8 -->
     <g transform="translate(273.684192 69.553235) scale(0.065 -0.065)">
      <defs>
-      <path id="DejaVuSans-39" d="M 703 97 
-L 703 672 
-Q 941 559 1184 500 
-Q 1428 441 1663 441 
-Q 2288 441 2617 861 
-Q 2947 1281 2994 2138 
-Q 2813 1869 2534 1725 
-Q 2256 1581 1919 1581 
-Q 1219 1581 811 2004 
-Q 403 2428 403 3163 
-Q 403 3881 828 4315 
-Q 1253 4750 1959 4750 
-Q 2769 4750 3195 4129 
-Q 3622 3509 3622 2328 
-Q 3622 1225 3098 567 
-Q 2575 -91 1691 -91 
-Q 1453 -91 1209 -44 
-Q 966 3 703 97 
+      <path id="DejaVuSans-38" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
 z
-M 1959 2075 
-Q 2384 2075 2632 2365 
-Q 2881 2656 2881 3163 
-Q 2881 3666 2632 3958 
-Q 2384 4250 1959 4250 
-Q 1534 4250 1286 3958 
-Q 1038 3666 1038 3163 
-Q 1038 2656 1286 2365 
-Q 1534 2075 1959 2075 
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_26">
-    <!-- -12 -->
+    <!-- -13 -->
     <g transform="translate(311.893778 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
@@ -1391,7 +1368,7 @@ z
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_27">
@@ -1418,26 +1395,26 @@ z
     </g>
    </g>
    <g id="text_30">
-    <!-- -5 -->
+    <!-- -4 -->
     <g transform="translate(475.071185 69.553235) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_31">
-    <!-- -52 -->
+    <!-- -53 -->
     <g transform="translate(513.280771 69.553235) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_32">
-    <!-- -27 -->
+    <!-- -28 -->
     <g transform="translate(553.558169 69.553235) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_33">
@@ -1465,6 +1442,38 @@ z
    <g id="text_36">
     <!-- -16 -->
     <g transform="translate(231.338981 106.389018) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
@@ -1540,6 +1549,38 @@ z
    <g id="text_43">
     <!-- +9 -->
     <g transform="translate(513.797724 106.389018) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(83.789062 0)"/>
     </g>
@@ -1600,47 +1641,6 @@ z
    <g id="text_50">
     <!-- +184 -->
     <g transform="translate(308.275106 143.2248) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-38" d="M 2034 2216 
-Q 1584 2216 1326 1975 
-Q 1069 1734 1069 1313 
-Q 1069 891 1326 650 
-Q 1584 409 2034 409 
-Q 2484 409 2743 651 
-Q 3003 894 3003 1313 
-Q 3003 1734 2745 1975 
-Q 2488 2216 2034 2216 
-z
-M 1403 2484 
-Q 997 2584 770 2862 
-Q 544 3141 544 3541 
-Q 544 4100 942 4425 
-Q 1341 4750 2034 4750 
-Q 2731 4750 3128 4425 
-Q 3525 4100 3525 3541 
-Q 3525 3141 3298 2862 
-Q 3072 2584 2669 2484 
-Q 3125 2378 3379 2068 
-Q 3634 1759 3634 1313 
-Q 3634 634 3220 271 
-Q 2806 -91 2034 -91 
-Q 1263 -91 848 271 
-Q 434 634 434 1313 
-Q 434 1759 690 2068 
-Q 947 2378 1403 2484 
-z
-M 1172 3481 
-Q 1172 3119 1398 2916 
-Q 1625 2713 2034 2713 
-Q 2441 2713 2670 2916 
-Q 2900 3119 2900 3481 
-Q 2900 3844 2670 4047 
-Q 2441 4250 2034 4250 
-Q 1625 4250 1398 4047 
-Q 1172 3844 1172 3481 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
@@ -2190,18 +2190,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB1ElEQVR4nO2b0a3DMAwD7cSzvM3fmI47gvpxCK6ENABhnkQ5aZH5P/7OAGpdFyEzBiQDnija2qSEghnZhIIZCa3NyWQkmZFOKJhRsDXsOopmJJwjaEPOmxHirE3MWjOqhSBr2EAGMyKtMVpc+ynYwe3viNQVbA0LrZDRFbxGbNbWyM3auG0RGbo1Qp0IZCSMiG2OgtNvbL+Oke6BvddIWaQ1qP3RjGSTLXypwdaIMP2ctWb0olAzKkr4LhLMCPvnOJiRbo6CrTWjF4WCGYHWJtU1TKgZvSZkfNAKZhRsDftFa96MkJCRrf29ausyWrOtWiMjmxDH6FAfDJzzIEKctQc60ToDEqJOBLbfZs04RxQjobWOSFXrjM0IdURqIaG1jkhVPmvGOUqOCPLJMdh+6kRk+zFGMtjKOdK13zbZ2EBGMxLOkSz90YygK9tozSbUa6Qu4RxtRifZ2np0jDY32YiOc44gIQo2aI1ZkB2Rb4SiIyJbtcr0Q0IPdCQyIpCQDnZHpC5uQ27uOtJFBBptH2zlHOnab+uaMSK29htXrW2NKK0hOtlrxLaPjIxys4a99x9dRKgTgUK69gsZ9RxVFWzNyIi6RZIZtbXfE+qI1BU8R5i1D2e5X2tFkZmlAAAAAElFTkSuQmCC" id="image411661f893" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-69.84" width="12.96" height="253.44"/>
+iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB1ElEQVR4nO2b0a3DMAwD7cSzvM3fmI47gvpxCK6ENABhnkQ5aZH5P/7OAGpdFyEzBiQDnija2qSEghnZhIIZCa3NyWQkmZFOKJhRsDXsOopmJJwjaEPOmxHirE3MWjOqhSBr2EAGMyKtMVpc+ynYwe3viNQVbA0LrZDRFbxGbNbWyM3auG0RGbo1Qp0IZCSMiG2OgtNvbL+Oke6BvddIWaQ1qP3RjGSTLXypwdaIMP2ctWb0olAzKkr4LhLMCPvnOJiRbo6CrTWjF4WCGYHWJtU1TKgZvSZkfNAKZhRsDftFa96MkJCRrf29ausyWrOtWiMjmxDH6FAfDJzzIEKctQc60ToDEqJOBLbfZs04RxQjobWOSFXrjM0IdURqIaG1jkhVPmvGOUqOCPLJMdh+6kRk+zFGMtjKOdK13zbZ2EBGMxLOkSz90YygK9tozSbUa6Qu4RxtRifZ2np0jDY32YiOc44gIQo2aI1ZkB2Rb4SiIyJbtcr0Q0IPdCQyIpCQDnZHpC5uQ27uOtJFBBptH2zlHOnab+uaMSK29htXrW2NKK0hOtlrxLaPjIxys4a99x9dRKgTgUK69gsZ9RxVFWzNyIi6RZIZtbXfE+qI1BU8R5i1D2e5X2tFkZmlAAAAAElFTkSuQmCC" id="image0be774663a" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-69.84" width="12.96" height="253.44"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_21">
       <defs>
-       <path id="mda4db4a269" d="M 0 0 
+       <path id="m85d39d1788" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mda4db4a269" x="601.779688" y="322.507463" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m85d39d1788" x="601.779688" y="322.507463" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_117">
@@ -2224,7 +2224,7 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#mda4db4a269" x="601.779688" y="280.566603" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m85d39d1788" x="601.779688" y="280.566603" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_118">
@@ -2238,7 +2238,7 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#mda4db4a269" x="601.779688" y="238.625742" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m85d39d1788" x="601.779688" y="238.625742" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_119">
@@ -2252,7 +2252,7 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mda4db4a269" x="601.779688" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m85d39d1788" x="601.779688" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_120">
@@ -2265,7 +2265,7 @@ z
     <g id="ytick_13">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#mda4db4a269" x="601.779688" y="154.74402" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m85d39d1788" x="601.779688" y="154.74402" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_121">
@@ -2278,7 +2278,7 @@ z
     <g id="ytick_14">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mda4db4a269" x="601.779688" y="112.803159" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m85d39d1788" x="601.779688" y="112.803159" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_122">
@@ -2291,7 +2291,7 @@ z
     <g id="ytick_15">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#mda4db4a269" x="601.779688" y="70.862298" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m85d39d1788" x="601.779688" y="70.862298" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_123">
@@ -2907,8 +2907,8 @@ z
    </g>
   </g>
   <g id="text_126">
-   <!-- 2026-07-07T22:17:01Z  ·  Linux chungus2 x86_64  ·  commit dcf4b958  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(44.687422 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-08T05:15:03Z  ·  Linux chungus2 x86_64  ·  commit cf8297c9  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(44.98 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2997,16 +2997,16 @@ z
     <use xlink:href="#DejaVuSans-37" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
     <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3046,109 +3046,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3135.351562 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3190.332031 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3225.537109 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3289.160156 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3352.636719 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3416.259766 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3479.882812 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3543.505859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3575.292969 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3607.080078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3638.867188 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3670.654297 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3702.441406 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3730.224609 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3791.748047 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3853.027344 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3916.40625 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3979.882812 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4018.746094 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4079.927734 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4139.107422 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4200.630859 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4241.744141 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4275.435547 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4303.21875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4364.742188 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4426.021484 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4489.400391 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4553.023438 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4586.714844 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4645.894531 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4709.517578 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4741.304688 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4804.927734 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4868.550781 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4900.337891 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4963.960938 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5000.044922 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5038.908203 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5093.888672 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5157.511719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5189.298828 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5221.085938 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5252.873047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5284.660156 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5316.447266 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5355.65625 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5419.035156 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5457.898438 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5519.080078 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5582.458984 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5645.935547 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5709.314453 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5772.791016 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5836.169922 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5875.378906 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5907.166016 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5990.955078 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6022.742188 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6120.154297 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6181.677734 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6245.154297 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6272.9375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6334.216797 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6397.595703 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6429.382812 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6481.482422 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6544.861328 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6606.140625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6669.617188 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6721.716797 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6785.095703 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6846.277344 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6885.486328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6919.177734 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6950.964844 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6992.078125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7053.357422 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7092.566406 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7120.349609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7181.53125 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7213.318359 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7241.101562 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7293.201172 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7324.988281 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7388.464844 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7449.988281 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7489.197266 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7550.720703 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7590.083984 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7687.496094 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7715.279297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7778.658203 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7806.441406 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7858.541016 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7897.75 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7925.533203 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3126.855469 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3162.060547 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3225.683594 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3289.306641 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3352.929688 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3416.552734 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3471.533203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3535.15625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3566.943359 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3598.730469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3630.517578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3662.304688 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3694.091797 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3721.875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3783.398438 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3844.677734 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3908.056641 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3971.533203 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4010.396484 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4071.578125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4130.757812 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4192.28125 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4233.394531 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4267.085938 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4294.869141 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4356.392578 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4417.671875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4481.050781 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4544.673828 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4578.365234 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4637.544922 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4701.167969 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4732.955078 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4796.578125 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4860.201172 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4891.988281 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4955.611328 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4991.695312 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5030.558594 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5085.539062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5149.162109 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5180.949219 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5212.736328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5244.523438 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5276.310547 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5308.097656 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5347.306641 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5410.685547 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5449.548828 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5510.730469 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5574.109375 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5637.585938 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5700.964844 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5764.441406 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5827.820312 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5867.029297 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5898.816406 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5982.605469 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6014.392578 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6111.804688 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6173.328125 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6236.804688 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6264.587891 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6325.867188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6389.246094 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6421.033203 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6473.132812 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6536.511719 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6597.791016 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6661.267578 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6713.367188 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6776.746094 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6837.927734 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6877.136719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6910.828125 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6942.615234 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6983.728516 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7045.007812 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7084.216797 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7112 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7173.181641 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7204.96875 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7232.751953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7284.851562 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7316.638672 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7380.115234 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7441.638672 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7480.847656 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7542.371094 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7581.734375 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7679.146484 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7706.929688 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7770.308594 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7798.091797 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7850.191406 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7889.400391 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7917.183594 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pa081a4fe07">
+  <clipPath id="p22e929e887">
    <rect x="95.67625" y="49.34175" width="483.328783" height="294.686261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_compress_pareto.svg
+++ b/bench/graphs/silesia_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 61.085542 412.80375 
 L 61.085542 48.323125 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m3fadb05946" d="M 0 0 
+       <path id="maad06caff6" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m3fadb05946" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#maad06caff6" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -130,11 +130,11 @@ z
      <g id="line2d_3">
       <path d="M 145.270284 412.80375 
 L 145.270284 48.323125 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m3fadb05946" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#maad06caff6" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -177,11 +177,11 @@ z
      <g id="line2d_5">
       <path d="M 229.455026 412.80375 
 L 229.455026 48.323125 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m3fadb05946" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#maad06caff6" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -219,11 +219,11 @@ z
      <g id="line2d_7">
       <path d="M 313.639768 412.80375 
 L 313.639768 48.323125 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m3fadb05946" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#maad06caff6" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -272,11 +272,11 @@ z
      <g id="line2d_9">
       <path d="M 397.82451 412.80375 
 L 397.82451 48.323125 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m3fadb05946" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#maad06caff6" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -334,11 +334,11 @@ z
      <g id="line2d_11">
       <path d="M 482.009253 412.80375 
 L 482.009253 48.323125 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m3fadb05946" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#maad06caff6" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -355,11 +355,11 @@ L 482.009253 48.323125
      <g id="line2d_13">
       <path d="M 566.193995 412.80375 
 L 566.193995 48.323125 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m3fadb05946" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#maad06caff6" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -856,16 +856,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 368.08164 
 L 637.2 368.08164 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="m5d6eb16867" d="M 0 0 
+       <path id="maaf9d1593f" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m5d6eb16867" x="49.078125" y="368.08164" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#maaf9d1593f" x="49.078125" y="368.08164" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -897,11 +897,11 @@ z
      <g id="line2d_17">
       <path d="M 49.078125 243.439835 
 L 637.2 243.439835 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m5d6eb16867" x="49.078125" y="243.439835" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#maaf9d1593f" x="49.078125" y="243.439835" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -917,11 +917,11 @@ L 637.2 243.439835
      <g id="line2d_19">
       <path d="M 49.078125 118.798029 
 L 637.2 118.798029 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m5d6eb16867" x="49.078125" y="118.798029" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#maaf9d1593f" x="49.078125" y="118.798029" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -937,16 +937,16 @@ L 637.2 118.798029
      <g id="line2d_21">
       <path d="M 49.078125 405.602562 
 L 637.2 405.602562 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="m4b9d2d8365" d="M 0 0 
+       <path id="m97b5a6fb54" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m4b9d2d8365" x="49.078125" y="405.602562" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97b5a6fb54" x="49.078125" y="405.602562" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -954,11 +954,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 395.733268 
 L 637.2 395.733268 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m4b9d2d8365" x="49.078125" y="395.733268" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97b5a6fb54" x="49.078125" y="395.733268" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -966,11 +966,11 @@ L 637.2 395.733268
      <g id="line2d_25">
       <path d="M 49.078125 387.3889 
 L 637.2 387.3889 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m4b9d2d8365" x="49.078125" y="387.3889" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97b5a6fb54" x="49.078125" y="387.3889" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -978,11 +978,11 @@ L 637.2 387.3889
      <g id="line2d_27">
       <path d="M 49.078125 380.160679 
 L 637.2 380.160679 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m4b9d2d8365" x="49.078125" y="380.160679" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97b5a6fb54" x="49.078125" y="380.160679" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -990,11 +990,11 @@ L 637.2 380.160679
      <g id="line2d_29">
       <path d="M 49.078125 373.784936 
 L 637.2 373.784936 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m4b9d2d8365" x="49.078125" y="373.784936" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97b5a6fb54" x="49.078125" y="373.784936" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1002,11 +1002,11 @@ L 637.2 373.784936
      <g id="line2d_31">
       <path d="M 49.078125 330.560718 
 L 637.2 330.560718 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m4b9d2d8365" x="49.078125" y="330.560718" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97b5a6fb54" x="49.078125" y="330.560718" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1014,11 +1014,11 @@ L 637.2 330.560718
      <g id="line2d_33">
       <path d="M 49.078125 308.612385 
 L 637.2 308.612385 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m4b9d2d8365" x="49.078125" y="308.612385" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97b5a6fb54" x="49.078125" y="308.612385" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1026,11 +1026,11 @@ L 637.2 308.612385
      <g id="line2d_35">
       <path d="M 49.078125 293.039796 
 L 637.2 293.039796 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m4b9d2d8365" x="49.078125" y="293.039796" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97b5a6fb54" x="49.078125" y="293.039796" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1038,11 +1038,11 @@ L 637.2 293.039796
      <g id="line2d_37">
       <path d="M 49.078125 280.960757 
 L 637.2 280.960757 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m4b9d2d8365" x="49.078125" y="280.960757" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97b5a6fb54" x="49.078125" y="280.960757" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1050,11 +1050,11 @@ L 637.2 280.960757
      <g id="line2d_39">
       <path d="M 49.078125 271.091463 
 L 637.2 271.091463 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m4b9d2d8365" x="49.078125" y="271.091463" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97b5a6fb54" x="49.078125" y="271.091463" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1062,11 +1062,11 @@ L 637.2 271.091463
      <g id="line2d_41">
       <path d="M 49.078125 262.747094 
 L 637.2 262.747094 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m4b9d2d8365" x="49.078125" y="262.747094" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97b5a6fb54" x="49.078125" y="262.747094" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1074,11 +1074,11 @@ L 637.2 262.747094
      <g id="line2d_43">
       <path d="M 49.078125 255.518874 
 L 637.2 255.518874 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m4b9d2d8365" x="49.078125" y="255.518874" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97b5a6fb54" x="49.078125" y="255.518874" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1086,11 +1086,11 @@ L 637.2 255.518874
      <g id="line2d_45">
       <path d="M 49.078125 249.143131 
 L 637.2 249.143131 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m4b9d2d8365" x="49.078125" y="249.143131" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97b5a6fb54" x="49.078125" y="249.143131" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1098,11 +1098,11 @@ L 637.2 249.143131
      <g id="line2d_47">
       <path d="M 49.078125 205.918912 
 L 637.2 205.918912 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m4b9d2d8365" x="49.078125" y="205.918912" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97b5a6fb54" x="49.078125" y="205.918912" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1110,11 +1110,11 @@ L 637.2 205.918912
      <g id="line2d_49">
       <path d="M 49.078125 183.97058 
 L 637.2 183.97058 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m4b9d2d8365" x="49.078125" y="183.97058" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97b5a6fb54" x="49.078125" y="183.97058" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1122,11 +1122,11 @@ L 637.2 183.97058
      <g id="line2d_51">
       <path d="M 49.078125 168.39799 
 L 637.2 168.39799 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m4b9d2d8365" x="49.078125" y="168.39799" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97b5a6fb54" x="49.078125" y="168.39799" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1134,11 +1134,11 @@ L 637.2 168.39799
      <g id="line2d_53">
       <path d="M 49.078125 156.318951 
 L 637.2 156.318951 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#m4b9d2d8365" x="49.078125" y="156.318951" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97b5a6fb54" x="49.078125" y="156.318951" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1146,11 +1146,11 @@ L 637.2 156.318951
      <g id="line2d_55">
       <path d="M 49.078125 146.449658 
 L 637.2 146.449658 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#m4b9d2d8365" x="49.078125" y="146.449658" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97b5a6fb54" x="49.078125" y="146.449658" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1158,11 +1158,11 @@ L 637.2 146.449658
      <g id="line2d_57">
       <path d="M 49.078125 138.105289 
 L 637.2 138.105289 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#m4b9d2d8365" x="49.078125" y="138.105289" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97b5a6fb54" x="49.078125" y="138.105289" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1170,11 +1170,11 @@ L 637.2 138.105289
      <g id="line2d_59">
       <path d="M 49.078125 130.877068 
 L 637.2 130.877068 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#m4b9d2d8365" x="49.078125" y="130.877068" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97b5a6fb54" x="49.078125" y="130.877068" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1182,11 +1182,11 @@ L 637.2 130.877068
      <g id="line2d_61">
       <path d="M 49.078125 124.501326 
 L 637.2 124.501326 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#m4b9d2d8365" x="49.078125" y="124.501326" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97b5a6fb54" x="49.078125" y="124.501326" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1194,11 +1194,11 @@ L 637.2 124.501326
      <g id="line2d_63">
       <path d="M 49.078125 81.277107 
 L 637.2 81.277107 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#m4b9d2d8365" x="49.078125" y="81.277107" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97b5a6fb54" x="49.078125" y="81.277107" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1206,11 +1206,11 @@ L 637.2 81.277107
      <g id="line2d_65">
       <path d="M 49.078125 59.328775 
 L 637.2 59.328775 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#m4b9d2d8365" x="49.078125" y="59.328775" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97b5a6fb54" x="49.078125" y="59.328775" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1332,7 +1332,7 @@ L 637.2 48.323125
    </g>
    <g id="text_13">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(324.643112 123.282456) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(324.643112 122.945186) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1364,7 +1364,7 @@ z
    </g>
    <g id="text_14">
     <!-- L10 -->
-    <g style="fill: #d62728" transform="translate(102.799363 312.940018) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(102.799363 313.255405) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1686,23 +1686,23 @@ z
    </g>
    <g id="line2d_67">
     <defs>
-     <path id="ma1cf627ba0" d="M -2.5 2.5 
+     <path id="mab211ebae0" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p742c5d33d3)">
-     <use xlink:href="#ma1cf627ba0" x="377.110281" y="104.685421" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma1cf627ba0" x="323.801439" y="110.409833" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma1cf627ba0" x="272.665744" y="126.308323" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma1cf627ba0" x="235.168828" y="128.026741" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma1cf627ba0" x="186.228265" y="149.377587" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma1cf627ba0" x="158.303164" y="171.457731" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma1cf627ba0" x="149.489547" y="182.192614" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma1cf627ba0" x="140.563162" y="202.482797" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma1cf627ba0" x="138.984853" y="209.328911" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p74e4003240)">
+     <use xlink:href="#mab211ebae0" x="377.110281" y="104.685421" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mab211ebae0" x="323.801439" y="110.409833" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mab211ebae0" x="272.665744" y="126.308323" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mab211ebae0" x="235.168828" y="128.026741" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mab211ebae0" x="186.228265" y="149.377587" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mab211ebae0" x="158.303164" y="171.457731" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mab211ebae0" x="149.489547" y="182.192614" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mab211ebae0" x="140.563162" y="202.482797" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mab211ebae0" x="138.984853" y="209.328911" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_68">
@@ -1755,7 +1755,7 @@ L 327.133241 110.069256
 L 326.02264 110.18302 
 L 324.91204 110.296545 
 L 323.801439 110.409833 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_69">
     <path d="M 323.801439 110.409833 
@@ -1807,7 +1807,7 @@ L 275.861725 125.44037
 L 274.796398 125.731236 
 L 273.731071 126.020548 
 L 272.665744 126.308323 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_70">
     <path d="M 272.665744 126.308323 
@@ -1859,7 +1859,7 @@ L 237.512385 127.920923
 L 236.7312 127.956219 
 L 235.950014 127.991491 
 L 235.168828 128.026741 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_71">
     <path d="M 235.168828 128.026741 
@@ -1911,7 +1911,7 @@ L 189.28705 148.263499
 L 188.267455 148.637415 
 L 187.24786 149.008766 
 L 186.228265 149.377587 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_72">
     <path d="M 186.228265 149.377587 
@@ -1963,7 +1963,7 @@ L 160.048483 170.312481
 L 159.46671 170.696929 
 L 158.884937 171.078667 
 L 158.303164 171.457731 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_73">
     <path d="M 158.303164 171.457731 
@@ -2015,7 +2015,7 @@ L 150.040398 181.580576
 L 149.856781 181.785359 
 L 149.673164 181.989369 
 L 149.489547 182.192614 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_74">
     <path d="M 149.489547 182.192614 
@@ -2067,7 +2067,7 @@ L 141.121061 201.414753
 L 140.935095 201.773114 
 L 140.749129 202.129119 
 L 140.563162 202.482797 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_75">
     <path d="M 140.563162 202.482797 
@@ -2119,26 +2119,26 @@ L 139.083497 208.925481
 L 139.050616 209.060292 
 L 139.017734 209.194768 
 L 138.984853 209.328911 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_76">
     <defs>
-     <path id="m7d582679f5" d="M 0 -2.5 
+     <path id="m4630ed54f3" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p742c5d33d3)">
-     <use xlink:href="#m7d582679f5" x="610.467187" y="71.939349" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7d582679f5" x="319.880958" y="101.884157" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7d582679f5" x="210.281253" y="129.778154" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7d582679f5" x="196.287076" y="133.586625" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7d582679f5" x="176.054419" y="147.38645" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7d582679f5" x="152.161413" y="174.753272" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7d582679f5" x="146.720208" y="186.587648" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7d582679f5" x="143.994022" y="196.356323" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7d582679f5" x="142.666037" y="200.180971" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p74e4003240)">
+     <use xlink:href="#m4630ed54f3" x="610.467187" y="71.939349" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4630ed54f3" x="319.880958" y="101.884157" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4630ed54f3" x="210.281253" y="129.778154" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4630ed54f3" x="196.287076" y="133.586625" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4630ed54f3" x="176.054419" y="147.38645" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4630ed54f3" x="152.161413" y="174.753272" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4630ed54f3" x="146.720208" y="186.587648" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4630ed54f3" x="143.994022" y="196.356323" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4630ed54f3" x="142.666037" y="200.180971" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_77">
@@ -2191,7 +2191,7 @@ L 338.042598 100.427247
 L 331.988718 100.917253 
 L 325.934838 101.402864 
 L 319.880958 101.884157 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_78">
     <path d="M 319.880958 101.884157 
@@ -2243,7 +2243,7 @@ L 217.131235 128.398367
 L 214.847908 128.862215 
 L 212.564581 129.322122 
 L 210.281253 129.778154 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_79">
     <path d="M 210.281253 129.778154 
@@ -2295,7 +2295,7 @@ L 197.161712 133.356286
 L 196.870166 133.433175 
 L 196.578621 133.509954 
 L 196.287076 133.586625 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_80">
     <path d="M 196.287076 133.586625 
@@ -2347,7 +2347,7 @@ L 177.31896 146.619719
 L 176.897447 146.876504 
 L 176.475933 147.132078 
 L 176.054419 147.38645 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_81">
     <path d="M 176.054419 147.38645 
@@ -2399,7 +2399,7 @@ L 153.654726 173.393769
 L 153.156955 173.850741 
 L 152.659184 174.303887 
 L 152.161413 174.753272 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_82">
     <path d="M 152.161413 174.753272 
@@ -2451,7 +2451,7 @@ L 147.060283 185.919158
 L 146.946925 186.142906 
 L 146.833566 186.365734 
 L 146.720208 186.587648 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_83">
     <path d="M 146.720208 186.587648 
@@ -2503,7 +2503,7 @@ L 144.164409 195.794799
 L 144.107613 195.982622 
 L 144.050817 196.169795 
 L 143.994022 196.356323 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_84">
     <path d="M 143.994022 196.356323 
@@ -2555,30 +2555,30 @@ L 142.749036 199.949687
 L 142.72137 200.026891 
 L 142.693704 200.103986 
 L 142.666037 200.180971 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_85">
     <defs>
-     <path id="m96f07e8d5c" d="M -0 3.535534 
+     <path id="m12a7ea9915" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p742c5d33d3)">
-     <use xlink:href="#m96f07e8d5c" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m96f07e8d5c" x="242.839153" y="80.778898" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m96f07e8d5c" x="218.251194" y="86.377096" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m96f07e8d5c" x="197.814984" y="90.309617" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m96f07e8d5c" x="166.378359" y="99.066934" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m96f07e8d5c" x="145.830392" y="110.431955" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m96f07e8d5c" x="134.598477" y="126.026287" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m96f07e8d5c" x="124.077268" y="149.033155" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m96f07e8d5c" x="122.462976" y="157.476606" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m96f07e8d5c" x="81.012077" y="220.06889" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m96f07e8d5c" x="77.44276" y="239.652656" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m96f07e8d5c" x="76.953425" y="252.706566" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p74e4003240)">
+     <use xlink:href="#m12a7ea9915" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m12a7ea9915" x="242.839153" y="80.778898" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m12a7ea9915" x="218.251194" y="86.377096" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m12a7ea9915" x="197.814984" y="90.309617" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m12a7ea9915" x="166.378359" y="99.066934" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m12a7ea9915" x="145.830392" y="110.431955" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m12a7ea9915" x="134.598477" y="126.026287" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m12a7ea9915" x="124.077268" y="149.033155" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m12a7ea9915" x="122.462976" y="157.476606" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m12a7ea9915" x="81.012077" y="220.06889" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m12a7ea9915" x="77.44276" y="239.652656" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m12a7ea9915" x="76.953425" y="252.706566" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_86">
@@ -2631,7 +2631,7 @@ L 245.91379 79.91142
 L 244.888911 80.202126 
 L 243.864032 80.49128 
 L 242.839153 80.778898 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_87">
     <path d="M 242.839153 80.778898 
@@ -2683,7 +2683,7 @@ L 219.787941 86.043669
 L 219.275692 86.155039 
 L 218.763443 86.266182 
 L 218.251194 86.377096 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_88">
     <path d="M 218.251194 86.377096 
@@ -2735,7 +2735,7 @@ L 199.092247 90.072029
 L 198.666492 90.151341 
 L 198.240738 90.230537 
 L 197.814984 90.309617 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_89">
     <path d="M 197.814984 90.309617 
@@ -2787,7 +2787,7 @@ L 168.343148 98.559208
 L 167.688219 98.72898 
 L 167.033289 98.898221 
 L 166.378359 99.066934 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_90">
     <path d="M 166.378359 99.066934 
@@ -2839,7 +2839,7 @@ L 147.11464 109.78743
 L 146.686557 110.003126 
 L 146.258475 110.217965 
 L 145.830392 110.431955 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_91">
     <path d="M 145.830392 110.431955 
@@ -2891,7 +2891,7 @@ L 135.300472 125.172774
 L 135.066474 125.458776 
 L 134.832476 125.743276 
 L 134.598477 126.026287 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_92">
     <path d="M 134.598477 126.026287 
@@ -2943,7 +2943,7 @@ L 124.734843 147.848882
 L 124.515652 148.246526 
 L 124.29646 148.641269 
 L 124.077268 149.033155 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_93">
     <path d="M 124.077268 149.033155 
@@ -2995,7 +2995,7 @@ L 122.56387 156.985769
 L 122.530239 157.149876 
 L 122.496607 157.313488 
 L 122.462976 157.476606 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_94">
     <path d="M 122.462976 157.476606 
@@ -3047,7 +3047,7 @@ L 83.602758 217.699074
 L 82.739198 218.500595 
 L 81.875637 219.290422 
 L 81.012077 220.06889 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_95">
     <path d="M 81.012077 220.06889 
@@ -3099,7 +3099,7 @@ L 77.665842 238.615761
 L 77.591481 238.963605 
 L 77.517121 239.309227 
 L 77.44276 239.652656 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_96">
     <path d="M 77.44276 239.652656 
@@ -3151,23 +3151,23 @@ L 76.984008 251.97672
 L 76.973814 252.221097 
 L 76.96362 252.464376 
 L 76.953425 252.706566 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_97">
     <defs>
-     <path id="m457dfffd5e" d="M -0 2.5 
+     <path id="m1b90c7204a" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p742c5d33d3)">
-     <use xlink:href="#m457dfffd5e" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p74e4003240)">
+     <use xlink:href="#m1b90c7204a" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_98">
     <defs>
-     <path id="m14ef7faacd" d="M -0.833333 2.5 
+     <path id="m3490b95b44" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -3182,16 +3182,16 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p742c5d33d3)">
-     <use xlink:href="#m14ef7faacd" x="432.495268" y="96.067622" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m14ef7faacd" x="300.62247" y="112.493412" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m14ef7faacd" x="266.967623" y="120.8136" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m14ef7faacd" x="226.040946" y="122.099593" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m14ef7faacd" x="180.985721" y="141.85872" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m14ef7faacd" x="164.441833" y="156.106179" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m14ef7faacd" x="157.761315" y="165.23787" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m14ef7faacd" x="151.269082" y="178.700983" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m14ef7faacd" x="150.327087" y="185.23695" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p74e4003240)">
+     <use xlink:href="#m3490b95b44" x="432.495268" y="96.067622" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3490b95b44" x="300.62247" y="112.493412" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3490b95b44" x="266.967623" y="120.8136" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3490b95b44" x="226.040946" y="122.099593" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3490b95b44" x="180.985721" y="141.85872" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3490b95b44" x="164.441833" y="156.106179" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3490b95b44" x="157.761315" y="165.23787" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3490b95b44" x="151.269082" y="178.700983" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3490b95b44" x="150.327087" y="185.23695" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_99">
@@ -3244,7 +3244,7 @@ L 308.86452 111.600609
 L 306.11717 111.899849 
 L 303.36982 112.197444 
 L 300.62247 112.493412 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_100">
     <path d="M 300.62247 112.493412 
@@ -3296,7 +3296,7 @@ L 269.071051 120.329422
 L 268.369908 120.491297 
 L 267.668766 120.652688 
 L 266.967623 120.8136 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_101">
     <path d="M 266.967623 120.8136 
@@ -3348,7 +3348,7 @@ L 228.598863 122.020108
 L 227.746224 122.046616 
 L 226.893585 122.073111 
 L 226.040946 122.099593 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_102">
     <path d="M 226.040946 122.099593 
@@ -3400,7 +3400,7 @@ L 183.801673 140.814056
 L 182.863022 141.164522 
 L 181.924372 141.512734 
 L 180.985721 141.85872 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_103">
     <path d="M 180.985721 141.85872 
@@ -3452,7 +3452,7 @@ L 165.475826 155.317544
 L 165.131161 155.581701 
 L 164.786497 155.844575 
 L 164.441833 156.106179 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_104">
     <path d="M 164.441833 156.106179 
@@ -3504,7 +3504,7 @@ L 158.178848 164.710119
 L 158.03967 164.886608 
 L 157.900493 165.062524 
 L 157.761315 165.23787 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_105">
     <path d="M 157.761315 165.23787 
@@ -3556,7 +3556,7 @@ L 151.674847 177.950842
 L 151.539592 178.202046 
 L 151.404337 178.452089 
 L 151.269082 178.700983 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_106">
     <path d="M 151.269082 178.700983 
@@ -3608,11 +3608,11 @@ L 150.385962 184.850776
 L 150.366337 184.979807 
 L 150.346712 185.108531 
 L 150.327087 185.23695 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_107">
     <defs>
-     <path id="mc490e39ac2" d="M -1.25 2.5 
+     <path id="m0bbf0d1caa" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -3627,16 +3627,16 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p742c5d33d3)">
-     <use xlink:href="#mc490e39ac2" x="345.030867" y="136.859359" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc490e39ac2" x="273.364924" y="143.571257" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc490e39ac2" x="240.719951" y="149.310846" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc490e39ac2" x="221.353978" y="154.160538" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc490e39ac2" x="207.129625" y="156.092215" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc490e39ac2" x="181.064802" y="166.758473" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc490e39ac2" x="179.282169" y="170.289343" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc490e39ac2" x="177.719335" y="175.489948" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc490e39ac2" x="177.643939" y="181.552088" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p74e4003240)">
+     <use xlink:href="#m0bbf0d1caa" x="345.030867" y="136.859359" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0bbf0d1caa" x="273.364924" y="143.571257" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0bbf0d1caa" x="240.719951" y="149.310846" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0bbf0d1caa" x="221.353978" y="154.160538" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0bbf0d1caa" x="207.129625" y="156.092215" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0bbf0d1caa" x="181.064802" y="166.758473" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0bbf0d1caa" x="179.282169" y="170.289343" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0bbf0d1caa" x="177.719335" y="175.489948" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0bbf0d1caa" x="177.643939" y="181.552088" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_108">
@@ -3689,7 +3689,7 @@ L 277.844045 143.175283
 L 276.351005 143.307597 
 L 274.857964 143.439587 
 L 273.364924 143.571257 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_109">
     <path d="M 273.364924 143.571257 
@@ -3741,7 +3741,7 @@ L 242.760262 148.96941
 L 242.080158 149.083462 
 L 241.400055 149.197273 
 L 240.719951 149.310846 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_110">
     <path d="M 240.719951 149.310846 
@@ -3793,7 +3793,7 @@ L 222.564351 153.869835
 L 222.160893 153.966909 
 L 221.757435 154.06381 
 L 221.353978 154.160538 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_111">
     <path d="M 221.353978 154.160538 
@@ -3845,7 +3845,7 @@ L 208.018647 155.973483
 L 207.722306 156.013089 
 L 207.425965 156.052666 
 L 207.129625 156.092215 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_112">
     <path d="M 207.129625 156.092215 
@@ -3897,7 +3897,7 @@ L 182.693853 166.149994
 L 182.150836 166.353581 
 L 181.607819 166.556405 
 L 181.064802 166.758473 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_113">
     <path d="M 181.064802 166.758473 
@@ -3949,7 +3949,7 @@ L 179.393584 170.075284
 L 179.356445 170.146731 
 L 179.319307 170.218084 
 L 179.282169 170.289343 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_114">
     <path d="M 179.282169 170.289343 
@@ -4001,7 +4001,7 @@ L 177.817012 175.179146
 L 177.784453 175.282945 
 L 177.751894 175.386546 
 L 177.719335 175.489948 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_115">
     <path d="M 177.719335 175.489948 
@@ -4053,11 +4053,11 @@ L 177.648651 181.192458
 L 177.64708 181.3126 
 L 177.645509 181.432477 
 L 177.643939 181.552088 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_116">
     <defs>
-     <path id="m874c9f298f" d="M 0 -2.5 
+     <path id="mcd48b79e53" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -4070,16 +4070,16 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p742c5d33d3)">
-     <use xlink:href="#m874c9f298f" x="226.871027" y="113.224491" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m874c9f298f" x="226.871027" y="113.066324" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m874c9f298f" x="226.871027" y="113.178221" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m874c9f298f" x="226.871027" y="113.089884" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m874c9f298f" x="177.768423" y="132.327899" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m874c9f298f" x="160.37503" y="145.652356" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m874c9f298f" x="153.995779" y="152.678629" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m874c9f298f" x="147.106887" y="168.143801" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m874c9f298f" x="145.871703" y="175.118358" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p74e4003240)">
+     <use xlink:href="#mcd48b79e53" x="226.871027" y="113.224491" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mcd48b79e53" x="226.871027" y="113.066324" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mcd48b79e53" x="226.871027" y="113.178221" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mcd48b79e53" x="226.871027" y="113.089884" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mcd48b79e53" x="177.768423" y="132.327899" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mcd48b79e53" x="160.37503" y="145.652356" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mcd48b79e53" x="153.995779" y="152.678629" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mcd48b79e53" x="147.106887" y="168.143801" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mcd48b79e53" x="145.871703" y="175.118358" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_117">
@@ -4132,7 +4132,7 @@ L 226.871027 113.076223
 L 226.871027 113.072924 
 L 226.871027 113.069624 
 L 226.871027 113.066324 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_118">
     <path d="M 226.871027 113.066324 
@@ -4184,7 +4184,7 @@ L 226.871027 113.171234
 L 226.871027 113.173563 
 L 226.871027 113.175892 
 L 226.871027 113.178221 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_119">
     <path d="M 226.871027 113.178221 
@@ -4236,7 +4236,7 @@ L 226.871027 113.09541
 L 226.871027 113.093568 
 L 226.871027 113.091726 
 L 226.871027 113.089884 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_120">
     <path d="M 226.871027 113.089884 
@@ -4288,7 +4288,7 @@ L 180.837336 131.306392
 L 179.814365 131.649041 
 L 178.791394 131.989534 
 L 177.768423 132.327899 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_121">
     <path d="M 177.768423 132.327899 
@@ -4340,7 +4340,7 @@ L 161.462117 144.909076
 L 161.099755 145.157972 
 L 160.737393 145.405728 
 L 160.37503 145.652356 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_122">
     <path d="M 160.37503 145.652356 
@@ -4392,7 +4392,7 @@ L 154.394483 152.265218
 L 154.261581 152.403373 
 L 154.12868 152.541176 
 L 153.995779 152.678629 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_123">
     <path d="M 153.995779 152.678629 
@@ -4444,7 +4444,7 @@ L 147.537442 167.296442
 L 147.393924 167.580372 
 L 147.250405 167.862819 
 L 147.106887 168.143801 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_124">
     <path d="M 147.106887 168.143801 
@@ -4496,11 +4496,11 @@ L 145.948902 174.70781
 L 145.923169 174.845005 
 L 145.897436 174.981854 
 L 145.871703 175.118358 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_125">
     <defs>
-     <path id="mb3359871ee" d="M 0 -2.5 
+     <path id="m06d668cb62" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -4509,16 +4509,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p742c5d33d3)">
-     <use xlink:href="#mb3359871ee" x="585.66883" y="173.051371" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb3359871ee" x="527.144592" y="175.326465" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb3359871ee" x="457.339427" y="183.688849" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb3359871ee" x="292.124837" y="178.486631" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb3359871ee" x="243.129344" y="190.369032" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb3359871ee" x="213.541392" y="204.43395" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb3359871ee" x="204.551957" y="212.140784" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb3359871ee" x="195.860087" y="228.582256" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb3359871ee" x="194.019853" y="234.294862" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p74e4003240)">
+     <use xlink:href="#m06d668cb62" x="585.66883" y="173.051371" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m06d668cb62" x="527.144592" y="175.326465" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m06d668cb62" x="457.339427" y="183.688849" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m06d668cb62" x="292.124837" y="178.486631" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m06d668cb62" x="243.129344" y="190.369032" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m06d668cb62" x="213.541392" y="204.43395" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m06d668cb62" x="204.551957" y="212.140784" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m06d668cb62" x="195.860087" y="228.582256" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m06d668cb62" x="194.019853" y="234.294862" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_126">
@@ -4571,7 +4571,7 @@ L 530.802357 175.187039
 L 529.583102 175.233554 
 L 528.363847 175.28003 
 L 527.144592 175.326465 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_127">
     <path d="M 527.144592 175.326465 
@@ -4623,7 +4623,7 @@ L 461.70225 183.20239
 L 460.247976 183.36503 
 L 458.793701 183.527182 
 L 457.339427 183.688849 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_128">
     <path d="M 457.339427 183.688849 
@@ -4675,7 +4675,7 @@ L 302.450749 178.826834
 L 299.008779 178.713671 
 L 295.566808 178.60027 
 L 292.124837 178.486631 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_129">
     <path d="M 292.124837 178.486631 
@@ -4727,7 +4727,7 @@ L 246.191563 189.6981
 L 245.170823 189.922669 
 L 244.150084 190.146311 
 L 243.129344 190.369032 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_130">
     <path d="M 243.129344 190.369032 
@@ -4779,7 +4779,7 @@ L 215.390639 203.654226
 L 214.774224 203.915384 
 L 214.157808 204.175288 
 L 213.541392 204.43395 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_131">
     <path d="M 213.541392 204.43395 
@@ -4831,7 +4831,7 @@ L 205.113797 211.689953
 L 204.926517 211.840648 
 L 204.739237 211.990924 
 L 204.551957 212.140784 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_132">
     <path d="M 204.551957 212.140784 
@@ -4883,7 +4883,7 @@ L 196.403329 227.688717
 L 196.222248 227.988205 
 L 196.041168 228.286045 
 L 195.860087 228.582256 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_133">
     <path d="M 195.860087 228.582256 
@@ -4935,7 +4935,7 @@ L 194.134867 233.954953
 L 194.096529 234.068494 
 L 194.058191 234.181796 
 L 194.019853 234.294862 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="legend_1">
     <g id="patch_7">
@@ -4953,7 +4953,7 @@ z
     </g>
     <g id="line2d_134">
      <defs>
-      <path id="ma723d285d8" d="M 0 3.5 
+      <path id="m375b4c06a5" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -4966,7 +4966,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#ma723d285d8" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m375b4c06a5" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -5025,7 +5025,7 @@ z
     </g>
     <g id="line2d_135">
      <g>
-      <use xlink:href="#ma1cf627ba0" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mab211ebae0" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -5039,7 +5039,7 @@ z
     </g>
     <g id="line2d_136">
      <g>
-      <use xlink:href="#m7d582679f5" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m4630ed54f3" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -5084,7 +5084,7 @@ z
     </g>
     <g id="line2d_137">
      <g>
-      <use xlink:href="#m96f07e8d5c" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m12a7ea9915" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -5127,7 +5127,7 @@ z
     </g>
     <g id="line2d_138">
      <g>
-      <use xlink:href="#m457dfffd5e" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m1b90c7204a" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -5143,7 +5143,7 @@ z
     </g>
     <g id="line2d_139">
      <g>
-      <use xlink:href="#m14ef7faacd" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m3490b95b44" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -5197,7 +5197,7 @@ z
     </g>
     <g id="line2d_140">
      <g>
-      <use xlink:href="#mc490e39ac2" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m0bbf0d1caa" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -5262,7 +5262,7 @@ z
     </g>
     <g id="line2d_141">
      <g>
-      <use xlink:href="#m874c9f298f" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#mcd48b79e53" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -5300,7 +5300,7 @@ z
     </g>
     <g id="line2d_142">
      <g>
-      <use xlink:href="#mb3359871ee" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m06d668cb62" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -5370,486 +5370,486 @@ z
     </g>
    </g>
    <g id="line2d_143">
-    <g clip-path="url(#p742c5d33d3)">
-     <use xlink:href="#ma723d285d8" x="319.643112" y="128.282456" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#ma723d285d8" x="269.129958" y="143.692386" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#ma723d285d8" x="247.452898" y="149.000294" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#ma723d285d8" x="192.820547" y="160.764254" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#ma723d285d8" x="180.389901" y="171.025709" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#ma723d285d8" x="156.350594" y="180.873863" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#ma723d285d8" x="147.843012" y="189.683742" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#ma723d285d8" x="146.231533" y="194.452828" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#ma723d285d8" x="119.590386" y="289.17326" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#ma723d285d8" x="97.799363" y="317.940018" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <g clip-path="url(#p74e4003240)">
+     <use xlink:href="#m375b4c06a5" x="319.643112" y="127.945186" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m375b4c06a5" x="269.129958" y="143.690466" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m375b4c06a5" x="247.452898" y="148.824512" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m375b4c06a5" x="192.820547" y="161.125912" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m375b4c06a5" x="180.389901" y="171.387141" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m375b4c06a5" x="156.350594" y="180.996719" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m375b4c06a5" x="147.843012" y="190.039348" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m375b4c06a5" x="146.231533" y="193.926532" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m375b4c06a5" x="119.590386" y="290.182508" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m375b4c06a5" x="97.799363" y="318.255405" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
    <g id="line2d_144">
-    <path d="M 319.643112 128.282456 
-L 318.590755 128.652587 
-L 317.538397 129.020205 
-L 316.48604 129.385343 
-L 315.433682 129.748035 
-L 314.381325 130.108313 
-L 313.328968 130.466208 
-L 312.27661 130.821753 
-L 311.224253 131.174978 
-L 310.171896 131.525913 
-L 309.119538 131.874588 
-L 308.067181 132.22103 
-L 307.014823 132.56527 
-L 305.962466 132.907335 
-L 304.910109 133.247251 
-L 303.857751 133.585046 
-L 302.805394 133.920747 
-L 301.753037 134.254378 
-L 300.700679 134.585966 
-L 299.648322 134.915534 
-L 298.595965 135.243109 
-L 297.543607 135.568713 
-L 296.49125 135.89237 
-L 295.438892 136.214103 
-L 294.386535 136.533936 
-L 293.334178 136.85189 
-L 292.28182 137.167987 
-L 291.229463 137.482249 
-L 290.177106 137.794697 
-L 289.124748 138.105352 
-L 288.072391 138.414235 
-L 287.020033 138.721364 
-L 285.967676 139.026761 
-L 284.915319 139.330445 
-L 283.862961 139.632435 
-L 282.810604 139.932749 
-L 281.758247 140.231406 
-L 280.705889 140.528424 
-L 279.653532 140.823822 
-L 278.601175 141.117616 
-L 277.548817 141.409825 
-L 276.49646 141.700464 
-L 275.444102 141.989552 
-L 274.391745 142.277103 
-L 273.339388 142.563136 
-L 272.28703 142.847664 
-L 271.234673 143.130705 
-L 270.182316 143.412274 
-L 269.129958 143.692386 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 319.643112 127.945186 
+L 318.590755 128.32457 
+L 317.538397 128.701313 
+L 316.48604 129.075452 
+L 315.433682 129.447023 
+L 314.381325 129.81606 
+L 313.328968 130.182599 
+L 312.27661 130.546673 
+L 311.224253 130.908314 
+L 310.171896 131.267555 
+L 309.119538 131.624428 
+L 308.067181 131.978964 
+L 307.014823 132.331192 
+L 305.962466 132.681143 
+L 304.910109 133.028847 
+L 303.857751 133.374331 
+L 302.805394 133.717625 
+L 301.753037 134.058755 
+L 300.700679 134.397748 
+L 299.648322 134.734632 
+L 298.595965 135.069432 
+L 297.543607 135.402175 
+L 296.49125 135.732884 
+L 295.438892 136.061585 
+L 294.386535 136.388302 
+L 293.334178 136.71306 
+L 292.28182 137.03588 
+L 291.229463 137.356787 
+L 290.177106 137.675802 
+L 289.124748 137.992948 
+L 288.072391 138.308247 
+L 287.020033 138.621721 
+L 285.967676 138.933389 
+L 284.915319 139.243273 
+L 283.862961 139.551393 
+L 282.810604 139.857769 
+L 281.758247 140.162421 
+L 280.705889 140.465368 
+L 279.653532 140.766629 
+L 278.601175 141.066223 
+L 277.548817 141.364167 
+L 276.49646 141.660481 
+L 275.444102 141.955181 
+L 274.391745 142.248286 
+L 273.339388 142.539812 
+L 272.28703 142.829777 
+L 271.234673 143.118196 
+L 270.182316 143.405087 
+L 269.129958 143.690466 
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_145">
-    <path d="M 269.129958 143.692386 
-L 268.678353 143.808446 
-L 268.226747 143.924258 
-L 267.775142 144.039822 
-L 267.323537 144.155141 
-L 266.871931 144.270214 
-L 266.420326 144.385043 
-L 265.96872 144.499629 
-L 265.517115 144.613973 
-L 265.065509 144.728076 
-L 264.613904 144.841939 
-L 264.162299 144.955563 
-L 263.710693 145.068949 
-L 263.259088 145.182098 
-L 262.807482 145.295011 
-L 262.355877 145.407689 
-L 261.904271 145.520133 
-L 261.452666 145.632344 
-L 261.001061 145.744322 
-L 260.549455 145.85607 
-L 260.09785 145.967587 
-L 259.646244 146.078875 
-L 259.194639 146.189935 
-L 258.743034 146.300767 
-L 258.291428 146.411373 
-L 257.839823 146.521753 
-L 257.388217 146.631909 
-L 256.936612 146.741841 
-L 256.485006 146.85155 
-L 256.033401 146.961037 
-L 255.581796 147.070304 
-L 255.13019 147.17935 
-L 254.678585 147.288177 
-L 254.226979 147.396785 
-L 253.775374 147.505176 
-L 253.323769 147.613351 
-L 252.872163 147.72131 
-L 252.420558 147.829053 
-L 251.968952 147.936583 
-L 251.517347 148.0439 
-L 251.065741 148.151004 
-L 250.614136 148.257897 
-L 250.162531 148.364579 
-L 249.710925 148.471051 
-L 249.25932 148.577315 
-L 248.807714 148.68337 
-L 248.356109 148.789218 
-L 247.904503 148.894859 
-L 247.452898 149.000294 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 269.129958 143.690466 
+L 268.678353 143.802546 
+L 268.226747 143.914394 
+L 267.775142 144.026011 
+L 267.323537 144.137399 
+L 266.871931 144.248558 
+L 266.420326 144.359489 
+L 265.96872 144.470194 
+L 265.517115 144.580672 
+L 265.065509 144.690925 
+L 264.613904 144.800955 
+L 264.162299 144.910761 
+L 263.710693 145.020345 
+L 263.259088 145.129707 
+L 262.807482 145.238849 
+L 262.355877 145.347771 
+L 261.904271 145.456475 
+L 261.452666 145.564961 
+L 261.001061 145.673229 
+L 260.549455 145.781282 
+L 260.09785 145.889119 
+L 259.646244 145.996742 
+L 259.194639 146.104152 
+L 258.743034 146.211348 
+L 258.291428 146.318333 
+L 257.839823 146.425107 
+L 257.388217 146.531671 
+L 256.936612 146.638025 
+L 256.485006 146.744171 
+L 256.033401 146.850108 
+L 255.581796 146.95584 
+L 255.13019 147.061364 
+L 254.678585 147.166684 
+L 254.226979 147.271799 
+L 253.775374 147.376711 
+L 253.323769 147.481419 
+L 252.872163 147.585925 
+L 252.420558 147.69023 
+L 251.968952 147.794334 
+L 251.517347 147.898239 
+L 251.065741 148.001944 
+L 250.614136 148.105452 
+L 250.162531 148.208761 
+L 249.710925 148.311874 
+L 249.25932 148.414791 
+L 248.807714 148.517512 
+L 248.356109 148.620039 
+L 247.904503 148.722372 
+L 247.452898 148.824512 
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_146">
-    <path d="M 247.452898 149.000294 
-L 246.314724 149.273356 
-L 245.17655 149.545048 
-L 244.038376 149.815383 
-L 242.900202 150.084375 
-L 241.762028 150.352036 
-L 240.623854 150.618381 
-L 239.48568 150.883421 
-L 238.347506 151.14717 
-L 237.209332 151.40964 
-L 236.071158 151.670844 
-L 234.932984 151.930793 
-L 233.79481 152.1895 
-L 232.656636 152.446977 
-L 231.518462 152.703234 
-L 230.380288 152.958284 
-L 229.242114 153.212138 
-L 228.10394 153.464807 
-L 226.965766 153.716303 
-L 225.827592 153.966635 
-L 224.689418 154.215814 
-L 223.551244 154.463852 
-L 222.41307 154.710759 
-L 221.274896 154.956545 
-L 220.136722 155.201219 
-L 218.998548 155.444793 
-L 217.860374 155.687275 
-L 216.7222 155.928676 
-L 215.584026 156.169006 
-L 214.445852 156.408273 
-L 213.307678 156.646487 
-L 212.169505 156.883657 
-L 211.031331 157.119793 
-L 209.893157 157.354904 
-L 208.754983 157.588997 
-L 207.616809 157.822082 
-L 206.478635 158.054169 
-L 205.340461 158.285264 
-L 204.202287 158.515377 
-L 203.064113 158.744516 
-L 201.925939 158.972689 
-L 200.787765 159.199904 
-L 199.649591 159.426169 
-L 198.511417 159.651493 
-L 197.373243 159.875883 
-L 196.235069 160.099346 
-L 195.096895 160.32189 
-L 193.958721 160.543524 
-L 192.820547 160.764254 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 247.452898 148.824512 
+L 246.314724 149.111486 
+L 245.17655 149.396947 
+L 244.038376 149.68091 
+L 242.900202 149.963392 
+L 241.762028 150.244406 
+L 240.623854 150.52397 
+L 239.48568 150.802097 
+L 238.347506 151.078803 
+L 237.209332 151.354101 
+L 236.071158 151.628006 
+L 234.932984 151.900532 
+L 233.79481 152.171694 
+L 232.656636 152.441503 
+L 231.518462 152.709974 
+L 230.380288 152.977121 
+L 229.242114 153.242955 
+L 228.10394 153.50749 
+L 226.965766 153.770739 
+L 225.827592 154.032714 
+L 224.689418 154.293427 
+L 223.551244 154.552891 
+L 222.41307 154.811116 
+L 221.274896 155.068116 
+L 220.136722 155.323901 
+L 218.998548 155.578483 
+L 217.860374 155.831874 
+L 216.7222 156.084084 
+L 215.584026 156.335124 
+L 214.445852 156.585006 
+L 213.307678 156.833739 
+L 212.169505 157.081335 
+L 211.031331 157.327803 
+L 209.893157 157.573154 
+L 208.754983 157.817398 
+L 207.616809 158.060545 
+L 206.478635 158.302605 
+L 205.340461 158.543587 
+L 204.202287 158.783501 
+L 203.064113 159.022356 
+L 201.925939 159.260162 
+L 200.787765 159.496928 
+L 199.649591 159.732663 
+L 198.511417 159.967375 
+L 197.373243 160.201075 
+L 196.235069 160.43377 
+L 195.096895 160.665468 
+L 193.958721 160.89618 
+L 192.820547 161.125912 
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_147">
-    <path d="M 192.820547 160.764254 
-L 192.561575 160.99913 
-L 192.302603 161.232991 
-L 192.043631 161.465847 
-L 191.78466 161.697705 
-L 191.525688 161.928574 
-L 191.266716 162.158463 
-L 191.007744 162.387379 
-L 190.748773 162.615332 
-L 190.489801 162.842329 
-L 190.230829 163.068377 
-L 189.971857 163.293486 
-L 189.712885 163.517663 
-L 189.453914 163.740915 
-L 189.194942 163.963249 
-L 188.93597 164.184675 
-L 188.676998 164.405198 
-L 188.418027 164.624827 
-L 188.159055 164.843568 
-L 187.900083 165.061429 
-L 187.641111 165.278416 
-L 187.382139 165.494538 
-L 187.123168 165.709799 
-L 186.864196 165.924208 
-L 186.605224 166.137771 
-L 186.346252 166.350495 
-L 186.087281 166.562387 
-L 185.828309 166.773452 
-L 185.569337 166.983697 
-L 185.310365 167.193129 
-L 185.051393 167.401753 
-L 184.792422 167.609577 
-L 184.53345 167.816606 
-L 184.274478 168.022846 
-L 184.015506 168.228303 
-L 183.756535 168.432984 
-L 183.497563 168.636893 
-L 183.238591 168.840037 
-L 182.979619 169.042422 
-L 182.720647 169.244053 
-L 182.461676 169.444935 
-L 182.202704 169.645075 
-L 181.943732 169.844478 
-L 181.68476 170.043148 
-L 181.425789 170.241092 
-L 181.166817 170.438315 
-L 180.907845 170.634823 
-L 180.648873 170.830619 
-L 180.389901 171.025709 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 192.820547 161.125912 
+L 192.561575 161.360782 
+L 192.302603 161.594638 
+L 192.043631 161.827488 
+L 191.78466 162.05934 
+L 191.525688 162.290204 
+L 191.266716 162.520088 
+L 191.007744 162.748999 
+L 190.748773 162.976946 
+L 190.489801 163.203937 
+L 190.230829 163.429981 
+L 189.971857 163.655084 
+L 189.712885 163.879256 
+L 189.453914 164.102502 
+L 189.194942 164.324832 
+L 188.93597 164.546253 
+L 188.676998 164.766771 
+L 188.418027 164.986395 
+L 188.159055 165.205131 
+L 187.900083 165.422987 
+L 187.641111 165.639969 
+L 187.382139 165.856086 
+L 187.123168 166.071343 
+L 186.864196 166.285747 
+L 186.605224 166.499305 
+L 186.346252 166.712025 
+L 186.087281 166.923911 
+L 185.828309 167.134972 
+L 185.569337 167.345212 
+L 185.310365 167.55464 
+L 185.051393 167.76326 
+L 184.792422 167.971079 
+L 184.53345 168.178104 
+L 184.274478 168.384339 
+L 184.015506 168.589792 
+L 183.756535 168.794468 
+L 183.497563 168.998373 
+L 183.238591 169.201513 
+L 182.979619 169.403894 
+L 182.720647 169.60552 
+L 182.461676 169.806399 
+L 182.202704 170.006534 
+L 181.943732 170.205933 
+L 181.68476 170.404599 
+L 181.425789 170.60254 
+L 181.166817 170.799759 
+L 180.907845 170.996262 
+L 180.648873 171.192054 
+L 180.389901 171.387141 
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_148">
-    <path d="M 180.389901 171.025709 
-L 179.889083 171.250262 
-L 179.388264 171.473886 
-L 178.887445 171.69659 
-L 178.386626 171.918382 
-L 177.885807 172.139269 
-L 177.384988 172.359258 
-L 176.884169 172.578357 
-L 176.38335 172.796573 
-L 175.882531 173.013912 
-L 175.381713 173.230382 
-L 174.880894 173.44599 
-L 174.380075 173.660743 
-L 173.879256 173.874647 
-L 173.378437 174.087709 
-L 172.877618 174.299936 
-L 172.376799 174.511334 
-L 171.87598 174.721909 
-L 171.375161 174.931669 
-L 170.874342 175.140619 
-L 170.373524 175.348765 
-L 169.872705 175.556115 
-L 169.371886 175.762672 
-L 168.871067 175.968445 
-L 168.370248 176.173439 
-L 167.869429 176.377659 
-L 167.36861 176.581111 
-L 166.867791 176.783802 
-L 166.366972 176.985737 
-L 165.866154 177.186921 
-L 165.365335 177.38736 
-L 164.864516 177.58706 
-L 164.363697 177.786025 
-L 163.862878 177.984262 
-L 163.362059 178.181776 
-L 162.86124 178.378572 
-L 162.360421 178.574654 
-L 161.859602 178.770029 
-L 161.358783 178.964702 
-L 160.857965 179.158677 
-L 160.357146 179.351959 
-L 159.856327 179.544553 
-L 159.355508 179.736465 
-L 158.854689 179.927699 
-L 158.35387 180.118259 
-L 157.853051 180.308151 
-L 157.352232 180.49738 
-L 156.851413 180.685949 
-L 156.350594 180.873863 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 180.389901 171.387141 
+L 179.889083 171.605768 
+L 179.388264 171.823516 
+L 178.887445 172.040392 
+L 178.386626 172.256402 
+L 177.885807 172.471554 
+L 177.384988 172.685853 
+L 176.884169 172.899308 
+L 176.38335 173.111925 
+L 175.882531 173.323709 
+L 175.381713 173.534668 
+L 174.880894 173.744809 
+L 174.380075 173.954136 
+L 173.879256 174.162657 
+L 173.378437 174.370378 
+L 172.877618 174.577305 
+L 172.376799 174.783444 
+L 171.87598 174.988801 
+L 171.375161 175.193382 
+L 170.874342 175.397193 
+L 170.373524 175.600239 
+L 169.872705 175.802526 
+L 169.371886 176.00406 
+L 168.871067 176.204847 
+L 168.370248 176.404892 
+L 167.869429 176.6042 
+L 167.36861 176.802777 
+L 166.867791 177.000628 
+L 166.366972 177.197758 
+L 165.866154 177.394174 
+L 165.365335 177.589879 
+L 164.864516 177.784879 
+L 164.363697 177.979179 
+L 163.862878 178.172785 
+L 163.362059 178.3657 
+L 162.86124 178.55793 
+L 162.360421 178.74948 
+L 161.859602 178.940355 
+L 161.358783 179.130559 
+L 160.857965 179.320097 
+L 160.357146 179.508973 
+L 159.856327 179.697193 
+L 159.355508 179.884761 
+L 158.854689 180.071681 
+L 158.35387 180.257957 
+L 157.853051 180.443595 
+L 157.352232 180.628599 
+L 156.851413 180.812972 
+L 156.350594 180.996719 
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_149">
-    <path d="M 156.350594 180.873863 
-L 156.173353 181.072816 
-L 155.996112 181.27104 
-L 155.818871 181.468542 
-L 155.641629 181.665325 
-L 155.464388 181.861395 
-L 155.287147 182.056758 
-L 155.109905 182.251418 
-L 154.932664 182.445381 
-L 154.755423 182.638651 
-L 154.578182 182.831234 
-L 154.40094 183.023134 
-L 154.223699 183.214356 
-L 154.046458 183.404905 
-L 153.869216 183.594785 
-L 153.691975 183.784002 
-L 153.514734 183.972559 
-L 153.337492 184.160462 
-L 153.160251 184.347715 
-L 152.98301 184.534323 
-L 152.805769 184.72029 
-L 152.628527 184.905619 
-L 152.451286 185.090317 
-L 152.274045 185.274386 
-L 152.096803 185.457832 
-L 151.919562 185.640658 
-L 151.742321 185.822868 
-L 151.56508 186.004468 
-L 151.387838 186.18546 
-L 151.210597 186.365849 
-L 151.033356 186.545639 
-L 150.856114 186.724833 
-L 150.678873 186.903437 
-L 150.501632 187.081453 
-L 150.32439 187.258885 
-L 150.147149 187.435738 
-L 149.969908 187.612015 
-L 149.792667 187.78772 
-L 149.615425 187.962856 
-L 149.438184 188.137428 
-L 149.260943 188.311438 
-L 149.083701 188.484891 
-L 148.90646 188.657789 
-L 148.729219 188.830138 
-L 148.551977 189.001939 
-L 148.374736 189.173196 
-L 148.197495 189.343914 
-L 148.020254 189.514095 
-L 147.843012 189.683742 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 156.350594 180.996719 
+L 156.173353 181.201369 
+L 155.996112 181.405248 
+L 155.818871 181.608363 
+L 155.641629 181.810717 
+L 155.464388 182.012319 
+L 155.287147 182.213172 
+L 155.109905 182.413282 
+L 154.932664 182.612656 
+L 154.755423 182.811298 
+L 154.578182 183.009214 
+L 154.40094 183.206408 
+L 154.223699 183.402887 
+L 154.046458 183.598656 
+L 153.869216 183.793719 
+L 153.691975 183.988081 
+L 153.514734 184.181748 
+L 153.337492 184.374725 
+L 153.160251 184.567016 
+L 152.98301 184.758627 
+L 152.805769 184.949562 
+L 152.628527 185.139825 
+L 152.451286 185.329423 
+L 152.274045 185.518358 
+L 152.096803 185.706636 
+L 151.919562 185.894262 
+L 151.742321 186.08124 
+L 151.56508 186.267574 
+L 151.387838 186.453268 
+L 151.210597 186.638328 
+L 151.033356 186.822758 
+L 150.856114 187.006561 
+L 150.678873 187.189742 
+L 150.501632 187.372305 
+L 150.32439 187.554255 
+L 150.147149 187.735595 
+L 149.969908 187.91633 
+L 149.792667 188.096463 
+L 149.615425 188.275999 
+L 149.438184 188.454942 
+L 149.260943 188.633294 
+L 149.083701 188.811061 
+L 148.90646 188.988247 
+L 148.729219 189.164854 
+L 148.551977 189.340887 
+L 148.374736 189.516349 
+L 148.197495 189.691244 
+L 148.020254 189.865576 
+L 147.843012 190.039348 
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_150">
-    <path d="M 147.843012 189.683742 
-L 147.80944 189.787507 
-L 147.775867 189.891073 
-L 147.742295 189.994441 
-L 147.708722 190.097613 
-L 147.67515 190.200588 
-L 147.641577 190.303367 
-L 147.608005 190.405952 
-L 147.574432 190.508343 
-L 147.54086 190.61054 
-L 147.507287 190.712545 
-L 147.473715 190.814358 
-L 147.440142 190.915979 
-L 147.40657 191.017411 
-L 147.372997 191.118652 
-L 147.339425 191.219705 
-L 147.305852 191.320569 
-L 147.27228 191.421246 
-L 147.238707 191.521736 
-L 147.205135 191.62204 
-L 147.171562 191.722158 
-L 147.13799 191.822091 
-L 147.104417 191.92184 
-L 147.070845 192.021406 
-L 147.037273 192.120789 
-L 147.0037 192.21999 
-L 146.970128 192.319009 
-L 146.936555 192.417848 
-L 146.902983 192.516506 
-L 146.86941 192.614985 
-L 146.835838 192.713285 
-L 146.802265 192.811407 
-L 146.768693 192.909351 
-L 146.73512 193.007119 
-L 146.701548 193.10471 
-L 146.667975 193.202125 
-L 146.634403 193.299366 
-L 146.60083 193.396432 
-L 146.567258 193.493325 
-L 146.533685 193.590044 
-L 146.500113 193.686591 
-L 146.46654 193.782966 
-L 146.432968 193.879169 
-L 146.399395 193.975202 
-L 146.365823 194.071065 
-L 146.33225 194.166758 
-L 146.298678 194.262283 
-L 146.265105 194.357639 
-L 146.231533 194.452828 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 147.843012 190.039348 
+L 147.80944 190.123245 
+L 147.775867 190.207012 
+L 147.742295 190.290649 
+L 147.708722 190.374157 
+L 147.67515 190.457537 
+L 147.641577 190.540788 
+L 147.608005 190.623912 
+L 147.574432 190.706908 
+L 147.54086 190.789777 
+L 147.507287 190.872519 
+L 147.473715 190.955135 
+L 147.440142 191.037625 
+L 147.40657 191.11999 
+L 147.372997 191.202229 
+L 147.339425 191.284344 
+L 147.305852 191.366335 
+L 147.27228 191.448201 
+L 147.238707 191.529944 
+L 147.205135 191.611563 
+L 147.171562 191.69306 
+L 147.13799 191.774434 
+L 147.104417 191.855686 
+L 147.070845 191.936816 
+L 147.037273 192.017825 
+L 147.0037 192.098713 
+L 146.970128 192.17948 
+L 146.936555 192.260127 
+L 146.902983 192.340653 
+L 146.86941 192.42106 
+L 146.835838 192.501348 
+L 146.802265 192.581517 
+L 146.768693 192.661568 
+L 146.73512 192.7415 
+L 146.701548 192.821314 
+L 146.667975 192.901011 
+L 146.634403 192.980591 
+L 146.60083 193.060054 
+L 146.567258 193.1394 
+L 146.533685 193.21863 
+L 146.500113 193.297745 
+L 146.46654 193.376744 
+L 146.432968 193.455627 
+L 146.399395 193.534396 
+L 146.365823 193.613051 
+L 146.33225 193.691592 
+L 146.298678 193.770018 
+L 146.265105 193.848332 
+L 146.231533 193.926532 
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_151">
-    <path d="M 146.231533 194.452828 
-L 145.676509 199.564516 
-L 145.121485 204.234876 
-L 144.566461 208.534094 
-L 144.011437 212.51684 
-L 143.456413 216.226528 
-L 142.901389 219.69821 
-L 142.346365 222.960593 
-L 141.791342 226.037485 
-L 141.236318 228.948849 
-L 140.681294 231.71159 
-L 140.12627 234.340147 
-L 139.571246 236.846953 
-L 139.016222 239.24279 
-L 138.461198 241.537066 
-L 137.906174 243.738044 
-L 137.35115 245.853016 
-L 136.796126 247.888451 
-L 136.241103 249.850115 
-L 135.686079 251.74317 
-L 135.131055 253.572253 
-L 134.576031 255.341546 
-L 134.021007 257.054835 
-L 133.465983 258.715556 
-L 132.910959 260.326841 
-L 132.355935 261.891547 
-L 131.800911 263.412291 
-L 131.245887 264.891477 
-L 130.690864 266.331316 
-L 130.13584 267.733847 
-L 129.580816 269.100954 
-L 129.025792 270.434383 
-L 128.470768 271.735754 
-L 127.915744 273.006572 
-L 127.36072 274.248238 
-L 126.805696 275.46206 
-L 126.250672 276.649259 
-L 125.695648 277.810979 
-L 125.140625 278.94829 
-L 124.585601 280.062197 
-L 124.030577 281.153643 
-L 123.475553 282.223517 
-L 122.920529 283.272654 
-L 122.365505 284.301844 
-L 121.810481 285.311831 
-L 121.255457 286.303317 
-L 120.700433 287.27697 
-L 120.145409 288.233418 
-L 119.590386 289.17326 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 146.231533 193.926532 
+L 145.676509 199.207827 
+L 145.121485 204.019349 
+L 144.566461 208.437886 
+L 144.011437 212.522814 
+L 143.456413 216.320992 
+L 142.901389 219.870051 
+L 142.346365 223.200668 
+L 141.791342 226.338181 
+L 141.236318 229.30376 
+L 140.681294 232.115274 
+L 140.12627 234.787943 
+L 139.571246 237.334838 
+L 139.016222 239.767265 
+L 138.461198 242.095074 
+L 137.906174 244.326894 
+L 137.35115 246.470329 
+L 136.796126 248.532112 
+L 136.241103 250.518239 
+L 135.686079 252.434064 
+L 135.131055 254.284395 
+L 134.576031 256.073563 
+L 134.021007 257.805481 
+L 133.465983 259.483701 
+L 132.910959 261.111452 
+L 132.355935 262.691681 
+L 131.800911 264.227085 
+L 131.245887 265.720136 
+L 130.690864 267.173109 
+L 130.13584 268.588099 
+L 129.580816 269.967042 
+L 129.025792 271.311728 
+L 128.470768 272.623819 
+L 127.915744 273.904857 
+L 127.36072 275.156278 
+L 126.805696 276.379421 
+L 126.250672 277.575536 
+L 125.695648 278.745791 
+L 125.140625 279.89128 
+L 124.585601 281.013032 
+L 124.030577 282.112008 
+L 123.475553 283.189117 
+L 122.920529 284.24521 
+L 122.365505 285.281093 
+L 121.810481 286.297524 
+L 121.255457 287.295221 
+L 120.700433 288.274861 
+L 120.145409 289.237088 
+L 119.590386 290.182508 
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_152">
-    <path d="M 119.590386 289.17326 
-L 119.136406 289.958481 
-L 118.682426 290.732475 
-L 118.228447 291.495558 
-L 117.774467 292.248033 
-L 117.320487 292.990191 
-L 116.866508 293.722311 
-L 116.412528 294.444662 
-L 115.958549 295.1575 
-L 115.504569 295.861072 
-L 115.050589 296.555617 
-L 114.59661 297.241364 
-L 114.14263 297.918532 
-L 113.68865 298.587333 
-L 113.234671 299.247971 
-L 112.780691 299.900645 
-L 112.326712 300.545542 
-L 111.872732 301.182847 
-L 111.418752 301.812735 
-L 110.964773 302.435379 
-L 110.510793 303.050942 
-L 110.056813 303.659583 
-L 109.602834 304.261457 
-L 109.148854 304.856712 
-L 108.694874 305.445493 
-L 108.240895 306.027939 
-L 107.786915 306.604184 
-L 107.332936 307.174359 
-L 106.878956 307.738592 
-L 106.424976 308.297003 
-L 105.970997 308.849713 
-L 105.517017 309.396836 
-L 105.063037 309.938485 
-L 104.609058 310.474767 
-L 104.155078 311.005789 
-L 103.701099 311.531652 
-L 103.247119 312.052455 
-L 102.793139 312.568296 
-L 102.33916 313.079267 
-L 101.88518 313.58546 
-L 101.4312 314.086963 
-L 100.977221 314.583863 
-L 100.523241 315.076242 
-L 100.069262 315.564184 
-L 99.615282 316.047766 
-L 99.161302 316.527066 
-L 98.707323 317.00216 
-L 98.253343 317.47312 
-L 97.799363 317.940018 
-" clip-path="url(#p742c5d33d3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 119.590386 290.182508 
+L 119.136406 290.943639 
+L 118.682426 291.694216 
+L 118.228447 292.434528 
+L 117.774467 293.164852 
+L 117.320487 293.885453 
+L 116.866508 294.596588 
+L 116.412528 295.298501 
+L 115.958549 295.991429 
+L 115.504569 296.675599 
+L 115.050589 297.351229 
+L 114.59661 298.018531 
+L 114.14263 298.677706 
+L 113.68865 299.328951 
+L 113.234671 299.972454 
+L 112.780691 300.608397 
+L 112.326712 301.236955 
+L 111.872732 301.858299 
+L 111.418752 302.472591 
+L 110.964773 303.07999 
+L 110.510793 303.68065 
+L 110.056813 304.274717 
+L 109.602834 304.862335 
+L 109.148854 305.443643 
+L 108.694874 306.018775 
+L 108.240895 306.58786 
+L 107.786915 307.151024 
+L 107.332936 307.70839 
+L 106.878956 308.260075 
+L 106.424976 308.806195 
+L 105.970997 309.346859 
+L 105.517017 309.882177 
+L 105.063037 310.412253 
+L 104.609058 310.937188 
+L 104.155078 311.457082 
+L 103.701099 311.97203 
+L 103.247119 312.482125 
+L 102.793139 312.987458 
+L 102.33916 313.488118 
+L 101.88518 313.984189 
+L 101.4312 314.475756 
+L 100.977221 314.962898 
+L 100.523241 315.445696 
+L 100.069262 315.924226 
+L 99.615282 316.398563 
+L 99.161302 316.868779 
+L 98.707323 317.334945 
+L 98.253343 317.797132 
+L 97.799363 318.255405 
+" clip-path="url(#p74e4003240)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
   </g>
   <g id="text_25">
@@ -6166,8 +6166,8 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-07-07T22:17:01Z  ·  Linux chungus2 x86_64  ·  commit dcf4b958  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(44.687422 465.66) scale(0.07 -0.07)">
+   <!-- 2026-07-08T05:15:03Z  ·  Linux chungus2 x86_64  ·  commit cf8297c9  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(44.98 465.66) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -6188,6 +6188,31 @@ L 1638 0
 L 1638 4134 
 L -19 4134 
 L -19 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-3a" d="M 750 794 
@@ -6290,31 +6315,6 @@ Q 1038 2656 1286 2365
 Q 1534 2075 1959 2075 
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
-z
-" transform="scale(0.015625)"/>
      <path id="DejaVuSans-3d" d="M 678 2906 
 L 4684 2906 
 L 4684 2381 
@@ -6353,16 +6353,16 @@ z
     <use xlink:href="#DejaVuSans-37" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
     <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -6402,109 +6402,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3135.351562 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3190.332031 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3225.537109 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3289.160156 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3352.636719 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3416.259766 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3479.882812 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3543.505859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3575.292969 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3607.080078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3638.867188 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3670.654297 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3702.441406 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3730.224609 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3791.748047 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3853.027344 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3916.40625 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3979.882812 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4018.746094 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4079.927734 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4139.107422 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4200.630859 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4241.744141 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4275.435547 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4303.21875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4364.742188 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4426.021484 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4489.400391 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4553.023438 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4586.714844 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4645.894531 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4709.517578 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4741.304688 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4804.927734 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4868.550781 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4900.337891 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4963.960938 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5000.044922 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5038.908203 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5093.888672 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5157.511719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5189.298828 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5221.085938 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5252.873047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5284.660156 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5316.447266 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5355.65625 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5419.035156 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5457.898438 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5519.080078 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5582.458984 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5645.935547 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5709.314453 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5772.791016 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5836.169922 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5875.378906 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5907.166016 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5990.955078 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6022.742188 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6120.154297 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6181.677734 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6245.154297 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6272.9375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6334.216797 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6397.595703 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6429.382812 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6481.482422 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6544.861328 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6606.140625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6669.617188 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6721.716797 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6785.095703 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6846.277344 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6885.486328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6919.177734 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6950.964844 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6992.078125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7053.357422 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7092.566406 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7120.349609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7181.53125 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7213.318359 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7241.101562 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7293.201172 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7324.988281 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7388.464844 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7449.988281 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7489.197266 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7550.720703 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7590.083984 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7687.496094 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7715.279297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7778.658203 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7806.441406 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7858.541016 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7897.75 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7925.533203 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3126.855469 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3162.060547 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3225.683594 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3289.306641 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3352.929688 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3416.552734 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3471.533203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3535.15625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3566.943359 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3598.730469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3630.517578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3662.304688 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3694.091797 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3721.875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3783.398438 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3844.677734 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3908.056641 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3971.533203 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4010.396484 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4071.578125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4130.757812 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4192.28125 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4233.394531 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4267.085938 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4294.869141 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4356.392578 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4417.671875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4481.050781 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4544.673828 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4578.365234 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4637.544922 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4701.167969 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4732.955078 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4796.578125 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4860.201172 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4891.988281 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4955.611328 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4991.695312 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5030.558594 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5085.539062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5149.162109 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5180.949219 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5212.736328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5244.523438 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5276.310547 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5308.097656 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5347.306641 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5410.685547 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5449.548828 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5510.730469 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5574.109375 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5637.585938 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5700.964844 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5764.441406 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5827.820312 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5867.029297 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5898.816406 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5982.605469 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6014.392578 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6111.804688 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6173.328125 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6236.804688 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6264.587891 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6325.867188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6389.246094 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6421.033203 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6473.132812 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6536.511719 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6597.791016 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6661.267578 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6713.367188 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6776.746094 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6837.927734 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6877.136719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6910.828125 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6942.615234 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6983.728516 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7045.007812 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7084.216797 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7112 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7173.181641 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7204.96875 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7232.751953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7284.851562 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7316.638672 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7380.115234 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7441.638672 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7480.847656 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7542.371094 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7581.734375 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7679.146484 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7706.929688 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7770.308594 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7798.091797 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7850.191406 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7889.400391 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7917.183594 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p742c5d33d3">
+  <clipPath id="p74e4003240">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_decode_density.svg
+++ b/bench/graphs/silesia_decode_density.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 82.373685 412.80375 
 L 82.373685 47.3475 
-" clip-path="url(#p7c4c6f9290)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p680be4c89e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="mba05d95da4" d="M 0 0 
+       <path id="m7a8e571a58" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mba05d95da4" x="82.373685" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7a8e571a58" x="82.373685" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -111,11 +111,11 @@ z
      <g id="line2d_3">
       <path d="M 165.44644 412.80375 
 L 165.44644 47.3475 
-" clip-path="url(#p7c4c6f9290)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p680be4c89e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mba05d95da4" x="165.44644" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7a8e571a58" x="165.44644" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -157,11 +157,11 @@ z
      <g id="line2d_5">
       <path d="M 248.519195 412.80375 
 L 248.519195 47.3475 
-" clip-path="url(#p7c4c6f9290)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p680be4c89e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#mba05d95da4" x="248.519195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7a8e571a58" x="248.519195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -211,11 +211,11 @@ z
      <g id="line2d_7">
       <path d="M 331.59195 412.80375 
 L 331.59195 47.3475 
-" clip-path="url(#p7c4c6f9290)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p680be4c89e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#mba05d95da4" x="331.59195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7a8e571a58" x="331.59195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -252,11 +252,11 @@ z
      <g id="line2d_9">
       <path d="M 414.664704 412.80375 
 L 414.664704 47.3475 
-" clip-path="url(#p7c4c6f9290)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p680be4c89e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#mba05d95da4" x="414.664704" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7a8e571a58" x="414.664704" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -299,11 +299,11 @@ z
      <g id="line2d_11">
       <path d="M 497.737459 412.80375 
 L 497.737459 47.3475 
-" clip-path="url(#p7c4c6f9290)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p680be4c89e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#mba05d95da4" x="497.737459" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7a8e571a58" x="497.737459" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -351,11 +351,11 @@ z
      <g id="line2d_13">
       <path d="M 580.810214 412.80375 
 L 580.810214 47.3475 
-" clip-path="url(#p7c4c6f9290)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p680be4c89e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mba05d95da4" x="580.810214" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7a8e571a58" x="580.810214" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -895,23 +895,23 @@ z
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
      <g id="line2d_15">
-      <path d="M 49.078125 391.82245 
-L 637.2 391.82245 
-" clip-path="url(#p7c4c6f9290)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 391.704881 
+L 637.2 391.704881 
+" clip-path="url(#p680be4c89e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="m81ab6ffa09" d="M 0 0 
+       <path id="m0156bcdcec" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m81ab6ffa09" x="49.078125" y="391.82245" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0156bcdcec" x="49.078125" y="391.704881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- $\mathdefault{10^{2}}$ -->
-      <g transform="translate(24.478125 395.621669) scale(0.1 -0.1)">
+      <g transform="translate(24.478125 395.5041) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
        <use xlink:href="#DejaVuSans-32" transform="translate(128.203125 39.046875) scale(0.7)"/>
@@ -920,18 +920,18 @@ L -3.5 0
     </g>
     <g id="ytick_2">
      <g id="line2d_17">
-      <path d="M 49.078125 265.911133 
-L 637.2 265.911133 
-" clip-path="url(#p7c4c6f9290)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 262.40581 
+L 637.2 262.40581 
+" clip-path="url(#p680be4c89e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m81ab6ffa09" x="49.078125" y="265.911133" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0156bcdcec" x="49.078125" y="262.40581" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- $\mathdefault{10^{3}}$ -->
-      <g transform="translate(24.478125 269.710352) scale(0.1 -0.1)">
+      <g transform="translate(24.478125 266.205029) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
        <use xlink:href="#DejaVuSans-33" transform="translate(128.203125 39.046875) scale(0.7)"/>
@@ -940,18 +940,18 @@ L 637.2 265.911133
     </g>
     <g id="ytick_3">
      <g id="line2d_19">
-      <path d="M 49.078125 139.999816 
-L 637.2 139.999816 
-" clip-path="url(#p7c4c6f9290)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 133.106739 
+L 637.2 133.106739 
+" clip-path="url(#p680be4c89e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m81ab6ffa09" x="49.078125" y="139.999816" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0156bcdcec" x="49.078125" y="133.106739" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- $\mathdefault{10^{4}}$ -->
-      <g transform="translate(24.478125 143.799035) scale(0.1 -0.1)">
+      <g transform="translate(24.478125 136.905958) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.684375)"/>
        <use xlink:href="#DejaVuSans-34" transform="translate(128.203125 38.965625) scale(0.7)"/>
@@ -960,282 +960,270 @@ L 637.2 139.999816
     </g>
     <g id="ytick_4">
      <g id="line2d_21">
-      <path d="M 49.078125 411.32636 
-L 637.2 411.32636 
-" clip-path="url(#p7c4c6f9290)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 411.73356 
+L 637.2 411.73356 
+" clip-path="url(#p680be4c89e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="m60c8c8c61a" d="M 0 0 
+       <path id="m0f004a3113" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m60c8c8c61a" x="49.078125" y="411.32636" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0f004a3113" x="49.078125" y="411.73356" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_5">
      <g id="line2d_23">
-      <path d="M 49.078125 404.024518 
-L 637.2 404.024518 
-" clip-path="url(#p7c4c6f9290)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 404.235256 
+L 637.2 404.235256 
+" clip-path="url(#p680be4c89e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m60c8c8c61a" x="49.078125" y="404.024518" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0f004a3113" x="49.078125" y="404.235256" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_6">
      <g id="line2d_25">
-      <path d="M 49.078125 397.583836 
-L 637.2 397.583836 
-" clip-path="url(#p7c4c6f9290)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 397.621282 
+L 637.2 397.621282 
+" clip-path="url(#p680be4c89e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m60c8c8c61a" x="49.078125" y="397.583836" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0f004a3113" x="49.078125" y="397.621282" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_7">
      <g id="line2d_27">
-      <path d="M 49.078125 353.919367 
-L 637.2 353.919367 
-" clip-path="url(#p7c4c6f9290)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 352.781982 
+L 637.2 352.781982 
+" clip-path="url(#p680be4c89e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m60c8c8c61a" x="49.078125" y="353.919367" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0f004a3113" x="49.078125" y="352.781982" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_8">
      <g id="line2d_29">
-      <path d="M 49.078125 331.747485 
-L 637.2 331.747485 
-" clip-path="url(#p7c4c6f9290)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 330.013546 
+L 637.2 330.013546 
+" clip-path="url(#p680be4c89e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m60c8c8c61a" x="49.078125" y="331.747485" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0f004a3113" x="49.078125" y="330.013546" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_9">
      <g id="line2d_31">
-      <path d="M 49.078125 316.016284 
-L 637.2 316.016284 
-" clip-path="url(#p7c4c6f9290)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 313.859083 
+L 637.2 313.859083 
+" clip-path="url(#p680be4c89e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m60c8c8c61a" x="49.078125" y="316.016284" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0f004a3113" x="49.078125" y="313.859083" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_10">
      <g id="line2d_33">
-      <path d="M 49.078125 303.814216 
-L 637.2 303.814216 
-" clip-path="url(#p7c4c6f9290)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 301.328709 
+L 637.2 301.328709 
+" clip-path="url(#p680be4c89e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m60c8c8c61a" x="49.078125" y="303.814216" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0f004a3113" x="49.078125" y="301.328709" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_11">
      <g id="line2d_35">
-      <path d="M 49.078125 293.844402 
-L 637.2 293.844402 
-" clip-path="url(#p7c4c6f9290)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 291.090647 
+L 637.2 291.090647 
+" clip-path="url(#p680be4c89e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m60c8c8c61a" x="49.078125" y="293.844402" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0f004a3113" x="49.078125" y="291.090647" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_12">
      <g id="line2d_37">
-      <path d="M 49.078125 285.415043 
-L 637.2 285.415043 
-" clip-path="url(#p7c4c6f9290)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 282.434489 
+L 637.2 282.434489 
+" clip-path="url(#p680be4c89e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m60c8c8c61a" x="49.078125" y="285.415043" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0f004a3113" x="49.078125" y="282.434489" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_13">
      <g id="line2d_39">
-      <path d="M 49.078125 278.113201 
-L 637.2 278.113201 
-" clip-path="url(#p7c4c6f9290)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 274.936185 
+L 637.2 274.936185 
+" clip-path="url(#p680be4c89e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m60c8c8c61a" x="49.078125" y="278.113201" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0f004a3113" x="49.078125" y="274.936185" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_14">
      <g id="line2d_41">
-      <path d="M 49.078125 271.672519 
-L 637.2 271.672519 
-" clip-path="url(#p7c4c6f9290)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 268.322211 
+L 637.2 268.322211 
+" clip-path="url(#p680be4c89e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m60c8c8c61a" x="49.078125" y="271.672519" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0f004a3113" x="49.078125" y="268.322211" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_15">
      <g id="line2d_43">
-      <path d="M 49.078125 228.00805 
-L 637.2 228.00805 
-" clip-path="url(#p7c4c6f9290)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 223.482911 
+L 637.2 223.482911 
+" clip-path="url(#p680be4c89e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m60c8c8c61a" x="49.078125" y="228.00805" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0f004a3113" x="49.078125" y="223.482911" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_16">
      <g id="line2d_45">
-      <path d="M 49.078125 205.836168 
-L 637.2 205.836168 
-" clip-path="url(#p7c4c6f9290)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 200.714475 
+L 637.2 200.714475 
+" clip-path="url(#p680be4c89e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m60c8c8c61a" x="49.078125" y="205.836168" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0f004a3113" x="49.078125" y="200.714475" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_17">
      <g id="line2d_47">
-      <path d="M 49.078125 190.104967 
-L 637.2 190.104967 
-" clip-path="url(#p7c4c6f9290)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 184.560012 
+L 637.2 184.560012 
+" clip-path="url(#p680be4c89e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m60c8c8c61a" x="49.078125" y="190.104967" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0f004a3113" x="49.078125" y="184.560012" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_18">
      <g id="line2d_49">
-      <path d="M 49.078125 177.9029 
-L 637.2 177.9029 
-" clip-path="url(#p7c4c6f9290)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 172.029638 
+L 637.2 172.029638 
+" clip-path="url(#p680be4c89e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m60c8c8c61a" x="49.078125" y="177.9029" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0f004a3113" x="49.078125" y="172.029638" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_19">
      <g id="line2d_51">
-      <path d="M 49.078125 167.933085 
-L 637.2 167.933085 
-" clip-path="url(#p7c4c6f9290)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 161.791576 
+L 637.2 161.791576 
+" clip-path="url(#p680be4c89e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m60c8c8c61a" x="49.078125" y="167.933085" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0f004a3113" x="49.078125" y="161.791576" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_20">
      <g id="line2d_53">
-      <path d="M 49.078125 159.503726 
-L 637.2 159.503726 
-" clip-path="url(#p7c4c6f9290)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 153.135419 
+L 637.2 153.135419 
+" clip-path="url(#p680be4c89e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#m60c8c8c61a" x="49.078125" y="159.503726" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0f004a3113" x="49.078125" y="153.135419" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_21">
      <g id="line2d_55">
-      <path d="M 49.078125 152.201884 
-L 637.2 152.201884 
-" clip-path="url(#p7c4c6f9290)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 145.637114 
+L 637.2 145.637114 
+" clip-path="url(#p680be4c89e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#m60c8c8c61a" x="49.078125" y="152.201884" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0f004a3113" x="49.078125" y="145.637114" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_22">
      <g id="line2d_57">
-      <path d="M 49.078125 145.761202 
-L 637.2 145.761202 
-" clip-path="url(#p7c4c6f9290)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 139.02314 
+L 637.2 139.02314 
+" clip-path="url(#p680be4c89e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#m60c8c8c61a" x="49.078125" y="145.761202" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0f004a3113" x="49.078125" y="139.02314" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_23">
      <g id="line2d_59">
-      <path d="M 49.078125 102.096733 
-L 637.2 102.096733 
-" clip-path="url(#p7c4c6f9290)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 94.18384 
+L 637.2 94.18384 
+" clip-path="url(#p680be4c89e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#m60c8c8c61a" x="49.078125" y="102.096733" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0f004a3113" x="49.078125" y="94.18384" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_24">
      <g id="line2d_61">
-      <path d="M 49.078125 79.924851 
-L 637.2 79.924851 
-" clip-path="url(#p7c4c6f9290)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 71.415404 
+L 637.2 71.415404 
+" clip-path="url(#p680be4c89e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#m60c8c8c61a" x="49.078125" y="79.924851" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0f004a3113" x="49.078125" y="71.415404" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_25">
      <g id="line2d_63">
-      <path d="M 49.078125 64.19365 
-L 637.2 64.19365 
-" clip-path="url(#p7c4c6f9290)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 55.260942 
+L 637.2 55.260942 
+" clip-path="url(#p680be4c89e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#m60c8c8c61a" x="49.078125" y="64.19365" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_26">
-     <g id="line2d_65">
-      <path d="M 49.078125 51.991583 
-L 637.2 51.991583 
-" clip-path="url(#p7c4c6f9290)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_66">
-      <g>
-       <use xlink:href="#m60c8c8c61a" x="49.078125" y="51.991583" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0f004a3113" x="49.078125" y="55.260942" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1395,10 +1383,10 @@ z
      </g>
     </g>
    </g>
-   <g id="line2d_67">
+   <g id="line2d_65">
     <path d="M 49.078125 63.959148 
 L 637.2 63.959148 
-" clip-path="url(#p7c4c6f9290)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
+" clip-path="url(#p680be4c89e)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
    </g>
    <g id="patch_3">
     <path d="M 49.078125 412.80375 
@@ -1421,7 +1409,7 @@ L 637.2 47.3475
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_13">
-    <!--  memcpy ceiling ≈ 40 GB/s -->
+    <!--  memcpy ceiling ≈ 34 GB/s -->
     <g style="fill: #777777" transform="translate(525.255641 62.295398) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-79" d="M 2059 -325 
@@ -1526,8 +1514,8 @@ z
      <use xlink:href="#DejaVuSans-20" transform="translate(824.267578 0)"/>
      <use xlink:href="#DejaVuSans-2248" transform="translate(856.054688 0)"/>
      <use xlink:href="#DejaVuSans-20" transform="translate(939.84375 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(971.630859 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(1035.253906 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(971.630859 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(1035.253906 0)"/>
      <use xlink:href="#DejaVuSans-20" transform="translate(1098.876953 0)"/>
      <use xlink:href="#DejaVuSans-47" transform="translate(1130.664062 0)"/>
      <use xlink:href="#DejaVuSans-42" transform="translate(1208.154297 0)"/>
@@ -1760,80 +1748,80 @@ z
      <use xlink:href="#DejaVuSans-Bold-72" transform="translate(910.302734 0)"/>
     </g>
    </g>
-   <g id="line2d_68">
+   <g id="line2d_66">
     <defs>
-     <path id="mc35b0b71a8" d="M -2.5 2.5 
+     <path id="me53f83d605" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p7c4c6f9290)">
-     <use xlink:href="#mc35b0b71a8" x="75.810937" y="263.216607" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc35b0b71a8" x="105.634056" y="269.620798" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc35b0b71a8" x="204.490635" y="301.215031" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc35b0b71a8" x="234.479899" y="307.658059" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc35b0b71a8" x="242.537956" y="315.917944" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc35b0b71a8" x="300.771958" y="298.734802" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc35b0b71a8" x="303.26414" y="310.074879" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc35b0b71a8" x="304.261013" y="319.328576" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc35b0b71a8" x="313.897453" y="319.101018" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc35b0b71a8" x="414.166268" y="335.426532" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc35b0b71a8" x="587.289889" y="328.826648" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc35b0b71a8" x="610.467187" y="319.678275" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p680be4c89e)">
+     <use xlink:href="#me53f83d605" x="75.810937" y="259.855155" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me53f83d605" x="105.634056" y="265.938927" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me53f83d605" x="204.490635" y="298.901071" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me53f83d605" x="234.479899" y="305.325394" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me53f83d605" x="242.537956" y="313.871719" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me53f83d605" x="300.771958" y="296.163824" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me53f83d605" x="303.26414" y="307.811996" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me53f83d605" x="304.261013" y="317.768407" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me53f83d605" x="313.897453" y="317.046128" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me53f83d605" x="414.166268" y="334.239826" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me53f83d605" x="587.289889" y="326.989285" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me53f83d605" x="610.467187" y="317.631614" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
-   <g id="line2d_69">
+   <g id="line2d_67">
     <defs>
-     <path id="ma5b4b61f77" d="M 0 -2.5 
+     <path id="m44b9300a35" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p7c4c6f9290)">
-     <use xlink:href="#ma5b4b61f77" x="75.810937" y="262.505003" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma5b4b61f77" x="105.634056" y="256.516219" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma5b4b61f77" x="204.490635" y="300.455891" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma5b4b61f77" x="234.479899" y="298.72384" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma5b4b61f77" x="242.537956" y="307.046683" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma5b4b61f77" x="300.771958" y="287.726284" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma5b4b61f77" x="303.26414" y="300.256724" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma5b4b61f77" x="304.261013" y="315.235818" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma5b4b61f77" x="313.897453" y="307.4765" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma5b4b61f77" x="414.166268" y="326.223389" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma5b4b61f77" x="587.289889" y="329.609806" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma5b4b61f77" x="610.467187" y="318.379704" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p680be4c89e)">
+     <use xlink:href="#m44b9300a35" x="75.810937" y="260.589175" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m44b9300a35" x="105.634056" y="252.857513" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m44b9300a35" x="204.490635" y="298.460747" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m44b9300a35" x="234.479899" y="296.569922" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m44b9300a35" x="242.537956" y="305.18929" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m44b9300a35" x="300.771958" y="284.722625" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m44b9300a35" x="303.26414" y="298.103322" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m44b9300a35" x="304.261013" y="313.553876" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m44b9300a35" x="313.897453" y="305.230207" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m44b9300a35" x="414.166268" y="324.642795" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m44b9300a35" x="587.289889" y="327.692489" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m44b9300a35" x="610.467187" y="316.101699" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
-   <g id="line2d_70">
+   <g id="line2d_68">
     <defs>
-     <path id="m941a5478ac" d="M -0 3.535534 
+     <path id="m17bf470173" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p7c4c6f9290)">
-     <use xlink:href="#m941a5478ac" x="75.810937" y="231.044207" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m941a5478ac" x="105.634056" y="233.464672" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m941a5478ac" x="204.490635" y="259.725746" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m941a5478ac" x="234.479899" y="262.023129" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m941a5478ac" x="242.537956" y="273.368182" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m941a5478ac" x="300.771958" y="259.408271" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m941a5478ac" x="303.26414" y="270.926655" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m941a5478ac" x="304.261013" y="281.595692" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m941a5478ac" x="313.897453" y="277.309155" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m941a5478ac" x="414.166268" y="296.377475" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m941a5478ac" x="587.289889" y="301.735817" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m941a5478ac" x="610.467187" y="297.040139" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p680be4c89e)">
+     <use xlink:href="#m17bf470173" x="75.810937" y="225.965651" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m17bf470173" x="105.634056" y="228.938253" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m17bf470173" x="204.490635" y="258.019194" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m17bf470173" x="234.479899" y="258.821044" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m17bf470173" x="242.537956" y="270.414702" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m17bf470173" x="300.771958" y="256.579496" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m17bf470173" x="303.26414" y="267.771493" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m17bf470173" x="304.261013" y="279.371728" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m17bf470173" x="313.897453" y="274.217125" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m17bf470173" x="414.166268" y="293.754647" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m17bf470173" x="587.289889" y="299.239816" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m17bf470173" x="610.467187" y="294.360463" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
-   <g id="line2d_71">
+   <g id="line2d_69">
     <defs>
-     <path id="m7498fa8ab3" d="M -0.833333 2.5 
+     <path id="mae8cbcd89e" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -1848,24 +1836,24 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p7c4c6f9290)">
-     <use xlink:href="#m7498fa8ab3" x="75.810937" y="286.910165" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7498fa8ab3" x="105.634056" y="294.974253" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7498fa8ab3" x="204.490635" y="327.107019" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7498fa8ab3" x="234.479899" y="335.778593" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7498fa8ab3" x="242.537956" y="341.647351" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7498fa8ab3" x="300.771958" y="337.663009" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7498fa8ab3" x="303.26414" y="345.502509" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7498fa8ab3" x="304.261013" y="345.645685" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7498fa8ab3" x="313.897453" y="351.930007" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7498fa8ab3" x="414.166268" y="363.456717" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7498fa8ab3" x="587.289889" y="368.243436" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7498fa8ab3" x="610.467187" y="356.848113" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p680be4c89e)">
+     <use xlink:href="#mae8cbcd89e" x="75.810937" y="283.969839" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mae8cbcd89e" x="105.634056" y="292.250898" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mae8cbcd89e" x="204.490635" y="325.248225" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mae8cbcd89e" x="234.479899" y="334.153114" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mae8cbcd89e" x="242.537956" y="340.179777" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mae8cbcd89e" x="300.771958" y="336.088233" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mae8cbcd89e" x="303.26414" y="344.138661" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mae8cbcd89e" x="304.261013" y="344.285689" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mae8cbcd89e" x="313.897453" y="350.739096" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mae8cbcd89e" x="414.166268" y="362.575943" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mae8cbcd89e" x="587.289889" y="367.491453" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mae8cbcd89e" x="610.467187" y="355.789528" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
-   <g id="line2d_72">
+   <g id="line2d_70">
     <defs>
-     <path id="m0a9f961ba3" d="M -1.25 2.5 
+     <path id="m3419fbb401" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -1880,24 +1868,24 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p7c4c6f9290)">
-     <use xlink:href="#m0a9f961ba3" x="75.810937" y="328.907922" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0a9f961ba3" x="105.634056" y="342.121252" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0a9f961ba3" x="204.490635" y="364.316276" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0a9f961ba3" x="234.479899" y="371.357513" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0a9f961ba3" x="242.537956" y="368.122771" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0a9f961ba3" x="300.771958" y="365.072092" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0a9f961ba3" x="303.26414" y="374.607784" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0a9f961ba3" x="304.261013" y="366.131688" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0a9f961ba3" x="313.897453" y="378.589014" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0a9f961ba3" x="414.166268" y="386.15027" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0a9f961ba3" x="587.289889" y="392.30027" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0a9f961ba3" x="610.467187" y="391.11076" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p680be4c89e)">
+     <use xlink:href="#m3419fbb401" x="75.810937" y="327.097582" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3419fbb401" x="105.634056" y="340.666428" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3419fbb401" x="204.490635" y="363.458629" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3419fbb401" x="234.479899" y="370.689316" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3419fbb401" x="242.537956" y="367.367541" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3419fbb401" x="300.771958" y="364.234781" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3419fbb401" x="303.26414" y="374.027039" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3419fbb401" x="304.261013" y="365.322887" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3419fbb401" x="313.897453" y="378.115388" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3419fbb401" x="414.166268" y="385.880085" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3419fbb401" x="587.289889" y="392.195557" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3419fbb401" x="610.467187" y="390.974042" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
-   <g id="line2d_73">
+   <g id="line2d_71">
     <defs>
-     <path id="mf5545b46a6" d="M 0 -2.5 
+     <path id="mf83d0aa56a" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -1910,24 +1898,24 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p7c4c6f9290)">
-     <use xlink:href="#mf5545b46a6" x="75.810937" y="274.450514" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mf5545b46a6" x="105.634056" y="287.578172" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mf5545b46a6" x="204.490635" y="320.76932" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mf5545b46a6" x="234.479899" y="321.538199" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mf5545b46a6" x="242.537956" y="326.688339" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mf5545b46a6" x="300.771958" y="333.426229" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mf5545b46a6" x="303.26414" y="337.000867" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mf5545b46a6" x="304.261013" y="346.386297" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mf5545b46a6" x="313.897453" y="336.174424" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mf5545b46a6" x="414.166268" y="357.767316" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mf5545b46a6" x="587.289889" y="366.526213" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mf5545b46a6" x="610.467187" y="361.324423" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p680be4c89e)">
+     <use xlink:href="#mf83d0aa56a" x="75.810937" y="271.174951" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf83d0aa56a" x="105.634056" y="284.65582" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf83d0aa56a" x="204.490635" y="318.740005" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf83d0aa56a" x="234.479899" y="319.529571" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf83d0aa56a" x="242.537956" y="324.818279" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf83d0aa56a" x="300.771958" y="331.737458" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf83d0aa56a" x="303.26414" y="335.408275" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf83d0aa56a" x="304.261013" y="345.046228" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf83d0aa56a" x="313.897453" y="334.559596" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf83d0aa56a" x="414.166268" y="356.733464" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf83d0aa56a" x="587.289889" y="365.728026" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf83d0aa56a" x="610.467187" y="360.386277" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
-   <g id="line2d_74">
+   <g id="line2d_72">
     <defs>
-     <path id="med96bdb3a1" d="M 0 -2.5 
+     <path id="m177cf62846" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -1936,19 +1924,19 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p7c4c6f9290)">
-     <use xlink:href="#med96bdb3a1" x="75.810937" y="345.30596" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#med96bdb3a1" x="105.634056" y="352.048776" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#med96bdb3a1" x="204.490635" y="367.386827" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#med96bdb3a1" x="234.479899" y="374.711659" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#med96bdb3a1" x="242.537956" y="380.187639" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#med96bdb3a1" x="300.771958" y="368.991079" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#med96bdb3a1" x="303.26414" y="375.43221" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#med96bdb3a1" x="304.261013" y="381.227374" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#med96bdb3a1" x="313.897453" y="385.221601" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#med96bdb3a1" x="414.166268" y="390.900659" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#med96bdb3a1" x="587.289889" y="396.192102" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#med96bdb3a1" x="610.467187" y="386.05669" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p680be4c89e)">
+     <use xlink:href="#m177cf62846" x="75.810937" y="343.936824" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m177cf62846" x="105.634056" y="350.861061" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m177cf62846" x="204.490635" y="366.611796" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m177cf62846" x="234.479899" y="374.133709" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m177cf62846" x="242.537956" y="379.757025" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m177cf62846" x="300.771958" y="368.259211" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m177cf62846" x="303.26414" y="374.873647" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m177cf62846" x="304.261013" y="380.824735" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m177cf62846" x="313.897453" y="384.92643" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m177cf62846" x="414.166268" y="390.758289" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m177cf62846" x="587.289889" y="396.192102" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m177cf62846" x="610.467187" y="385.783988" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="legend_1">
@@ -1965,9 +1953,9 @@ Q 422.84625 254.871875 424.44625 254.871875
 z
 " style="fill: #ffffff; opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter"/>
     </g>
-    <g id="line2d_75">
+    <g id="line2d_73">
      <defs>
-      <path id="m8ae5d5f173" d="M 0 3.5 
+      <path id="m4c577bb117" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -1980,7 +1968,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m8ae5d5f173" x="434.04625" y="211.758125" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m4c577bb117" x="434.04625" y="211.758125" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_15">
@@ -2037,9 +2025,9 @@ z
       <use xlink:href="#DejaVuSans-29" transform="translate(776.953125 0)"/>
      </g>
     </g>
-    <g id="line2d_76">
+    <g id="line2d_74">
      <g>
-      <use xlink:href="#mc35b0b71a8" x="434.04625" y="223.500625" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#me53f83d605" x="434.04625" y="223.500625" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_16">
@@ -2051,9 +2039,9 @@ z
       <use xlink:href="#DejaVuSans-62" transform="translate(108.056641 0)"/>
      </g>
     </g>
-    <g id="line2d_77">
+    <g id="line2d_75">
      <g>
-      <use xlink:href="#ma5b4b61f77" x="434.04625" y="235.243125" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m44b9300a35" x="434.04625" y="235.243125" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -2096,9 +2084,9 @@ z
       <use xlink:href="#DejaVuSans-65" transform="translate(527.34375 0)"/>
      </g>
     </g>
-    <g id="line2d_78">
+    <g id="line2d_76">
      <g>
-      <use xlink:href="#m941a5478ac" x="434.04625" y="247.208125" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m17bf470173" x="434.04625" y="247.208125" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -2116,9 +2104,9 @@ z
       <use xlink:href="#DejaVuSans-65" transform="translate(407.519531 0)"/>
      </g>
     </g>
-    <g id="line2d_79">
+    <g id="line2d_77">
      <g>
-      <use xlink:href="#m7498fa8ab3" x="537.72375" y="211.758125" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mae8cbcd89e" x="537.72375" y="211.758125" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -2143,9 +2131,9 @@ z
       <use xlink:href="#DejaVuSans-65" transform="translate(849.263672 0)"/>
      </g>
     </g>
-    <g id="line2d_80">
+    <g id="line2d_78">
      <g>
-      <use xlink:href="#m0a9f961ba3" x="537.72375" y="223.500625" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m3419fbb401" x="537.72375" y="223.500625" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -2208,9 +2196,9 @@ z
       <use xlink:href="#DejaVuSans-65" transform="translate(323.4375 0)"/>
      </g>
     </g>
-    <g id="line2d_81">
+    <g id="line2d_79">
      <g>
-      <use xlink:href="#mf5545b46a6" x="537.72375" y="235.243125" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#mf83d0aa56a" x="537.72375" y="235.243125" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_21">
@@ -2246,9 +2234,9 @@ z
       <use xlink:href="#DejaVuSans-65" transform="translate(541.601562 0)"/>
      </g>
     </g>
-    <g id="line2d_82">
+    <g id="line2d_80">
      <g>
-      <use xlink:href="#med96bdb3a1" x="537.72375" y="246.985625" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m177cf62846" x="537.72375" y="246.985625" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -2317,20 +2305,20 @@ z
      </g>
     </g>
    </g>
-   <g id="line2d_83">
-    <g clip-path="url(#p7c4c6f9290)">
-     <use xlink:href="#m8ae5d5f173" x="75.810937" y="298.510024" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m8ae5d5f173" x="105.634056" y="315.672864" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m8ae5d5f173" x="204.490635" y="347.595466" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m8ae5d5f173" x="234.479899" y="355.186159" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m8ae5d5f173" x="242.537956" y="354.419257" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m8ae5d5f173" x="300.771958" y="342.079401" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m8ae5d5f173" x="303.26414" y="366.152202" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m8ae5d5f173" x="304.261013" y="375.092892" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m8ae5d5f173" x="313.897453" y="369.574066" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m8ae5d5f173" x="414.166268" y="382.204646" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m8ae5d5f173" x="587.289889" y="393.510593" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m8ae5d5f173" x="610.467187" y="371.196024" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+   <g id="line2d_81">
+    <g clip-path="url(#p680be4c89e)">
+     <use xlink:href="#m4c577bb117" x="75.810937" y="294.545282" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m4c577bb117" x="105.634056" y="312.927677" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m4c577bb117" x="204.490635" y="344.578479" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m4c577bb117" x="234.479899" y="354.059875" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m4c577bb117" x="242.537956" y="352.891589" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m4c577bb117" x="300.771958" y="340.501486" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m4c577bb117" x="303.26414" y="364.510892" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m4c577bb117" x="304.261013" y="370.952568" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m4c577bb117" x="313.897453" y="368.783167" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m4c577bb117" x="414.166268" y="381.205378" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m4c577bb117" x="587.289889" y="392.782071" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m4c577bb117" x="610.467187" y="370.913777" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
   </g>
@@ -2892,40 +2880,9 @@ z
    </g>
   </g>
   <g id="text_24">
-   <!-- 2026-07-05T23:02:37Z  ·  Linux chungus2 x86_64  ·  commit 9c93b270  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(43.687734 465.66) scale(0.07 -0.07)">
+   <!-- 2026-07-08T05:19:02Z  ·  Linux chungus2 x86_64  ·  commit cf8297c9  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(44.98 465.66) scale(0.07 -0.07)">
     <defs>
-     <path id="DejaVuSans-54" d="M -19 4666 
-L 3928 4666 
-L 3928 4134 
-L 2272 4134 
-L 2272 0 
-L 1638 0 
-L 1638 4134 
-L -19 4134 
-L -19 4666 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-3a" d="M 750 794 
-L 1409 794 
-L 1409 0 
-L 750 0 
-L 750 794 
-z
-M 750 3309 
-L 1409 3309 
-L 1409 2516 
-L 750 2516 
-L 750 3309 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-b7" d="M 684 2619 
-L 1344 2619 
-L 1344 1825 
-L 684 1825 
-L 684 2619 
-z
-" transform="scale(0.015625)"/>
      <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
 Q 1069 1734 1069 1313 
@@ -2965,6 +2922,30 @@ Q 1625 4250 1398 4047
 Q 1172 3844 1172 3481 
 z
 " transform="scale(0.015625)"/>
+     <path id="DejaVuSans-54" d="M -19 4666 
+L 3928 4666 
+L 3928 4134 
+L 2272 4134 
+L 2272 0 
+L 1638 0 
+L 1638 4134 
+L -19 4134 
+L -19 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-3a" d="M 750 794 
+L 1409 794 
+L 1409 0 
+L 750 0 
+L 750 794 
+z
+M 750 3309 
+L 1409 3309 
+L 1409 2516 
+L 750 2516 
+L 750 3309 
+z
+" transform="scale(0.015625)"/>
      <path id="DejaVuSans-39" d="M 703 97 
 L 703 672 
 Q 941 559 1184 500 
@@ -2993,6 +2974,13 @@ Q 1534 4250 1286 3958
 Q 1038 3666 1038 3163 
 Q 1038 2656 1286 2365 
 Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-b7" d="M 684 2619 
+L 1344 2619 
+L 1344 1825 
+L 684 1825 
+L 684 2619 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-3d" d="M 678 2906 
@@ -3033,16 +3021,16 @@ z
     <use xlink:href="#DejaVuSans-37" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3082,109 +3070,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3190.478516 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3254.101562 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3317.724609 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3381.201172 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3444.824219 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3508.447266 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3572.070312 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3603.857422 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3635.644531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3667.431641 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3699.21875 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3731.005859 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3758.789062 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3820.3125 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3881.591797 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3944.970703 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4008.447266 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4047.310547 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4108.492188 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4167.671875 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4229.195312 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4270.308594 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4304 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4331.783203 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4393.306641 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4454.585938 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4517.964844 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4581.587891 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4615.279297 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4674.458984 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4738.082031 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4769.869141 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4833.492188 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4897.115234 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4928.902344 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4992.525391 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5028.609375 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5067.472656 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5122.453125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5186.076172 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5217.863281 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5249.650391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5281.4375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5313.224609 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5345.011719 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5384.220703 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5447.599609 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5486.462891 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5547.644531 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5611.023438 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5674.5 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5737.878906 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5801.355469 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5864.734375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5903.943359 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5935.730469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6019.519531 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6051.306641 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6148.71875 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6210.242188 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6273.71875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6301.501953 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6362.78125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6426.160156 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6457.947266 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6510.046875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6573.425781 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6634.705078 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6698.181641 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6750.28125 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6813.660156 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6874.841797 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6914.050781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6947.742188 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6979.529297 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7020.642578 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7081.921875 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7121.130859 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7148.914062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7210.095703 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7241.882812 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7269.666016 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7321.765625 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7353.552734 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7417.029297 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7478.552734 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7517.761719 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7579.285156 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7618.648438 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7716.060547 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7743.84375 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7807.222656 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7835.005859 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7887.105469 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7926.314453 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7954.097656 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3126.855469 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3162.060547 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3225.683594 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3289.306641 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3352.929688 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3416.552734 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3471.533203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3535.15625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3566.943359 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3598.730469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3630.517578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3662.304688 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3694.091797 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3721.875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3783.398438 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3844.677734 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3908.056641 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3971.533203 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4010.396484 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4071.578125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4130.757812 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4192.28125 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4233.394531 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4267.085938 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4294.869141 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4356.392578 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4417.671875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4481.050781 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4544.673828 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4578.365234 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4637.544922 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4701.167969 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4732.955078 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4796.578125 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4860.201172 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4891.988281 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4955.611328 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4991.695312 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5030.558594 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5085.539062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5149.162109 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5180.949219 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5212.736328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5244.523438 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5276.310547 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5308.097656 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5347.306641 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5410.685547 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5449.548828 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5510.730469 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5574.109375 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5637.585938 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5700.964844 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5764.441406 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5827.820312 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5867.029297 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5898.816406 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5982.605469 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6014.392578 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6111.804688 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6173.328125 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6236.804688 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6264.587891 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6325.867188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6389.246094 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6421.033203 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6473.132812 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6536.511719 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6597.791016 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6661.267578 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6713.367188 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6776.746094 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6837.927734 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6877.136719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6910.828125 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6942.615234 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6983.728516 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7045.007812 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7084.216797 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7112 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7173.181641 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7204.96875 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7232.751953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7284.851562 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7316.638672 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7380.115234 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7441.638672 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7480.847656 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7542.371094 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7581.734375 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7679.146484 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7706.929688 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7770.308594 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7798.091797 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7850.191406 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7889.400391 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7917.183594 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p7c4c6f9290">
+  <clipPath id="p680be4c89e">
    <rect x="49.078125" y="47.3475" width="588.121875" height="365.45625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_decode_ranking.svg
+++ b/bench/graphs/silesia_decode_ranking.svg
@@ -40,23 +40,23 @@ z
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
-      <path d="M 290.788615 308.04375 
-L 290.788615 56.7075 
-" clip-path="url(#pad8457e370)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 294.744152 308.04375 
+L 294.744152 56.7075 
+" clip-path="url(#p89f9079984)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="md1cfdf40ec" d="M 0 0 
+       <path id="m4765673d54" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#md1cfdf40ec" x="290.788615" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4765673d54" x="294.744152" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
       <!-- $\mathdefault{10^{3}}$ -->
-      <g transform="translate(281.988615 322.642188) scale(0.1 -0.1)">
+      <g transform="translate(285.944152 322.642188) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -134,18 +134,18 @@ z
     </g>
     <g id="xtick_2">
      <g id="line2d_3">
-      <path d="M 447.590599 308.04375 
-L 447.590599 56.7075 
-" clip-path="url(#pad8457e370)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 455.642045 308.04375 
+L 455.642045 56.7075 
+" clip-path="url(#p89f9079984)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#md1cfdf40ec" x="447.590599" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4765673d54" x="455.642045" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
       <!-- $\mathdefault{10^{4}}$ -->
-      <g transform="translate(438.790599 322.642188) scale(0.1 -0.1)">
+      <g transform="translate(446.842045 322.642188) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -175,246 +175,234 @@ z
     </g>
     <g id="xtick_3">
      <g id="line2d_5">
-      <path d="M 181.188732 308.04375 
-L 181.188732 56.7075 
-" clip-path="url(#pad8457e370)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 182.281351 308.04375 
+L 182.281351 56.7075 
+" clip-path="url(#p89f9079984)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <defs>
-       <path id="md305e1d50d" d="M 0 0 
+       <path id="m647fec5082" d="M 0 0 
 L 0 2 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#md305e1d50d" x="181.188732" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m647fec5082" x="182.281351" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_4">
      <g id="line2d_7">
-      <path d="M 208.800191 308.04375 
-L 208.800191 56.7075 
-" clip-path="url(#pad8457e370)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 210.614063 308.04375 
+L 210.614063 56.7075 
+" clip-path="url(#p89f9079984)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#md305e1d50d" x="208.800191" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m647fec5082" x="210.614063" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_5">
      <g id="line2d_9">
-      <path d="M 228.390833 308.04375 
-L 228.390833 56.7075 
-" clip-path="url(#pad8457e370)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 230.716443 308.04375 
+L 230.716443 56.7075 
+" clip-path="url(#p89f9079984)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#md305e1d50d" x="228.390833" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m647fec5082" x="230.716443" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_6">
      <g id="line2d_11">
-      <path d="M 243.586515 308.04375 
-L 243.586515 56.7075 
-" clip-path="url(#pad8457e370)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 246.30906 308.04375 
+L 246.30906 56.7075 
+" clip-path="url(#p89f9079984)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#md305e1d50d" x="243.586515" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m647fec5082" x="246.30906" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_7">
      <g id="line2d_13">
-      <path d="M 256.002291 308.04375 
-L 256.002291 56.7075 
-" clip-path="url(#pad8457e370)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 259.049155 308.04375 
+L 259.049155 56.7075 
+" clip-path="url(#p89f9079984)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#md305e1d50d" x="256.002291" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m647fec5082" x="259.049155" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_8">
      <g id="line2d_15">
-      <path d="M 266.499681 308.04375 
-L 266.499681 56.7075 
-" clip-path="url(#pad8457e370)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 269.820753 308.04375 
+L 269.820753 56.7075 
+" clip-path="url(#p89f9079984)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <g>
-       <use xlink:href="#md305e1d50d" x="266.499681" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m647fec5082" x="269.820753" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_9">
      <g id="line2d_17">
-      <path d="M 275.592933 308.04375 
-L 275.592933 56.7075 
-" clip-path="url(#pad8457e370)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 279.151535 308.04375 
+L 279.151535 56.7075 
+" clip-path="url(#p89f9079984)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#md305e1d50d" x="275.592933" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m647fec5082" x="279.151535" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_10">
      <g id="line2d_19">
-      <path d="M 283.61375 308.04375 
-L 283.61375 56.7075 
-" clip-path="url(#pad8457e370)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 287.381868 308.04375 
+L 287.381868 56.7075 
+" clip-path="url(#p89f9079984)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#md305e1d50d" x="283.61375" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m647fec5082" x="287.381868" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_11">
      <g id="line2d_21">
-      <path d="M 337.990716 308.04375 
-L 337.990716 56.7075 
-" clip-path="url(#pad8457e370)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 343.179244 308.04375 
+L 343.179244 56.7075 
+" clip-path="url(#p89f9079984)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#md305e1d50d" x="337.990716" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m647fec5082" x="343.179244" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_12">
      <g id="line2d_23">
-      <path d="M 365.602174 308.04375 
-L 365.602174 56.7075 
-" clip-path="url(#pad8457e370)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 371.511956 308.04375 
+L 371.511956 56.7075 
+" clip-path="url(#p89f9079984)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#md305e1d50d" x="365.602174" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m647fec5082" x="371.511956" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_13">
      <g id="line2d_25">
-      <path d="M 385.192816 308.04375 
-L 385.192816 56.7075 
-" clip-path="url(#pad8457e370)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 391.614336 308.04375 
+L 391.614336 56.7075 
+" clip-path="url(#p89f9079984)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#md305e1d50d" x="385.192816" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m647fec5082" x="391.614336" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_14">
      <g id="line2d_27">
-      <path d="M 400.388498 308.04375 
-L 400.388498 56.7075 
-" clip-path="url(#pad8457e370)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 407.206953 308.04375 
+L 407.206953 56.7075 
+" clip-path="url(#p89f9079984)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#md305e1d50d" x="400.388498" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m647fec5082" x="407.206953" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_15">
      <g id="line2d_29">
-      <path d="M 412.804275 308.04375 
-L 412.804275 56.7075 
-" clip-path="url(#pad8457e370)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 419.947048 308.04375 
+L 419.947048 56.7075 
+" clip-path="url(#p89f9079984)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#md305e1d50d" x="412.804275" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m647fec5082" x="419.947048" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_16">
      <g id="line2d_31">
-      <path d="M 423.301664 308.04375 
-L 423.301664 56.7075 
-" clip-path="url(#pad8457e370)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 430.718646 308.04375 
+L 430.718646 56.7075 
+" clip-path="url(#p89f9079984)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#md305e1d50d" x="423.301664" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m647fec5082" x="430.718646" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_17">
      <g id="line2d_33">
-      <path d="M 432.394917 308.04375 
-L 432.394917 56.7075 
-" clip-path="url(#pad8457e370)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 440.049428 308.04375 
+L 440.049428 56.7075 
+" clip-path="url(#p89f9079984)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#md305e1d50d" x="432.394917" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m647fec5082" x="440.049428" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_18">
      <g id="line2d_35">
-      <path d="M 440.415734 308.04375 
-L 440.415734 56.7075 
-" clip-path="url(#pad8457e370)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 448.279761 308.04375 
+L 448.279761 56.7075 
+" clip-path="url(#p89f9079984)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#md305e1d50d" x="440.415734" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m647fec5082" x="448.279761" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_19">
      <g id="line2d_37">
-      <path d="M 494.792699 308.04375 
-L 494.792699 56.7075 
-" clip-path="url(#pad8457e370)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 504.077137 308.04375 
+L 504.077137 56.7075 
+" clip-path="url(#p89f9079984)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#md305e1d50d" x="494.792699" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m647fec5082" x="504.077137" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_20">
      <g id="line2d_39">
-      <path d="M 522.404158 308.04375 
-L 522.404158 56.7075 
-" clip-path="url(#pad8457e370)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 532.409849 308.04375 
+L 532.409849 56.7075 
+" clip-path="url(#p89f9079984)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#md305e1d50d" x="522.404158" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m647fec5082" x="532.409849" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_21">
      <g id="line2d_41">
-      <path d="M 541.9948 308.04375 
-L 541.9948 56.7075 
-" clip-path="url(#pad8457e370)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 552.512229 308.04375 
+L 552.512229 56.7075 
+" clip-path="url(#p89f9079984)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#md305e1d50d" x="541.9948" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_22">
-     <g id="line2d_43">
-      <path d="M 557.190482 308.04375 
-L 557.190482 56.7075 
-" clip-path="url(#pad8457e370)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_44">
-      <g>
-       <use xlink:href="#md305e1d50d" x="557.190482" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m647fec5082" x="552.512229" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -983,14 +971,14 @@ z
    </g>
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
-     <g id="line2d_45">
+     <g id="line2d_43">
       <defs>
-       <path id="m846275b4b7" d="M 0 0 
+       <path id="m17ed1dd579" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m846275b4b7" x="139.360469" y="296.619375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m17ed1dd579" x="139.360469" y="296.619375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -1060,9 +1048,9 @@ z
      </g>
     </g>
     <g id="ytick_2">
-     <g id="line2d_46">
+     <g id="line2d_44">
       <g>
-       <use xlink:href="#m846275b4b7" x="139.360469" y="263.978304" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m17ed1dd579" x="139.360469" y="263.978304" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -1127,9 +1115,9 @@ z
      </g>
     </g>
     <g id="ytick_3">
-     <g id="line2d_47">
+     <g id="line2d_45">
       <g>
-       <use xlink:href="#m846275b4b7" x="139.360469" y="231.337232" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m17ed1dd579" x="139.360469" y="231.337232" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -1240,9 +1228,9 @@ z
      </g>
     </g>
     <g id="ytick_4">
-     <g id="line2d_48">
+     <g id="line2d_46">
       <g>
-       <use xlink:href="#m846275b4b7" x="139.360469" y="198.696161" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m17ed1dd579" x="139.360469" y="198.696161" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -1296,9 +1284,9 @@ z
      </g>
     </g>
     <g id="ytick_5">
-     <g id="line2d_49">
+     <g id="line2d_47">
       <g>
-       <use xlink:href="#m846275b4b7" x="139.360469" y="166.055089" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m17ed1dd579" x="139.360469" y="166.055089" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -1343,9 +1331,9 @@ z
      </g>
     </g>
     <g id="ytick_6">
-     <g id="line2d_50">
+     <g id="line2d_48">
       <g>
-       <use xlink:href="#m846275b4b7" x="139.360469" y="133.414018" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m17ed1dd579" x="139.360469" y="133.414018" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -1359,9 +1347,9 @@ z
      </g>
     </g>
     <g id="ytick_7">
-     <g id="line2d_51">
+     <g id="line2d_49">
       <g>
-       <use xlink:href="#m846275b4b7" x="139.360469" y="100.772946" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m17ed1dd579" x="139.360469" y="100.772946" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -1406,9 +1394,9 @@ z
      </g>
     </g>
     <g id="ytick_8">
-     <g id="line2d_52">
+     <g id="line2d_50">
       <g>
-       <use xlink:href="#m846275b4b7" x="139.360469" y="68.131875" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m17ed1dd579" x="139.360469" y="68.131875" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -1430,48 +1418,48 @@ z
    </g>
    <g id="LineCollection_1">
     <path d="M 139.360469 296.619375 
-L 154.556151 296.619375 
-" clip-path="url(#pad8457e370)" style="fill: none; stroke: #17becf; stroke-opacity: 0.9; stroke-width: 1.3"/>
+L 154.953086 296.619375 
+" clip-path="url(#p89f9079984)" style="fill: none; stroke: #17becf; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_2">
     <path d="M 139.360469 263.978304 
-L 162.32653 263.978304 
-" clip-path="url(#pad8457e370)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.9; stroke-width: 1.3"/>
+L 162.926438 263.978304 
+" clip-path="url(#p89f9079984)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_3">
     <path d="M 139.360469 231.337232 
-L 178.681331 231.337232 
-" clip-path="url(#pad8457e370)" style="fill: none; stroke: #d62728; stroke-opacity: 0.9; stroke-width: 2.4"/>
+L 180.69803 231.337232 
+" clip-path="url(#p89f9079984)" style="fill: none; stroke: #d62728; stroke-opacity: 0.9; stroke-width: 2.4"/>
    </g>
    <g id="LineCollection_4">
     <path d="M 139.360469 198.696161 
-L 201.044126 198.696161 
-" clip-path="url(#pad8457e370)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.9; stroke-width: 1.3"/>
+L 202.655398 198.696161 
+" clip-path="url(#p89f9079984)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_5">
     <path d="M 139.360469 166.055089 
-L 209.976983 166.055089 
-" clip-path="url(#pad8457e370)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.9; stroke-width: 1.3"/>
+L 211.821595 166.055089 
+" clip-path="url(#p89f9079984)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_6">
     <path d="M 139.360469 133.414018 
-L 239.121093 133.414018 
-" clip-path="url(#pad8457e370)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.9; stroke-width: 1.3"/>
+L 241.580515 133.414018 
+" clip-path="url(#p89f9079984)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_7">
     <path d="M 139.360469 100.772946 
-L 247.282543 100.772946 
-" clip-path="url(#pad8457e370)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.9; stroke-width: 1.3"/>
+L 249.65136 100.772946 
+" clip-path="url(#p89f9079984)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_8">
     <path d="M 139.360469 68.131875 
-L 285.279501 68.131875 
-" clip-path="url(#pad8457e370)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.9; stroke-width: 1.3"/>
+L 288.669073 68.131875 
+" clip-path="url(#p89f9079984)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
-   <g id="line2d_53">
-    <path d="M 542.286834 308.04375 
-L 542.286834 56.7075 
-" clip-path="url(#pad8457e370)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
+   <g id="line2d_51">
+    <path d="M 541.688307 308.04375 
+L 541.688307 56.7075 
+" clip-path="url(#p89f9079984)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
    </g>
    <g id="patch_3">
     <path d="M 139.360469 308.04375 
@@ -1495,7 +1483,7 @@ L 565.2 56.7075
    </g>
    <g id="text_12">
     <!-- 135 -->
-    <g style="fill: #17becf" transform="translate(157.878675 298.964844) scale(0.085 -0.085)">
+    <g style="fill: #17becf" transform="translate(158.362399 298.964844) scale(0.085 -0.085)">
      <defs>
       <path id="DejaVuSans-35" d="M 691 4666 
 L 3169 4666 
@@ -1530,7 +1518,7 @@ z
    </g>
    <g id="text_13">
     <!-- 152 -->
-    <g style="fill: #e377c2" transform="translate(165.649054 266.323772) scale(0.085 -0.085)">
+    <g style="fill: #e377c2" transform="translate(166.335752 266.323772) scale(0.085 -0.085)">
      <defs>
       <path id="DejaVuSans-32" d="M 1228 531 
 L 3431 531 
@@ -1563,8 +1551,8 @@ z
     </g>
    </g>
    <g id="text_14">
-    <!-- 193 -->
-    <g style="fill: #d62728" transform="translate(182.003855 233.682701) scale(0.085 -0.085)">
+    <!-- 196 -->
+    <g style="fill: #d62728" transform="translate(184.107344 233.682701) scale(0.085 -0.085)">
      <defs>
       <path id="DejaVuSans-Bold-31" d="M 750 831 
 L 1813 831 
@@ -1610,47 +1598,45 @@ Q 1491 2759 1650 2554
 Q 1809 2350 2125 2350 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-33" d="M 2981 2516 
-Q 3453 2394 3698 2092 
-Q 3944 1791 3944 1325 
-Q 3944 631 3412 270 
-Q 2881 -91 1863 -91 
-Q 1503 -91 1142 -33 
-Q 781 25 428 141 
-L 428 1069 
-Q 766 900 1098 814 
-Q 1431 728 1753 728 
-Q 2231 728 2486 893 
-Q 2741 1059 2741 1369 
-Q 2741 1688 2480 1852 
-Q 2219 2016 1709 2016 
-L 1228 2016 
-L 1228 2791 
-L 1734 2791 
-Q 2188 2791 2409 2933 
-Q 2631 3075 2631 3366 
-Q 2631 3634 2415 3781 
-Q 2200 3928 1806 3928 
-Q 1516 3928 1219 3862 
-Q 922 3797 628 3669 
-L 628 4550 
-Q 984 4650 1334 4700 
-Q 1684 4750 2022 4750 
-Q 2931 4750 3382 4451 
-Q 3834 4153 3834 3553 
-Q 3834 3144 3618 2883 
-Q 3403 2622 2981 2516 
+      <path id="DejaVuSans-Bold-36" d="M 2316 2303 
+Q 2000 2303 1842 2098 
+Q 1684 1894 1684 1484 
+Q 1684 1075 1842 870 
+Q 2000 666 2316 666 
+Q 2634 666 2792 870 
+Q 2950 1075 2950 1484 
+Q 2950 1894 2792 2098 
+Q 2634 2303 2316 2303 
+z
+M 3803 4544 
+L 3803 3681 
+Q 3506 3822 3243 3889 
+Q 2981 3956 2731 3956 
+Q 2194 3956 1894 3657 
+Q 1594 3359 1544 2772 
+Q 1750 2925 1990 3001 
+Q 2231 3078 2516 3078 
+Q 3231 3078 3670 2659 
+Q 4109 2241 4109 1563 
+Q 4109 813 3618 361 
+Q 3128 -91 2303 -91 
+Q 1394 -91 895 523 
+Q 397 1138 397 2266 
+Q 397 3422 980 4083 
+Q 1563 4744 2578 4744 
+Q 2900 4744 3203 4694 
+Q 3506 4644 3803 4544 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-Bold-31"/>
      <use xlink:href="#DejaVuSans-Bold-39" transform="translate(69.580078 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-33" transform="translate(139.160156 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-36" transform="translate(139.160156 0)"/>
     </g>
    </g>
    <g id="text_15">
     <!-- 268 -->
-    <g style="fill: #8c564b" transform="translate(204.36665 201.041629) scale(0.085 -0.085)">
+    <g style="fill: #8c564b" transform="translate(206.064712 201.041629) scale(0.085 -0.085)">
      <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -1729,31 +1715,43 @@ z
    </g>
    <g id="text_16">
     <!-- 305 -->
-    <g style="fill: #bcbd22" transform="translate(213.299507 168.400558) scale(0.085 -0.085)">
+    <g style="fill: #bcbd22" transform="translate(215.230908 168.400558) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_17">
-    <!-- 468 -->
-    <g style="fill: #1f77b4" transform="translate(242.443617 135.759487) scale(0.085 -0.085)">
+    <!-- 467 -->
+    <g style="fill: #1f77b4" transform="translate(244.989828 135.759487) scale(0.085 -0.085)">
+     <defs>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_18">
-    <!-- 528 -->
-    <g style="fill: #2ca02c" transform="translate(250.605067 103.118415) scale(0.085 -0.085)">
+    <!-- 524 -->
+    <g style="fill: #2ca02c" transform="translate(253.060673 103.118415) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_19">
-    <!-- 922 -->
-    <g style="fill: #9467bd" transform="translate(288.602025 70.477344) scale(0.085 -0.085)">
+    <!-- 917 -->
+    <g style="fill: #9467bd" transform="translate(292.078386 70.477344) scale(0.085 -0.085)">
      <defs>
       <path id="DejaVuSans-39" d="M 703 97 
 L 703 672 
@@ -1787,13 +1785,13 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_20">
-    <!-- memcpy ≈ 40 GB/s  -->
-    <g style="fill: #777777" transform="translate(540.623084 128.870982) rotate(-90) scale(0.08 -0.08)">
+    <!-- memcpy ≈ 34 GB/s  -->
+    <g style="fill: #777777" transform="translate(540.024557 128.870982) rotate(-90) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-79" d="M 2059 -325 
 Q 1816 -950 1584 -1140 
@@ -1863,8 +1861,8 @@ z
      <use xlink:href="#DejaVuSans-20" transform="translate(433.984375 0)"/>
      <use xlink:href="#DejaVuSans-2248" transform="translate(465.771484 0)"/>
      <use xlink:href="#DejaVuSans-20" transform="translate(549.560547 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(581.347656 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(644.970703 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(581.347656 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(644.970703 0)"/>
      <use xlink:href="#DejaVuSans-20" transform="translate(708.59375 0)"/>
      <use xlink:href="#DejaVuSans-47" transform="translate(740.380859 0)"/>
      <use xlink:href="#DejaVuSans-42" transform="translate(817.871094 0)"/>
@@ -1873,9 +1871,9 @@ z
      <use xlink:href="#DejaVuSans-20" transform="translate(972.265625 0)"/>
     </g>
    </g>
-   <g id="line2d_54">
+   <g id="line2d_52">
     <defs>
-     <path id="m132ce2a851" d="M 0 3 
+     <path id="m3ee9b5e8c1" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1887,13 +1885,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #17becf"/>
     </defs>
-    <g clip-path="url(#pad8457e370)">
-     <use xlink:href="#m132ce2a851" x="154.556151" y="296.619375" style="fill: #17becf; stroke: #17becf"/>
+    <g clip-path="url(#p89f9079984)">
+     <use xlink:href="#m3ee9b5e8c1" x="154.953086" y="296.619375" style="fill: #17becf; stroke: #17becf"/>
     </g>
    </g>
-   <g id="line2d_55">
+   <g id="line2d_53">
     <defs>
-     <path id="meab2220eb7" d="M 0 3 
+     <path id="m1e29d26b4c" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1905,13 +1903,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #e377c2"/>
     </defs>
-    <g clip-path="url(#pad8457e370)">
-     <use xlink:href="#meab2220eb7" x="162.32653" y="263.978304" style="fill: #e377c2; stroke: #e377c2"/>
+    <g clip-path="url(#p89f9079984)">
+     <use xlink:href="#m1e29d26b4c" x="162.926438" y="263.978304" style="fill: #e377c2; stroke: #e377c2"/>
     </g>
    </g>
-   <g id="line2d_56">
+   <g id="line2d_54">
     <defs>
-     <path id="mfc4c4956a5" d="M 0 5 
+     <path id="m1c2f46d6c6" d="M 0 5 
 C 1.326016 5 2.597899 4.473168 3.535534 3.535534 
 C 4.473168 2.597899 5 1.326016 5 0 
 C 5 -1.326016 4.473168 -2.597899 3.535534 -3.535534 
@@ -1923,13 +1921,13 @@ C -2.597899 4.473168 -1.326016 5 0 5
 z
 " style="stroke: #d62728"/>
     </defs>
-    <g clip-path="url(#pad8457e370)">
-     <use xlink:href="#mfc4c4956a5" x="178.681331" y="231.337232" style="fill: #d62728; stroke: #d62728"/>
+    <g clip-path="url(#p89f9079984)">
+     <use xlink:href="#m1c2f46d6c6" x="180.69803" y="231.337232" style="fill: #d62728; stroke: #d62728"/>
     </g>
    </g>
-   <g id="line2d_57">
+   <g id="line2d_55">
     <defs>
-     <path id="m3247c2044c" d="M 0 3 
+     <path id="m47dedbbc33" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1941,13 +1939,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #8c564b"/>
     </defs>
-    <g clip-path="url(#pad8457e370)">
-     <use xlink:href="#m3247c2044c" x="201.044126" y="198.696161" style="fill: #8c564b; stroke: #8c564b"/>
+    <g clip-path="url(#p89f9079984)">
+     <use xlink:href="#m47dedbbc33" x="202.655398" y="198.696161" style="fill: #8c564b; stroke: #8c564b"/>
     </g>
    </g>
-   <g id="line2d_58">
+   <g id="line2d_56">
     <defs>
-     <path id="mf12cb4b7ad" d="M 0 3 
+     <path id="m0ee63c5587" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1959,13 +1957,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #bcbd22"/>
     </defs>
-    <g clip-path="url(#pad8457e370)">
-     <use xlink:href="#mf12cb4b7ad" x="209.976983" y="166.055089" style="fill: #bcbd22; stroke: #bcbd22"/>
+    <g clip-path="url(#p89f9079984)">
+     <use xlink:href="#m0ee63c5587" x="211.821595" y="166.055089" style="fill: #bcbd22; stroke: #bcbd22"/>
     </g>
    </g>
-   <g id="line2d_59">
+   <g id="line2d_57">
     <defs>
-     <path id="m90b232df21" d="M 0 3 
+     <path id="m8545de5f96" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1977,13 +1975,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #1f77b4"/>
     </defs>
-    <g clip-path="url(#pad8457e370)">
-     <use xlink:href="#m90b232df21" x="239.121093" y="133.414018" style="fill: #1f77b4; stroke: #1f77b4"/>
+    <g clip-path="url(#p89f9079984)">
+     <use xlink:href="#m8545de5f96" x="241.580515" y="133.414018" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
-   <g id="line2d_60">
+   <g id="line2d_58">
     <defs>
-     <path id="me6a6dc1d06" d="M 0 3 
+     <path id="md1c5753bba" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1995,13 +1993,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #2ca02c"/>
     </defs>
-    <g clip-path="url(#pad8457e370)">
-     <use xlink:href="#me6a6dc1d06" x="247.282543" y="100.772946" style="fill: #2ca02c; stroke: #2ca02c"/>
+    <g clip-path="url(#p89f9079984)">
+     <use xlink:href="#md1c5753bba" x="249.65136" y="100.772946" style="fill: #2ca02c; stroke: #2ca02c"/>
     </g>
    </g>
-   <g id="line2d_61">
+   <g id="line2d_59">
     <defs>
-     <path id="mea3f864004" d="M 0 3 
+     <path id="maef9e33324" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -2013,8 +2011,8 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #9467bd"/>
     </defs>
-    <g clip-path="url(#pad8457e370)">
-     <use xlink:href="#mea3f864004" x="285.279501" y="68.131875" style="fill: #9467bd; stroke: #9467bd"/>
+    <g clip-path="url(#p89f9079984)">
+     <use xlink:href="#maef9e33324" x="288.669073" y="68.131875" style="fill: #9467bd; stroke: #9467bd"/>
     </g>
    </g>
   </g>
@@ -2478,36 +2476,6 @@ L 588 0
 L 588 4666 
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Bold-36" d="M 2316 2303 
-Q 2000 2303 1842 2098 
-Q 1684 1894 1684 1484 
-Q 1684 1075 1842 870 
-Q 2000 666 2316 666 
-Q 2634 666 2792 870 
-Q 2950 1075 2950 1484 
-Q 2950 1894 2792 2098 
-Q 2634 2303 2316 2303 
-z
-M 3803 4544 
-L 3803 3681 
-Q 3506 3822 3243 3889 
-Q 2981 3956 2731 3956 
-Q 2194 3956 1894 3657 
-Q 1594 3359 1544 2772 
-Q 1750 2925 1990 3001 
-Q 2231 3078 2516 3078 
-Q 3231 3078 3670 2659 
-Q 4109 2241 4109 1563 
-Q 4109 813 3618 361 
-Q 3128 -91 2303 -91 
-Q 1394 -91 895 523 
-Q 397 1138 397 2266 
-Q 397 3422 980 4083 
-Q 1563 4744 2578 4744 
-Q 2900 4744 3203 4694 
-Q 3506 4644 3803 4544 
-z
-" transform="scale(0.015625)"/>
      <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
 Q 4578 3584 4928 3584 
@@ -2627,19 +2595,9 @@ z
    </g>
   </g>
   <g id="text_22">
-   <!-- 2026-07-05T23:02:37Z  ·  Linux chungus2 x86_64  ·  commit 9c93b270  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(7.687734 358.2) scale(0.07 -0.07)">
+   <!-- 2026-07-08T05:19:02Z  ·  Linux chungus2 x86_64  ·  commit cf8297c9  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(8.98 358.2) scale(0.07 -0.07)">
     <defs>
-     <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
-z
-" transform="scale(0.015625)"/>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
 L 3928 4134 
@@ -2718,16 +2676,16 @@ z
     <use xlink:href="#DejaVuSans-37" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2767,109 +2725,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3190.478516 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3254.101562 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3317.724609 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3381.201172 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3444.824219 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3508.447266 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3572.070312 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3603.857422 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3635.644531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3667.431641 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3699.21875 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3731.005859 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3758.789062 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3820.3125 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3881.591797 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3944.970703 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4008.447266 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4047.310547 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4108.492188 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4167.671875 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4229.195312 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4270.308594 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4304 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4331.783203 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4393.306641 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4454.585938 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4517.964844 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4581.587891 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4615.279297 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4674.458984 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4738.082031 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4769.869141 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4833.492188 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4897.115234 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4928.902344 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4992.525391 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5028.609375 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5067.472656 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5122.453125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5186.076172 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5217.863281 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5249.650391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5281.4375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5313.224609 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5345.011719 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5384.220703 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5447.599609 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5486.462891 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5547.644531 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5611.023438 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5674.5 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5737.878906 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5801.355469 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5864.734375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5903.943359 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5935.730469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6019.519531 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6051.306641 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6148.71875 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6210.242188 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6273.71875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6301.501953 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6362.78125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6426.160156 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6457.947266 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6510.046875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6573.425781 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6634.705078 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6698.181641 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6750.28125 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6813.660156 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6874.841797 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6914.050781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6947.742188 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6979.529297 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7020.642578 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7081.921875 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7121.130859 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7148.914062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7210.095703 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7241.882812 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7269.666016 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7321.765625 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7353.552734 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7417.029297 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7478.552734 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7517.761719 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7579.285156 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7618.648438 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7716.060547 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7743.84375 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7807.222656 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7835.005859 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7887.105469 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7926.314453 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7954.097656 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3126.855469 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3162.060547 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3225.683594 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3289.306641 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3352.929688 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3416.552734 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3471.533203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3535.15625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3566.943359 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3598.730469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3630.517578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3662.304688 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3694.091797 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3721.875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3783.398438 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3844.677734 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3908.056641 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3971.533203 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4010.396484 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4071.578125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4130.757812 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4192.28125 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4233.394531 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4267.085938 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4294.869141 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4356.392578 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4417.671875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4481.050781 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4544.673828 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4578.365234 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4637.544922 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4701.167969 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4732.955078 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4796.578125 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4860.201172 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4891.988281 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4955.611328 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4991.695312 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5030.558594 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5085.539062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5149.162109 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5180.949219 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5212.736328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5244.523438 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5276.310547 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5308.097656 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5347.306641 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5410.685547 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5449.548828 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5510.730469 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5574.109375 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5637.585938 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5700.964844 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5764.441406 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5827.820312 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5867.029297 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5898.816406 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5982.605469 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6014.392578 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6111.804688 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6173.328125 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6236.804688 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6264.587891 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6325.867188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6389.246094 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6421.033203 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6473.132812 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6536.511719 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6597.791016 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6661.267578 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6713.367188 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6776.746094 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6837.927734 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6877.136719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6910.828125 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6942.615234 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6983.728516 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7045.007812 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7084.216797 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7112 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7173.181641 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7204.96875 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7232.751953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7284.851562 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7316.638672 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7380.115234 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7441.638672 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7480.847656 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7542.371094 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7581.734375 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7679.146484 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7706.929688 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7770.308594 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7798.091797 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7850.191406 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7889.400391 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7917.183594 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pad8457e370">
+  <clipPath id="p89f9079984">
    <rect x="139.360469" y="56.7075" width="425.839531" height="251.33625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_ratio_heatmap.svg
+++ b/bench/graphs/silesia_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.34175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p15995ccbd3)">
+   <g clip-path="url(#p1597b4b923)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAosAAAGaCAYAAABniAm0AAAJ/klEQVR4nO3Yu45eVx2H4ZnM+IDHmbEtSCLCQcJRQAqBEoWCKhWCgmvgCmioqBB3QMUN0KGI0k1KpACBEAogSkIQB1lDjB1jGXs8Mx9X8BYoWvqjT89zBT9pb6397rV7fvsnm50tdPLTW9MTlrjw6svTE5bZfebT0xOW2Lz1u+kJS+x+5aXpCUtsHt6fnrDM8fdfm56wxDM/+tb0hCV2bzw7PWGNk4fTC5Y5/+V2nvdPTQ8AAOD/l1gEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACDt/vvktc30iBUO/nU8PWGJDw+vTE9Y5j+nD6YnLPHZj06mJyzx0aeem56wxPnmfHrCMtf3b0xPWOPOB9MLlrh/fTuf19N//tP0hGU2L35tesISbhYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEj7B3duT29Y48q16QVLbDYn0xOW+czrv56esMar35xesMTRh/+YnrDG+en0gnUOtvT8uHR1esESh//czu/z3c/fnJ6wzPW/vj09YQk3iwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEDafXJ2azM9YoW94/enJyxx++mL0xOWefDk3vSEJW7+5d70hCVOv/z16QlLPDy9Pz1hmaO9a9MTlti896vpCUs8+sLL0xOWuPz2G9MTlnn81VemJyzhZhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIuz9/73ub6REr3Lh8MD1hiXfu3ZmesMx3f/yb6QlL/PaH356esMTRpaPpCUv84BdvTk9Y5hvPX56esMR3br4yPWGJ1//2xvSEJa5e2M73cGdnZ+dn796dnrCEm0UAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAg7T45u7WZHrHC3cfH0xOWONg/nJ6wzDv3fj89YYkXrr00PWGJzeZ8esISV0+39x/67+fbeS4+f/DC9IQlHp09nJ6wxLaeHTs7Ozt7T+1PT1hie09FAAA+NrEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAApP293f3pDUt8cu/G9IQ19i5OL1jm6NLR9IQlDvYPpycscbY5nZ6wxPmF7f2Hfm5zZXoC/4Nt/T6fbB5NT1jm/uPj6QlLbO+pCADAxyYWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBI+4/OHk5vWOLy7v70hCU+ePDH6QnLnJ6fTE9Y4/jd6QVL3D86nJ6wxOHFG9MTljk5ezQ9YYlP3H5/esISj5/93PSEJQ7+8Nb0hGUef/FL0xOWcLMIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAApP8Cc6OciHDVLsgAAAAASUVORK5CYII=" id="imaged420a3313d" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="468.72" height="295.2"/>
+iVBORw0KGgoAAAANSUhEUgAAAosAAAGaCAYAAABniAm0AAAJ/klEQVR4nO3Yu45eVx2H4ZnM+IDHmbEtSCLCQcJRQAqBEoWCKhWCgmvgCmioqBB3QMUN0KGI0k1KpACBEAogSkIQB1lDjB1jGXs8Mx9X8BYoWvqjT89zBT9pb6397rV7fvsnm50tdPLTW9MTlrjw6svTE5bZfebT0xOW2Lz1u+kJS+x+5aXpCUtsHt6fnrDM8fdfm56wxDM/+tb0hCV2bzw7PWGNk4fTC5Y5/+V2nvdPTQ8AAOD/l1gEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACDt/vvktc30iBUO/nU8PWGJDw+vTE9Y5j+nD6YnLPHZj06mJyzx0aeem56wxPnmfHrCMtf3b0xPWOPOB9MLlrh/fTuf19N//tP0hGU2L35tesISbhYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEj7B3duT29Y48q16QVLbDYn0xOW+czrv56esMar35xesMTRh/+YnrDG+en0gnUOtvT8uHR1esESh//czu/z3c/fnJ6wzPW/vj09YQk3iwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEDafXJ2azM9YoW94/enJyxx++mL0xOWefDk3vSEJW7+5d70hCVOv/z16QlLPDy9Pz1hmaO9a9MTlti896vpCUs8+sLL0xOWuPz2G9MTlnn81VemJyzhZhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIuz9/73ub6REr3Lh8MD1hiXfu3ZmesMx3f/yb6QlL/PaH356esMTRpaPpCUv84BdvTk9Y5hvPX56esMR3br4yPWGJ1//2xvSEJa5e2M73cGdnZ+dn796dnrCEm0UAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAg7T45u7WZHrHC3cfH0xOWONg/nJ6wzDv3fj89YYkXrr00PWGJzeZ8esISV0+39x/67+fbeS4+f/DC9IQlHp09nJ6wxLaeHTs7Ozt7T+1PT1hie09FAAA+NrEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAApP293f3pDUt8cu/G9IQ19i5OL1jm6NLR9IQlDvYPpycscbY5nZ6wxPmF7f2Hfm5zZXoC/4Nt/T6fbB5NT1jm/uPj6QlLbO+pCADAxyYWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBI+4/OHk5vWOLy7v70hCU+ePDH6QnLnJ6fTE9Y4/jd6QVL3D86nJ6wxOHFG9MTljk5ezQ9YYlP3H5/esISj5/93PSEJQ7+8Nb0hGUef/FL0xOWcLMIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAApP8Cc6OciHDVLsgAAAAASUVORK5CYII=" id="imageb3fbb0913e" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="468.72" height="295.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m9a3625595e" d="M 0 0 
+       <path id="maa6c27615d" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m9a3625595e" x="115.182137" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#maa6c27615d" x="115.182137" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m9a3625595e" x="154.193912" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#maa6c27615d" x="154.193912" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m9a3625595e" x="193.205687" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#maa6c27615d" x="193.205687" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m9a3625595e" x="232.217462" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#maa6c27615d" x="232.217462" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m9a3625595e" x="271.229237" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#maa6c27615d" x="271.229237" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m9a3625595e" x="310.241012" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#maa6c27615d" x="310.241012" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m9a3625595e" x="349.252787" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#maa6c27615d" x="349.252787" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m9a3625595e" x="388.264562" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#maa6c27615d" x="388.264562" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m9a3625595e" x="427.276336" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#maa6c27615d" x="427.276336" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m9a3625595e" x="466.288111" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#maa6c27615d" x="466.288111" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m9a3625595e" x="505.299886" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#maa6c27615d" x="505.299886" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m9a3625595e" x="544.311661" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#maa6c27615d" x="544.311661" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="me22f5a0b56" d="M 0 0 
+       <path id="m26f4f5b296" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#me22f5a0b56" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m26f4f5b296" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#me22f5a0b56" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m26f4f5b296" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#me22f5a0b56" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m26f4f5b296" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#me22f5a0b56" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m26f4f5b296" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -836,7 +836,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#me22f5a0b56" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m26f4f5b296" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -899,7 +899,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#me22f5a0b56" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m26f4f5b296" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -966,7 +966,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#me22f5a0b56" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m26f4f5b296" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1047,7 +1047,7 @@ z
     <g id="ytick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#me22f5a0b56" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m26f4f5b296" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -2060,18 +2060,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABEAAAFUCAYAAADCj9eRAAAB2ElEQVR4nO2aQY7EIAwEIeFP+6X9/33C3MPcKKSS1TygZRftNlLS2//fbJtn9KvvajAi17ZCM7Uzeg+TEyJhsh4TE8D25ZhYRMJkPSYmmZ0zIhfQEMPkJq74JpgQlUBMABkIrOV2KLMRItXMhrQjqcQUSszsbGuomFSbHULEAlblE0klor1zMaG0XwnDBDAsBVY0O4CIBizlE4ntEbCijK3mE8vKUPkEEIF8YslYje2RZFP5BJkdCxOonf1i6jEhRICOyjEBzFaPiWd2iChoYbKKhMkqgmSsh4kkHkU+6UyeACJEJaLZ6QQTzy7WtGPyicX2Kp/c+yKaATTliSWoTXsnPllEEtTLGX37f+7WRpuPQ4RhomlntCdMTohATIDbKceEaGfOD1BJZueIiImJZQBNTCxgw2Q91N7Zf7RBsxMmR0TqMdmvxPRmI0TmDJNVJExWkTBZRcJkFSnFZH6Q5aVhQrQzkYUOVEIxIXxSjAnRDjQ7mndsZud9VEwsPtFcsWjvaNZofHKoEpFPELCPJmORdqblMWxiYjEbw+QJk/dR+SQD+BbROFbEJAP4Q4RgQpiNCupKIhAT4gewakws7YTJIREoY4FPeNWYaNoJk18iQNqXY1LKJ1/07Ct/l+QCQgAAAABJRU5ErkJggg==" id="image745ca6cab4" transform="scale(1 -1) translate(0 -244.8)" x="573.84" y="-74.16" width="12.24" height="244.8"/>
+iVBORw0KGgoAAAANSUhEUgAAABEAAAFUCAYAAADCj9eRAAAB2ElEQVR4nO2aQY7EIAwEIeFP+6X9/33C3MPcKKSS1TygZRftNlLS2//fbJtn9KvvajAi17ZCM7Uzeg+TEyJhsh4TE8D25ZhYRMJkPSYmmZ0zIhfQEMPkJq74JpgQlUBMABkIrOV2KLMRItXMhrQjqcQUSszsbGuomFSbHULEAlblE0klor1zMaG0XwnDBDAsBVY0O4CIBizlE4ntEbCijK3mE8vKUPkEEIF8YslYje2RZFP5BJkdCxOonf1i6jEhRICOyjEBzFaPiWd2iChoYbKKhMkqgmSsh4kkHkU+6UyeACJEJaLZ6QQTzy7WtGPyicX2Kp/c+yKaATTliSWoTXsnPllEEtTLGX37f+7WRpuPQ4RhomlntCdMTohATIDbKceEaGfOD1BJZueIiImJZQBNTCxgw2Q91N7Zf7RBsxMmR0TqMdmvxPRmI0TmDJNVJExWkTBZRcJkFSnFZH6Q5aVhQrQzkYUOVEIxIXxSjAnRDjQ7mndsZud9VEwsPtFcsWjvaNZofHKoEpFPELCPJmORdqblMWxiYjEbw+QJk/dR+SQD+BbROFbEJAP4Q4RgQpiNCupKIhAT4gewakws7YTJIREoY4FPeNWYaNoJk18iQNqXY1LKJ1/07Ct/l+QCQgAAAABJRU5ErkJggg==" id="image03e06980bd" transform="scale(1 -1) translate(0 -244.8)" x="573.84" y="-74.16" width="12.24" height="244.8"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_21">
       <defs>
-       <path id="m292dde7fd2" d="M 0 0 
+       <path id="mbd3c522bf9" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m292dde7fd2" x="585.876562" y="282.022672" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbd3c522bf9" x="585.876562" y="282.022672" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_117">
@@ -2097,7 +2097,7 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m292dde7fd2" x="585.876562" y="239.353777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbd3c522bf9" x="585.876562" y="239.353777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_118">
@@ -2114,7 +2114,7 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m292dde7fd2" x="585.876562" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbd3c522bf9" x="585.876562" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_119">
@@ -2130,7 +2130,7 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m292dde7fd2" x="585.876562" y="154.015985" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbd3c522bf9" x="585.876562" y="154.015985" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_120">
@@ -2146,7 +2146,7 @@ z
     <g id="ytick_13">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m292dde7fd2" x="585.876562" y="111.347089" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbd3c522bf9" x="585.876562" y="111.347089" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_121">
@@ -2739,9 +2739,48 @@ z
    </g>
   </g>
   <g id="text_124">
-   <!-- 2026-07-07T22:17:01Z  ·  Linux chungus2 x86_64  ·  commit dcf4b958  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(44.687422 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-08T05:15:03Z  ·  Linux chungus2 x86_64  ·  commit cf8297c9  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(44.98 401.184) scale(0.07 -0.07)">
     <defs>
+     <path id="DejaVuSans-38" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
 L 3928 4134 
@@ -2804,45 +2843,6 @@ M 1991 3584
 L 1991 3584 
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-38" d="M 2034 2216 
-Q 1584 2216 1326 1975 
-Q 1069 1734 1069 1313 
-Q 1069 891 1326 650 
-Q 1584 409 2034 409 
-Q 2484 409 2743 651 
-Q 3003 894 3003 1313 
-Q 3003 1734 2745 1975 
-Q 2488 2216 2034 2216 
-z
-M 1403 2484 
-Q 997 2584 770 2862 
-Q 544 3141 544 3541 
-Q 544 4100 942 4425 
-Q 1341 4750 2034 4750 
-Q 2731 4750 3128 4425 
-Q 3525 4100 3525 3541 
-Q 3525 3141 3298 2862 
-Q 3072 2584 2669 2484 
-Q 3125 2378 3379 2068 
-Q 3634 1759 3634 1313 
-Q 3634 634 3220 271 
-Q 2806 -91 2034 -91 
-Q 1263 -91 848 271 
-Q 434 634 434 1313 
-Q 434 1759 690 2068 
-Q 947 2378 1403 2484 
-z
-M 1172 3481 
-Q 1172 3119 1398 2916 
-Q 1625 2713 2034 2713 
-Q 2441 2713 2670 2916 
-Q 2900 3119 2900 3481 
-Q 2900 3844 2670 4047 
-Q 2441 4250 2034 4250 
-Q 1625 4250 1398 4047 
-Q 1172 3844 1172 3481 
-z
-" transform="scale(0.015625)"/>
      <path id="DejaVuSans-3b" d="M 750 3309 
 L 1409 3309 
 L 1409 2516 
@@ -2868,16 +2868,16 @@ z
     <use xlink:href="#DejaVuSans-37" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
     <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2917,109 +2917,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3135.351562 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3190.332031 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3225.537109 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3289.160156 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3352.636719 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3416.259766 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3479.882812 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3543.505859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3575.292969 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3607.080078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3638.867188 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3670.654297 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3702.441406 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3730.224609 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3791.748047 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3853.027344 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3916.40625 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3979.882812 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4018.746094 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4079.927734 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4139.107422 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4200.630859 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4241.744141 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4275.435547 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4303.21875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4364.742188 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4426.021484 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4489.400391 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4553.023438 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4586.714844 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4645.894531 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4709.517578 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4741.304688 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4804.927734 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4868.550781 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4900.337891 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4963.960938 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5000.044922 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5038.908203 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5093.888672 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5157.511719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5189.298828 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5221.085938 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5252.873047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5284.660156 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5316.447266 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5355.65625 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5419.035156 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5457.898438 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5519.080078 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5582.458984 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5645.935547 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5709.314453 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5772.791016 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5836.169922 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5875.378906 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5907.166016 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5990.955078 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6022.742188 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6120.154297 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6181.677734 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6245.154297 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6272.9375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6334.216797 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6397.595703 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6429.382812 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6481.482422 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6544.861328 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6606.140625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6669.617188 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6721.716797 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6785.095703 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6846.277344 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6885.486328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6919.177734 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6950.964844 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6992.078125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7053.357422 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7092.566406 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7120.349609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7181.53125 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7213.318359 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7241.101562 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7293.201172 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7324.988281 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7388.464844 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7449.988281 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7489.197266 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7550.720703 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7590.083984 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7687.496094 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7715.279297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7778.658203 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7806.441406 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7858.541016 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7897.75 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7925.533203 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3126.855469 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3162.060547 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3225.683594 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3289.306641 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3352.929688 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3416.552734 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3471.533203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3535.15625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3566.943359 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3598.730469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3630.517578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3662.304688 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3694.091797 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3721.875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3783.398438 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3844.677734 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3908.056641 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3971.533203 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4010.396484 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4071.578125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4130.757812 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4192.28125 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4233.394531 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4267.085938 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4294.869141 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4356.392578 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4417.671875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4481.050781 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4544.673828 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4578.365234 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4637.544922 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4701.167969 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4732.955078 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4796.578125 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4860.201172 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4891.988281 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4955.611328 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4991.695312 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5030.558594 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5085.539062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5149.162109 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5180.949219 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5212.736328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5244.523438 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5276.310547 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5308.097656 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5347.306641 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5410.685547 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5449.548828 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5510.730469 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5574.109375 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5637.585938 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5700.964844 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5764.441406 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5827.820312 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5867.029297 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5898.816406 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5982.605469 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6014.392578 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6111.804688 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6173.328125 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6236.804688 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6264.587891 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6325.867188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6389.246094 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6421.033203 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6473.132812 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6536.511719 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6597.791016 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6661.267578 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6713.367188 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6776.746094 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6837.927734 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6877.136719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6910.828125 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6942.615234 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6983.728516 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7045.007812 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7084.216797 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7112 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7173.181641 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7204.96875 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7232.751953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7284.851562 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7316.638672 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7380.115234 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7441.638672 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7480.847656 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7542.371094 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7581.734375 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7679.146484 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7706.929688 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7770.308594 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7798.091797 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7850.191406 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7889.400391 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7917.183594 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p15995ccbd3">
+  <clipPath id="p1597b4b923">
    <rect x="95.67625" y="49.34175" width="468.141298" height="294.686261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_summary.svg
+++ b/bench/graphs/silesia_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="573.025156pt" height="386.202469pt" viewBox="0 0 573.025156 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="572.44pt" height="386.202469pt" viewBox="0 0 572.44 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,232 +22,232 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 386.202469 
-L 573.025156 386.202469 
-L 573.025156 0 
+L 572.44 386.202469 
+L 572.44 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 188.637578 104.1264 
-L 293.262578 104.1264 
-L 293.262578 74.7432 
-L 188.637578 74.7432 
+    <path d="M 188.345 104.1264 
+L 292.97 104.1264 
+L 292.97 74.7432 
+L 188.345 74.7432 
 z
-" clip-path="url(#p3031c1b8b3)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd44c8d21fd)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 293.262578 104.1264 
-L 397.887578 104.1264 
-L 397.887578 74.7432 
-L 293.262578 74.7432 
+    <path d="M 292.97 104.1264 
+L 397.595 104.1264 
+L 397.595 74.7432 
+L 292.97 74.7432 
 z
-" clip-path="url(#p3031c1b8b3)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd44c8d21fd)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 397.887578 104.1264 
-L 502.512578 104.1264 
-L 502.512578 74.7432 
-L 397.887578 74.7432 
+    <path d="M 397.595 104.1264 
+L 502.22 104.1264 
+L 502.22 74.7432 
+L 397.595 74.7432 
 z
-" clip-path="url(#p3031c1b8b3)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd44c8d21fd)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 188.637578 133.5096 
-L 293.262578 133.5096 
-L 293.262578 104.1264 
-L 188.637578 104.1264 
+    <path d="M 188.345 133.5096 
+L 292.97 133.5096 
+L 292.97 104.1264 
+L 188.345 104.1264 
 z
-" clip-path="url(#p3031c1b8b3)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd44c8d21fd)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 293.262578 133.5096 
-L 397.887578 133.5096 
-L 397.887578 104.1264 
-L 293.262578 104.1264 
+    <path d="M 292.97 133.5096 
+L 397.595 133.5096 
+L 397.595 104.1264 
+L 292.97 104.1264 
 z
-" clip-path="url(#p3031c1b8b3)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd44c8d21fd)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 397.887578 133.5096 
-L 502.512578 133.5096 
-L 502.512578 104.1264 
-L 397.887578 104.1264 
+    <path d="M 397.595 133.5096 
+L 502.22 133.5096 
+L 502.22 104.1264 
+L 397.595 104.1264 
 z
-" clip-path="url(#p3031c1b8b3)" style="fill: #fece7c; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd44c8d21fd)" style="fill: #fece7c; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 188.637578 162.8928 
-L 293.262578 162.8928 
-L 293.262578 133.5096 
-L 188.637578 133.5096 
+    <path d="M 188.345 162.8928 
+L 292.97 162.8928 
+L 292.97 133.5096 
+L 188.345 133.5096 
 z
-" clip-path="url(#p3031c1b8b3)" style="fill: #fee08b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd44c8d21fd)" style="fill: #fee08b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 293.262578 162.8928 
-L 397.887578 162.8928 
-L 397.887578 133.5096 
-L 293.262578 133.5096 
+    <path d="M 292.97 162.8928 
+L 397.595 162.8928 
+L 397.595 133.5096 
+L 292.97 133.5096 
 z
-" clip-path="url(#p3031c1b8b3)" style="fill: #feefa3; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd44c8d21fd)" style="fill: #feefa3; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 397.887578 162.8928 
-L 502.512578 162.8928 
-L 502.512578 133.5096 
-L 397.887578 133.5096 
+    <path d="M 397.595 162.8928 
+L 502.22 162.8928 
+L 502.22 133.5096 
+L 397.595 133.5096 
 z
-" clip-path="url(#p3031c1b8b3)" style="fill: #fdbf6f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd44c8d21fd)" style="fill: #fdbf6f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 188.637578 192.276 
-L 293.262578 192.276 
-L 293.262578 162.8928 
-L 188.637578 162.8928 
+    <path d="M 188.345 192.276 
+L 292.97 192.276 
+L 292.97 162.8928 
+L 188.345 162.8928 
 z
-" clip-path="url(#p3031c1b8b3)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd44c8d21fd)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 293.262578 192.276 
-L 397.887578 192.276 
-L 397.887578 162.8928 
-L 293.262578 162.8928 
+    <path d="M 292.97 192.276 
+L 397.595 192.276 
+L 397.595 162.8928 
+L 292.97 162.8928 
 z
-" clip-path="url(#p3031c1b8b3)" style="fill: #fede89; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd44c8d21fd)" style="fill: #fede89; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 397.887578 192.276 
-L 502.512578 192.276 
-L 502.512578 162.8928 
-L 397.887578 162.8928 
+    <path d="M 397.595 192.276 
+L 502.22 192.276 
+L 502.22 162.8928 
+L 397.595 162.8928 
 z
-" clip-path="url(#p3031c1b8b3)" style="fill: #f7814c; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd44c8d21fd)" style="fill: #f7814c; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 188.637578 221.6592 
-L 293.262578 221.6592 
-L 293.262578 192.276 
-L 188.637578 192.276 
+    <path d="M 188.345 221.6592 
+L 292.97 221.6592 
+L 292.97 192.276 
+L 188.345 192.276 
 z
-" clip-path="url(#p3031c1b8b3)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd44c8d21fd)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 293.262578 221.6592 
-L 397.887578 221.6592 
-L 397.887578 192.276 
-L 293.262578 192.276 
+    <path d="M 292.97 221.6592 
+L 397.595 221.6592 
+L 397.595 192.276 
+L 292.97 192.276 
 z
-" clip-path="url(#p3031c1b8b3)" style="fill: #fed27f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd44c8d21fd)" style="fill: #fed27f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 397.887578 221.6592 
-L 502.512578 221.6592 
-L 502.512578 192.276 
-L 397.887578 192.276 
+    <path d="M 397.595 221.6592 
+L 502.22 221.6592 
+L 502.22 192.276 
+L 397.595 192.276 
 z
-" clip-path="url(#p3031c1b8b3)" style="fill: #fffcba; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd44c8d21fd)" style="fill: #fffcba; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 188.637578 251.0424 
-L 293.262578 251.0424 
-L 293.262578 221.6592 
-L 188.637578 221.6592 
+    <path d="M 188.345 251.0424 
+L 292.97 251.0424 
+L 292.97 221.6592 
+L 188.345 221.6592 
 z
-" clip-path="url(#p3031c1b8b3)" style="fill: #fff3ac; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd44c8d21fd)" style="fill: #fff3ac; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 293.262578 251.0424 
-L 397.887578 251.0424 
-L 397.887578 221.6592 
-L 293.262578 221.6592 
+    <path d="M 292.97 251.0424 
+L 397.595 251.0424 
+L 397.595 221.6592 
+L 292.97 221.6592 
 z
-" clip-path="url(#p3031c1b8b3)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd44c8d21fd)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 397.887578 251.0424 
-L 502.512578 251.0424 
-L 502.512578 221.6592 
-L 397.887578 221.6592 
+    <path d="M 397.595 251.0424 
+L 502.22 251.0424 
+L 502.22 221.6592 
+L 397.595 221.6592 
 z
-" clip-path="url(#p3031c1b8b3)" style="fill: #e8f59f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd44c8d21fd)" style="fill: #e8f59f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 188.637578 280.4256 
-L 293.262578 280.4256 
-L 293.262578 251.0424 
-L 188.637578 251.0424 
+    <path d="M 188.345 280.4256 
+L 292.97 280.4256 
+L 292.97 251.0424 
+L 188.345 251.0424 
 z
-" clip-path="url(#p3031c1b8b3)" style="fill: #feec9f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd44c8d21fd)" style="fill: #feec9f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 293.262578 280.4256 
-L 397.887578 280.4256 
-L 397.887578 251.0424 
-L 293.262578 251.0424 
+    <path d="M 292.97 280.4256 
+L 397.595 280.4256 
+L 397.595 251.0424 
+L 292.97 251.0424 
 z
-" clip-path="url(#p3031c1b8b3)" style="fill: #fdc171; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd44c8d21fd)" style="fill: #fdc171; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 397.887578 280.4256 
-L 502.512578 280.4256 
-L 502.512578 251.0424 
-L 397.887578 251.0424 
+    <path d="M 397.595 280.4256 
+L 502.22 280.4256 
+L 502.22 251.0424 
+L 397.595 251.0424 
 z
-" clip-path="url(#p3031c1b8b3)" style="fill: #f88c51; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd44c8d21fd)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 188.637578 309.8088 
-L 293.262578 309.8088 
-L 293.262578 280.4256 
-L 188.637578 280.4256 
+    <path d="M 188.345 309.8088 
+L 292.97 309.8088 
+L 292.97 280.4256 
+L 188.345 280.4256 
 z
-" clip-path="url(#p3031c1b8b3)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd44c8d21fd)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 293.262578 309.8088 
-L 397.887578 309.8088 
-L 397.887578 280.4256 
-L 293.262578 280.4256 
+    <path d="M 292.97 309.8088 
+L 397.595 309.8088 
+L 397.595 280.4256 
+L 292.97 280.4256 
 z
-" clip-path="url(#p3031c1b8b3)" style="fill: #fa9b58; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd44c8d21fd)" style="fill: #fa9b58; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 397.887578 309.8088 
-L 502.512578 309.8088 
-L 502.512578 280.4256 
-L 397.887578 280.4256 
+    <path d="M 397.595 309.8088 
+L 502.22 309.8088 
+L 502.22 280.4256 
+L 397.595 280.4256 
 z
-" clip-path="url(#p3031c1b8b3)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd44c8d21fd)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 188.637578 339.192 
-L 293.262578 339.192 
-L 293.262578 309.8088 
-L 188.637578 309.8088 
+    <path d="M 188.345 339.192 
+L 292.97 339.192 
+L 292.97 309.8088 
+L 188.345 309.8088 
 z
-" clip-path="url(#p3031c1b8b3)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd44c8d21fd)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 293.262578 339.192 
-L 397.887578 339.192 
-L 397.887578 309.8088 
-L 293.262578 309.8088 
+    <path d="M 292.97 339.192 
+L 397.595 339.192 
+L 397.595 309.8088 
+L 292.97 309.8088 
 z
-" clip-path="url(#p3031c1b8b3)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd44c8d21fd)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 397.887578 339.192 
-L 502.512578 339.192 
-L 502.512578 309.8088 
-L 397.887578 309.8088 
+    <path d="M 397.595 339.192 
+L 502.22 339.192 
+L 502.22 309.8088 
+L 397.595 309.8088 
 z
-" clip-path="url(#p3031c1b8b3)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd44c8d21fd)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(121.624844 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(121.332266 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(228.909063 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(228.616484 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(307.481172 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(307.188594 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(405.832891 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(405.540313 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(117.562578 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(117.27 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.320 -->
-    <g transform="translate(229.498828 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(229.20625 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -918,7 +918,7 @@ z
    </g>
    <g id="text_7">
     <!-- 117 -->
-    <g transform="translate(337.940078 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(337.6475 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -952,7 +952,7 @@ z
    </g>
    <g id="text_8">
     <!-- 852 -->
-    <g transform="translate(442.565078 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(442.2725 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -1026,7 +1026,7 @@ z
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(112.200703 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(111.908125 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1125,7 +1125,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.324 -->
-    <g transform="translate(229.498828 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(229.20625 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1156,7 +1156,7 @@ z
    </g>
    <g id="text_11">
     <!-- 61 -->
-    <g transform="translate(340.485078 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(340.1925 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -1195,7 +1195,7 @@ z
    </g>
    <g id="text_12">
     <!-- 312 -->
-    <g transform="translate(442.565078 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(442.2725 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
@@ -1203,7 +1203,7 @@ z
    </g>
    <g id="text_13">
     <!-- Go compress/flate -->
-    <g transform="translate(99.893828 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(99.60125 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -1374,7 +1374,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.325 -->
-    <g transform="translate(229.498828 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(229.20625 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1384,14 +1384,14 @@ z
    </g>
    <g id="text_15">
     <!-- 50 -->
-    <g transform="translate(340.485078 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(340.1925 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
     <!-- 275 -->
-    <g transform="translate(442.565078 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(442.2725 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
@@ -1399,7 +1399,7 @@ z
    </g>
    <g id="text_17">
     <!-- JS fflate -->
-    <g transform="translate(120.926328 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(120.63375 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1459,7 +1459,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.329 -->
-    <g transform="translate(229.498828 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(229.20625 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-39" d="M 703 97 
 L 703 672 
@@ -1501,14 +1501,14 @@ z
    </g>
    <g id="text_19">
     <!-- 41 -->
-    <g transform="translate(340.485078 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(340.1925 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
     <!-- 160 -->
-    <g transform="translate(442.565078 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(442.2725 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -1516,7 +1516,7 @@ z
    </g>
    <g id="text_21">
     <!-- zlib -->
-    <g transform="translate(129.463828 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(129.17125 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1540,7 +1540,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.323 -->
-    <g transform="translate(229.498828 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(229.20625 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1550,14 +1550,14 @@ z
    </g>
    <g id="text_23">
     <!-- 38 -->
-    <g transform="translate(340.485078 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(340.1925 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_24">
     <!-- 448 -->
-    <g transform="translate(442.565078 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(442.2725 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(127.246094 0)"/>
@@ -1565,7 +1565,7 @@ z
    </g>
    <g id="text_25">
     <!-- miniz_oxide -->
-    <g transform="translate(112.770078 238.44705) scale(0.08 -0.08)">
+    <g transform="translate(112.4775 238.44705) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6e" d="M 3513 2113 
 L 3513 0 
@@ -1624,7 +1624,7 @@ z
    </g>
    <g id="text_26">
     <!-- 0.322 -->
-    <g transform="translate(229.498828 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(229.20625 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1634,14 +1634,14 @@ z
    </g>
    <g id="text_27">
     <!-- 36 -->
-    <g transform="translate(340.485078 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(340.1925 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_28">
     <!-- 527 -->
-    <g transform="translate(442.565078 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(442.2725 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
@@ -1649,7 +1649,7 @@ z
    </g>
    <g id="text_29">
     <!-- lean-zip (native) -->
-    <g transform="translate(99.271953 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(98.979375 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1758,7 +1758,7 @@ z
    </g>
    <g id="text_30">
     <!-- 0.323 -->
-    <g transform="translate(228.298203 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(228.005625 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1852,14 +1852,14 @@ z
    </g>
    <g id="text_31">
     <!-- 32 -->
-    <g transform="translate(340.008828 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(339.71625 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-Bold-33"/>
      <use xlink:href="#DejaVuSans-Bold-32" transform="translate(69.580078 0)"/>
     </g>
    </g>
    <g id="text_32">
-    <!-- 178 -->
-    <g transform="translate(441.850703 267.9415) scale(0.08 -0.08)">
+    <!-- 185 -->
+    <g transform="translate(441.558125 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-31" d="M 750 831 
 L 1813 831 
@@ -1873,16 +1873,6 @@ L 4013 831
 L 4013 0 
 L 750 0 
 L 750 831 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-37" d="M 428 4666 
-L 3944 4666 
-L 3944 3988 
-L 2125 0 
-L 953 0 
-L 2675 3781 
-L 428 3781 
-L 428 4666 
 z
 " transform="scale(0.015625)"/>
       <path id="DejaVuSans-Bold-38" d="M 2228 2088 
@@ -1924,15 +1914,40 @@ Q 1941 3994 1786 3844
 Q 1631 3694 1631 3419 
 z
 " transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-35" d="M 678 4666 
+L 3669 4666 
+L 3669 3781 
+L 1638 3781 
+L 1638 3059 
+Q 1775 3097 1914 3117 
+Q 2053 3138 2203 3138 
+Q 3056 3138 3531 2711 
+Q 4006 2284 4006 1522 
+Q 4006 766 3489 337 
+Q 2972 -91 2053 -91 
+Q 1656 -91 1267 -14 
+Q 878 63 494 219 
+L 494 1166 
+Q 875 947 1217 837 
+Q 1559 728 1863 728 
+Q 2300 728 2551 942 
+Q 2803 1156 2803 1522 
+Q 2803 1891 2551 2103 
+Q 2300 2316 1863 2316 
+Q 1603 2316 1309 2248 
+Q 1016 2181 678 2041 
+L 678 4666 
+z
+" transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-Bold-31"/>
-     <use xlink:href="#DejaVuSans-Bold-37" transform="translate(69.580078 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-38" transform="translate(139.160156 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-38" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-35" transform="translate(139.160156 0)"/>
     </g>
    </g>
    <g id="text_33">
     <!-- OCaml decompress -->
-    <g transform="translate(97.386953 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(97.094375 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -1997,7 +2012,7 @@ z
    </g>
    <g id="text_34">
     <!-- 0.336 -->
-    <g transform="translate(229.498828 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(229.20625 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -2007,21 +2022,21 @@ z
    </g>
    <g id="text_35">
     <!-- 21 -->
-    <g transform="translate(340.485078 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(340.1925 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_36">
     <!-- 69 -->
-    <g transform="translate(445.110078 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(444.8175 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-36"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(125.608203 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(125.315625 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -2032,7 +2047,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.303 -->
-    <g transform="translate(229.498828 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(229.20625 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -2042,13 +2057,13 @@ z
    </g>
    <g id="text_39">
     <!-- 1 -->
-    <g transform="translate(343.030078 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(342.7375 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(446.200078 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(445.9075 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2064,7 +2079,7 @@ z
   </g>
   <g id="text_41">
    <!-- silesia — geomean over files, level 6 -->
-   <g transform="translate(153.114297 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(152.821719 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-2014" d="M 344 2156 
 L 6056 2156 
@@ -2208,7 +2223,7 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-07-07T22:17:01Z  ·  Linux chungus2 x86_64  ·  commit dcf4b958  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-07-08T05:15:03Z  ·  Linux chungus2 x86_64  ·  commit cf8297c9  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2347,16 +2362,16 @@ z
     <use xlink:href="#DejaVuSans-37" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
     <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2396,110 +2411,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3135.351562 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3190.332031 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3225.537109 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3289.160156 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3352.636719 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3416.259766 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3479.882812 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3543.505859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3575.292969 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3607.080078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3638.867188 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3670.654297 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3702.441406 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3730.224609 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3791.748047 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3853.027344 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3916.40625 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3979.882812 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4018.746094 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4079.927734 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4139.107422 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4200.630859 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4241.744141 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4275.435547 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4303.21875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4364.742188 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4426.021484 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4489.400391 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4553.023438 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4586.714844 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4645.894531 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4709.517578 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4741.304688 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4804.927734 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4868.550781 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4900.337891 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4963.960938 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5000.044922 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5038.908203 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5093.888672 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5157.511719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5189.298828 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5221.085938 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5252.873047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5284.660156 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5316.447266 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5355.65625 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5419.035156 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5457.898438 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5519.080078 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5582.458984 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5645.935547 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5709.314453 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5772.791016 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5836.169922 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5875.378906 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5907.166016 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5990.955078 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6022.742188 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6120.154297 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6181.677734 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6245.154297 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6272.9375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6334.216797 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6397.595703 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6429.382812 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6481.482422 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6544.861328 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6606.140625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6669.617188 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6721.716797 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6785.095703 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6846.277344 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6885.486328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6919.177734 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6950.964844 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6992.078125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7053.357422 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7092.566406 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7120.349609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7181.53125 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7213.318359 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7241.101562 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7293.201172 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7324.988281 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7388.464844 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7449.988281 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7489.197266 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7550.720703 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7590.083984 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7687.496094 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7715.279297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7778.658203 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7806.441406 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7858.541016 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7897.75 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7925.533203 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3126.855469 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3162.060547 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3225.683594 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3289.306641 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3352.929688 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3416.552734 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3471.533203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3535.15625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3566.943359 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3598.730469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3630.517578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3662.304688 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3694.091797 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3721.875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3783.398438 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3844.677734 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3908.056641 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3971.533203 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4010.396484 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4071.578125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4130.757812 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4192.28125 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4233.394531 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4267.085938 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4294.869141 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4356.392578 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4417.671875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4481.050781 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4544.673828 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4578.365234 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4637.544922 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4701.167969 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4732.955078 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4796.578125 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4860.201172 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4891.988281 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4955.611328 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4991.695312 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5030.558594 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5085.539062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5149.162109 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5180.949219 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5212.736328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5244.523438 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5276.310547 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5308.097656 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5347.306641 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5410.685547 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5449.548828 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5510.730469 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5574.109375 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5637.585938 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5700.964844 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5764.441406 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5827.820312 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5867.029297 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5898.816406 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5982.605469 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6014.392578 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6111.804688 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6173.328125 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6236.804688 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6264.587891 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6325.867188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6389.246094 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6421.033203 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6473.132812 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6536.511719 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6597.791016 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6661.267578 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6713.367188 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6776.746094 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6837.927734 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6877.136719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6910.828125 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6942.615234 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6983.728516 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7045.007812 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7084.216797 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7112 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7173.181641 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7204.96875 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7232.751953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7284.851562 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7316.638672 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7380.115234 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7441.638672 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7480.847656 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7542.371094 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7581.734375 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7679.146484 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7706.929688 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7770.308594 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7798.091797 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7850.191406 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7889.400391 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7917.183594 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p3031c1b8b3">
-   <rect x="84.012578" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="pd44c8d21fd">
+   <rect x="83.72" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/results/decode_density.json
+++ b/bench/results/decode_density.json
@@ -1,5411 +1,5412 @@
 {
-"meta": {
-"date": "2026-07-05T23:02:37Z",
-"machine": "Linux chungus2 x86_64",
-"git_commit": "9c93b270",
-"toolchain": "leanprover/lean4:v4.30.0-rc2",
-"experiment": "decode-density: fixed libdeflate input, ratio = libdeflate compression ratio, decompress_mbps = each decoder on identical streams; compressor field holds the decoder name"
-},
-"results": [
-{
-"compressor": "native",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 1,
-"out_size": 4217525,
-"ratio": 0.4138,
-"compress_mbps": null,
-"decompress_mbps": 118.97
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 1,
-"out_size": 4217525,
-"ratio": 0.4138,
-"compress_mbps": null,
-"decompress_mbps": 384.45
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 1,
-"out_size": 4217525,
-"ratio": 0.4138,
-"compress_mbps": null,
-"decompress_mbps": 452.1
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 1,
-"out_size": 4217525,
-"ratio": 0.4138,
-"compress_mbps": null,
-"decompress_mbps": 775.35
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 1,
-"out_size": 4217525,
-"ratio": 0.4138,
-"compress_mbps": null,
-"decompress_mbps": 33944.96
-},
-{
-"compressor": "native",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 3,
-"out_size": 3989875,
-"ratio": 0.3915,
-"compress_mbps": null,
-"decompress_mbps": 141.59
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 3,
-"out_size": 3989875,
-"ratio": 0.3915,
-"compress_mbps": null,
-"decompress_mbps": 387.94
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 3,
-"out_size": 3989875,
-"ratio": 0.3915,
-"compress_mbps": null,
-"decompress_mbps": 487.03
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 3,
-"out_size": 3989875,
-"ratio": 0.3915,
-"compress_mbps": null,
-"decompress_mbps": 864.76
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 3,
-"out_size": 3989875,
-"ratio": 0.3915,
-"compress_mbps": null,
-"decompress_mbps": 35667.72
-},
-{
-"compressor": "native",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 6,
-"out_size": 3859436,
-"ratio": 0.3787,
-"compress_mbps": null,
-"decompress_mbps": 150.21
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 6,
-"out_size": 3859436,
-"ratio": 0.3787,
-"compress_mbps": null,
-"decompress_mbps": 378.06
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 6,
-"out_size": 3859436,
-"ratio": 0.3787,
-"compress_mbps": null,
-"decompress_mbps": 467.61
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 6,
-"out_size": 3859436,
-"ratio": 0.3787,
-"compress_mbps": null,
-"decompress_mbps": 811.85
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 6,
-"out_size": 3859436,
-"ratio": 0.3787,
-"compress_mbps": null,
-"decompress_mbps": 43688.59
-},
-{
-"compressor": "native",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 9,
-"out_size": 3810354,
-"ratio": 0.3738,
-"compress_mbps": null,
-"decompress_mbps": 153.31
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 9,
-"out_size": 3810354,
-"ratio": 0.3738,
-"compress_mbps": null,
-"decompress_mbps": 373.29
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 9,
-"out_size": 3810354,
-"ratio": 0.3738,
-"compress_mbps": null,
-"decompress_mbps": 442.12
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 9,
-"out_size": 3810354,
-"ratio": 0.3738,
-"compress_mbps": null,
-"decompress_mbps": 747.7
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 9,
-"out_size": 3810354,
-"ratio": 0.3738,
-"compress_mbps": null,
-"decompress_mbps": 47953.99
-},
-{
-"compressor": "native",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 12,
-"out_size": 3679105,
-"ratio": 0.361,
-"compress_mbps": null,
-"decompress_mbps": 152.48
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 12,
-"out_size": 3679105,
-"ratio": 0.361,
-"compress_mbps": null,
-"decompress_mbps": 422.62
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 12,
-"out_size": 3679105,
-"ratio": 0.361,
-"compress_mbps": null,
-"decompress_mbps": 499.35
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 12,
-"out_size": 3679105,
-"ratio": 0.361,
-"compress_mbps": null,
-"decompress_mbps": 906.76
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 12,
-"out_size": 3679105,
-"ratio": 0.361,
-"compress_mbps": null,
-"decompress_mbps": 43066.47
-},
-{
-"compressor": "native",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 1,
-"out_size": 20192961,
-"ratio": 0.3942,
-"compress_mbps": null,
-"decompress_mbps": 161.14
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 1,
-"out_size": 20192961,
-"ratio": 0.3942,
-"compress_mbps": null,
-"decompress_mbps": 376.08
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 1,
-"out_size": 20192961,
-"ratio": 0.3942,
-"compress_mbps": null,
-"decompress_mbps": 425.11
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 1,
-"out_size": 20192961,
-"ratio": 0.3942,
-"compress_mbps": null,
-"decompress_mbps": 736.05
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 1,
-"out_size": 20192961,
-"ratio": 0.3942,
-"compress_mbps": null,
-"decompress_mbps": 20164.15
-},
-{
-"compressor": "native",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 3,
-"out_size": 19234937,
-"ratio": 0.3755,
-"compress_mbps": null,
-"decompress_mbps": 126.49
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 3,
-"out_size": 19234937,
-"ratio": 0.3755,
-"compress_mbps": null,
-"decompress_mbps": 372.0
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 3,
-"out_size": 19234937,
-"ratio": 0.3755,
-"compress_mbps": null,
-"decompress_mbps": 390.61
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 3,
-"out_size": 19234937,
-"ratio": 0.3755,
-"compress_mbps": null,
-"decompress_mbps": 721.99
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 3,
-"out_size": 19234937,
-"ratio": 0.3755,
-"compress_mbps": null,
-"decompress_mbps": 19245.67
-},
-{
-"compressor": "native",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 6,
-"out_size": 18805391,
-"ratio": 0.3671,
-"compress_mbps": null,
-"decompress_mbps": 135.79
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 6,
-"out_size": 18805391,
-"ratio": 0.3671,
-"compress_mbps": null,
-"decompress_mbps": 376.49
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 6,
-"out_size": 18805391,
-"ratio": 0.3671,
-"compress_mbps": null,
-"decompress_mbps": 405.75
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 6,
-"out_size": 18805391,
-"ratio": 0.3671,
-"compress_mbps": null,
-"decompress_mbps": 750.64
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 6,
-"out_size": 18805391,
-"ratio": 0.3671,
-"compress_mbps": null,
-"decompress_mbps": 19744.6
-},
-{
-"compressor": "native",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 9,
-"out_size": 18713659,
-"ratio": 0.3654,
-"compress_mbps": null,
-"decompress_mbps": 139.42
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 9,
-"out_size": 18713659,
-"ratio": 0.3654,
-"compress_mbps": null,
-"decompress_mbps": 381.58
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 9,
-"out_size": 18713659,
-"ratio": 0.3654,
-"compress_mbps": null,
-"decompress_mbps": 409.84
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 9,
-"out_size": 18713659,
-"ratio": 0.3654,
-"compress_mbps": null,
-"decompress_mbps": 760.07
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 9,
-"out_size": 18713659,
-"ratio": 0.3654,
-"compress_mbps": null,
-"decompress_mbps": 19731.02
-},
-{
-"compressor": "native",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 12,
-"out_size": 18241312,
-"ratio": 0.3561,
-"compress_mbps": null,
-"decompress_mbps": 125.9
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 12,
-"out_size": 18241312,
-"ratio": 0.3561,
-"compress_mbps": null,
-"decompress_mbps": 380.98
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 12,
-"out_size": 18241312,
-"ratio": 0.3561,
-"compress_mbps": null,
-"decompress_mbps": 397.0
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 12,
-"out_size": 18241312,
-"ratio": 0.3561,
-"compress_mbps": null,
-"decompress_mbps": 742.04
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 12,
-"out_size": 18241312,
-"ratio": 0.3561,
-"compress_mbps": null,
-"decompress_mbps": 19790.26
-},
-{
-"compressor": "native",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 1,
-"out_size": 3740775,
-"ratio": 0.3752,
-"compress_mbps": null,
-"decompress_mbps": 137.25
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 1,
-"out_size": 3740775,
-"ratio": 0.3752,
-"compress_mbps": null,
-"decompress_mbps": 445.75
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 1,
-"out_size": 3740775,
-"ratio": 0.3752,
-"compress_mbps": null,
-"decompress_mbps": 537.11
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 1,
-"out_size": 3740775,
-"ratio": 0.3752,
-"compress_mbps": null,
-"decompress_mbps": 846.26
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 1,
-"out_size": 3740775,
-"ratio": 0.3752,
-"compress_mbps": null,
-"decompress_mbps": 41043.32
-},
-{
-"compressor": "native",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 3,
-"out_size": 3672389,
-"ratio": 0.3683,
-"compress_mbps": null,
-"decompress_mbps": 145.95
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 3,
-"out_size": 3672389,
-"ratio": 0.3683,
-"compress_mbps": null,
-"decompress_mbps": 453.49
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 3,
-"out_size": 3672389,
-"ratio": 0.3683,
-"compress_mbps": null,
-"decompress_mbps": 535.77
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 3,
-"out_size": 3672389,
-"ratio": 0.3683,
-"compress_mbps": null,
-"decompress_mbps": 889.89
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 3,
-"out_size": 3672389,
-"ratio": 0.3683,
-"compress_mbps": null,
-"decompress_mbps": 55821.06
-},
-{
-"compressor": "native",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 6,
-"out_size": 3648644,
-"ratio": 0.3659,
-"compress_mbps": null,
-"decompress_mbps": 159.91
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 6,
-"out_size": 3648644,
-"ratio": 0.3659,
-"compress_mbps": null,
-"decompress_mbps": 445.91
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 6,
-"out_size": 3648644,
-"ratio": 0.3659,
-"compress_mbps": null,
-"decompress_mbps": 533.61
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 6,
-"out_size": 3648644,
-"ratio": 0.3659,
-"compress_mbps": null,
-"decompress_mbps": 912.36
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 6,
-"out_size": 3648644,
-"ratio": 0.3659,
-"compress_mbps": null,
-"decompress_mbps": 57953.9
-},
-{
-"compressor": "native",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 9,
-"out_size": 3625176,
-"ratio": 0.3636,
-"compress_mbps": null,
-"decompress_mbps": 163.42
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 9,
-"out_size": 3625176,
-"ratio": 0.3636,
-"compress_mbps": null,
-"decompress_mbps": 452.28
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 9,
-"out_size": 3625176,
-"ratio": 0.3636,
-"compress_mbps": null,
-"decompress_mbps": 521.07
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 9,
-"out_size": 3625176,
-"ratio": 0.3636,
-"compress_mbps": null,
-"decompress_mbps": 904.02
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 9,
-"out_size": 3625176,
-"ratio": 0.3636,
-"compress_mbps": null,
-"decompress_mbps": 36113.45
-},
-{
-"compressor": "native",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 12,
-"out_size": 3447985,
-"ratio": 0.3458,
-"compress_mbps": null,
-"decompress_mbps": 154.79
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 12,
-"out_size": 3447985,
-"ratio": 0.3458,
-"compress_mbps": null,
-"decompress_mbps": 484.53
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 12,
-"out_size": 3447985,
-"ratio": 0.3458,
-"compress_mbps": null,
-"decompress_mbps": 521.27
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 12,
-"out_size": 3447985,
-"ratio": 0.3458,
-"compress_mbps": null,
-"decompress_mbps": 902.55
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 12,
-"out_size": 3447985,
-"ratio": 0.3458,
-"compress_mbps": null,
-"decompress_mbps": 36437.83
-},
-{
-"compressor": "native",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 1,
-"out_size": 3837577,
-"ratio": 0.1144,
-"compress_mbps": null,
-"decompress_mbps": 379.2
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 1,
-"out_size": 3837577,
-"ratio": 0.1144,
-"compress_mbps": null,
-"decompress_mbps": 874.36
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 1,
-"out_size": 3837577,
-"ratio": 0.1144,
-"compress_mbps": null,
-"decompress_mbps": 857.94
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 1,
-"out_size": 3837577,
-"ratio": 0.1144,
-"compress_mbps": null,
-"decompress_mbps": 1783.26
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 1,
-"out_size": 3837577,
-"ratio": 0.1144,
-"compress_mbps": null,
-"decompress_mbps": 19092.03
-},
-{
-"compressor": "native",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 3,
-"out_size": 3599455,
-"ratio": 0.1073,
-"compress_mbps": null,
-"decompress_mbps": 441.16
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 3,
-"out_size": 3599455,
-"ratio": 0.1073,
-"compress_mbps": null,
-"decompress_mbps": 950.96
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 3,
-"out_size": 3599455,
-"ratio": 0.1073,
-"compress_mbps": null,
-"decompress_mbps": 923.7
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 3,
-"out_size": 3599455,
-"ratio": 0.1073,
-"compress_mbps": null,
-"decompress_mbps": 1832.92
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 3,
-"out_size": 3599455,
-"ratio": 0.1073,
-"compress_mbps": null,
-"decompress_mbps": 20578.25
-},
-{
-"compressor": "native",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 6,
-"out_size": 3091741,
-"ratio": 0.0921,
-"compress_mbps": null,
-"decompress_mbps": 550.93
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 6,
-"out_size": 3091741,
-"ratio": 0.0921,
-"compress_mbps": null,
-"decompress_mbps": 1050.51
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 6,
-"out_size": 3091741,
-"ratio": 0.0921,
-"compress_mbps": null,
-"decompress_mbps": 1064.27
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 6,
-"out_size": 3091741,
-"ratio": 0.0921,
-"compress_mbps": null,
-"decompress_mbps": 1891.98
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 6,
-"out_size": 3091741,
-"ratio": 0.0921,
-"compress_mbps": null,
-"decompress_mbps": 19343.07
-},
-{
-"compressor": "native",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 9,
-"out_size": 2925243,
-"ratio": 0.0872,
-"compress_mbps": null,
-"decompress_mbps": 628.5
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 9,
-"out_size": 2925243,
-"ratio": 0.0872,
-"compress_mbps": null,
-"decompress_mbps": 1112.33
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 9,
-"out_size": 2925243,
-"ratio": 0.0872,
-"compress_mbps": null,
-"decompress_mbps": 1123.8
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 9,
-"out_size": 2925243,
-"ratio": 0.0872,
-"compress_mbps": null,
-"decompress_mbps": 1961.55
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 9,
-"out_size": 2925243,
-"ratio": 0.0872,
-"compress_mbps": null,
-"decompress_mbps": 20130.69
-},
-{
-"compressor": "native",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 12,
-"out_size": 2748273,
-"ratio": 0.0819,
-"compress_mbps": null,
-"decompress_mbps": 582.9
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 12,
-"out_size": 2748273,
-"ratio": 0.0819,
-"compress_mbps": null,
-"decompress_mbps": 1126.1
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 12,
-"out_size": 2748273,
-"ratio": 0.0819,
-"compress_mbps": null,
-"decompress_mbps": 1119.9
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 12,
-"out_size": 2748273,
-"ratio": 0.0819,
-"compress_mbps": null,
-"decompress_mbps": 1939.26
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 12,
-"out_size": 2748273,
-"ratio": 0.0819,
-"compress_mbps": null,
-"decompress_mbps": 19807.23
-},
-{
-"compressor": "native",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 1,
-"out_size": 3275124,
-"ratio": 0.5324,
-"compress_mbps": null,
-"decompress_mbps": 126.85
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 1,
-"out_size": 3275124,
-"ratio": 0.5324,
-"compress_mbps": null,
-"decompress_mbps": 284.13
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 1,
-"out_size": 3275124,
-"ratio": 0.5324,
-"compress_mbps": null,
-"decompress_mbps": 361.41
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 1,
-"out_size": 3275124,
-"ratio": 0.5324,
-"compress_mbps": null,
-"decompress_mbps": 581.81
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 1,
-"out_size": 3275124,
-"ratio": 0.5324,
-"compress_mbps": null,
-"decompress_mbps": 49702.97
-},
-{
-"compressor": "native",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 3,
-"out_size": 3137061,
-"ratio": 0.5099,
-"compress_mbps": null,
-"decompress_mbps": 112.07
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 3,
-"out_size": 3137061,
-"ratio": 0.5099,
-"compress_mbps": null,
-"decompress_mbps": 277.11
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 3,
-"out_size": 3137061,
-"ratio": 0.5099,
-"compress_mbps": null,
-"decompress_mbps": 321.72
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 3,
-"out_size": 3137061,
-"ratio": 0.5099,
-"compress_mbps": null,
-"decompress_mbps": 552.65
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 3,
-"out_size": 3137061,
-"ratio": 0.5099,
-"compress_mbps": null,
-"decompress_mbps": 63123.33
-},
-{
-"compressor": "native",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 6,
-"out_size": 3072378,
-"ratio": 0.4994,
-"compress_mbps": null,
-"decompress_mbps": 119.23
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 6,
-"out_size": 3072378,
-"ratio": 0.4994,
-"compress_mbps": null,
-"decompress_mbps": 280.48
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 6,
-"out_size": 3072378,
-"ratio": 0.4994,
-"compress_mbps": null,
-"decompress_mbps": 331.89
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 6,
-"out_size": 3072378,
-"ratio": 0.4994,
-"compress_mbps": null,
-"decompress_mbps": 572.84
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 6,
-"out_size": 3072378,
-"ratio": 0.4994,
-"compress_mbps": null,
-"decompress_mbps": 63056.17
-},
-{
-"compressor": "native",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 9,
-"out_size": 3066968,
-"ratio": 0.4985,
-"compress_mbps": null,
-"decompress_mbps": 123.03
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 9,
-"out_size": 3066968,
-"ratio": 0.4985,
-"compress_mbps": null,
-"decompress_mbps": 282.99
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 9,
-"out_size": 3066968,
-"ratio": 0.4985,
-"compress_mbps": null,
-"decompress_mbps": 339.66
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 9,
-"out_size": 3066968,
-"ratio": 0.4985,
-"compress_mbps": null,
-"decompress_mbps": 583.56
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 9,
-"out_size": 3066968,
-"ratio": 0.4985,
-"compress_mbps": null,
-"decompress_mbps": 60259.72
-},
-{
-"compressor": "native",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 12,
-"out_size": 2994086,
-"ratio": 0.4867,
-"compress_mbps": null,
-"decompress_mbps": 112.06
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 12,
-"out_size": 2994086,
-"ratio": 0.4867,
-"compress_mbps": null,
-"decompress_mbps": 275.89
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 12,
-"out_size": 2994086,
-"ratio": 0.4867,
-"compress_mbps": null,
-"decompress_mbps": 315.31
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 12,
-"out_size": 2994086,
-"ratio": 0.4867,
-"compress_mbps": null,
-"decompress_mbps": 562.11
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 12,
-"out_size": 2994086,
-"ratio": 0.4867,
-"compress_mbps": null,
-"decompress_mbps": 62337.97
-},
-{
-"compressor": "native",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 1,
-"out_size": 3868663,
-"ratio": 0.3836,
-"compress_mbps": null,
-"decompress_mbps": 189.81
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 1,
-"out_size": 3868663,
-"ratio": 0.3836,
-"compress_mbps": null,
-"decompress_mbps": 516.11
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 1,
-"out_size": 3868663,
-"ratio": 0.3836,
-"compress_mbps": null,
-"decompress_mbps": 622.32
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 1,
-"out_size": 3868663,
-"ratio": 0.3836,
-"compress_mbps": null,
-"decompress_mbps": 1047.11
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 1,
-"out_size": 3868663,
-"ratio": 0.3836,
-"compress_mbps": null,
-"decompress_mbps": 53913.91
-},
-{
-"compressor": "native",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 3,
-"out_size": 3818964,
-"ratio": 0.3787,
-"compress_mbps": null,
-"decompress_mbps": 225.46
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 3,
-"out_size": 3818964,
-"ratio": 0.3787,
-"compress_mbps": null,
-"decompress_mbps": 541.29
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 3,
-"out_size": 3818964,
-"ratio": 0.3787,
-"compress_mbps": null,
-"decompress_mbps": 624.18
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 3,
-"out_size": 3818964,
-"ratio": 0.3787,
-"compress_mbps": null,
-"decompress_mbps": 1101.24
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 3,
-"out_size": 3818964,
-"ratio": 0.3787,
-"compress_mbps": null,
-"decompress_mbps": 55576.82
-},
-{
-"compressor": "native",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 6,
-"out_size": 3660266,
-"ratio": 0.3629,
-"compress_mbps": null,
-"decompress_mbps": 248.35
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 6,
-"out_size": 3660266,
-"ratio": 0.3629,
-"compress_mbps": null,
-"decompress_mbps": 548.67
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 6,
-"out_size": 3660266,
-"ratio": 0.3629,
-"compress_mbps": null,
-"decompress_mbps": 671.03
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 6,
-"out_size": 3660266,
-"ratio": 0.3629,
-"compress_mbps": null,
-"decompress_mbps": 1126.28
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 6,
-"out_size": 3660266,
-"ratio": 0.3629,
-"compress_mbps": null,
-"decompress_mbps": 53055.94
-},
-{
-"compressor": "native",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 9,
-"out_size": 3654860,
-"ratio": 0.3624,
-"compress_mbps": null,
-"decompress_mbps": 251.11
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 9,
-"out_size": 3654860,
-"ratio": 0.3624,
-"compress_mbps": null,
-"decompress_mbps": 547.87
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 9,
-"out_size": 3654860,
-"ratio": 0.3624,
-"compress_mbps": null,
-"decompress_mbps": 670.97
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 9,
-"out_size": 3654860,
-"ratio": 0.3624,
-"compress_mbps": null,
-"decompress_mbps": 1117.62
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 9,
-"out_size": 3654860,
-"ratio": 0.3624,
-"compress_mbps": null,
-"decompress_mbps": 44988.74
-},
-{
-"compressor": "native",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 12,
-"out_size": 3608138,
-"ratio": 0.3577,
-"compress_mbps": null,
-"decompress_mbps": 243.51
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 12,
-"out_size": 3608138,
-"ratio": 0.3577,
-"compress_mbps": null,
-"decompress_mbps": 551.4
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 12,
-"out_size": 3608138,
-"ratio": 0.3577,
-"compress_mbps": null,
-"decompress_mbps": 668.75
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 12,
-"out_size": 3608138,
-"ratio": 0.3577,
-"compress_mbps": null,
-"decompress_mbps": 1111.85
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 12,
-"out_size": 3608138,
-"ratio": 0.3577,
-"compress_mbps": null,
-"decompress_mbps": 56859.78
-},
-{
-"compressor": "native",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 1,
-"out_size": 2197055,
-"ratio": 0.3315,
-"compress_mbps": null,
-"decompress_mbps": 141.14
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 1,
-"out_size": 2197055,
-"ratio": 0.3315,
-"compress_mbps": null,
-"decompress_mbps": 430.56
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 1,
-"out_size": 2197055,
-"ratio": 0.3315,
-"compress_mbps": null,
-"decompress_mbps": 534.47
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 1,
-"out_size": 2197055,
-"ratio": 0.3315,
-"compress_mbps": null,
-"decompress_mbps": 1010.71
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 1,
-"out_size": 2197055,
-"ratio": 0.3315,
-"compress_mbps": null,
-"decompress_mbps": 62527.25
-},
-{
-"compressor": "native",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 3,
-"out_size": 2021047,
-"ratio": 0.305,
-"compress_mbps": null,
-"decompress_mbps": 178.69
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 3,
-"out_size": 2021047,
-"ratio": 0.305,
-"compress_mbps": null,
-"decompress_mbps": 464.35
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 3,
-"out_size": 2021047,
-"ratio": 0.305,
-"compress_mbps": null,
-"decompress_mbps": 580.89
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 3,
-"out_size": 2021047,
-"ratio": 0.305,
-"compress_mbps": null,
-"decompress_mbps": 1172.57
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 3,
-"out_size": 2021047,
-"ratio": 0.305,
-"compress_mbps": null,
-"decompress_mbps": 62743.89
-},
-{
-"compressor": "native",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 6,
-"out_size": 1876257,
-"ratio": 0.2831,
-"compress_mbps": null,
-"decompress_mbps": 195.42
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 6,
-"out_size": 1876257,
-"ratio": 0.2831,
-"compress_mbps": null,
-"decompress_mbps": 466.06
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 6,
-"out_size": 1876257,
-"ratio": 0.2831,
-"compress_mbps": null,
-"decompress_mbps": 548.78
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 6,
-"out_size": 1876257,
-"ratio": 0.2831,
-"compress_mbps": null,
-"decompress_mbps": 1073.69
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 6,
-"out_size": 1876257,
-"ratio": 0.2831,
-"compress_mbps": null,
-"decompress_mbps": 60651.53
-},
-{
-"compressor": "native",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 9,
-"out_size": 1806374,
-"ratio": 0.2726,
-"compress_mbps": null,
-"decompress_mbps": 208.83
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 9,
-"out_size": 1806374,
-"ratio": 0.2726,
-"compress_mbps": null,
-"decompress_mbps": 454.78
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 9,
-"out_size": 1806374,
-"ratio": 0.2726,
-"compress_mbps": null,
-"decompress_mbps": 522.68
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 9,
-"out_size": 1806374,
-"ratio": 0.2726,
-"compress_mbps": null,
-"decompress_mbps": 987.45
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 9,
-"out_size": 1806374,
-"ratio": 0.2726,
-"compress_mbps": null,
-"decompress_mbps": 62563.77
-},
-{
-"compressor": "native",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 12,
-"out_size": 1696488,
-"ratio": 0.256,
-"compress_mbps": null,
-"decompress_mbps": 201.14
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 12,
-"out_size": 1696488,
-"ratio": 0.256,
-"compress_mbps": null,
-"decompress_mbps": 533.82
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 12,
-"out_size": 1696488,
-"ratio": 0.256,
-"compress_mbps": null,
-"decompress_mbps": 586.07
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 12,
-"out_size": 1696488,
-"ratio": 0.256,
-"compress_mbps": null,
-"decompress_mbps": 1176.93
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 12,
-"out_size": 1696488,
-"ratio": 0.256,
-"compress_mbps": null,
-"decompress_mbps": 62150.95
-},
-{
-"compressor": "native",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 1,
-"out_size": 5866517,
-"ratio": 0.2715,
-"compress_mbps": null,
-"decompress_mbps": 218.77
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 1,
-"out_size": 5866517,
-"ratio": 0.2715,
-"compress_mbps": null,
-"decompress_mbps": 558.92
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 1,
-"out_size": 5866517,
-"ratio": 0.2715,
-"compress_mbps": null,
-"decompress_mbps": 587.4
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 1,
-"out_size": 5866517,
-"ratio": 0.2715,
-"compress_mbps": null,
-"decompress_mbps": 1086.9
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 1,
-"out_size": 5866517,
-"ratio": 0.2715,
-"compress_mbps": null,
-"decompress_mbps": 18952.59
-},
-{
-"compressor": "native",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 3,
-"out_size": 5605878,
-"ratio": 0.2595,
-"compress_mbps": null,
-"decompress_mbps": 206.89
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 3,
-"out_size": 5605878,
-"ratio": 0.2595,
-"compress_mbps": null,
-"decompress_mbps": 570.72
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 3,
-"out_size": 5605878,
-"ratio": 0.2595,
-"compress_mbps": null,
-"decompress_mbps": 595.75
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 3,
-"out_size": 5605878,
-"ratio": 0.2595,
-"compress_mbps": null,
-"decompress_mbps": 1143.07
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 3,
-"out_size": 5605878,
-"ratio": 0.2595,
-"compress_mbps": null,
-"decompress_mbps": 18575.65
-},
-{
-"compressor": "native",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 6,
-"out_size": 5337149,
-"ratio": 0.247,
-"compress_mbps": null,
-"decompress_mbps": 224.52
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 6,
-"out_size": 5337149,
-"ratio": 0.247,
-"compress_mbps": null,
-"decompress_mbps": 524.34
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 6,
-"out_size": 5337149,
-"ratio": 0.247,
-"compress_mbps": null,
-"decompress_mbps": 531.67
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 6,
-"out_size": 5337149,
-"ratio": 0.247,
-"compress_mbps": null,
-"decompress_mbps": 1119.76
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 6,
-"out_size": 5337149,
-"ratio": 0.247,
-"compress_mbps": null,
-"decompress_mbps": 19690.08
-},
-{
-"compressor": "native",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 9,
-"out_size": 5270405,
-"ratio": 0.2439,
-"compress_mbps": null,
-"decompress_mbps": 234.48
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 9,
-"out_size": 5270405,
-"ratio": 0.2439,
-"compress_mbps": null,
-"decompress_mbps": 526.09
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 9,
-"out_size": 5270405,
-"ratio": 0.2439,
-"compress_mbps": null,
-"decompress_mbps": 534.08
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 9,
-"out_size": 5270405,
-"ratio": 0.2439,
-"compress_mbps": null,
-"decompress_mbps": 1069.59
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 9,
-"out_size": 5270405,
-"ratio": 0.2439,
-"compress_mbps": null,
-"decompress_mbps": 25135.82
-},
-{
-"compressor": "native",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 12,
-"out_size": 5118130,
-"ratio": 0.2369,
-"compress_mbps": null,
-"decompress_mbps": 199.74
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 12,
-"out_size": 5118130,
-"ratio": 0.2369,
-"compress_mbps": null,
-"decompress_mbps": 544.7
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 12,
-"out_size": 5118130,
-"ratio": 0.2369,
-"compress_mbps": null,
-"decompress_mbps": 524.15
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 12,
-"out_size": 5118130,
-"ratio": 0.2369,
-"compress_mbps": null,
-"decompress_mbps": 1079.34
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 12,
-"out_size": 5118130,
-"ratio": 0.2369,
-"compress_mbps": null,
-"decompress_mbps": 18171.25
-},
-{
-"compressor": "native",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 1,
-"out_size": 5575128,
-"ratio": 0.7688,
-"compress_mbps": null,
-"decompress_mbps": 129.24
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 1,
-"out_size": 5575128,
-"ratio": 0.7688,
-"compress_mbps": null,
-"decompress_mbps": 376.41
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 1,
-"out_size": 5575128,
-"ratio": 0.7688,
-"compress_mbps": null,
-"decompress_mbps": 392.2
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 1,
-"out_size": 5575128,
-"ratio": 0.7688,
-"compress_mbps": null,
-"decompress_mbps": 581.05
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 1,
-"out_size": 5575128,
-"ratio": 0.7688,
-"compress_mbps": null,
-"decompress_mbps": 54864.45
-},
-{
-"compressor": "native",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 3,
-"out_size": 5397999,
-"ratio": 0.7444,
-"compress_mbps": null,
-"decompress_mbps": 137.46
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 3,
-"out_size": 5397999,
-"ratio": 0.7444,
-"compress_mbps": null,
-"decompress_mbps": 377.0
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 3,
-"out_size": 5397999,
-"ratio": 0.7444,
-"compress_mbps": null,
-"decompress_mbps": 389.27
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 3,
-"out_size": 5397999,
-"ratio": 0.7444,
-"compress_mbps": null,
-"decompress_mbps": 578.18
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 3,
-"out_size": 5397999,
-"ratio": 0.7444,
-"compress_mbps": null,
-"decompress_mbps": 61774.2
-},
-{
-"compressor": "native",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 6,
-"out_size": 5335405,
-"ratio": 0.7357,
-"compress_mbps": null,
-"decompress_mbps": 145.82
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 6,
-"out_size": 5335405,
-"ratio": 0.7357,
-"compress_mbps": null,
-"decompress_mbps": 374.09
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 6,
-"out_size": 5335405,
-"ratio": 0.7357,
-"compress_mbps": null,
-"decompress_mbps": 383.08
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 6,
-"out_size": 5335405,
-"ratio": 0.7357,
-"compress_mbps": null,
-"decompress_mbps": 565.94
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 6,
-"out_size": 5335405,
-"ratio": 0.7357,
-"compress_mbps": null,
-"decompress_mbps": 61647.56
-},
-{
-"compressor": "native",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 9,
-"out_size": 5323197,
-"ratio": 0.734,
-"compress_mbps": null,
-"decompress_mbps": 146.7
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 9,
-"out_size": 5323197,
-"ratio": 0.734,
-"compress_mbps": null,
-"decompress_mbps": 377.02
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 9,
-"out_size": 5323197,
-"ratio": 0.734,
-"compress_mbps": null,
-"decompress_mbps": 382.94
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 9,
-"out_size": 5323197,
-"ratio": 0.734,
-"compress_mbps": null,
-"decompress_mbps": 567.86
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 9,
-"out_size": 5323197,
-"ratio": 0.734,
-"compress_mbps": null,
-"decompress_mbps": 62040.75
-},
-{
-"compressor": "native",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 12,
-"out_size": 5250745,
-"ratio": 0.724,
-"compress_mbps": null,
-"decompress_mbps": 143.69
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 12,
-"out_size": 5250745,
-"ratio": 0.724,
-"compress_mbps": null,
-"decompress_mbps": 378.32
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 12,
-"out_size": 5250745,
-"ratio": 0.724,
-"compress_mbps": null,
-"decompress_mbps": 390.8
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 12,
-"out_size": 5250745,
-"ratio": 0.724,
-"compress_mbps": null,
-"decompress_mbps": 585.62
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 12,
-"out_size": 5250745,
-"ratio": 0.724,
-"compress_mbps": null,
-"decompress_mbps": 61979.04
-},
-{
-"compressor": "native",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 1,
-"out_size": 13550569,
-"ratio": 0.3268,
-"compress_mbps": null,
-"decompress_mbps": 157.72
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 1,
-"out_size": 13550569,
-"ratio": 0.3268,
-"compress_mbps": null,
-"decompress_mbps": 387.87
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 1,
-"out_size": 13550569,
-"ratio": 0.3268,
-"compress_mbps": null,
-"decompress_mbps": 436.93
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 1,
-"out_size": 13550569,
-"ratio": 0.3268,
-"compress_mbps": null,
-"decompress_mbps": 841.6
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 1,
-"out_size": 13550569,
-"ratio": 0.3268,
-"compress_mbps": null,
-"decompress_mbps": 19682.67
-},
-{
-"compressor": "native",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 3,
-"out_size": 12839361,
-"ratio": 0.3097,
-"compress_mbps": null,
-"decompress_mbps": 185.53
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 3,
-"out_size": 12839361,
-"ratio": 0.3097,
-"compress_mbps": null,
-"decompress_mbps": 398.22
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 3,
-"out_size": 12839361,
-"ratio": 0.3097,
-"compress_mbps": null,
-"decompress_mbps": 465.01
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 3,
-"out_size": 12839361,
-"ratio": 0.3097,
-"compress_mbps": null,
-"decompress_mbps": 910.81
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 3,
-"out_size": 12839361,
-"ratio": 0.3097,
-"compress_mbps": null,
-"decompress_mbps": 19359.91
-},
-{
-"compressor": "native",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 6,
-"out_size": 12140474,
-"ratio": 0.2928,
-"compress_mbps": null,
-"decompress_mbps": 198.18
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 6,
-"out_size": 12140474,
-"ratio": 0.2928,
-"compress_mbps": null,
-"decompress_mbps": 400.72
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 6,
-"out_size": 12140474,
-"ratio": 0.2928,
-"compress_mbps": null,
-"decompress_mbps": 471.3
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 6,
-"out_size": 12140474,
-"ratio": 0.2928,
-"compress_mbps": null,
-"decompress_mbps": 872.52
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 6,
-"out_size": 12140474,
-"ratio": 0.2928,
-"compress_mbps": null,
-"decompress_mbps": 19408.74
-},
-{
-"compressor": "native",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 9,
-"out_size": 11882496,
-"ratio": 0.2866,
-"compress_mbps": null,
-"decompress_mbps": 204.78
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 9,
-"out_size": 11882496,
-"ratio": 0.2866,
-"compress_mbps": null,
-"decompress_mbps": 401.49
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 9,
-"out_size": 11882496,
-"ratio": 0.2866,
-"compress_mbps": null,
-"decompress_mbps": 465.21
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 9,
-"out_size": 11882496,
-"ratio": 0.2866,
-"compress_mbps": null,
-"decompress_mbps": 841.53
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 9,
-"out_size": 11882496,
-"ratio": 0.2866,
-"compress_mbps": null,
-"decompress_mbps": 19613.54
-},
-{
-"compressor": "native",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 12,
-"out_size": 11520871,
-"ratio": 0.2779,
-"compress_mbps": null,
-"decompress_mbps": 201.58
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 12,
-"out_size": 11520871,
-"ratio": 0.2779,
-"compress_mbps": null,
-"decompress_mbps": 420.5
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 12,
-"out_size": 11520871,
-"ratio": 0.2779,
-"compress_mbps": null,
-"decompress_mbps": 485.62
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 12,
-"out_size": 11520871,
-"ratio": 0.2779,
-"compress_mbps": null,
-"decompress_mbps": 886.23
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 12,
-"out_size": 11520871,
-"ratio": 0.2779,
-"compress_mbps": null,
-"decompress_mbps": 19508.19
-},
-{
-"compressor": "native",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 1,
-"out_size": 6293390,
-"ratio": 0.7426,
-"compress_mbps": null,
-"decompress_mbps": 139.21
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 1,
-"out_size": 6293390,
-"ratio": 0.7426,
-"compress_mbps": null,
-"decompress_mbps": 328.26
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 1,
-"out_size": 6293390,
-"ratio": 0.7426,
-"compress_mbps": null,
-"decompress_mbps": 351.89
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 1,
-"out_size": 6293390,
-"ratio": 0.7426,
-"compress_mbps": null,
-"decompress_mbps": 507.33
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 1,
-"out_size": 6293390,
-"ratio": 0.7426,
-"compress_mbps": null,
-"decompress_mbps": 42407.41
-},
-{
-"compressor": "native",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 3,
-"out_size": 6058381,
-"ratio": 0.7149,
-"compress_mbps": null,
-"decompress_mbps": 93.93
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 3,
-"out_size": 6058381,
-"ratio": 0.7149,
-"compress_mbps": null,
-"decompress_mbps": 274.68
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 3,
-"out_size": 6058381,
-"ratio": 0.7149,
-"compress_mbps": null,
-"decompress_mbps": 293.49
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 3,
-"out_size": 6058381,
-"ratio": 0.7149,
-"compress_mbps": null,
-"decompress_mbps": 467.2
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 3,
-"out_size": 6058381,
-"ratio": 0.7149,
-"compress_mbps": null,
-"decompress_mbps": 60064.85
-},
-{
-"compressor": "native",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 6,
-"out_size": 5998438,
-"ratio": 0.7078,
-"compress_mbps": null,
-"decompress_mbps": 96.96
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 6,
-"out_size": 5998438,
-"ratio": 0.7078,
-"compress_mbps": null,
-"decompress_mbps": 316.46
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 6,
-"out_size": 5998438,
-"ratio": 0.7078,
-"compress_mbps": null,
-"decompress_mbps": 311.96
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 6,
-"out_size": 5998438,
-"ratio": 0.7078,
-"compress_mbps": null,
-"decompress_mbps": 519.37
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 6,
-"out_size": 5998438,
-"ratio": 0.7078,
-"compress_mbps": null,
-"decompress_mbps": 58898.68
-},
-{
-"compressor": "native",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 9,
-"out_size": 5986859,
-"ratio": 0.7065,
-"compress_mbps": null,
-"decompress_mbps": 98.57
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 9,
-"out_size": 5986859,
-"ratio": 0.7065,
-"compress_mbps": null,
-"decompress_mbps": 311.05
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 9,
-"out_size": 5986859,
-"ratio": 0.7065,
-"compress_mbps": null,
-"decompress_mbps": 303.89
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 9,
-"out_size": 5986859,
-"ratio": 0.7065,
-"compress_mbps": null,
-"decompress_mbps": 507.18
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 9,
-"out_size": 5986859,
-"ratio": 0.7065,
-"compress_mbps": null,
-"decompress_mbps": 37749.44
-},
-{
-"compressor": "native",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 12,
-"out_size": 5747146,
-"ratio": 0.6782,
-"compress_mbps": null,
-"decompress_mbps": 90.01
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 12,
-"out_size": 5747146,
-"ratio": 0.6782,
-"compress_mbps": null,
-"decompress_mbps": 297.0
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 12,
-"out_size": 5747146,
-"ratio": 0.6782,
-"compress_mbps": null,
-"decompress_mbps": 323.41
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 12,
-"out_size": 5747146,
-"ratio": 0.6782,
-"compress_mbps": null,
-"decompress_mbps": 563.85
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 12,
-"out_size": 5747146,
-"ratio": 0.6782,
-"compress_mbps": null,
-"decompress_mbps": 47628.58
-},
-{
-"compressor": "native",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 1,
-"out_size": 887708,
-"ratio": 0.1661,
-"compress_mbps": null,
-"decompress_mbps": 272.32
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 1,
-"out_size": 887708,
-"ratio": 0.1661,
-"compress_mbps": null,
-"decompress_mbps": 757.67
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 1,
-"out_size": 887708,
-"ratio": 0.1661,
-"compress_mbps": null,
-"decompress_mbps": 903.86
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 1,
-"out_size": 887708,
-"ratio": 0.1661,
-"compress_mbps": null,
-"decompress_mbps": 1656.23
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 1,
-"out_size": 887708,
-"ratio": 0.1661,
-"compress_mbps": null,
-"decompress_mbps": 64455.5
-},
-{
-"compressor": "native",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 3,
-"out_size": 793388,
-"ratio": 0.1484,
-"compress_mbps": null,
-"decompress_mbps": 345.08
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 3,
-"out_size": 793388,
-"ratio": 0.1484,
-"compress_mbps": null,
-"decompress_mbps": 848.53
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 3,
-"out_size": 793388,
-"ratio": 0.1484,
-"compress_mbps": null,
-"decompress_mbps": 1067.3
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 3,
-"out_size": 793388,
-"ratio": 0.1484,
-"compress_mbps": null,
-"decompress_mbps": 1811.22
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 3,
-"out_size": 793388,
-"ratio": 0.1484,
-"compress_mbps": null,
-"decompress_mbps": 64949.88
-},
-{
-"compressor": "native",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 6,
-"out_size": 684405,
-"ratio": 0.128,
-"compress_mbps": null,
-"decompress_mbps": 402.52
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 6,
-"out_size": 684405,
-"ratio": 0.128,
-"compress_mbps": null,
-"decompress_mbps": 934.41
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 6,
-"out_size": 684405,
-"ratio": 0.128,
-"compress_mbps": null,
-"decompress_mbps": 1187.45
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 6,
-"out_size": 684405,
-"ratio": 0.128,
-"compress_mbps": null,
-"decompress_mbps": 1810.06
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 6,
-"out_size": 684405,
-"ratio": 0.128,
-"compress_mbps": null,
-"decompress_mbps": 64874.66
-},
-{
-"compressor": "native",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 9,
-"out_size": 649494,
-"ratio": 0.1215,
-"compress_mbps": null,
-"decompress_mbps": 430.31
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 9,
-"out_size": 649494,
-"ratio": 0.1215,
-"compress_mbps": null,
-"decompress_mbps": 978.15
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 9,
-"out_size": 649494,
-"ratio": 0.1215,
-"compress_mbps": null,
-"decompress_mbps": 1208.02
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 9,
-"out_size": 649494,
-"ratio": 0.1215,
-"compress_mbps": null,
-"decompress_mbps": 1808.3
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 9,
-"out_size": 649494,
-"ratio": 0.1215,
-"compress_mbps": null,
-"decompress_mbps": 64529.74
-},
-{
-"compressor": "native",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 12,
-"out_size": 629349,
-"ratio": 0.1177,
-"compress_mbps": null,
-"decompress_mbps": 403.04
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 12,
-"out_size": 629349,
-"ratio": 0.1177,
-"compress_mbps": null,
-"decompress_mbps": 1002.47
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 12,
-"out_size": 629349,
-"ratio": 0.1177,
-"compress_mbps": null,
-"decompress_mbps": 1206.09
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 12,
-"out_size": 629349,
-"ratio": 0.1177,
-"compress_mbps": null,
-"decompress_mbps": 1861.15
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 12,
-"out_size": 629349,
-"ratio": 0.1177,
-"compress_mbps": null,
-"decompress_mbps": 52967.06
-},
-{
-"compressor": "go",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 1,
-"out_size": 4217525,
-"ratio": 0.4138,
-"compress_mbps": null,
-"decompress_mbps": 193.18
-},
-{
-"compressor": "go",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 12,
-"out_size": 3679105,
-"ratio": 0.361,
-"compress_mbps": null,
-"decompress_mbps": 222.38
-},
-{
-"compressor": "go",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 3,
-"out_size": 3989875,
-"ratio": 0.3915,
-"compress_mbps": null,
-"decompress_mbps": 211.53
-},
-{
-"compressor": "go",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 6,
-"out_size": 3859436,
-"ratio": 0.3787,
-"compress_mbps": null,
-"decompress_mbps": 207.41
-},
-{
-"compressor": "go",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 9,
-"out_size": 3810354,
-"ratio": 0.3738,
-"compress_mbps": null,
-"decompress_mbps": 206.33
-},
-{
-"compressor": "go",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 1,
-"out_size": 20192961,
-"ratio": 0.3942,
-"compress_mbps": null,
-"decompress_mbps": 238.5
-},
-{
-"compressor": "go",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 12,
-"out_size": 18241312,
-"ratio": 0.3561,
-"compress_mbps": null,
-"decompress_mbps": 231.85
-},
-{
-"compressor": "go",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 3,
-"out_size": 19234937,
-"ratio": 0.3755,
-"compress_mbps": null,
-"decompress_mbps": 227.07
-},
-{
-"compressor": "go",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 6,
-"out_size": 18805391,
-"ratio": 0.3671,
-"compress_mbps": null,
-"decompress_mbps": 232.67
-},
-{
-"compressor": "go",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 9,
-"out_size": 18713659,
-"ratio": 0.3654,
-"compress_mbps": null,
-"decompress_mbps": 237.74
-},
-{
-"compressor": "go",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 1,
-"out_size": 3740775,
-"ratio": 0.3752,
-"compress_mbps": null,
-"decompress_mbps": 234.99
-},
-{
-"compressor": "go",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 12,
-"out_size": 3447985,
-"ratio": 0.3458,
-"compress_mbps": null,
-"decompress_mbps": 239
-},
-{
-"compressor": "go",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 3,
-"out_size": 3672389,
-"ratio": 0.3683,
-"compress_mbps": null,
-"decompress_mbps": 228.73
-},
-{
-"compressor": "go",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 6,
-"out_size": 3648644,
-"ratio": 0.3659,
-"compress_mbps": null,
-"decompress_mbps": 233.28
-},
-{
-"compressor": "go",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 9,
-"out_size": 3625176,
-"ratio": 0.3636,
-"compress_mbps": null,
-"decompress_mbps": 232.5
-},
-{
-"compressor": "go",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 1,
-"out_size": 3837577,
-"ratio": 0.1144,
-"compress_mbps": null,
-"decompress_mbps": 558.1
-},
-{
-"compressor": "go",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 12,
-"out_size": 2748273,
-"ratio": 0.0819,
-"compress_mbps": null,
-"decompress_mbps": 806.01
-},
-{
-"compressor": "go",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 3,
-"out_size": 3599455,
-"ratio": 0.1073,
-"compress_mbps": null,
-"decompress_mbps": 589.23
-},
-{
-"compressor": "go",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 6,
-"out_size": 3091741,
-"ratio": 0.0921,
-"compress_mbps": null,
-"decompress_mbps": 681.12
-},
-{
-"compressor": "go",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 9,
-"out_size": 2925243,
-"ratio": 0.0872,
-"compress_mbps": null,
-"decompress_mbps": 806.12
-},
-{
-"compressor": "go",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 1,
-"out_size": 3275124,
-"ratio": 0.5324,
-"compress_mbps": null,
-"decompress_mbps": 169.98
-},
-{
-"compressor": "go",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 12,
-"out_size": 2994086,
-"ratio": 0.4867,
-"compress_mbps": null,
-"decompress_mbps": 162.31
-},
-{
-"compressor": "go",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 3,
-"out_size": 3137061,
-"ratio": 0.5099,
-"compress_mbps": null,
-"decompress_mbps": 160.56
-},
-{
-"compressor": "go",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 6,
-"out_size": 3072378,
-"ratio": 0.4994,
-"compress_mbps": null,
-"decompress_mbps": 167.99
-},
-{
-"compressor": "go",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 9,
-"out_size": 3066968,
-"ratio": 0.4985,
-"compress_mbps": null,
-"decompress_mbps": 170.43
-},
-{
-"compressor": "go",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 1,
-"out_size": 3868663,
-"ratio": 0.3836,
-"compress_mbps": null,
-"decompress_mbps": 256.05
-},
-{
-"compressor": "go",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 12,
-"out_size": 3608138,
-"ratio": 0.3577,
-"compress_mbps": null,
-"decompress_mbps": 274.68
-},
-{
-"compressor": "go",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 3,
-"out_size": 3818964,
-"ratio": 0.3787,
-"compress_mbps": null,
-"decompress_mbps": 272.57
-},
-{
-"compressor": "go",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 6,
-"out_size": 3660266,
-"ratio": 0.3629,
-"compress_mbps": null,
-"decompress_mbps": 269.24
-},
-{
-"compressor": "go",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 9,
-"out_size": 3654860,
-"ratio": 0.3624,
-"compress_mbps": null,
-"decompress_mbps": 271.4
-},
-{
-"compressor": "go",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 1,
-"out_size": 2197055,
-"ratio": 0.3315,
-"compress_mbps": null,
-"decompress_mbps": 228.21
-},
-{
-"compressor": "go",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 12,
-"out_size": 1696488,
-"ratio": 0.256,
-"compress_mbps": null,
-"decompress_mbps": 284.67
-},
-{
-"compressor": "go",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 3,
-"out_size": 2021047,
-"ratio": 0.305,
-"compress_mbps": null,
-"decompress_mbps": 259.33
-},
-{
-"compressor": "go",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 6,
-"out_size": 1876257,
-"ratio": 0.2831,
-"compress_mbps": null,
-"decompress_mbps": 278.68
-},
-{
-"compressor": "go",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 9,
-"out_size": 1806374,
-"ratio": 0.2726,
-"compress_mbps": null,
-"decompress_mbps": 260.47
-},
-{
-"compressor": "go",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 1,
-"out_size": 5866517,
-"ratio": 0.2715,
-"compress_mbps": null,
-"decompress_mbps": 306.44
-},
-{
-"compressor": "go",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 12,
-"out_size": 5118130,
-"ratio": 0.2369,
-"compress_mbps": null,
-"decompress_mbps": 329.17
-},
-{
-"compressor": "go",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 3,
-"out_size": 5605878,
-"ratio": 0.2595,
-"compress_mbps": null,
-"decompress_mbps": 321.14
-},
-{
-"compressor": "go",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 6,
-"out_size": 5337149,
-"ratio": 0.247,
-"compress_mbps": null,
-"decompress_mbps": 326.57
-},
-{
-"compressor": "go",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 9,
-"out_size": 5270405,
-"ratio": 0.2439,
-"compress_mbps": null,
-"decompress_mbps": 333.52
-},
-{
-"compressor": "go",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 1,
-"out_size": 5575128,
-"ratio": 0.7688,
-"compress_mbps": null,
-"decompress_mbps": 184.18
-},
-{
-"compressor": "go",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 12,
-"out_size": 5250745,
-"ratio": 0.724,
-"compress_mbps": null,
-"decompress_mbps": 187.33
-},
-{
-"compressor": "go",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 3,
-"out_size": 5397999,
-"ratio": 0.7444,
-"compress_mbps": null,
-"decompress_mbps": 187.33
-},
-{
-"compressor": "go",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 6,
-"out_size": 5335405,
-"ratio": 0.7357,
-"compress_mbps": null,
-"decompress_mbps": 189.57
-},
-{
-"compressor": "go",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 9,
-"out_size": 5323197,
-"ratio": 0.734,
-"compress_mbps": null,
-"decompress_mbps": 190.6
-},
-{
-"compressor": "go",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 1,
-"out_size": 13550569,
-"ratio": 0.3268,
-"compress_mbps": null,
-"decompress_mbps": 230.55
-},
-{
-"compressor": "go",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 12,
-"out_size": 11520871,
-"ratio": 0.2779,
-"compress_mbps": null,
-"decompress_mbps": 261.07
-},
-{
-"compressor": "go",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 3,
-"out_size": 12839361,
-"ratio": 0.3097,
-"compress_mbps": null,
-"decompress_mbps": 239.46
-},
-{
-"compressor": "go",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 6,
-"out_size": 12140474,
-"ratio": 0.2928,
-"compress_mbps": null,
-"decompress_mbps": 250.32
-},
-{
-"compressor": "go",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 9,
-"out_size": 11882496,
-"ratio": 0.2866,
-"compress_mbps": null,
-"decompress_mbps": 253.35
-},
-{
-"compressor": "go",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 1,
-"out_size": 6293390,
-"ratio": 0.7426,
-"compress_mbps": null,
-"decompress_mbps": 173.81
-},
-{
-"compressor": "go",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 12,
-"out_size": 5747146,
-"ratio": 0.6782,
-"compress_mbps": null,
-"decompress_mbps": 143.3
-},
-{
-"compressor": "go",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 3,
-"out_size": 6058381,
-"ratio": 0.7149,
-"compress_mbps": null,
-"decompress_mbps": 142.12
-},
-{
-"compressor": "go",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 6,
-"out_size": 5998438,
-"ratio": 0.7078,
-"compress_mbps": null,
-"decompress_mbps": 153.91
-},
-{
-"compressor": "go",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 9,
-"out_size": 5986859,
-"ratio": 0.7065,
-"compress_mbps": null,
-"decompress_mbps": 151.08
-},
-{
-"compressor": "go",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 1,
-"out_size": 887708,
-"ratio": 0.1661,
-"compress_mbps": null,
-"decompress_mbps": 447.02
-},
-{
-"compressor": "go",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 12,
-"out_size": 629349,
-"ratio": 0.1177,
-"compress_mbps": null,
-"decompress_mbps": 614.33
-},
-{
-"compressor": "go",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 3,
-"out_size": 793388,
-"ratio": 0.1484,
-"compress_mbps": null,
-"decompress_mbps": 514.94
-},
-{
-"compressor": "go",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 6,
-"out_size": 684405,
-"ratio": 0.128,
-"compress_mbps": null,
-"decompress_mbps": 587.73
-},
-{
-"compressor": "go",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 9,
-"out_size": 649494,
-"ratio": 0.1215,
-"compress_mbps": null,
-"decompress_mbps": 616.6
-},
-{
-"compressor": "zig",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 1,
-"out_size": 4217525,
-"ratio": 0.4138,
-"compress_mbps": null,
-"decompress_mbps": 234.26
-},
-{
-"compressor": "zig",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 12,
-"out_size": 3679105,
-"ratio": 0.361,
-"compress_mbps": null,
-"decompress_mbps": 294.85
-},
-{
-"compressor": "zig",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 3,
-"out_size": 3989875,
-"ratio": 0.3915,
-"compress_mbps": null,
-"decompress_mbps": 276.87
-},
-{
-"compressor": "zig",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 6,
-"out_size": 3859436,
-"ratio": 0.3787,
-"compress_mbps": null,
-"decompress_mbps": 276.67
-},
-{
-"compressor": "zig",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 9,
-"out_size": 3810354,
-"ratio": 0.3738,
-"compress_mbps": null,
-"decompress_mbps": 266.23
-},
-{
-"compressor": "zig",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 1,
-"out_size": 20192961,
-"ratio": 0.3942,
-"compress_mbps": null,
-"decompress_mbps": 237.96
-},
-{
-"compressor": "zig",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 12,
-"out_size": 18241312,
-"ratio": 0.3561,
-"compress_mbps": null,
-"decompress_mbps": 218.61
-},
-{
-"compressor": "zig",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 3,
-"out_size": 19234937,
-"ratio": 0.3755,
-"compress_mbps": null,
-"decompress_mbps": 220.09
-},
-{
-"compressor": "zig",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 6,
-"out_size": 18805391,
-"ratio": 0.3671,
-"compress_mbps": null,
-"decompress_mbps": 229.54
-},
-{
-"compressor": "zig",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 9,
-"out_size": 18713659,
-"ratio": 0.3654,
-"compress_mbps": null,
-"decompress_mbps": 232.43
-},
-{
-"compressor": "zig",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 1,
-"out_size": 3740775,
-"ratio": 0.3752,
-"compress_mbps": null,
-"decompress_mbps": 236.21
-},
-{
-"compressor": "zig",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 12,
-"out_size": 3447985,
-"ratio": 0.3458,
-"compress_mbps": null,
-"decompress_mbps": 271.12
-},
-{
-"compressor": "zig",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 3,
-"out_size": 3672389,
-"ratio": 0.3683,
-"compress_mbps": null,
-"decompress_mbps": 261.49
-},
-{
-"compressor": "zig",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 6,
-"out_size": 3648644,
-"ratio": 0.3659,
-"compress_mbps": null,
-"decompress_mbps": 272.52
-},
-{
-"compressor": "zig",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 9,
-"out_size": 3625176,
-"ratio": 0.3636,
-"compress_mbps": null,
-"decompress_mbps": 271.77
-},
-{
-"compressor": "zig",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 1,
-"out_size": 3837577,
-"ratio": 0.1144,
-"compress_mbps": null,
-"decompress_mbps": 687.46
-},
-{
-"compressor": "zig",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 12,
-"out_size": 2748273,
-"ratio": 0.0819,
-"compress_mbps": null,
-"decompress_mbps": 858.5
-},
-{
-"compressor": "zig",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 3,
-"out_size": 3599455,
-"ratio": 0.1073,
-"compress_mbps": null,
-"decompress_mbps": 754.55
-},
-{
-"compressor": "zig",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 6,
-"out_size": 3091741,
-"ratio": 0.0921,
-"compress_mbps": null,
-"decompress_mbps": 855.42
-},
-{
-"compressor": "zig",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 9,
-"out_size": 2925243,
-"ratio": 0.0872,
-"compress_mbps": null,
-"decompress_mbps": 915.03
-},
-{
-"compressor": "zig",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 1,
-"out_size": 3275124,
-"ratio": 0.5324,
-"compress_mbps": null,
-"decompress_mbps": 177.18
-},
-{
-"compressor": "zig",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 12,
-"out_size": 2994086,
-"ratio": 0.4867,
-"compress_mbps": null,
-"decompress_mbps": 182.73
-},
-{
-"compressor": "zig",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 3,
-"out_size": 3137061,
-"ratio": 0.5099,
-"compress_mbps": null,
-"decompress_mbps": 178.19
-},
-{
-"compressor": "zig",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 6,
-"out_size": 3072378,
-"ratio": 0.4994,
-"compress_mbps": null,
-"decompress_mbps": 186.41
-},
-{
-"compressor": "zig",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 9,
-"out_size": 3066968,
-"ratio": 0.4985,
-"compress_mbps": null,
-"decompress_mbps": 189.24
-},
-{
-"compressor": "zig",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 1,
-"out_size": 3868663,
-"ratio": 0.3836,
-"compress_mbps": null,
-"decompress_mbps": 255.54
-},
-{
-"compressor": "zig",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 12,
-"out_size": 3608138,
-"ratio": 0.3577,
-"compress_mbps": null,
-"decompress_mbps": 293.57
-},
-{
-"compressor": "zig",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 3,
-"out_size": 3818964,
-"ratio": 0.3787,
-"compress_mbps": null,
-"decompress_mbps": 287.69
-},
-{
-"compressor": "zig",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 6,
-"out_size": 3660266,
-"ratio": 0.3629,
-"compress_mbps": null,
-"decompress_mbps": 290.93
-},
-{
-"compressor": "zig",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 9,
-"out_size": 3654860,
-"ratio": 0.3624,
-"compress_mbps": null,
-"decompress_mbps": 291.06
-},
-{
-"compressor": "zig",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 1,
-"out_size": 2197055,
-"ratio": 0.3315,
-"compress_mbps": null,
-"decompress_mbps": 290.11
-},
-{
-"compressor": "zig",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 12,
-"out_size": 1696488,
-"ratio": 0.256,
-"compress_mbps": null,
-"decompress_mbps": 379.91
-},
-{
-"compressor": "zig",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 3,
-"out_size": 2021047,
-"ratio": 0.305,
-"compress_mbps": null,
-"decompress_mbps": 356.83
-},
-{
-"compressor": "zig",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 6,
-"out_size": 1876257,
-"ratio": 0.2831,
-"compress_mbps": null,
-"decompress_mbps": 361.58
-},
-{
-"compressor": "zig",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 9,
-"out_size": 1806374,
-"ratio": 0.2726,
-"compress_mbps": null,
-"decompress_mbps": 352.8
-},
-{
-"compressor": "zig",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 1,
-"out_size": 5866517,
-"ratio": 0.2715,
-"compress_mbps": null,
-"decompress_mbps": 354.81
-},
-{
-"compressor": "zig",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 12,
-"out_size": 5118130,
-"ratio": 0.2369,
-"compress_mbps": null,
-"decompress_mbps": 336.21
-},
-{
-"compressor": "zig",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 3,
-"out_size": 5605878,
-"ratio": 0.2595,
-"compress_mbps": null,
-"decompress_mbps": 345.18
-},
-{
-"compressor": "zig",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 6,
-"out_size": 5337149,
-"ratio": 0.247,
-"compress_mbps": null,
-"decompress_mbps": 366.7
-},
-{
-"compressor": "zig",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 9,
-"out_size": 5270405,
-"ratio": 0.2439,
-"compress_mbps": null,
-"decompress_mbps": 371.81
-},
-{
-"compressor": "zig",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 1,
-"out_size": 5575128,
-"ratio": 0.7688,
-"compress_mbps": null,
-"decompress_mbps": 159.73
-},
-{
-"compressor": "zig",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 12,
-"out_size": 5250745,
-"ratio": 0.724,
-"compress_mbps": null,
-"decompress_mbps": 177.11
-},
-{
-"compressor": "zig",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 3,
-"out_size": 5397999,
-"ratio": 0.7444,
-"compress_mbps": null,
-"decompress_mbps": 173.27
-},
-{
-"compressor": "zig",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 6,
-"out_size": 5335405,
-"ratio": 0.7357,
-"compress_mbps": null,
-"decompress_mbps": 174.67
-},
-{
-"compressor": "zig",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 9,
-"out_size": 5323197,
-"ratio": 0.734,
-"compress_mbps": null,
-"decompress_mbps": 175.68
-},
-{
-"compressor": "zig",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 1,
-"out_size": 13550569,
-"ratio": 0.3268,
-"compress_mbps": null,
-"decompress_mbps": 276.68
-},
-{
-"compressor": "zig",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 12,
-"out_size": 11520871,
-"ratio": 0.2779,
-"compress_mbps": null,
-"decompress_mbps": 335.81
-},
-{
-"compressor": "zig",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 3,
-"out_size": 12839361,
-"ratio": 0.3097,
-"compress_mbps": null,
-"decompress_mbps": 323.61
-},
-{
-"compressor": "zig",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 6,
-"out_size": 12140474,
-"ratio": 0.2928,
-"compress_mbps": null,
-"decompress_mbps": 329.08
-},
-{
-"compressor": "zig",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 9,
-"out_size": 11882496,
-"ratio": 0.2866,
-"compress_mbps": null,
-"decompress_mbps": 327.84
-},
-{
-"compressor": "zig",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 1,
-"out_size": 6293390,
-"ratio": 0.7426,
-"compress_mbps": null,
-"decompress_mbps": 151.36
-},
-{
-"compressor": "zig",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 12,
-"out_size": 5747146,
-"ratio": 0.6782,
-"compress_mbps": null,
-"decompress_mbps": 150.35
-},
-{
-"compressor": "zig",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 3,
-"out_size": 6058381,
-"ratio": 0.7149,
-"compress_mbps": null,
-"decompress_mbps": 144.89
-},
-{
-"compressor": "zig",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 6,
-"out_size": 5998438,
-"ratio": 0.7078,
-"compress_mbps": null,
-"decompress_mbps": 158.82
-},
-{
-"compressor": "zig",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 9,
-"out_size": 5986859,
-"ratio": 0.7065,
-"compress_mbps": null,
-"decompress_mbps": 156.89
-},
-{
-"compressor": "zig",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 1,
-"out_size": 887708,
-"ratio": 0.1661,
-"compress_mbps": null,
-"decompress_mbps": 516.23
-},
-{
-"compressor": "zig",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 12,
-"out_size": 629349,
-"ratio": 0.1177,
-"compress_mbps": null,
-"decompress_mbps": 678.15
-},
-{
-"compressor": "zig",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 3,
-"out_size": 793388,
-"ratio": 0.1484,
-"compress_mbps": null,
-"decompress_mbps": 614.14
-},
-{
-"compressor": "zig",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 6,
-"out_size": 684405,
-"ratio": 0.128,
-"compress_mbps": null,
-"decompress_mbps": 672.85
-},
-{
-"compressor": "zig",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 9,
-"out_size": 649494,
-"ratio": 0.1215,
-"compress_mbps": null,
-"decompress_mbps": 690.32
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 1,
-"out_size": 4217525,
-"ratio": 0.4138,
-"compress_mbps": null,
-"decompress_mbps": 106.82
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 12,
-"out_size": 3679105,
-"ratio": 0.361,
-"compress_mbps": null,
-"decompress_mbps": 120.03
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 3,
-"out_size": 3989875,
-"ratio": 0.3915,
-"compress_mbps": null,
-"decompress_mbps": 114.3
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 6,
-"out_size": 3859436,
-"ratio": 0.3787,
-"compress_mbps": null,
-"decompress_mbps": 112.83
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 9,
-"out_size": 3810354,
-"ratio": 0.3738,
-"compress_mbps": null,
-"decompress_mbps": 112.94
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 1,
-"out_size": 20192961,
-"ratio": 0.3942,
-"compress_mbps": null,
-"decompress_mbps": 124.08
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 12,
-"out_size": 18241312,
-"ratio": 0.3561,
-"compress_mbps": null,
-"decompress_mbps": 115.12
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 3,
-"out_size": 19234937,
-"ratio": 0.3755,
-"compress_mbps": null,
-"decompress_mbps": 114.37
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 6,
-"out_size": 18805391,
-"ratio": 0.3671,
-"compress_mbps": null,
-"decompress_mbps": 121.38
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 9,
-"out_size": 18713659,
-"ratio": 0.3654,
-"compress_mbps": null,
-"decompress_mbps": 122.55
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 1,
-"out_size": 3740775,
-"ratio": 0.3752,
-"compress_mbps": null,
-"decompress_mbps": 138.35
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 12,
-"out_size": 3447985,
-"ratio": 0.3458,
-"compress_mbps": null,
-"decompress_mbps": 130.3
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 3,
-"out_size": 3672389,
-"ratio": 0.3683,
-"compress_mbps": null,
-"decompress_mbps": 134.64
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 6,
-"out_size": 3648644,
-"ratio": 0.3659,
-"compress_mbps": null,
-"decompress_mbps": 134.95
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 9,
-"out_size": 3625176,
-"ratio": 0.3636,
-"compress_mbps": null,
-"decompress_mbps": 133.84
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 1,
-"out_size": 3837577,
-"ratio": 0.1144,
-"compress_mbps": null,
-"decompress_mbps": 206.85
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 12,
-"out_size": 2748273,
-"ratio": 0.0819,
-"compress_mbps": null,
-"decompress_mbps": 234.61
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 3,
-"out_size": 3599455,
-"ratio": 0.1073,
-"compress_mbps": null,
-"decompress_mbps": 222.8
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 6,
-"out_size": 3091741,
-"ratio": 0.0921,
-"compress_mbps": null,
-"decompress_mbps": 234.12
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 9,
-"out_size": 2925243,
-"ratio": 0.0872,
-"compress_mbps": null,
-"decompress_mbps": 229.17
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 1,
-"out_size": 3275124,
-"ratio": 0.5324,
-"compress_mbps": null,
-"decompress_mbps": 107.3
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 12,
-"out_size": 2994086,
-"ratio": 0.4867,
-"compress_mbps": null,
-"decompress_mbps": 97.22
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 3,
-"out_size": 3137061,
-"ratio": 0.5099,
-"compress_mbps": null,
-"decompress_mbps": 97.87
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 6,
-"out_size": 3072378,
-"ratio": 0.4994,
-"compress_mbps": null,
-"decompress_mbps": 101.7
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 9,
-"out_size": 3066968,
-"ratio": 0.4985,
-"compress_mbps": null,
-"decompress_mbps": 103.58
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 1,
-"out_size": 3868663,
-"ratio": 0.3836,
-"compress_mbps": null,
-"decompress_mbps": 148.86
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 12,
-"out_size": 3608138,
-"ratio": 0.3577,
-"compress_mbps": null,
-"decompress_mbps": 151.28
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 3,
-"out_size": 3818964,
-"ratio": 0.3787,
-"compress_mbps": null,
-"decompress_mbps": 149.38
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 6,
-"out_size": 3660266,
-"ratio": 0.3629,
-"compress_mbps": null,
-"decompress_mbps": 151.82
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 9,
-"out_size": 3654860,
-"ratio": 0.3624,
-"compress_mbps": null,
-"decompress_mbps": 152.33
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 1,
-"out_size": 2197055,
-"ratio": 0.3315,
-"compress_mbps": null,
-"decompress_mbps": 126.98
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 12,
-"out_size": 1696488,
-"ratio": 0.256,
-"compress_mbps": null,
-"decompress_mbps": 149.99
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 3,
-"out_size": 2021047,
-"ratio": 0.305,
-"compress_mbps": null,
-"decompress_mbps": 135.97
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 6,
-"out_size": 1876257,
-"ratio": 0.2831,
-"compress_mbps": null,
-"decompress_mbps": 136.74
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 9,
-"out_size": 1806374,
-"ratio": 0.2726,
-"compress_mbps": null,
-"decompress_mbps": 139.34
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 1,
-"out_size": 5866517,
-"ratio": 0.2715,
-"compress_mbps": null,
-"decompress_mbps": 156.49
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 12,
-"out_size": 5118130,
-"ratio": 0.2369,
-"compress_mbps": null,
-"decompress_mbps": 154.0
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 3,
-"out_size": 5605878,
-"ratio": 0.2595,
-"compress_mbps": null,
-"decompress_mbps": 153.12
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 6,
-"out_size": 5337149,
-"ratio": 0.247,
-"compress_mbps": null,
-"decompress_mbps": 156.34
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 9,
-"out_size": 5270405,
-"ratio": 0.2439,
-"compress_mbps": null,
-"decompress_mbps": 157.59
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 1,
-"out_size": 5575128,
-"ratio": 0.7688,
-"compress_mbps": null,
-"decompress_mbps": 108.51
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 12,
-"out_size": 5250745,
-"ratio": 0.724,
-"compress_mbps": null,
-"decompress_mbps": 111.52
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 3,
-"out_size": 5397999,
-"ratio": 0.7444,
-"compress_mbps": null,
-"decompress_mbps": 112.12
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 6,
-"out_size": 5335405,
-"ratio": 0.7357,
-"compress_mbps": null,
-"decompress_mbps": 111.12
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 9,
-"out_size": 5323197,
-"ratio": 0.734,
-"compress_mbps": null,
-"decompress_mbps": 115.55
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 1,
-"out_size": 13550569,
-"ratio": 0.3268,
-"compress_mbps": null,
-"decompress_mbps": 116.36
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 12,
-"out_size": 11520871,
-"ratio": 0.2779,
-"compress_mbps": null,
-"decompress_mbps": 127.08
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 3,
-"out_size": 12839361,
-"ratio": 0.3097,
-"compress_mbps": null,
-"decompress_mbps": 124.53
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 6,
-"out_size": 12140474,
-"ratio": 0.2928,
-"compress_mbps": null,
-"decompress_mbps": 123.71
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 9,
-"out_size": 11882496,
-"ratio": 0.2866,
-"compress_mbps": null,
-"decompress_mbps": 129.14
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 1,
-"out_size": 6293390,
-"ratio": 0.7426,
-"compress_mbps": null,
-"decompress_mbps": 107.47
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 12,
-"out_size": 5747146,
-"ratio": 0.6782,
-"compress_mbps": null,
-"decompress_mbps": 92.71
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 3,
-"out_size": 6058381,
-"ratio": 0.7149,
-"compress_mbps": null,
-"decompress_mbps": 90.59
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 6,
-"out_size": 5998438,
-"ratio": 0.7078,
-"compress_mbps": null,
-"decompress_mbps": 92.32
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 9,
-"out_size": 5986859,
-"ratio": 0.7065,
-"compress_mbps": null,
-"decompress_mbps": 94.47
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 1,
-"out_size": 887708,
-"ratio": 0.1661,
-"compress_mbps": null,
-"decompress_mbps": 190.84
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 12,
-"out_size": 629349,
-"ratio": 0.1177,
-"compress_mbps": null,
-"decompress_mbps": 217.91
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 3,
-"out_size": 793388,
-"ratio": 0.1484,
-"compress_mbps": null,
-"decompress_mbps": 205.95
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 6,
-"out_size": 684405,
-"ratio": 0.128,
-"compress_mbps": null,
-"decompress_mbps": 206.96
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 9,
-"out_size": 649494,
-"ratio": 0.1215,
-"compress_mbps": null,
-"decompress_mbps": 209.58
-},
-{
-"compressor": "js",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 1,
-"out_size": 4217525,
-"ratio": 0.4138,
-"compress_mbps": null,
-"decompress_mbps": 111.17
-},
-{
-"compressor": "js",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 12,
-"out_size": 3679105,
-"ratio": 0.361,
-"compress_mbps": null,
-"decompress_mbps": 129.5
-},
-{
-"compressor": "js",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 3,
-"out_size": 3989875,
-"ratio": 0.3915,
-"compress_mbps": null,
-"decompress_mbps": 136.08
-},
-{
-"compressor": "js",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 6,
-"out_size": 3859436,
-"ratio": 0.3787,
-"compress_mbps": null,
-"decompress_mbps": 127.38
-},
-{
-"compressor": "js",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 9,
-"out_size": 3810354,
-"ratio": 0.3738,
-"compress_mbps": null,
-"decompress_mbps": 119.02
-},
-{
-"compressor": "js",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 1,
-"out_size": 20192961,
-"ratio": 0.3942,
-"compress_mbps": null,
-"decompress_mbps": 160.99
-},
-{
-"compressor": "js",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 12,
-"out_size": 18241312,
-"ratio": 0.3561,
-"compress_mbps": null,
-"decompress_mbps": 171.52
-},
-{
-"compressor": "js",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 3,
-"out_size": 19234937,
-"ratio": 0.3755,
-"compress_mbps": null,
-"decompress_mbps": 166.26
-},
-{
-"compressor": "js",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 6,
-"out_size": 18805391,
-"ratio": 0.3671,
-"compress_mbps": null,
-"decompress_mbps": 159.97
-},
-{
-"compressor": "js",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 9,
-"out_size": 18713659,
-"ratio": 0.3654,
-"compress_mbps": null,
-"decompress_mbps": 162.96
-},
-{
-"compressor": "js",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 1,
-"out_size": 3740775,
-"ratio": 0.3752,
-"compress_mbps": null,
-"decompress_mbps": 144.1
-},
-{
-"compressor": "js",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 12,
-"out_size": 3447985,
-"ratio": 0.3458,
-"compress_mbps": null,
-"decompress_mbps": 144.41
-},
-{
-"compressor": "js",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 3,
-"out_size": 3672389,
-"ratio": 0.3683,
-"compress_mbps": null,
-"decompress_mbps": 145.09
-},
-{
-"compressor": "js",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 6,
-"out_size": 3648644,
-"ratio": 0.3659,
-"compress_mbps": null,
-"decompress_mbps": 137
-},
-{
-"compressor": "js",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 9,
-"out_size": 3625176,
-"ratio": 0.3636,
-"compress_mbps": null,
-"decompress_mbps": 137.5
-},
-{
-"compressor": "js",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 1,
-"out_size": 3837577,
-"ratio": 0.1144,
-"compress_mbps": null,
-"decompress_mbps": 269.98
-},
-{
-"compressor": "js",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 12,
-"out_size": 2748273,
-"ratio": 0.0819,
-"compress_mbps": null,
-"decompress_mbps": 295.47
-},
-{
-"compressor": "js",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 3,
-"out_size": 3599455,
-"ratio": 0.1073,
-"compress_mbps": null,
-"decompress_mbps": 290.76
-},
-{
-"compressor": "js",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 6,
-"out_size": 3091741,
-"ratio": 0.0921,
-"compress_mbps": null,
-"decompress_mbps": 315.99
-},
-{
-"compressor": "js",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 9,
-"out_size": 2925243,
-"ratio": 0.0872,
-"compress_mbps": null,
-"decompress_mbps": 265.51
-},
-{
-"compressor": "js",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 1,
-"out_size": 3275124,
-"ratio": 0.5324,
-"compress_mbps": null,
-"decompress_mbps": 103.42
-},
-{
-"compressor": "js",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 12,
-"out_size": 2994086,
-"ratio": 0.4867,
-"compress_mbps": null,
-"decompress_mbps": 99.06
-},
-{
-"compressor": "js",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 3,
-"out_size": 3137061,
-"ratio": 0.5099,
-"compress_mbps": null,
-"decompress_mbps": 110.36
-},
-{
-"compressor": "js",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 6,
-"out_size": 3072378,
-"ratio": 0.4994,
-"compress_mbps": null,
-"decompress_mbps": 110.93
-},
-{
-"compressor": "js",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 9,
-"out_size": 3066968,
-"ratio": 0.4985,
-"compress_mbps": null,
-"decompress_mbps": 102.94
-},
-{
-"compressor": "js",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 1,
-"out_size": 3868663,
-"ratio": 0.3836,
-"compress_mbps": null,
-"decompress_mbps": 150.39
-},
-{
-"compressor": "js",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 12,
-"out_size": 3608138,
-"ratio": 0.3577,
-"compress_mbps": null,
-"decompress_mbps": 173
-},
-{
-"compressor": "js",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 3,
-"out_size": 3818964,
-"ratio": 0.3787,
-"compress_mbps": null,
-"decompress_mbps": 160.76
-},
-{
-"compressor": "js",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 6,
-"out_size": 3660266,
-"ratio": 0.3629,
-"compress_mbps": null,
-"decompress_mbps": 163.1
-},
-{
-"compressor": "js",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 9,
-"out_size": 3654860,
-"ratio": 0.3624,
-"compress_mbps": null,
-"decompress_mbps": 152.96
-},
-{
-"compressor": "js",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 1,
-"out_size": 2197055,
-"ratio": 0.3315,
-"compress_mbps": null,
-"decompress_mbps": 157.19
-},
-{
-"compressor": "js",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 12,
-"out_size": 1696488,
-"ratio": 0.256,
-"compress_mbps": null,
-"decompress_mbps": 144
-},
-{
-"compressor": "js",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 3,
-"out_size": 2021047,
-"ratio": 0.305,
-"compress_mbps": null,
-"decompress_mbps": 150.15
-},
-{
-"compressor": "js",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 6,
-"out_size": 1876257,
-"ratio": 0.2831,
-"compress_mbps": null,
-"decompress_mbps": 145.39
-},
-{
-"compressor": "js",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 9,
-"out_size": 1806374,
-"ratio": 0.2726,
-"compress_mbps": null,
-"decompress_mbps": 147.68
-},
-{
-"compressor": "js",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 1,
-"out_size": 5866517,
-"ratio": 0.2715,
-"compress_mbps": null,
-"decompress_mbps": 178.06
-},
-{
-"compressor": "js",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 12,
-"out_size": 5118130,
-"ratio": 0.2369,
-"compress_mbps": null,
-"decompress_mbps": 171.2
-},
-{
-"compressor": "js",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 3,
-"out_size": 5605878,
-"ratio": 0.2595,
-"compress_mbps": null,
-"decompress_mbps": 198.78
-},
-{
-"compressor": "js",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 6,
-"out_size": 5337149,
-"ratio": 0.247,
-"compress_mbps": null,
-"decompress_mbps": 165.37
-},
-{
-"compressor": "js",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 9,
-"out_size": 5270405,
-"ratio": 0.2439,
-"compress_mbps": null,
-"decompress_mbps": 175.33
-},
-{
-"compressor": "js",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 1,
-"out_size": 5575128,
-"ratio": 0.7688,
-"compress_mbps": null,
-"decompress_mbps": 100.52
-},
-{
-"compressor": "js",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 12,
-"out_size": 5250745,
-"ratio": 0.724,
-"compress_mbps": null,
-"decompress_mbps": 104.46
-},
-{
-"compressor": "js",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 3,
-"out_size": 5397999,
-"ratio": 0.7444,
-"compress_mbps": null,
-"decompress_mbps": 110.52
-},
-{
-"compressor": "js",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 6,
-"out_size": 5335405,
-"ratio": 0.7357,
-"compress_mbps": null,
-"decompress_mbps": 101.31
-},
-{
-"compressor": "js",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 9,
-"out_size": 5323197,
-"ratio": 0.734,
-"compress_mbps": null,
-"decompress_mbps": 110.4
-},
-{
-"compressor": "js",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 1,
-"out_size": 13550569,
-"ratio": 0.3268,
-"compress_mbps": null,
-"decompress_mbps": 141.85
-},
-{
-"compressor": "js",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 12,
-"out_size": 11520871,
-"ratio": 0.2779,
-"compress_mbps": null,
-"decompress_mbps": 160.25
-},
-{
-"compressor": "js",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 3,
-"out_size": 12839361,
-"ratio": 0.3097,
-"compress_mbps": null,
-"decompress_mbps": 151.06
-},
-{
-"compressor": "js",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 6,
-"out_size": 12140474,
-"ratio": 0.2928,
-"compress_mbps": null,
-"decompress_mbps": 154.25
-},
-{
-"compressor": "js",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 9,
-"out_size": 11882496,
-"ratio": 0.2866,
-"compress_mbps": null,
-"decompress_mbps": 155.8
-},
-{
-"compressor": "js",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 1,
-"out_size": 6293390,
-"ratio": 0.7426,
-"compress_mbps": null,
-"decompress_mbps": 108.07
-},
-{
-"compressor": "js",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 12,
-"out_size": 5747146,
-"ratio": 0.6782,
-"compress_mbps": null,
-"decompress_mbps": 108.74
-},
-{
-"compressor": "js",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 3,
-"out_size": 6058381,
-"ratio": 0.7149,
-"compress_mbps": null,
-"decompress_mbps": 105.2
-},
-{
-"compressor": "js",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 6,
-"out_size": 5998438,
-"ratio": 0.7078,
-"compress_mbps": null,
-"decompress_mbps": 99.13
-},
-{
-"compressor": "js",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 9,
-"out_size": 5986859,
-"ratio": 0.7065,
-"compress_mbps": null,
-"decompress_mbps": 107.79
-},
-{
-"compressor": "js",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 1,
-"out_size": 887708,
-"ratio": 0.1661,
-"compress_mbps": null,
-"decompress_mbps": 175.86
-},
-{
-"compressor": "js",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 12,
-"out_size": 629349,
-"ratio": 0.1177,
-"compress_mbps": null,
-"decompress_mbps": 264.72
-},
-{
-"compressor": "js",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 3,
-"out_size": 793388,
-"ratio": 0.1484,
-"compress_mbps": null,
-"decompress_mbps": 233.44
-},
-{
-"compressor": "js",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 6,
-"out_size": 684405,
-"ratio": 0.128,
-"compress_mbps": null,
-"decompress_mbps": 248.16
-},
-{
-"compressor": "js",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 9,
-"out_size": 649494,
-"ratio": 0.1215,
-"compress_mbps": null,
-"decompress_mbps": 254.37
-}
-]
+  "meta": {
+    "date": "2026-07-08T05:19:02Z",
+    "machine": "Linux chungus2 x86_64",
+    "git_commit": "cf8297c9",
+    "toolchain": "leanprover/lean4:v4.30.0-rc2",
+    "experiment": "decode-density: fixed libdeflate input, ratio = libdeflate compression ratio, decompress_mbps = each decoder on identical streams; compressor field holds the decoder name",
+    "external_rows_note": "go/js/zig/ocaml decode rows carried over from 9c93b270 (external decoders are unaffected by native-side changes)"
+  },
+  "results": [
+    {
+      "compressor": "native",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 1,
+      "out_size": 4217525,
+      "ratio": 0.4138,
+      "compress_mbps": null,
+      "decompress_mbps": 121.86
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 1,
+      "out_size": 4217525,
+      "ratio": 0.4138,
+      "compress_mbps": null,
+      "decompress_mbps": 384.34
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 1,
+      "out_size": 4217525,
+      "ratio": 0.4138,
+      "compress_mbps": null,
+      "decompress_mbps": 453.79
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 1,
+      "out_size": 4217525,
+      "ratio": 0.4138,
+      "compress_mbps": null,
+      "decompress_mbps": 768.12
+    },
+    {
+      "compressor": "memcpy",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 1,
+      "out_size": 4217525,
+      "ratio": 0.4138,
+      "compress_mbps": null,
+      "decompress_mbps": 35792.62
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 3,
+      "out_size": 3989875,
+      "ratio": 0.3915,
+      "compress_mbps": null,
+      "decompress_mbps": 142.52
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 3,
+      "out_size": 3989875,
+      "ratio": 0.3915,
+      "compress_mbps": null,
+      "decompress_mbps": 390.77
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 3,
+      "out_size": 3989875,
+      "ratio": 0.3915,
+      "compress_mbps": null,
+      "decompress_mbps": 491.37
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 3,
+      "out_size": 3989875,
+      "ratio": 0.3915,
+      "compress_mbps": null,
+      "decompress_mbps": 867.52
+    },
+    {
+      "compressor": "memcpy",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 3,
+      "out_size": 3989875,
+      "ratio": 0.3915,
+      "compress_mbps": null,
+      "decompress_mbps": 33597.08
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 6,
+      "out_size": 3859436,
+      "ratio": 0.3787,
+      "compress_mbps": null,
+      "decompress_mbps": 150.41
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 6,
+      "out_size": 3859436,
+      "ratio": 0.3787,
+      "compress_mbps": null,
+      "decompress_mbps": 377.93
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 6,
+      "out_size": 3859436,
+      "ratio": 0.3787,
+      "compress_mbps": null,
+      "decompress_mbps": 466.44
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 6,
+      "out_size": 3859436,
+      "ratio": 0.3787,
+      "compress_mbps": null,
+      "decompress_mbps": 810.31
+    },
+    {
+      "compressor": "memcpy",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 6,
+      "out_size": 3859436,
+      "ratio": 0.3787,
+      "compress_mbps": null,
+      "decompress_mbps": 38325.23
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 9,
+      "out_size": 3810354,
+      "ratio": 0.3738,
+      "compress_mbps": null,
+      "decompress_mbps": 152.84
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 9,
+      "out_size": 3810354,
+      "ratio": 0.3738,
+      "compress_mbps": null,
+      "decompress_mbps": 372.05
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 9,
+      "out_size": 3810354,
+      "ratio": 0.3738,
+      "compress_mbps": null,
+      "decompress_mbps": 438.94
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 9,
+      "out_size": 3810354,
+      "ratio": 0.3738,
+      "compress_mbps": null,
+      "decompress_mbps": 735.42
+    },
+    {
+      "compressor": "memcpy",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 9,
+      "out_size": 3810354,
+      "ratio": 0.3738,
+      "compress_mbps": null,
+      "decompress_mbps": 35735.91
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 12,
+      "out_size": 3679105,
+      "ratio": 0.361,
+      "compress_mbps": null,
+      "decompress_mbps": 152.96
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 12,
+      "out_size": 3679105,
+      "ratio": 0.361,
+      "compress_mbps": null,
+      "decompress_mbps": 422.43
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 12,
+      "out_size": 3679105,
+      "ratio": 0.361,
+      "compress_mbps": null,
+      "decompress_mbps": 499.18
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 12,
+      "out_size": 3679105,
+      "ratio": 0.361,
+      "compress_mbps": null,
+      "decompress_mbps": 907.94
+    },
+    {
+      "compressor": "memcpy",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 12,
+      "out_size": 3679105,
+      "ratio": 0.361,
+      "compress_mbps": null,
+      "decompress_mbps": 31748.69
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 1,
+      "out_size": 20192961,
+      "ratio": 0.3942,
+      "compress_mbps": null,
+      "decompress_mbps": 167.67
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 1,
+      "out_size": 20192961,
+      "ratio": 0.3942,
+      "compress_mbps": null,
+      "decompress_mbps": 372.81
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 1,
+      "out_size": 20192961,
+      "ratio": 0.3942,
+      "compress_mbps": null,
+      "decompress_mbps": 416.85
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 1,
+      "out_size": 20192961,
+      "ratio": 0.3942,
+      "compress_mbps": null,
+      "decompress_mbps": 727.61
+    },
+    {
+      "compressor": "memcpy",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 1,
+      "out_size": 20192961,
+      "ratio": 0.3942,
+      "compress_mbps": null,
+      "decompress_mbps": 20236.02
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 3,
+      "out_size": 19234937,
+      "ratio": 0.3755,
+      "compress_mbps": null,
+      "decompress_mbps": 134.31
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 3,
+      "out_size": 19234937,
+      "ratio": 0.3755,
+      "compress_mbps": null,
+      "decompress_mbps": 367.77
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 3,
+      "out_size": 19234937,
+      "ratio": 0.3755,
+      "compress_mbps": null,
+      "decompress_mbps": 383.71
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 3,
+      "out_size": 19234937,
+      "ratio": 0.3755,
+      "compress_mbps": null,
+      "decompress_mbps": 713.85
+    },
+    {
+      "compressor": "memcpy",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 3,
+      "out_size": 19234937,
+      "ratio": 0.3755,
+      "compress_mbps": null,
+      "decompress_mbps": 19699.23
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 6,
+      "out_size": 18805391,
+      "ratio": 0.3671,
+      "compress_mbps": null,
+      "decompress_mbps": 144.71
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 6,
+      "out_size": 18805391,
+      "ratio": 0.3671,
+      "compress_mbps": null,
+      "decompress_mbps": 373.1
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 6,
+      "out_size": 18805391,
+      "ratio": 0.3671,
+      "compress_mbps": null,
+      "decompress_mbps": 402.18
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 6,
+      "out_size": 18805391,
+      "ratio": 0.3671,
+      "compress_mbps": null,
+      "decompress_mbps": 739.24
+    },
+    {
+      "compressor": "memcpy",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 6,
+      "out_size": 18805391,
+      "ratio": 0.3671,
+      "compress_mbps": null,
+      "decompress_mbps": 19832.35
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 9,
+      "out_size": 18713659,
+      "ratio": 0.3654,
+      "compress_mbps": null,
+      "decompress_mbps": 148.65
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 9,
+      "out_size": 18713659,
+      "ratio": 0.3654,
+      "compress_mbps": null,
+      "decompress_mbps": 377.81
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 9,
+      "out_size": 18713659,
+      "ratio": 0.3654,
+      "compress_mbps": null,
+      "decompress_mbps": 407.62
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 9,
+      "out_size": 18713659,
+      "ratio": 0.3654,
+      "compress_mbps": null,
+      "decompress_mbps": 752.09
+    },
+    {
+      "compressor": "memcpy",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 9,
+      "out_size": 18713659,
+      "ratio": 0.3654,
+      "compress_mbps": null,
+      "decompress_mbps": 19893.49
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 12,
+      "out_size": 18241312,
+      "ratio": 0.3561,
+      "compress_mbps": null,
+      "decompress_mbps": 133.95
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 12,
+      "out_size": 18241312,
+      "ratio": 0.3561,
+      "compress_mbps": null,
+      "decompress_mbps": 376.83
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 12,
+      "out_size": 18241312,
+      "ratio": 0.3561,
+      "compress_mbps": null,
+      "decompress_mbps": 392.8
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 12,
+      "out_size": 18241312,
+      "ratio": 0.3561,
+      "compress_mbps": null,
+      "decompress_mbps": 736.73
+    },
+    {
+      "compressor": "memcpy",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 12,
+      "out_size": 18241312,
+      "ratio": 0.3561,
+      "compress_mbps": null,
+      "decompress_mbps": 19970.88
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 1,
+      "out_size": 3740775,
+      "ratio": 0.3752,
+      "compress_mbps": null,
+      "decompress_mbps": 143.89
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 1,
+      "out_size": 3740775,
+      "ratio": 0.3752,
+      "compress_mbps": null,
+      "decompress_mbps": 445.86
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 1,
+      "out_size": 3740775,
+      "ratio": 0.3752,
+      "compress_mbps": null,
+      "decompress_mbps": 538.22
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 1,
+      "out_size": 3740775,
+      "ratio": 0.3752,
+      "compress_mbps": null,
+      "decompress_mbps": 852.24
+    },
+    {
+      "compressor": "memcpy",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 1,
+      "out_size": 3740775,
+      "ratio": 0.3752,
+      "compress_mbps": null,
+      "decompress_mbps": 56779.03
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 3,
+      "out_size": 3672389,
+      "ratio": 0.3683,
+      "compress_mbps": null,
+      "decompress_mbps": 147.76
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 3,
+      "out_size": 3672389,
+      "ratio": 0.3683,
+      "compress_mbps": null,
+      "decompress_mbps": 453.38
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 3,
+      "out_size": 3672389,
+      "ratio": 0.3683,
+      "compress_mbps": null,
+      "decompress_mbps": 537.59
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 3,
+      "out_size": 3672389,
+      "ratio": 0.3683,
+      "compress_mbps": null,
+      "decompress_mbps": 898.39
+    },
+    {
+      "compressor": "memcpy",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 3,
+      "out_size": 3672389,
+      "ratio": 0.3683,
+      "compress_mbps": null,
+      "decompress_mbps": 34631.51
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 6,
+      "out_size": 3648644,
+      "ratio": 0.3659,
+      "compress_mbps": null,
+      "decompress_mbps": 162.3
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 6,
+      "out_size": 3648644,
+      "ratio": 0.3659,
+      "compress_mbps": null,
+      "decompress_mbps": 445.48
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 6,
+      "out_size": 3648644,
+      "ratio": 0.3659,
+      "compress_mbps": null,
+      "decompress_mbps": 529.56
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 6,
+      "out_size": 3648644,
+      "ratio": 0.3659,
+      "compress_mbps": null,
+      "decompress_mbps": 908.87
+    },
+    {
+      "compressor": "memcpy",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 6,
+      "out_size": 3648644,
+      "ratio": 0.3659,
+      "compress_mbps": null,
+      "decompress_mbps": 35084.5
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 9,
+      "out_size": 3625176,
+      "ratio": 0.3636,
+      "compress_mbps": null,
+      "decompress_mbps": 165.25
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 9,
+      "out_size": 3625176,
+      "ratio": 0.3636,
+      "compress_mbps": null,
+      "decompress_mbps": 451.06
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 9,
+      "out_size": 3625176,
+      "ratio": 0.3636,
+      "compress_mbps": null,
+      "decompress_mbps": 519.94
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 9,
+      "out_size": 3625176,
+      "ratio": 0.3636,
+      "compress_mbps": null,
+      "decompress_mbps": 912.45
+    },
+    {
+      "compressor": "memcpy",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 9,
+      "out_size": 3625176,
+      "ratio": 0.3636,
+      "compress_mbps": null,
+      "decompress_mbps": 34145.75
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 12,
+      "out_size": 3447985,
+      "ratio": 0.3458,
+      "compress_mbps": null,
+      "decompress_mbps": 158.12
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 12,
+      "out_size": 3447985,
+      "ratio": 0.3458,
+      "compress_mbps": null,
+      "decompress_mbps": 488.48
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 12,
+      "out_size": 3447985,
+      "ratio": 0.3458,
+      "compress_mbps": null,
+      "decompress_mbps": 518.51
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 12,
+      "out_size": 3447985,
+      "ratio": 0.3458,
+      "compress_mbps": null,
+      "decompress_mbps": 925.66
+    },
+    {
+      "compressor": "memcpy",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 12,
+      "out_size": 3447985,
+      "ratio": 0.3458,
+      "compress_mbps": null,
+      "decompress_mbps": 32477.85
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 1,
+      "out_size": 3837577,
+      "ratio": 0.1144,
+      "compress_mbps": null,
+      "decompress_mbps": 389.26
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 1,
+      "out_size": 3837577,
+      "ratio": 0.1144,
+      "compress_mbps": null,
+      "decompress_mbps": 881.86
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 1,
+      "out_size": 3837577,
+      "ratio": 0.1144,
+      "compress_mbps": null,
+      "decompress_mbps": 849.27
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 1,
+      "out_size": 3837577,
+      "ratio": 0.1144,
+      "compress_mbps": null,
+      "decompress_mbps": 1812.42
+    },
+    {
+      "compressor": "memcpy",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 1,
+      "out_size": 3837577,
+      "ratio": 0.1144,
+      "compress_mbps": null,
+      "decompress_mbps": 19653.0
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 3,
+      "out_size": 3599455,
+      "ratio": 0.1073,
+      "compress_mbps": null,
+      "decompress_mbps": 451.43
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 3,
+      "out_size": 3599455,
+      "ratio": 0.1073,
+      "compress_mbps": null,
+      "decompress_mbps": 951.32
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 3,
+      "out_size": 3599455,
+      "ratio": 0.1073,
+      "compress_mbps": null,
+      "decompress_mbps": 902.83
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 3,
+      "out_size": 3599455,
+      "ratio": 0.1073,
+      "compress_mbps": null,
+      "decompress_mbps": 1860.77
+    },
+    {
+      "compressor": "memcpy",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 3,
+      "out_size": 3599455,
+      "ratio": 0.1073,
+      "compress_mbps": null,
+      "decompress_mbps": 19901.87
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 6,
+      "out_size": 3091741,
+      "ratio": 0.0921,
+      "compress_mbps": null,
+      "decompress_mbps": 564.2
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 6,
+      "out_size": 3091741,
+      "ratio": 0.0921,
+      "compress_mbps": null,
+      "decompress_mbps": 1046.47
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 6,
+      "out_size": 3091741,
+      "ratio": 0.0921,
+      "compress_mbps": null,
+      "decompress_mbps": 1032.88
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 6,
+      "out_size": 3091741,
+      "ratio": 0.0921,
+      "compress_mbps": null,
+      "decompress_mbps": 1913.5
+    },
+    {
+      "compressor": "memcpy",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 6,
+      "out_size": 3091741,
+      "ratio": 0.0921,
+      "compress_mbps": null,
+      "decompress_mbps": 20092.97
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 9,
+      "out_size": 2925243,
+      "ratio": 0.0872,
+      "compress_mbps": null,
+      "decompress_mbps": 633.77
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 9,
+      "out_size": 2925243,
+      "ratio": 0.0872,
+      "compress_mbps": null,
+      "decompress_mbps": 1105.35
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 9,
+      "out_size": 2925243,
+      "ratio": 0.0872,
+      "compress_mbps": null,
+      "decompress_mbps": 1097.74
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 9,
+      "out_size": 2925243,
+      "ratio": 0.0872,
+      "compress_mbps": null,
+      "decompress_mbps": 1940.24
+    },
+    {
+      "compressor": "memcpy",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 9,
+      "out_size": 2925243,
+      "ratio": 0.0872,
+      "compress_mbps": null,
+      "decompress_mbps": 18821.1
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 12,
+      "out_size": 2748273,
+      "ratio": 0.0819,
+      "compress_mbps": null,
+      "decompress_mbps": 597.73
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 12,
+      "out_size": 2748273,
+      "ratio": 0.0819,
+      "compress_mbps": null,
+      "decompress_mbps": 1111.72
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 12,
+      "out_size": 2748273,
+      "ratio": 0.0819,
+      "compress_mbps": null,
+      "decompress_mbps": 1106.42
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 12,
+      "out_size": 2748273,
+      "ratio": 0.0819,
+      "compress_mbps": null,
+      "decompress_mbps": 1906.87
+    },
+    {
+      "compressor": "memcpy",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 12,
+      "out_size": 2748273,
+      "ratio": 0.0819,
+      "compress_mbps": null,
+      "decompress_mbps": 20126.4
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 1,
+      "out_size": 3275124,
+      "ratio": 0.5324,
+      "compress_mbps": null,
+      "decompress_mbps": 127.5
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 1,
+      "out_size": 3275124,
+      "ratio": 0.5324,
+      "compress_mbps": null,
+      "decompress_mbps": 279.72
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 1,
+      "out_size": 3275124,
+      "ratio": 0.5324,
+      "compress_mbps": null,
+      "decompress_mbps": 362.48
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 1,
+      "out_size": 3275124,
+      "ratio": 0.5324,
+      "compress_mbps": null,
+      "decompress_mbps": 580.68
+    },
+    {
+      "compressor": "memcpy",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 1,
+      "out_size": 3275124,
+      "ratio": 0.5324,
+      "compress_mbps": null,
+      "decompress_mbps": 42284.51
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 3,
+      "out_size": 3137061,
+      "ratio": 0.5099,
+      "compress_mbps": null,
+      "decompress_mbps": 113.43
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 3,
+      "out_size": 3137061,
+      "ratio": 0.5099,
+      "compress_mbps": null,
+      "decompress_mbps": 275.12
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 3,
+      "out_size": 3137061,
+      "ratio": 0.5099,
+      "compress_mbps": null,
+      "decompress_mbps": 321.56
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 3,
+      "out_size": 3137061,
+      "ratio": 0.5099,
+      "compress_mbps": null,
+      "decompress_mbps": 547.82
+    },
+    {
+      "compressor": "memcpy",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 3,
+      "out_size": 3137061,
+      "ratio": 0.5099,
+      "compress_mbps": null,
+      "decompress_mbps": 54660.35
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 6,
+      "out_size": 3072378,
+      "ratio": 0.4994,
+      "compress_mbps": null,
+      "decompress_mbps": 120.56
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 6,
+      "out_size": 3072378,
+      "ratio": 0.4994,
+      "compress_mbps": null,
+      "decompress_mbps": 278.25
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 6,
+      "out_size": 3072378,
+      "ratio": 0.4994,
+      "compress_mbps": null,
+      "decompress_mbps": 330.11
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 6,
+      "out_size": 3072378,
+      "ratio": 0.4994,
+      "compress_mbps": null,
+      "decompress_mbps": 572.2
+    },
+    {
+      "compressor": "memcpy",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 6,
+      "out_size": 3072378,
+      "ratio": 0.4994,
+      "compress_mbps": null,
+      "decompress_mbps": 50850.55
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 9,
+      "out_size": 3066968,
+      "ratio": 0.4985,
+      "compress_mbps": null,
+      "decompress_mbps": 124.07
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 9,
+      "out_size": 3066968,
+      "ratio": 0.4985,
+      "compress_mbps": null,
+      "decompress_mbps": 282.31
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 9,
+      "out_size": 3066968,
+      "ratio": 0.4985,
+      "compress_mbps": null,
+      "decompress_mbps": 335.28
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 9,
+      "out_size": 3066968,
+      "ratio": 0.4985,
+      "compress_mbps": null,
+      "decompress_mbps": 578.96
+    },
+    {
+      "compressor": "memcpy",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 9,
+      "out_size": 3066968,
+      "ratio": 0.4985,
+      "compress_mbps": null,
+      "decompress_mbps": 62690.99
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 12,
+      "out_size": 2994086,
+      "ratio": 0.4867,
+      "compress_mbps": null,
+      "decompress_mbps": 114.1
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 12,
+      "out_size": 2994086,
+      "ratio": 0.4867,
+      "compress_mbps": null,
+      "decompress_mbps": 273.74
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 12,
+      "out_size": 2994086,
+      "ratio": 0.4867,
+      "compress_mbps": null,
+      "decompress_mbps": 313.33
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 12,
+      "out_size": 2994086,
+      "ratio": 0.4867,
+      "compress_mbps": null,
+      "decompress_mbps": 558.71
+    },
+    {
+      "compressor": "memcpy",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 12,
+      "out_size": 2994086,
+      "ratio": 0.4867,
+      "compress_mbps": null,
+      "decompress_mbps": 60760.2
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 1,
+      "out_size": 3868663,
+      "ratio": 0.3836,
+      "compress_mbps": null,
+      "decompress_mbps": 196.12
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 1,
+      "out_size": 3868663,
+      "ratio": 0.3836,
+      "compress_mbps": null,
+      "decompress_mbps": 516.53
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 1,
+      "out_size": 3868663,
+      "ratio": 0.3836,
+      "compress_mbps": null,
+      "decompress_mbps": 618.98
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 1,
+      "out_size": 3868663,
+      "ratio": 0.3836,
+      "compress_mbps": null,
+      "decompress_mbps": 1046.7
+    },
+    {
+      "compressor": "memcpy",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 1,
+      "out_size": 3868663,
+      "ratio": 0.3836,
+      "compress_mbps": null,
+      "decompress_mbps": 57513.59
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 3,
+      "out_size": 3818964,
+      "ratio": 0.3787,
+      "compress_mbps": null,
+      "decompress_mbps": 225.48
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 3,
+      "out_size": 3818964,
+      "ratio": 0.3787,
+      "compress_mbps": null,
+      "decompress_mbps": 536.9
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 3,
+      "out_size": 3818964,
+      "ratio": 0.3787,
+      "compress_mbps": null,
+      "decompress_mbps": 622.47
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 3,
+      "out_size": 3818964,
+      "ratio": 0.3787,
+      "compress_mbps": null,
+      "decompress_mbps": 1089.25
+    },
+    {
+      "compressor": "memcpy",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 3,
+      "out_size": 3818964,
+      "ratio": 0.3787,
+      "compress_mbps": null,
+      "decompress_mbps": 56342.85
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 6,
+      "out_size": 3660266,
+      "ratio": 0.3629,
+      "compress_mbps": null,
+      "decompress_mbps": 248.89
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 6,
+      "out_size": 3660266,
+      "ratio": 0.3629,
+      "compress_mbps": null,
+      "decompress_mbps": 548.17
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 6,
+      "out_size": 3660266,
+      "ratio": 0.3629,
+      "compress_mbps": null,
+      "decompress_mbps": 672.05
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 6,
+      "out_size": 3660266,
+      "ratio": 0.3629,
+      "compress_mbps": null,
+      "decompress_mbps": 1109.33
+    },
+    {
+      "compressor": "memcpy",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 6,
+      "out_size": 3660266,
+      "ratio": 0.3629,
+      "compress_mbps": null,
+      "decompress_mbps": 57894.74
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 9,
+      "out_size": 3654860,
+      "ratio": 0.3624,
+      "compress_mbps": null,
+      "decompress_mbps": 252.03
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 9,
+      "out_size": 3654860,
+      "ratio": 0.3624,
+      "compress_mbps": null,
+      "decompress_mbps": 542.81
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 9,
+      "out_size": 3654860,
+      "ratio": 0.3624,
+      "compress_mbps": null,
+      "decompress_mbps": 671.35
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 9,
+      "out_size": 3654860,
+      "ratio": 0.3624,
+      "compress_mbps": null,
+      "decompress_mbps": 1112.59
+    },
+    {
+      "compressor": "memcpy",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 9,
+      "out_size": 3654860,
+      "ratio": 0.3624,
+      "compress_mbps": null,
+      "decompress_mbps": 54288.51
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 12,
+      "out_size": 3608138,
+      "ratio": 0.3577,
+      "compress_mbps": null,
+      "decompress_mbps": 246.41
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 12,
+      "out_size": 3608138,
+      "ratio": 0.3577,
+      "compress_mbps": null,
+      "decompress_mbps": 548.79
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 12,
+      "out_size": 3608138,
+      "ratio": 0.3577,
+      "compress_mbps": null,
+      "decompress_mbps": 662.74
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 12,
+      "out_size": 3608138,
+      "ratio": 0.3577,
+      "compress_mbps": null,
+      "decompress_mbps": 1102.82
+    },
+    {
+      "compressor": "memcpy",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 12,
+      "out_size": 3608138,
+      "ratio": 0.3577,
+      "compress_mbps": null,
+      "decompress_mbps": 35729.92
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 1,
+      "out_size": 2197055,
+      "ratio": 0.3315,
+      "compress_mbps": null,
+      "decompress_mbps": 145.56
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 1,
+      "out_size": 2197055,
+      "ratio": 0.3315,
+      "compress_mbps": null,
+      "decompress_mbps": 426.85
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 1,
+      "out_size": 2197055,
+      "ratio": 0.3315,
+      "compress_mbps": null,
+      "decompress_mbps": 531.7
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 1,
+      "out_size": 2197055,
+      "ratio": 0.3315,
+      "compress_mbps": null,
+      "decompress_mbps": 1011.65
+    },
+    {
+      "compressor": "memcpy",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 1,
+      "out_size": 2197055,
+      "ratio": 0.3315,
+      "compress_mbps": null,
+      "decompress_mbps": 42244.17
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 3,
+      "out_size": 2021047,
+      "ratio": 0.305,
+      "compress_mbps": null,
+      "decompress_mbps": 175.58
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 3,
+      "out_size": 2021047,
+      "ratio": 0.305,
+      "compress_mbps": null,
+      "decompress_mbps": 462.53
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 3,
+      "out_size": 2021047,
+      "ratio": 0.305,
+      "compress_mbps": null,
+      "decompress_mbps": 581.89
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 3,
+      "out_size": 2021047,
+      "ratio": 0.305,
+      "compress_mbps": null,
+      "decompress_mbps": 1162.65
+    },
+    {
+      "compressor": "memcpy",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 3,
+      "out_size": 2021047,
+      "ratio": 0.305,
+      "compress_mbps": null,
+      "decompress_mbps": 48860.79
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 6,
+      "out_size": 1876257,
+      "ratio": 0.2831,
+      "compress_mbps": null,
+      "decompress_mbps": 195.5
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 6,
+      "out_size": 1876257,
+      "ratio": 0.2831,
+      "compress_mbps": null,
+      "decompress_mbps": 465.65
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 6,
+      "out_size": 1876257,
+      "ratio": 0.2831,
+      "compress_mbps": null,
+      "decompress_mbps": 544.22
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 6,
+      "out_size": 1876257,
+      "ratio": 0.2831,
+      "compress_mbps": null,
+      "decompress_mbps": 1065.92
+    },
+    {
+      "compressor": "memcpy",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 6,
+      "out_size": 1876257,
+      "ratio": 0.2831,
+      "compress_mbps": null,
+      "decompress_mbps": 48477.77
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 9,
+      "out_size": 1806374,
+      "ratio": 0.2726,
+      "compress_mbps": null,
+      "decompress_mbps": 209.72
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 9,
+      "out_size": 1806374,
+      "ratio": 0.2726,
+      "compress_mbps": null,
+      "decompress_mbps": 451.84
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 9,
+      "out_size": 1806374,
+      "ratio": 0.2726,
+      "compress_mbps": null,
+      "decompress_mbps": 519.41
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 9,
+      "out_size": 1806374,
+      "ratio": 0.2726,
+      "compress_mbps": null,
+      "decompress_mbps": 987.18
+    },
+    {
+      "compressor": "memcpy",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 9,
+      "out_size": 1806374,
+      "ratio": 0.2726,
+      "compress_mbps": null,
+      "decompress_mbps": 45980.75
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 12,
+      "out_size": 1696488,
+      "ratio": 0.256,
+      "compress_mbps": null,
+      "decompress_mbps": 202.6
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 12,
+      "out_size": 1696488,
+      "ratio": 0.256,
+      "compress_mbps": null,
+      "decompress_mbps": 531.41
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 12,
+      "out_size": 1696488,
+      "ratio": 0.256,
+      "compress_mbps": null,
+      "decompress_mbps": 589.04
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 12,
+      "out_size": 1696488,
+      "ratio": 0.256,
+      "compress_mbps": null,
+      "decompress_mbps": 1170.26
+    },
+    {
+      "compressor": "memcpy",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 12,
+      "out_size": 1696488,
+      "ratio": 0.256,
+      "compress_mbps": null,
+      "decompress_mbps": 50787.03
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 1,
+      "out_size": 5866517,
+      "ratio": 0.2715,
+      "compress_mbps": null,
+      "decompress_mbps": 224.57
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 1,
+      "out_size": 5866517,
+      "ratio": 0.2715,
+      "compress_mbps": null,
+      "decompress_mbps": 557.05
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 1,
+      "out_size": 5866517,
+      "ratio": 0.2715,
+      "compress_mbps": null,
+      "decompress_mbps": 582.15
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 1,
+      "out_size": 5866517,
+      "ratio": 0.2715,
+      "compress_mbps": null,
+      "decompress_mbps": 1077.63
+    },
+    {
+      "compressor": "memcpy",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 1,
+      "out_size": 5866517,
+      "ratio": 0.2715,
+      "compress_mbps": null,
+      "decompress_mbps": 20456.1
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 3,
+      "out_size": 5605878,
+      "ratio": 0.2595,
+      "compress_mbps": null,
+      "decompress_mbps": 214.66
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 3,
+      "out_size": 5605878,
+      "ratio": 0.2595,
+      "compress_mbps": null,
+      "decompress_mbps": 569.39
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 3,
+      "out_size": 5605878,
+      "ratio": 0.2595,
+      "compress_mbps": null,
+      "decompress_mbps": 589.8
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 3,
+      "out_size": 5605878,
+      "ratio": 0.2595,
+      "compress_mbps": null,
+      "decompress_mbps": 1113.36
+    },
+    {
+      "compressor": "memcpy",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 3,
+      "out_size": 5605878,
+      "ratio": 0.2595,
+      "compress_mbps": null,
+      "decompress_mbps": 19841.78
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 6,
+      "out_size": 5337149,
+      "ratio": 0.247,
+      "compress_mbps": null,
+      "decompress_mbps": 231.46
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 6,
+      "out_size": 5337149,
+      "ratio": 0.247,
+      "compress_mbps": null,
+      "decompress_mbps": 522.09
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 6,
+      "out_size": 5337149,
+      "ratio": 0.247,
+      "compress_mbps": null,
+      "decompress_mbps": 526.2
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 6,
+      "out_size": 5337149,
+      "ratio": 0.247,
+      "compress_mbps": null,
+      "decompress_mbps": 1081.25
+    },
+    {
+      "compressor": "memcpy",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 6,
+      "out_size": 5337149,
+      "ratio": 0.247,
+      "compress_mbps": null,
+      "decompress_mbps": 19899.94
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 9,
+      "out_size": 5270405,
+      "ratio": 0.2439,
+      "compress_mbps": null,
+      "decompress_mbps": 242.27
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 9,
+      "out_size": 5270405,
+      "ratio": 0.2439,
+      "compress_mbps": null,
+      "decompress_mbps": 525.88
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 9,
+      "out_size": 5270405,
+      "ratio": 0.2439,
+      "compress_mbps": null,
+      "decompress_mbps": 524.96
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 9,
+      "out_size": 5270405,
+      "ratio": 0.2439,
+      "compress_mbps": null,
+      "decompress_mbps": 1069.01
+    },
+    {
+      "compressor": "memcpy",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 9,
+      "out_size": 5270405,
+      "ratio": 0.2439,
+      "compress_mbps": null,
+      "decompress_mbps": 18551.52
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 12,
+      "out_size": 5118130,
+      "ratio": 0.2369,
+      "compress_mbps": null,
+      "decompress_mbps": 208.92
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 12,
+      "out_size": 5118130,
+      "ratio": 0.2369,
+      "compress_mbps": null,
+      "decompress_mbps": 544.28
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 12,
+      "out_size": 5118130,
+      "ratio": 0.2369,
+      "compress_mbps": null,
+      "decompress_mbps": 524.79
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 12,
+      "out_size": 5118130,
+      "ratio": 0.2369,
+      "compress_mbps": null,
+      "decompress_mbps": 1079.85
+    },
+    {
+      "compressor": "memcpy",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 12,
+      "out_size": 5118130,
+      "ratio": 0.2369,
+      "compress_mbps": null,
+      "decompress_mbps": 21657.37
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 1,
+      "out_size": 5575128,
+      "ratio": 0.7688,
+      "compress_mbps": null,
+      "decompress_mbps": 131.66
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 1,
+      "out_size": 5575128,
+      "ratio": 0.7688,
+      "compress_mbps": null,
+      "decompress_mbps": 373.54
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 1,
+      "out_size": 5575128,
+      "ratio": 0.7688,
+      "compress_mbps": null,
+      "decompress_mbps": 392.4
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 1,
+      "out_size": 5575128,
+      "ratio": 0.7688,
+      "compress_mbps": null,
+      "decompress_mbps": 578.54
+    },
+    {
+      "compressor": "memcpy",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 1,
+      "out_size": 5575128,
+      "ratio": 0.7688,
+      "compress_mbps": null,
+      "decompress_mbps": 41302.33
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 3,
+      "out_size": 5397999,
+      "ratio": 0.7444,
+      "compress_mbps": null,
+      "decompress_mbps": 138.83
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 3,
+      "out_size": 5397999,
+      "ratio": 0.7444,
+      "compress_mbps": null,
+      "decompress_mbps": 373.39
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 3,
+      "out_size": 5397999,
+      "ratio": 0.7444,
+      "compress_mbps": null,
+      "decompress_mbps": 390.12
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 3,
+      "out_size": 5397999,
+      "ratio": 0.7444,
+      "compress_mbps": null,
+      "decompress_mbps": 573.64
+    },
+    {
+      "compressor": "memcpy",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 3,
+      "out_size": 5397999,
+      "ratio": 0.7444,
+      "compress_mbps": null,
+      "decompress_mbps": 59276.72
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 6,
+      "out_size": 5335405,
+      "ratio": 0.7357,
+      "compress_mbps": null,
+      "decompress_mbps": 144.81
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 6,
+      "out_size": 5335405,
+      "ratio": 0.7357,
+      "compress_mbps": null,
+      "decompress_mbps": 374.01
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 6,
+      "out_size": 5335405,
+      "ratio": 0.7357,
+      "compress_mbps": null,
+      "decompress_mbps": 384.34
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 6,
+      "out_size": 5335405,
+      "ratio": 0.7357,
+      "compress_mbps": null,
+      "decompress_mbps": 566.06
+    },
+    {
+      "compressor": "memcpy",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 6,
+      "out_size": 5335405,
+      "ratio": 0.7357,
+      "compress_mbps": null,
+      "decompress_mbps": 41787.21
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 9,
+      "out_size": 5323197,
+      "ratio": 0.734,
+      "compress_mbps": null,
+      "decompress_mbps": 146.46
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 9,
+      "out_size": 5323197,
+      "ratio": 0.734,
+      "compress_mbps": null,
+      "decompress_mbps": 376.33
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 9,
+      "out_size": 5323197,
+      "ratio": 0.734,
+      "compress_mbps": null,
+      "decompress_mbps": 383.52
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 9,
+      "out_size": 5323197,
+      "ratio": 0.734,
+      "compress_mbps": null,
+      "decompress_mbps": 563.33
+    },
+    {
+      "compressor": "memcpy",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 9,
+      "out_size": 5323197,
+      "ratio": 0.734,
+      "compress_mbps": null,
+      "decompress_mbps": 43312.66
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 12,
+      "out_size": 5250745,
+      "ratio": 0.724,
+      "compress_mbps": null,
+      "decompress_mbps": 141.66
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 12,
+      "out_size": 5250745,
+      "ratio": 0.724,
+      "compress_mbps": null,
+      "decompress_mbps": 378.28
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 12,
+      "out_size": 5250745,
+      "ratio": 0.724,
+      "compress_mbps": null,
+      "decompress_mbps": 392.79
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 12,
+      "out_size": 5250745,
+      "ratio": 0.724,
+      "compress_mbps": null,
+      "decompress_mbps": 574.48
+    },
+    {
+      "compressor": "memcpy",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 12,
+      "out_size": 5250745,
+      "ratio": 0.724,
+      "compress_mbps": null,
+      "decompress_mbps": 41391.32
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 1,
+      "out_size": 13550569,
+      "ratio": 0.3268,
+      "compress_mbps": null,
+      "decompress_mbps": 160.0
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 1,
+      "out_size": 13550569,
+      "ratio": 0.3268,
+      "compress_mbps": null,
+      "decompress_mbps": 384.68
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 1,
+      "out_size": 13550569,
+      "ratio": 0.3268,
+      "compress_mbps": null,
+      "decompress_mbps": 432.7
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 1,
+      "out_size": 13550569,
+      "ratio": 0.3268,
+      "compress_mbps": null,
+      "decompress_mbps": 834.58
+    },
+    {
+      "compressor": "memcpy",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 1,
+      "out_size": 13550569,
+      "ratio": 0.3268,
+      "compress_mbps": null,
+      "decompress_mbps": 19163.23
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 3,
+      "out_size": 12839361,
+      "ratio": 0.3097,
+      "compress_mbps": null,
+      "decompress_mbps": 186.69
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 3,
+      "out_size": 12839361,
+      "ratio": 0.3097,
+      "compress_mbps": null,
+      "decompress_mbps": 397.81
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 3,
+      "out_size": 12839361,
+      "ratio": 0.3097,
+      "compress_mbps": null,
+      "decompress_mbps": 456.38
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 3,
+      "out_size": 12839361,
+      "ratio": 0.3097,
+      "compress_mbps": null,
+      "decompress_mbps": 900.89
+    },
+    {
+      "compressor": "memcpy",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 3,
+      "out_size": 12839361,
+      "ratio": 0.3097,
+      "compress_mbps": null,
+      "decompress_mbps": 19532.32
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 6,
+      "out_size": 12140474,
+      "ratio": 0.2928,
+      "compress_mbps": null,
+      "decompress_mbps": 199.61
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 6,
+      "out_size": 12140474,
+      "ratio": 0.2928,
+      "compress_mbps": null,
+      "decompress_mbps": 399.91
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 6,
+      "out_size": 12140474,
+      "ratio": 0.2928,
+      "compress_mbps": null,
+      "decompress_mbps": 466.78
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 6,
+      "out_size": 12140474,
+      "ratio": 0.2928,
+      "compress_mbps": null,
+      "decompress_mbps": 867.08
+    },
+    {
+      "compressor": "memcpy",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 6,
+      "out_size": 12140474,
+      "ratio": 0.2928,
+      "compress_mbps": null,
+      "decompress_mbps": 19185.59
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 9,
+      "out_size": 11882496,
+      "ratio": 0.2866,
+      "compress_mbps": null,
+      "decompress_mbps": 206.22
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 9,
+      "out_size": 11882496,
+      "ratio": 0.2866,
+      "compress_mbps": null,
+      "decompress_mbps": 401.18
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 9,
+      "out_size": 11882496,
+      "ratio": 0.2866,
+      "compress_mbps": null,
+      "decompress_mbps": 461.16
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 9,
+      "out_size": 11882496,
+      "ratio": 0.2866,
+      "compress_mbps": null,
+      "decompress_mbps": 835.75
+    },
+    {
+      "compressor": "memcpy",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 9,
+      "out_size": 11882496,
+      "ratio": 0.2866,
+      "compress_mbps": null,
+      "decompress_mbps": 19895.94
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 12,
+      "out_size": 11520871,
+      "ratio": 0.2779,
+      "compress_mbps": null,
+      "decompress_mbps": 203.77
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 12,
+      "out_size": 11520871,
+      "ratio": 0.2779,
+      "compress_mbps": null,
+      "decompress_mbps": 418.92
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 12,
+      "out_size": 11520871,
+      "ratio": 0.2779,
+      "compress_mbps": null,
+      "decompress_mbps": 477.84
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 12,
+      "out_size": 11520871,
+      "ratio": 0.2779,
+      "compress_mbps": null,
+      "decompress_mbps": 874.33
+    },
+    {
+      "compressor": "memcpy",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 12,
+      "out_size": 11520871,
+      "ratio": 0.2779,
+      "compress_mbps": null,
+      "decompress_mbps": 19358.3
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 1,
+      "out_size": 6293390,
+      "ratio": 0.7426,
+      "compress_mbps": null,
+      "decompress_mbps": 140.97
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 1,
+      "out_size": 6293390,
+      "ratio": 0.7426,
+      "compress_mbps": null,
+      "decompress_mbps": 327.95
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 1,
+      "out_size": 6293390,
+      "ratio": 0.7426,
+      "compress_mbps": null,
+      "decompress_mbps": 352.66
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 1,
+      "out_size": 6293390,
+      "ratio": 0.7426,
+      "compress_mbps": null,
+      "decompress_mbps": 505.39
+    },
+    {
+      "compressor": "memcpy",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 1,
+      "out_size": 6293390,
+      "ratio": 0.7426,
+      "compress_mbps": null,
+      "decompress_mbps": 35026.2
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 3,
+      "out_size": 6058381,
+      "ratio": 0.7149,
+      "compress_mbps": null,
+      "decompress_mbps": 95.43
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 3,
+      "out_size": 6058381,
+      "ratio": 0.7149,
+      "compress_mbps": null,
+      "decompress_mbps": 274.74
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 3,
+      "out_size": 6058381,
+      "ratio": 0.7149,
+      "compress_mbps": null,
+      "decompress_mbps": 293.53
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 3,
+      "out_size": 6058381,
+      "ratio": 0.7149,
+      "compress_mbps": null,
+      "decompress_mbps": 465.38
+    },
+    {
+      "compressor": "memcpy",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 3,
+      "out_size": 6058381,
+      "ratio": 0.7149,
+      "compress_mbps": null,
+      "decompress_mbps": 38286.67
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 6,
+      "out_size": 5998438,
+      "ratio": 0.7078,
+      "compress_mbps": null,
+      "decompress_mbps": 98.1
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 6,
+      "out_size": 5998438,
+      "ratio": 0.7078,
+      "compress_mbps": null,
+      "decompress_mbps": 316.6
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 6,
+      "out_size": 5998438,
+      "ratio": 0.7078,
+      "compress_mbps": null,
+      "decompress_mbps": 312.66
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 6,
+      "out_size": 5998438,
+      "ratio": 0.7078,
+      "compress_mbps": null,
+      "decompress_mbps": 518.95
+    },
+    {
+      "compressor": "memcpy",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 6,
+      "out_size": 5998438,
+      "ratio": 0.7078,
+      "compress_mbps": null,
+      "decompress_mbps": 35930.81
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 9,
+      "out_size": 5986859,
+      "ratio": 0.7065,
+      "compress_mbps": null,
+      "decompress_mbps": 97.95
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 9,
+      "out_size": 5986859,
+      "ratio": 0.7065,
+      "compress_mbps": null,
+      "decompress_mbps": 310.55
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 9,
+      "out_size": 5986859,
+      "ratio": 0.7065,
+      "compress_mbps": null,
+      "decompress_mbps": 304.13
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 9,
+      "out_size": 5986859,
+      "ratio": 0.7065,
+      "compress_mbps": null,
+      "decompress_mbps": 506.21
+    },
+    {
+      "compressor": "memcpy",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 9,
+      "out_size": 5986859,
+      "ratio": 0.7065,
+      "compress_mbps": null,
+      "decompress_mbps": 33862.25
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 12,
+      "out_size": 5747146,
+      "ratio": 0.6782,
+      "compress_mbps": null,
+      "decompress_mbps": 90.96
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 12,
+      "out_size": 5747146,
+      "ratio": 0.6782,
+      "compress_mbps": null,
+      "decompress_mbps": 296.4
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 12,
+      "out_size": 5747146,
+      "ratio": 0.6782,
+      "compress_mbps": null,
+      "decompress_mbps": 323.8
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 12,
+      "out_size": 5747146,
+      "ratio": 0.6782,
+      "compress_mbps": null,
+      "decompress_mbps": 562.81
+    },
+    {
+      "compressor": "memcpy",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 12,
+      "out_size": 5747146,
+      "ratio": 0.6782,
+      "compress_mbps": null,
+      "decompress_mbps": 35640.36
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 1,
+      "out_size": 887708,
+      "ratio": 0.1661,
+      "compress_mbps": null,
+      "decompress_mbps": 279.3
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 1,
+      "out_size": 887708,
+      "ratio": 0.1661,
+      "compress_mbps": null,
+      "decompress_mbps": 754.21
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 1,
+      "out_size": 887708,
+      "ratio": 0.1661,
+      "compress_mbps": null,
+      "decompress_mbps": 898.55
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 1,
+      "out_size": 887708,
+      "ratio": 0.1661,
+      "compress_mbps": null,
+      "decompress_mbps": 1643.64
+    },
+    {
+      "compressor": "memcpy",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 1,
+      "out_size": 887708,
+      "ratio": 0.1661,
+      "compress_mbps": null,
+      "decompress_mbps": 49567.36
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 3,
+      "out_size": 793388,
+      "ratio": 0.1484,
+      "compress_mbps": null,
+      "decompress_mbps": 337.0
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 3,
+      "out_size": 793388,
+      "ratio": 0.1484,
+      "compress_mbps": null,
+      "decompress_mbps": 843.44
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 3,
+      "out_size": 793388,
+      "ratio": 0.1484,
+      "compress_mbps": null,
+      "decompress_mbps": 1059.26
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 3,
+      "out_size": 793388,
+      "ratio": 0.1484,
+      "compress_mbps": null,
+      "decompress_mbps": 1799.7
+    },
+    {
+      "compressor": "memcpy",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 3,
+      "out_size": 793388,
+      "ratio": 0.1484,
+      "compress_mbps": null,
+      "decompress_mbps": 48844.5
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 6,
+      "out_size": 684405,
+      "ratio": 0.128,
+      "compress_mbps": null,
+      "decompress_mbps": 406.69
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 6,
+      "out_size": 684405,
+      "ratio": 0.128,
+      "compress_mbps": null,
+      "decompress_mbps": 939.02
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 6,
+      "out_size": 684405,
+      "ratio": 0.128,
+      "compress_mbps": null,
+      "decompress_mbps": 1185.35
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 6,
+      "out_size": 684405,
+      "ratio": 0.128,
+      "compress_mbps": null,
+      "decompress_mbps": 1814.84
+    },
+    {
+      "compressor": "memcpy",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 6,
+      "out_size": 684405,
+      "ratio": 0.128,
+      "compress_mbps": null,
+      "decompress_mbps": 59651.71
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 9,
+      "out_size": 649494,
+      "ratio": 0.1215,
+      "compress_mbps": null,
+      "decompress_mbps": 439.8
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 9,
+      "out_size": 649494,
+      "ratio": 0.1215,
+      "compress_mbps": null,
+      "decompress_mbps": 978.35
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 9,
+      "out_size": 649494,
+      "ratio": 0.1215,
+      "compress_mbps": null,
+      "decompress_mbps": 1206.63
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 9,
+      "out_size": 649494,
+      "ratio": 0.1215,
+      "compress_mbps": null,
+      "decompress_mbps": 1802.61
+    },
+    {
+      "compressor": "memcpy",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 9,
+      "out_size": 649494,
+      "ratio": 0.1215,
+      "compress_mbps": null,
+      "decompress_mbps": 63986.25
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 12,
+      "out_size": 629349,
+      "ratio": 0.1177,
+      "compress_mbps": null,
+      "decompress_mbps": 418.38
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 12,
+      "out_size": 629349,
+      "ratio": 0.1177,
+      "compress_mbps": null,
+      "decompress_mbps": 1000.03
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 12,
+      "out_size": 629349,
+      "ratio": 0.1177,
+      "compress_mbps": null,
+      "decompress_mbps": 1189.76
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 12,
+      "out_size": 629349,
+      "ratio": 0.1177,
+      "compress_mbps": null,
+      "decompress_mbps": 1835.06
+    },
+    {
+      "compressor": "memcpy",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 12,
+      "out_size": 629349,
+      "ratio": 0.1177,
+      "compress_mbps": null,
+      "decompress_mbps": 43298.08
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 1,
+      "out_size": 4217525,
+      "ratio": 0.4138,
+      "compress_mbps": null,
+      "decompress_mbps": 193.18
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 12,
+      "out_size": 3679105,
+      "ratio": 0.361,
+      "compress_mbps": null,
+      "decompress_mbps": 222.38
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 3,
+      "out_size": 3989875,
+      "ratio": 0.3915,
+      "compress_mbps": null,
+      "decompress_mbps": 211.53
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 6,
+      "out_size": 3859436,
+      "ratio": 0.3787,
+      "compress_mbps": null,
+      "decompress_mbps": 207.41
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 9,
+      "out_size": 3810354,
+      "ratio": 0.3738,
+      "compress_mbps": null,
+      "decompress_mbps": 206.33
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 1,
+      "out_size": 20192961,
+      "ratio": 0.3942,
+      "compress_mbps": null,
+      "decompress_mbps": 238.5
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 12,
+      "out_size": 18241312,
+      "ratio": 0.3561,
+      "compress_mbps": null,
+      "decompress_mbps": 231.85
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 3,
+      "out_size": 19234937,
+      "ratio": 0.3755,
+      "compress_mbps": null,
+      "decompress_mbps": 227.07
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 6,
+      "out_size": 18805391,
+      "ratio": 0.3671,
+      "compress_mbps": null,
+      "decompress_mbps": 232.67
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 9,
+      "out_size": 18713659,
+      "ratio": 0.3654,
+      "compress_mbps": null,
+      "decompress_mbps": 237.74
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 1,
+      "out_size": 3740775,
+      "ratio": 0.3752,
+      "compress_mbps": null,
+      "decompress_mbps": 234.99
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 12,
+      "out_size": 3447985,
+      "ratio": 0.3458,
+      "compress_mbps": null,
+      "decompress_mbps": 239
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 3,
+      "out_size": 3672389,
+      "ratio": 0.3683,
+      "compress_mbps": null,
+      "decompress_mbps": 228.73
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 6,
+      "out_size": 3648644,
+      "ratio": 0.3659,
+      "compress_mbps": null,
+      "decompress_mbps": 233.28
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 9,
+      "out_size": 3625176,
+      "ratio": 0.3636,
+      "compress_mbps": null,
+      "decompress_mbps": 232.5
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 1,
+      "out_size": 3837577,
+      "ratio": 0.1144,
+      "compress_mbps": null,
+      "decompress_mbps": 558.1
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 12,
+      "out_size": 2748273,
+      "ratio": 0.0819,
+      "compress_mbps": null,
+      "decompress_mbps": 806.01
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 3,
+      "out_size": 3599455,
+      "ratio": 0.1073,
+      "compress_mbps": null,
+      "decompress_mbps": 589.23
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 6,
+      "out_size": 3091741,
+      "ratio": 0.0921,
+      "compress_mbps": null,
+      "decompress_mbps": 681.12
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 9,
+      "out_size": 2925243,
+      "ratio": 0.0872,
+      "compress_mbps": null,
+      "decompress_mbps": 806.12
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 1,
+      "out_size": 3275124,
+      "ratio": 0.5324,
+      "compress_mbps": null,
+      "decompress_mbps": 169.98
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 12,
+      "out_size": 2994086,
+      "ratio": 0.4867,
+      "compress_mbps": null,
+      "decompress_mbps": 162.31
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 3,
+      "out_size": 3137061,
+      "ratio": 0.5099,
+      "compress_mbps": null,
+      "decompress_mbps": 160.56
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 6,
+      "out_size": 3072378,
+      "ratio": 0.4994,
+      "compress_mbps": null,
+      "decompress_mbps": 167.99
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 9,
+      "out_size": 3066968,
+      "ratio": 0.4985,
+      "compress_mbps": null,
+      "decompress_mbps": 170.43
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 1,
+      "out_size": 3868663,
+      "ratio": 0.3836,
+      "compress_mbps": null,
+      "decompress_mbps": 256.05
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 12,
+      "out_size": 3608138,
+      "ratio": 0.3577,
+      "compress_mbps": null,
+      "decompress_mbps": 274.68
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 3,
+      "out_size": 3818964,
+      "ratio": 0.3787,
+      "compress_mbps": null,
+      "decompress_mbps": 272.57
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 6,
+      "out_size": 3660266,
+      "ratio": 0.3629,
+      "compress_mbps": null,
+      "decompress_mbps": 269.24
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 9,
+      "out_size": 3654860,
+      "ratio": 0.3624,
+      "compress_mbps": null,
+      "decompress_mbps": 271.4
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 1,
+      "out_size": 2197055,
+      "ratio": 0.3315,
+      "compress_mbps": null,
+      "decompress_mbps": 228.21
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 12,
+      "out_size": 1696488,
+      "ratio": 0.256,
+      "compress_mbps": null,
+      "decompress_mbps": 284.67
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 3,
+      "out_size": 2021047,
+      "ratio": 0.305,
+      "compress_mbps": null,
+      "decompress_mbps": 259.33
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 6,
+      "out_size": 1876257,
+      "ratio": 0.2831,
+      "compress_mbps": null,
+      "decompress_mbps": 278.68
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 9,
+      "out_size": 1806374,
+      "ratio": 0.2726,
+      "compress_mbps": null,
+      "decompress_mbps": 260.47
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 1,
+      "out_size": 5866517,
+      "ratio": 0.2715,
+      "compress_mbps": null,
+      "decompress_mbps": 306.44
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 12,
+      "out_size": 5118130,
+      "ratio": 0.2369,
+      "compress_mbps": null,
+      "decompress_mbps": 329.17
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 3,
+      "out_size": 5605878,
+      "ratio": 0.2595,
+      "compress_mbps": null,
+      "decompress_mbps": 321.14
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 6,
+      "out_size": 5337149,
+      "ratio": 0.247,
+      "compress_mbps": null,
+      "decompress_mbps": 326.57
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 9,
+      "out_size": 5270405,
+      "ratio": 0.2439,
+      "compress_mbps": null,
+      "decompress_mbps": 333.52
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 1,
+      "out_size": 5575128,
+      "ratio": 0.7688,
+      "compress_mbps": null,
+      "decompress_mbps": 184.18
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 12,
+      "out_size": 5250745,
+      "ratio": 0.724,
+      "compress_mbps": null,
+      "decompress_mbps": 187.33
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 3,
+      "out_size": 5397999,
+      "ratio": 0.7444,
+      "compress_mbps": null,
+      "decompress_mbps": 187.33
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 6,
+      "out_size": 5335405,
+      "ratio": 0.7357,
+      "compress_mbps": null,
+      "decompress_mbps": 189.57
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 9,
+      "out_size": 5323197,
+      "ratio": 0.734,
+      "compress_mbps": null,
+      "decompress_mbps": 190.6
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 1,
+      "out_size": 13550569,
+      "ratio": 0.3268,
+      "compress_mbps": null,
+      "decompress_mbps": 230.55
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 12,
+      "out_size": 11520871,
+      "ratio": 0.2779,
+      "compress_mbps": null,
+      "decompress_mbps": 261.07
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 3,
+      "out_size": 12839361,
+      "ratio": 0.3097,
+      "compress_mbps": null,
+      "decompress_mbps": 239.46
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 6,
+      "out_size": 12140474,
+      "ratio": 0.2928,
+      "compress_mbps": null,
+      "decompress_mbps": 250.32
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 9,
+      "out_size": 11882496,
+      "ratio": 0.2866,
+      "compress_mbps": null,
+      "decompress_mbps": 253.35
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 1,
+      "out_size": 6293390,
+      "ratio": 0.7426,
+      "compress_mbps": null,
+      "decompress_mbps": 173.81
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 12,
+      "out_size": 5747146,
+      "ratio": 0.6782,
+      "compress_mbps": null,
+      "decompress_mbps": 143.3
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 3,
+      "out_size": 6058381,
+      "ratio": 0.7149,
+      "compress_mbps": null,
+      "decompress_mbps": 142.12
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 6,
+      "out_size": 5998438,
+      "ratio": 0.7078,
+      "compress_mbps": null,
+      "decompress_mbps": 153.91
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 9,
+      "out_size": 5986859,
+      "ratio": 0.7065,
+      "compress_mbps": null,
+      "decompress_mbps": 151.08
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 1,
+      "out_size": 887708,
+      "ratio": 0.1661,
+      "compress_mbps": null,
+      "decompress_mbps": 447.02
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 12,
+      "out_size": 629349,
+      "ratio": 0.1177,
+      "compress_mbps": null,
+      "decompress_mbps": 614.33
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 3,
+      "out_size": 793388,
+      "ratio": 0.1484,
+      "compress_mbps": null,
+      "decompress_mbps": 514.94
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 6,
+      "out_size": 684405,
+      "ratio": 0.128,
+      "compress_mbps": null,
+      "decompress_mbps": 587.73
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 9,
+      "out_size": 649494,
+      "ratio": 0.1215,
+      "compress_mbps": null,
+      "decompress_mbps": 616.6
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 1,
+      "out_size": 4217525,
+      "ratio": 0.4138,
+      "compress_mbps": null,
+      "decompress_mbps": 234.26
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 12,
+      "out_size": 3679105,
+      "ratio": 0.361,
+      "compress_mbps": null,
+      "decompress_mbps": 294.85
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 3,
+      "out_size": 3989875,
+      "ratio": 0.3915,
+      "compress_mbps": null,
+      "decompress_mbps": 276.87
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 6,
+      "out_size": 3859436,
+      "ratio": 0.3787,
+      "compress_mbps": null,
+      "decompress_mbps": 276.67
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 9,
+      "out_size": 3810354,
+      "ratio": 0.3738,
+      "compress_mbps": null,
+      "decompress_mbps": 266.23
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 1,
+      "out_size": 20192961,
+      "ratio": 0.3942,
+      "compress_mbps": null,
+      "decompress_mbps": 237.96
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 12,
+      "out_size": 18241312,
+      "ratio": 0.3561,
+      "compress_mbps": null,
+      "decompress_mbps": 218.61
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 3,
+      "out_size": 19234937,
+      "ratio": 0.3755,
+      "compress_mbps": null,
+      "decompress_mbps": 220.09
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 6,
+      "out_size": 18805391,
+      "ratio": 0.3671,
+      "compress_mbps": null,
+      "decompress_mbps": 229.54
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 9,
+      "out_size": 18713659,
+      "ratio": 0.3654,
+      "compress_mbps": null,
+      "decompress_mbps": 232.43
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 1,
+      "out_size": 3740775,
+      "ratio": 0.3752,
+      "compress_mbps": null,
+      "decompress_mbps": 236.21
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 12,
+      "out_size": 3447985,
+      "ratio": 0.3458,
+      "compress_mbps": null,
+      "decompress_mbps": 271.12
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 3,
+      "out_size": 3672389,
+      "ratio": 0.3683,
+      "compress_mbps": null,
+      "decompress_mbps": 261.49
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 6,
+      "out_size": 3648644,
+      "ratio": 0.3659,
+      "compress_mbps": null,
+      "decompress_mbps": 272.52
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 9,
+      "out_size": 3625176,
+      "ratio": 0.3636,
+      "compress_mbps": null,
+      "decompress_mbps": 271.77
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 1,
+      "out_size": 3837577,
+      "ratio": 0.1144,
+      "compress_mbps": null,
+      "decompress_mbps": 687.46
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 12,
+      "out_size": 2748273,
+      "ratio": 0.0819,
+      "compress_mbps": null,
+      "decompress_mbps": 858.5
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 3,
+      "out_size": 3599455,
+      "ratio": 0.1073,
+      "compress_mbps": null,
+      "decompress_mbps": 754.55
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 6,
+      "out_size": 3091741,
+      "ratio": 0.0921,
+      "compress_mbps": null,
+      "decompress_mbps": 855.42
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 9,
+      "out_size": 2925243,
+      "ratio": 0.0872,
+      "compress_mbps": null,
+      "decompress_mbps": 915.03
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 1,
+      "out_size": 3275124,
+      "ratio": 0.5324,
+      "compress_mbps": null,
+      "decompress_mbps": 177.18
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 12,
+      "out_size": 2994086,
+      "ratio": 0.4867,
+      "compress_mbps": null,
+      "decompress_mbps": 182.73
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 3,
+      "out_size": 3137061,
+      "ratio": 0.5099,
+      "compress_mbps": null,
+      "decompress_mbps": 178.19
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 6,
+      "out_size": 3072378,
+      "ratio": 0.4994,
+      "compress_mbps": null,
+      "decompress_mbps": 186.41
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 9,
+      "out_size": 3066968,
+      "ratio": 0.4985,
+      "compress_mbps": null,
+      "decompress_mbps": 189.24
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 1,
+      "out_size": 3868663,
+      "ratio": 0.3836,
+      "compress_mbps": null,
+      "decompress_mbps": 255.54
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 12,
+      "out_size": 3608138,
+      "ratio": 0.3577,
+      "compress_mbps": null,
+      "decompress_mbps": 293.57
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 3,
+      "out_size": 3818964,
+      "ratio": 0.3787,
+      "compress_mbps": null,
+      "decompress_mbps": 287.69
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 6,
+      "out_size": 3660266,
+      "ratio": 0.3629,
+      "compress_mbps": null,
+      "decompress_mbps": 290.93
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 9,
+      "out_size": 3654860,
+      "ratio": 0.3624,
+      "compress_mbps": null,
+      "decompress_mbps": 291.06
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 1,
+      "out_size": 2197055,
+      "ratio": 0.3315,
+      "compress_mbps": null,
+      "decompress_mbps": 290.11
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 12,
+      "out_size": 1696488,
+      "ratio": 0.256,
+      "compress_mbps": null,
+      "decompress_mbps": 379.91
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 3,
+      "out_size": 2021047,
+      "ratio": 0.305,
+      "compress_mbps": null,
+      "decompress_mbps": 356.83
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 6,
+      "out_size": 1876257,
+      "ratio": 0.2831,
+      "compress_mbps": null,
+      "decompress_mbps": 361.58
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 9,
+      "out_size": 1806374,
+      "ratio": 0.2726,
+      "compress_mbps": null,
+      "decompress_mbps": 352.8
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 1,
+      "out_size": 5866517,
+      "ratio": 0.2715,
+      "compress_mbps": null,
+      "decompress_mbps": 354.81
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 12,
+      "out_size": 5118130,
+      "ratio": 0.2369,
+      "compress_mbps": null,
+      "decompress_mbps": 336.21
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 3,
+      "out_size": 5605878,
+      "ratio": 0.2595,
+      "compress_mbps": null,
+      "decompress_mbps": 345.18
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 6,
+      "out_size": 5337149,
+      "ratio": 0.247,
+      "compress_mbps": null,
+      "decompress_mbps": 366.7
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 9,
+      "out_size": 5270405,
+      "ratio": 0.2439,
+      "compress_mbps": null,
+      "decompress_mbps": 371.81
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 1,
+      "out_size": 5575128,
+      "ratio": 0.7688,
+      "compress_mbps": null,
+      "decompress_mbps": 159.73
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 12,
+      "out_size": 5250745,
+      "ratio": 0.724,
+      "compress_mbps": null,
+      "decompress_mbps": 177.11
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 3,
+      "out_size": 5397999,
+      "ratio": 0.7444,
+      "compress_mbps": null,
+      "decompress_mbps": 173.27
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 6,
+      "out_size": 5335405,
+      "ratio": 0.7357,
+      "compress_mbps": null,
+      "decompress_mbps": 174.67
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 9,
+      "out_size": 5323197,
+      "ratio": 0.734,
+      "compress_mbps": null,
+      "decompress_mbps": 175.68
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 1,
+      "out_size": 13550569,
+      "ratio": 0.3268,
+      "compress_mbps": null,
+      "decompress_mbps": 276.68
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 12,
+      "out_size": 11520871,
+      "ratio": 0.2779,
+      "compress_mbps": null,
+      "decompress_mbps": 335.81
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 3,
+      "out_size": 12839361,
+      "ratio": 0.3097,
+      "compress_mbps": null,
+      "decompress_mbps": 323.61
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 6,
+      "out_size": 12140474,
+      "ratio": 0.2928,
+      "compress_mbps": null,
+      "decompress_mbps": 329.08
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 9,
+      "out_size": 11882496,
+      "ratio": 0.2866,
+      "compress_mbps": null,
+      "decompress_mbps": 327.84
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 1,
+      "out_size": 6293390,
+      "ratio": 0.7426,
+      "compress_mbps": null,
+      "decompress_mbps": 151.36
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 12,
+      "out_size": 5747146,
+      "ratio": 0.6782,
+      "compress_mbps": null,
+      "decompress_mbps": 150.35
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 3,
+      "out_size": 6058381,
+      "ratio": 0.7149,
+      "compress_mbps": null,
+      "decompress_mbps": 144.89
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 6,
+      "out_size": 5998438,
+      "ratio": 0.7078,
+      "compress_mbps": null,
+      "decompress_mbps": 158.82
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 9,
+      "out_size": 5986859,
+      "ratio": 0.7065,
+      "compress_mbps": null,
+      "decompress_mbps": 156.89
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 1,
+      "out_size": 887708,
+      "ratio": 0.1661,
+      "compress_mbps": null,
+      "decompress_mbps": 516.23
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 12,
+      "out_size": 629349,
+      "ratio": 0.1177,
+      "compress_mbps": null,
+      "decompress_mbps": 678.15
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 3,
+      "out_size": 793388,
+      "ratio": 0.1484,
+      "compress_mbps": null,
+      "decompress_mbps": 614.14
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 6,
+      "out_size": 684405,
+      "ratio": 0.128,
+      "compress_mbps": null,
+      "decompress_mbps": 672.85
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 9,
+      "out_size": 649494,
+      "ratio": 0.1215,
+      "compress_mbps": null,
+      "decompress_mbps": 690.32
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 1,
+      "out_size": 4217525,
+      "ratio": 0.4138,
+      "compress_mbps": null,
+      "decompress_mbps": 106.82
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 12,
+      "out_size": 3679105,
+      "ratio": 0.361,
+      "compress_mbps": null,
+      "decompress_mbps": 120.03
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 3,
+      "out_size": 3989875,
+      "ratio": 0.3915,
+      "compress_mbps": null,
+      "decompress_mbps": 114.3
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 6,
+      "out_size": 3859436,
+      "ratio": 0.3787,
+      "compress_mbps": null,
+      "decompress_mbps": 112.83
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 9,
+      "out_size": 3810354,
+      "ratio": 0.3738,
+      "compress_mbps": null,
+      "decompress_mbps": 112.94
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 1,
+      "out_size": 20192961,
+      "ratio": 0.3942,
+      "compress_mbps": null,
+      "decompress_mbps": 124.08
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 12,
+      "out_size": 18241312,
+      "ratio": 0.3561,
+      "compress_mbps": null,
+      "decompress_mbps": 115.12
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 3,
+      "out_size": 19234937,
+      "ratio": 0.3755,
+      "compress_mbps": null,
+      "decompress_mbps": 114.37
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 6,
+      "out_size": 18805391,
+      "ratio": 0.3671,
+      "compress_mbps": null,
+      "decompress_mbps": 121.38
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 9,
+      "out_size": 18713659,
+      "ratio": 0.3654,
+      "compress_mbps": null,
+      "decompress_mbps": 122.55
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 1,
+      "out_size": 3740775,
+      "ratio": 0.3752,
+      "compress_mbps": null,
+      "decompress_mbps": 138.35
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 12,
+      "out_size": 3447985,
+      "ratio": 0.3458,
+      "compress_mbps": null,
+      "decompress_mbps": 130.3
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 3,
+      "out_size": 3672389,
+      "ratio": 0.3683,
+      "compress_mbps": null,
+      "decompress_mbps": 134.64
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 6,
+      "out_size": 3648644,
+      "ratio": 0.3659,
+      "compress_mbps": null,
+      "decompress_mbps": 134.95
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 9,
+      "out_size": 3625176,
+      "ratio": 0.3636,
+      "compress_mbps": null,
+      "decompress_mbps": 133.84
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 1,
+      "out_size": 3837577,
+      "ratio": 0.1144,
+      "compress_mbps": null,
+      "decompress_mbps": 206.85
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 12,
+      "out_size": 2748273,
+      "ratio": 0.0819,
+      "compress_mbps": null,
+      "decompress_mbps": 234.61
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 3,
+      "out_size": 3599455,
+      "ratio": 0.1073,
+      "compress_mbps": null,
+      "decompress_mbps": 222.8
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 6,
+      "out_size": 3091741,
+      "ratio": 0.0921,
+      "compress_mbps": null,
+      "decompress_mbps": 234.12
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 9,
+      "out_size": 2925243,
+      "ratio": 0.0872,
+      "compress_mbps": null,
+      "decompress_mbps": 229.17
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 1,
+      "out_size": 3275124,
+      "ratio": 0.5324,
+      "compress_mbps": null,
+      "decompress_mbps": 107.3
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 12,
+      "out_size": 2994086,
+      "ratio": 0.4867,
+      "compress_mbps": null,
+      "decompress_mbps": 97.22
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 3,
+      "out_size": 3137061,
+      "ratio": 0.5099,
+      "compress_mbps": null,
+      "decompress_mbps": 97.87
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 6,
+      "out_size": 3072378,
+      "ratio": 0.4994,
+      "compress_mbps": null,
+      "decompress_mbps": 101.7
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 9,
+      "out_size": 3066968,
+      "ratio": 0.4985,
+      "compress_mbps": null,
+      "decompress_mbps": 103.58
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 1,
+      "out_size": 3868663,
+      "ratio": 0.3836,
+      "compress_mbps": null,
+      "decompress_mbps": 148.86
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 12,
+      "out_size": 3608138,
+      "ratio": 0.3577,
+      "compress_mbps": null,
+      "decompress_mbps": 151.28
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 3,
+      "out_size": 3818964,
+      "ratio": 0.3787,
+      "compress_mbps": null,
+      "decompress_mbps": 149.38
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 6,
+      "out_size": 3660266,
+      "ratio": 0.3629,
+      "compress_mbps": null,
+      "decompress_mbps": 151.82
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 9,
+      "out_size": 3654860,
+      "ratio": 0.3624,
+      "compress_mbps": null,
+      "decompress_mbps": 152.33
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 1,
+      "out_size": 2197055,
+      "ratio": 0.3315,
+      "compress_mbps": null,
+      "decompress_mbps": 126.98
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 12,
+      "out_size": 1696488,
+      "ratio": 0.256,
+      "compress_mbps": null,
+      "decompress_mbps": 149.99
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 3,
+      "out_size": 2021047,
+      "ratio": 0.305,
+      "compress_mbps": null,
+      "decompress_mbps": 135.97
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 6,
+      "out_size": 1876257,
+      "ratio": 0.2831,
+      "compress_mbps": null,
+      "decompress_mbps": 136.74
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 9,
+      "out_size": 1806374,
+      "ratio": 0.2726,
+      "compress_mbps": null,
+      "decompress_mbps": 139.34
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 1,
+      "out_size": 5866517,
+      "ratio": 0.2715,
+      "compress_mbps": null,
+      "decompress_mbps": 156.49
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 12,
+      "out_size": 5118130,
+      "ratio": 0.2369,
+      "compress_mbps": null,
+      "decompress_mbps": 154.0
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 3,
+      "out_size": 5605878,
+      "ratio": 0.2595,
+      "compress_mbps": null,
+      "decompress_mbps": 153.12
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 6,
+      "out_size": 5337149,
+      "ratio": 0.247,
+      "compress_mbps": null,
+      "decompress_mbps": 156.34
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 9,
+      "out_size": 5270405,
+      "ratio": 0.2439,
+      "compress_mbps": null,
+      "decompress_mbps": 157.59
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 1,
+      "out_size": 5575128,
+      "ratio": 0.7688,
+      "compress_mbps": null,
+      "decompress_mbps": 108.51
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 12,
+      "out_size": 5250745,
+      "ratio": 0.724,
+      "compress_mbps": null,
+      "decompress_mbps": 111.52
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 3,
+      "out_size": 5397999,
+      "ratio": 0.7444,
+      "compress_mbps": null,
+      "decompress_mbps": 112.12
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 6,
+      "out_size": 5335405,
+      "ratio": 0.7357,
+      "compress_mbps": null,
+      "decompress_mbps": 111.12
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 9,
+      "out_size": 5323197,
+      "ratio": 0.734,
+      "compress_mbps": null,
+      "decompress_mbps": 115.55
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 1,
+      "out_size": 13550569,
+      "ratio": 0.3268,
+      "compress_mbps": null,
+      "decompress_mbps": 116.36
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 12,
+      "out_size": 11520871,
+      "ratio": 0.2779,
+      "compress_mbps": null,
+      "decompress_mbps": 127.08
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 3,
+      "out_size": 12839361,
+      "ratio": 0.3097,
+      "compress_mbps": null,
+      "decompress_mbps": 124.53
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 6,
+      "out_size": 12140474,
+      "ratio": 0.2928,
+      "compress_mbps": null,
+      "decompress_mbps": 123.71
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 9,
+      "out_size": 11882496,
+      "ratio": 0.2866,
+      "compress_mbps": null,
+      "decompress_mbps": 129.14
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 1,
+      "out_size": 6293390,
+      "ratio": 0.7426,
+      "compress_mbps": null,
+      "decompress_mbps": 107.47
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 12,
+      "out_size": 5747146,
+      "ratio": 0.6782,
+      "compress_mbps": null,
+      "decompress_mbps": 92.71
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 3,
+      "out_size": 6058381,
+      "ratio": 0.7149,
+      "compress_mbps": null,
+      "decompress_mbps": 90.59
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 6,
+      "out_size": 5998438,
+      "ratio": 0.7078,
+      "compress_mbps": null,
+      "decompress_mbps": 92.32
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 9,
+      "out_size": 5986859,
+      "ratio": 0.7065,
+      "compress_mbps": null,
+      "decompress_mbps": 94.47
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 1,
+      "out_size": 887708,
+      "ratio": 0.1661,
+      "compress_mbps": null,
+      "decompress_mbps": 190.84
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 12,
+      "out_size": 629349,
+      "ratio": 0.1177,
+      "compress_mbps": null,
+      "decompress_mbps": 217.91
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 3,
+      "out_size": 793388,
+      "ratio": 0.1484,
+      "compress_mbps": null,
+      "decompress_mbps": 205.95
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 6,
+      "out_size": 684405,
+      "ratio": 0.128,
+      "compress_mbps": null,
+      "decompress_mbps": 206.96
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 9,
+      "out_size": 649494,
+      "ratio": 0.1215,
+      "compress_mbps": null,
+      "decompress_mbps": 209.58
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 1,
+      "out_size": 4217525,
+      "ratio": 0.4138,
+      "compress_mbps": null,
+      "decompress_mbps": 111.17
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 12,
+      "out_size": 3679105,
+      "ratio": 0.361,
+      "compress_mbps": null,
+      "decompress_mbps": 129.5
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 3,
+      "out_size": 3989875,
+      "ratio": 0.3915,
+      "compress_mbps": null,
+      "decompress_mbps": 136.08
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 6,
+      "out_size": 3859436,
+      "ratio": 0.3787,
+      "compress_mbps": null,
+      "decompress_mbps": 127.38
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 9,
+      "out_size": 3810354,
+      "ratio": 0.3738,
+      "compress_mbps": null,
+      "decompress_mbps": 119.02
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 1,
+      "out_size": 20192961,
+      "ratio": 0.3942,
+      "compress_mbps": null,
+      "decompress_mbps": 160.99
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 12,
+      "out_size": 18241312,
+      "ratio": 0.3561,
+      "compress_mbps": null,
+      "decompress_mbps": 171.52
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 3,
+      "out_size": 19234937,
+      "ratio": 0.3755,
+      "compress_mbps": null,
+      "decompress_mbps": 166.26
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 6,
+      "out_size": 18805391,
+      "ratio": 0.3671,
+      "compress_mbps": null,
+      "decompress_mbps": 159.97
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 9,
+      "out_size": 18713659,
+      "ratio": 0.3654,
+      "compress_mbps": null,
+      "decompress_mbps": 162.96
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 1,
+      "out_size": 3740775,
+      "ratio": 0.3752,
+      "compress_mbps": null,
+      "decompress_mbps": 144.1
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 12,
+      "out_size": 3447985,
+      "ratio": 0.3458,
+      "compress_mbps": null,
+      "decompress_mbps": 144.41
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 3,
+      "out_size": 3672389,
+      "ratio": 0.3683,
+      "compress_mbps": null,
+      "decompress_mbps": 145.09
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 6,
+      "out_size": 3648644,
+      "ratio": 0.3659,
+      "compress_mbps": null,
+      "decompress_mbps": 137
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 9,
+      "out_size": 3625176,
+      "ratio": 0.3636,
+      "compress_mbps": null,
+      "decompress_mbps": 137.5
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 1,
+      "out_size": 3837577,
+      "ratio": 0.1144,
+      "compress_mbps": null,
+      "decompress_mbps": 269.98
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 12,
+      "out_size": 2748273,
+      "ratio": 0.0819,
+      "compress_mbps": null,
+      "decompress_mbps": 295.47
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 3,
+      "out_size": 3599455,
+      "ratio": 0.1073,
+      "compress_mbps": null,
+      "decompress_mbps": 290.76
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 6,
+      "out_size": 3091741,
+      "ratio": 0.0921,
+      "compress_mbps": null,
+      "decompress_mbps": 315.99
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 9,
+      "out_size": 2925243,
+      "ratio": 0.0872,
+      "compress_mbps": null,
+      "decompress_mbps": 265.51
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 1,
+      "out_size": 3275124,
+      "ratio": 0.5324,
+      "compress_mbps": null,
+      "decompress_mbps": 103.42
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 12,
+      "out_size": 2994086,
+      "ratio": 0.4867,
+      "compress_mbps": null,
+      "decompress_mbps": 99.06
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 3,
+      "out_size": 3137061,
+      "ratio": 0.5099,
+      "compress_mbps": null,
+      "decompress_mbps": 110.36
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 6,
+      "out_size": 3072378,
+      "ratio": 0.4994,
+      "compress_mbps": null,
+      "decompress_mbps": 110.93
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 9,
+      "out_size": 3066968,
+      "ratio": 0.4985,
+      "compress_mbps": null,
+      "decompress_mbps": 102.94
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 1,
+      "out_size": 3868663,
+      "ratio": 0.3836,
+      "compress_mbps": null,
+      "decompress_mbps": 150.39
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 12,
+      "out_size": 3608138,
+      "ratio": 0.3577,
+      "compress_mbps": null,
+      "decompress_mbps": 173
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 3,
+      "out_size": 3818964,
+      "ratio": 0.3787,
+      "compress_mbps": null,
+      "decompress_mbps": 160.76
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 6,
+      "out_size": 3660266,
+      "ratio": 0.3629,
+      "compress_mbps": null,
+      "decompress_mbps": 163.1
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 9,
+      "out_size": 3654860,
+      "ratio": 0.3624,
+      "compress_mbps": null,
+      "decompress_mbps": 152.96
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 1,
+      "out_size": 2197055,
+      "ratio": 0.3315,
+      "compress_mbps": null,
+      "decompress_mbps": 157.19
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 12,
+      "out_size": 1696488,
+      "ratio": 0.256,
+      "compress_mbps": null,
+      "decompress_mbps": 144
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 3,
+      "out_size": 2021047,
+      "ratio": 0.305,
+      "compress_mbps": null,
+      "decompress_mbps": 150.15
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 6,
+      "out_size": 1876257,
+      "ratio": 0.2831,
+      "compress_mbps": null,
+      "decompress_mbps": 145.39
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 9,
+      "out_size": 1806374,
+      "ratio": 0.2726,
+      "compress_mbps": null,
+      "decompress_mbps": 147.68
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 1,
+      "out_size": 5866517,
+      "ratio": 0.2715,
+      "compress_mbps": null,
+      "decompress_mbps": 178.06
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 12,
+      "out_size": 5118130,
+      "ratio": 0.2369,
+      "compress_mbps": null,
+      "decompress_mbps": 171.2
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 3,
+      "out_size": 5605878,
+      "ratio": 0.2595,
+      "compress_mbps": null,
+      "decompress_mbps": 198.78
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 6,
+      "out_size": 5337149,
+      "ratio": 0.247,
+      "compress_mbps": null,
+      "decompress_mbps": 165.37
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 9,
+      "out_size": 5270405,
+      "ratio": 0.2439,
+      "compress_mbps": null,
+      "decompress_mbps": 175.33
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 1,
+      "out_size": 5575128,
+      "ratio": 0.7688,
+      "compress_mbps": null,
+      "decompress_mbps": 100.52
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 12,
+      "out_size": 5250745,
+      "ratio": 0.724,
+      "compress_mbps": null,
+      "decompress_mbps": 104.46
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 3,
+      "out_size": 5397999,
+      "ratio": 0.7444,
+      "compress_mbps": null,
+      "decompress_mbps": 110.52
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 6,
+      "out_size": 5335405,
+      "ratio": 0.7357,
+      "compress_mbps": null,
+      "decompress_mbps": 101.31
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 9,
+      "out_size": 5323197,
+      "ratio": 0.734,
+      "compress_mbps": null,
+      "decompress_mbps": 110.4
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 1,
+      "out_size": 13550569,
+      "ratio": 0.3268,
+      "compress_mbps": null,
+      "decompress_mbps": 141.85
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 12,
+      "out_size": 11520871,
+      "ratio": 0.2779,
+      "compress_mbps": null,
+      "decompress_mbps": 160.25
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 3,
+      "out_size": 12839361,
+      "ratio": 0.3097,
+      "compress_mbps": null,
+      "decompress_mbps": 151.06
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 6,
+      "out_size": 12140474,
+      "ratio": 0.2928,
+      "compress_mbps": null,
+      "decompress_mbps": 154.25
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 9,
+      "out_size": 11882496,
+      "ratio": 0.2866,
+      "compress_mbps": null,
+      "decompress_mbps": 155.8
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 1,
+      "out_size": 6293390,
+      "ratio": 0.7426,
+      "compress_mbps": null,
+      "decompress_mbps": 108.07
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 12,
+      "out_size": 5747146,
+      "ratio": 0.6782,
+      "compress_mbps": null,
+      "decompress_mbps": 108.74
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 3,
+      "out_size": 6058381,
+      "ratio": 0.7149,
+      "compress_mbps": null,
+      "decompress_mbps": 105.2
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 6,
+      "out_size": 5998438,
+      "ratio": 0.7078,
+      "compress_mbps": null,
+      "decompress_mbps": 99.13
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 9,
+      "out_size": 5986859,
+      "ratio": 0.7065,
+      "compress_mbps": null,
+      "decompress_mbps": 107.79
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 1,
+      "out_size": 887708,
+      "ratio": 0.1661,
+      "compress_mbps": null,
+      "decompress_mbps": 175.86
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 12,
+      "out_size": 629349,
+      "ratio": 0.1177,
+      "compress_mbps": null,
+      "decompress_mbps": 264.72
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 3,
+      "out_size": 793388,
+      "ratio": 0.1484,
+      "compress_mbps": null,
+      "decompress_mbps": 233.44
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 6,
+      "out_size": 684405,
+      "ratio": 0.128,
+      "compress_mbps": null,
+      "decompress_mbps": 248.16
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 9,
+      "out_size": 649494,
+      "ratio": 0.1215,
+      "compress_mbps": null,
+      "decompress_mbps": 254.37
+    }
+  ]
 }

--- a/bench/results/latest.json
+++ b/bench/results/latest.json
@@ -1,8 +1,8 @@
 {
  "meta": {
-  "date": "2026-07-07T22:17:01Z",
+  "date": "2026-07-08T05:15:03Z",
   "machine": "Linux chungus2 x86_64",
-  "git_commit": "dcf4b958",
+  "git_commit": "cf8297c9",
   "toolchain": "leanprover/lean4:v4.30.0-rc2",
   "note": "compress_mbps/decompress_mbps are a median-of-5 snapshot on the machine above; ratio is deterministic"
  },
@@ -14,8 +14,8 @@
    "level": 1,
    "out_size": 60455,
    "ratio": 0.3975,
-   "compress_mbps": 66.86,
-   "decompress_mbps": 109.65
+   "compress_mbps": 66.87,
+   "decompress_mbps": 113.05
   },
   {
    "compressor": "native",
@@ -24,8 +24,8 @@
    "level": 2,
    "out_size": 56316,
    "ratio": 0.3703,
-   "compress_mbps": 48.87,
-   "decompress_mbps": 121.62
+   "compress_mbps": 48.77,
+   "decompress_mbps": 125.57
   },
   {
    "compressor": "native",
@@ -34,8 +34,8 @@
    "level": 3,
    "out_size": 55646,
    "ratio": 0.3659,
-   "compress_mbps": 43.64,
-   "decompress_mbps": 132.82
+   "compress_mbps": 43.08,
+   "decompress_mbps": 137.34
   },
   {
    "compressor": "native",
@@ -44,8 +44,8 @@
    "level": 4,
    "out_size": 54357,
    "ratio": 0.3574,
-   "compress_mbps": 34.15,
-   "decompress_mbps": 136.22
+   "compress_mbps": 34.12,
+   "decompress_mbps": 141.28
   },
   {
    "compressor": "native",
@@ -54,8 +54,8 @@
    "level": 5,
    "out_size": 54078,
    "ratio": 0.3556,
-   "compress_mbps": 27.59,
-   "decompress_mbps": 143.63
+   "compress_mbps": 27.34,
+   "decompress_mbps": 147.91
   },
   {
    "compressor": "native",
@@ -64,8 +64,8 @@
    "level": 6,
    "out_size": 54013,
    "ratio": 0.3551,
-   "compress_mbps": 26.89,
-   "decompress_mbps": 148.13
+   "compress_mbps": 26.71,
+   "decompress_mbps": 152.95
   },
   {
    "compressor": "native",
@@ -74,8 +74,8 @@
    "level": 7,
    "out_size": 53772,
    "ratio": 0.3536,
-   "compress_mbps": 22.67,
-   "decompress_mbps": 148.55
+   "compress_mbps": 22.43,
+   "decompress_mbps": 152.52
   },
   {
    "compressor": "native",
@@ -84,8 +84,8 @@
    "level": 8,
    "out_size": 53753,
    "ratio": 0.3534,
-   "compress_mbps": 21.73,
-   "decompress_mbps": 149.0
+   "compress_mbps": 21.66,
+   "decompress_mbps": 146.73
   },
   {
    "compressor": "native",
@@ -94,8 +94,8 @@
    "level": 9,
    "out_size": 52732,
    "ratio": 0.3467,
-   "compress_mbps": 4.16,
-   "decompress_mbps": 148.97
+   "compress_mbps": 3.99,
+   "decompress_mbps": 153.04
   },
   {
    "compressor": "native",
@@ -104,7 +104,7 @@
    "level": 10,
    "out_size": 52078,
    "ratio": 0.3424,
-   "compress_mbps": 2.28,
+   "compress_mbps": 2.26,
    "decompress_mbps": null
   },
   {
@@ -114,8 +114,8 @@
    "level": 1,
    "out_size": 53135,
    "ratio": 0.4245,
-   "compress_mbps": 61.38,
-   "decompress_mbps": 103.52
+   "compress_mbps": 61.17,
+   "decompress_mbps": 106.75
   },
   {
    "compressor": "native",
@@ -124,8 +124,8 @@
    "level": 2,
    "out_size": 50187,
    "ratio": 0.4009,
-   "compress_mbps": 45.9,
-   "decompress_mbps": 111.06
+   "compress_mbps": 45.35,
+   "decompress_mbps": 114.57
   },
   {
    "compressor": "native",
@@ -134,8 +134,8 @@
    "level": 3,
    "out_size": 49810,
    "ratio": 0.3979,
-   "compress_mbps": 41.56,
-   "decompress_mbps": 120.26
+   "compress_mbps": 40.85,
+   "decompress_mbps": 124.04
   },
   {
    "compressor": "native",
@@ -144,8 +144,8 @@
    "level": 4,
    "out_size": 48687,
    "ratio": 0.3889,
-   "compress_mbps": 32.4,
-   "decompress_mbps": 125.19
+   "compress_mbps": 32.26,
+   "decompress_mbps": 129.0
   },
   {
    "compressor": "native",
@@ -154,8 +154,8 @@
    "level": 5,
    "out_size": 48586,
    "ratio": 0.3881,
-   "compress_mbps": 27.97,
-   "decompress_mbps": 130.9
+   "compress_mbps": 27.83,
+   "decompress_mbps": 135.41
   },
   {
    "compressor": "native",
@@ -164,8 +164,8 @@
    "level": 6,
    "out_size": 48373,
    "ratio": 0.3864,
-   "compress_mbps": 25.93,
-   "decompress_mbps": 133.91
+   "compress_mbps": 26.0,
+   "decompress_mbps": 138.84
   },
   {
    "compressor": "native",
@@ -174,8 +174,8 @@
    "level": 7,
    "out_size": 48288,
    "ratio": 0.3858,
-   "compress_mbps": 23.62,
-   "decompress_mbps": 134.16
+   "compress_mbps": 23.65,
+   "decompress_mbps": 139.04
   },
   {
    "compressor": "native",
@@ -184,8 +184,8 @@
    "level": 8,
    "out_size": 48284,
    "ratio": 0.3857,
-   "compress_mbps": 23.3,
-   "decompress_mbps": 134.3
+   "compress_mbps": 23.35,
+   "decompress_mbps": 138.87
   },
   {
    "compressor": "native",
@@ -194,8 +194,8 @@
    "level": 9,
    "out_size": 47430,
    "ratio": 0.3789,
-   "compress_mbps": 4.48,
-   "decompress_mbps": 134.46
+   "compress_mbps": 4.4,
+   "decompress_mbps": 140.22
   },
   {
    "compressor": "native",
@@ -204,7 +204,7 @@
    "level": 10,
    "out_size": 46865,
    "ratio": 0.3744,
-   "compress_mbps": 2.67,
+   "compress_mbps": 2.64,
    "decompress_mbps": null
   },
   {
@@ -214,8 +214,8 @@
    "level": 1,
    "out_size": 8476,
    "ratio": 0.3445,
-   "compress_mbps": 60.18,
-   "decompress_mbps": 122.19
+   "compress_mbps": 60.76,
+   "decompress_mbps": 131.33
   },
   {
    "compressor": "native",
@@ -224,8 +224,8 @@
    "level": 2,
    "out_size": 8271,
    "ratio": 0.3362,
-   "compress_mbps": 50.4,
-   "decompress_mbps": 127.03
+   "compress_mbps": 50.75,
+   "decompress_mbps": 136.0
   },
   {
    "compressor": "native",
@@ -234,8 +234,8 @@
    "level": 3,
    "out_size": 8158,
    "ratio": 0.3316,
-   "compress_mbps": 48.63,
-   "decompress_mbps": 129.5
+   "compress_mbps": 48.51,
+   "decompress_mbps": 139.21
   },
   {
    "compressor": "native",
@@ -244,8 +244,8 @@
    "level": 4,
    "out_size": 7948,
    "ratio": 0.3231,
-   "compress_mbps": 43.46,
-   "decompress_mbps": 135.42
+   "compress_mbps": 43.17,
+   "decompress_mbps": 146.03
   },
   {
    "compressor": "native",
@@ -254,8 +254,8 @@
    "level": 5,
    "out_size": 7899,
    "ratio": 0.3211,
-   "compress_mbps": 37.02,
-   "decompress_mbps": 139.78
+   "compress_mbps": 36.81,
+   "decompress_mbps": 151.17
   },
   {
    "compressor": "native",
@@ -264,8 +264,8 @@
    "level": 6,
    "out_size": 7912,
    "ratio": 0.3216,
-   "compress_mbps": 36.46,
-   "decompress_mbps": 140.28
+   "compress_mbps": 36.41,
+   "decompress_mbps": 152.51
   },
   {
    "compressor": "native",
@@ -274,8 +274,8 @@
    "level": 7,
    "out_size": 7897,
    "ratio": 0.321,
-   "compress_mbps": 33.28,
-   "decompress_mbps": 141.44
+   "compress_mbps": 33.24,
+   "decompress_mbps": 153.26
   },
   {
    "compressor": "native",
@@ -284,8 +284,8 @@
    "level": 8,
    "out_size": 7897,
    "ratio": 0.321,
-   "compress_mbps": 32.95,
-   "decompress_mbps": 141.87
+   "compress_mbps": 33.04,
+   "decompress_mbps": 153.3
   },
   {
    "compressor": "native",
@@ -294,8 +294,8 @@
    "level": 9,
    "out_size": 7803,
    "ratio": 0.3172,
-   "compress_mbps": 4.74,
-   "decompress_mbps": 141.72
+   "compress_mbps": 4.66,
+   "decompress_mbps": 154.23
   },
   {
    "compressor": "native",
@@ -304,7 +304,7 @@
    "level": 10,
    "out_size": 7737,
    "ratio": 0.3145,
-   "compress_mbps": 2.78,
+   "compress_mbps": 2.75,
    "decompress_mbps": null
   },
   {
@@ -314,8 +314,8 @@
    "level": 1,
    "out_size": 3509,
    "ratio": 0.3147,
-   "compress_mbps": 45.66,
-   "decompress_mbps": 98.83
+   "compress_mbps": 46.19,
+   "decompress_mbps": 109.84
   },
   {
    "compressor": "native",
@@ -324,8 +324,8 @@
    "level": 2,
    "out_size": 3269,
    "ratio": 0.2932,
-   "compress_mbps": 39.96,
-   "decompress_mbps": 101.51
+   "compress_mbps": 40.06,
+   "decompress_mbps": 113.92
   },
   {
    "compressor": "native",
@@ -334,8 +334,8 @@
    "level": 3,
    "out_size": 3208,
    "ratio": 0.2877,
-   "compress_mbps": 38.9,
-   "decompress_mbps": 104.97
+   "compress_mbps": 39.15,
+   "decompress_mbps": 117.93
   },
   {
    "compressor": "native",
@@ -344,8 +344,8 @@
    "level": 4,
    "out_size": 3128,
    "ratio": 0.2805,
-   "compress_mbps": 36.06,
-   "decompress_mbps": 107.64
+   "compress_mbps": 36.2,
+   "decompress_mbps": 120.72
   },
   {
    "compressor": "native",
@@ -354,8 +354,8 @@
    "level": 5,
    "out_size": 3111,
    "ratio": 0.279,
-   "compress_mbps": 32.18,
-   "decompress_mbps": 109.48
+   "compress_mbps": 32.4,
+   "decompress_mbps": 123.56
   },
   {
    "compressor": "native",
@@ -364,8 +364,8 @@
    "level": 6,
    "out_size": 3119,
    "ratio": 0.2797,
-   "compress_mbps": 32.46,
-   "decompress_mbps": 110.26
+   "compress_mbps": 32.78,
+   "decompress_mbps": 125.02
   },
   {
    "compressor": "native",
@@ -374,8 +374,8 @@
    "level": 7,
    "out_size": 3111,
    "ratio": 0.279,
-   "compress_mbps": 30.63,
-   "decompress_mbps": 110.31
+   "compress_mbps": 30.7,
+   "decompress_mbps": 124.54
   },
   {
    "compressor": "native",
@@ -384,8 +384,8 @@
    "level": 8,
    "out_size": 3111,
    "ratio": 0.279,
-   "compress_mbps": 30.54,
-   "decompress_mbps": 110.29
+   "compress_mbps": 30.52,
+   "decompress_mbps": 124.99
   },
   {
    "compressor": "native",
@@ -394,8 +394,8 @@
    "level": 9,
    "out_size": 3056,
    "ratio": 0.2741,
-   "compress_mbps": 5.22,
-   "decompress_mbps": 110.44
+   "compress_mbps": 5.17,
+   "decompress_mbps": 124.99
   },
   {
    "compressor": "native",
@@ -404,7 +404,7 @@
    "level": 10,
    "out_size": 3032,
    "ratio": 0.2719,
-   "compress_mbps": 2.91,
+   "compress_mbps": 2.88,
    "decompress_mbps": null
   },
   {
@@ -414,8 +414,8 @@
    "level": 1,
    "out_size": 1282,
    "ratio": 0.3445,
-   "compress_mbps": 23.66,
-   "decompress_mbps": 55.63
+   "compress_mbps": 24.19,
+   "decompress_mbps": 65.31
   },
   {
    "compressor": "native",
@@ -424,8 +424,8 @@
    "level": 2,
    "out_size": 1225,
    "ratio": 0.3292,
-   "compress_mbps": 22.4,
-   "decompress_mbps": 56.62
+   "compress_mbps": 22.73,
+   "decompress_mbps": 66.33
   },
   {
    "compressor": "native",
@@ -434,8 +434,8 @@
    "level": 3,
    "out_size": 1220,
    "ratio": 0.3279,
-   "compress_mbps": 22.13,
-   "decompress_mbps": 56.59
+   "compress_mbps": 22.55,
+   "decompress_mbps": 66.59
   },
   {
    "compressor": "native",
@@ -444,8 +444,8 @@
    "level": 4,
    "out_size": 1213,
    "ratio": 0.326,
-   "compress_mbps": 21.62,
-   "decompress_mbps": 57.51
+   "compress_mbps": 21.9,
+   "decompress_mbps": 67.87
   },
   {
    "compressor": "native",
@@ -454,8 +454,8 @@
    "level": 5,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 20.82,
-   "decompress_mbps": 58.15
+   "compress_mbps": 21.07,
+   "decompress_mbps": 68.07
   },
   {
    "compressor": "native",
@@ -464,8 +464,8 @@
    "level": 6,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 20.43,
-   "decompress_mbps": 58.24
+   "compress_mbps": 20.87,
+   "decompress_mbps": 68.35
   },
   {
    "compressor": "native",
@@ -474,8 +474,8 @@
    "level": 7,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 20.26,
-   "decompress_mbps": 57.99
+   "compress_mbps": 20.76,
+   "decompress_mbps": 68.59
   },
   {
    "compressor": "native",
@@ -484,8 +484,8 @@
    "level": 8,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 20.25,
-   "decompress_mbps": 58.33
+   "compress_mbps": 20.74,
+   "decompress_mbps": 68.52
   },
   {
    "compressor": "native",
@@ -495,7 +495,7 @@
    "out_size": 1205,
    "ratio": 0.3238,
    "compress_mbps": 4.75,
-   "decompress_mbps": 58.27
+   "decompress_mbps": 68.25
   },
   {
    "compressor": "native",
@@ -504,7 +504,7 @@
    "level": 10,
    "out_size": 1191,
    "ratio": 0.3201,
-   "compress_mbps": 2.83,
+   "compress_mbps": 2.81,
    "decompress_mbps": null
   },
   {
@@ -514,8 +514,8 @@
    "level": 1,
    "out_size": 251793,
    "ratio": 0.2445,
-   "compress_mbps": 127.8,
-   "decompress_mbps": 206.06
+   "compress_mbps": 128.01,
+   "decompress_mbps": 213.58
   },
   {
    "compressor": "native",
@@ -524,8 +524,8 @@
    "level": 2,
    "out_size": 242565,
    "ratio": 0.2356,
-   "compress_mbps": 88.97,
-   "decompress_mbps": 220.59
+   "compress_mbps": 89.1,
+   "decompress_mbps": 229.63
   },
   {
    "compressor": "native",
@@ -534,8 +534,8 @@
    "level": 3,
    "out_size": 242532,
    "ratio": 0.2355,
-   "compress_mbps": 75.91,
-   "decompress_mbps": 229.51
+   "compress_mbps": 75.61,
+   "decompress_mbps": 239.66
   },
   {
    "compressor": "native",
@@ -544,8 +544,8 @@
    "level": 4,
    "out_size": 239953,
    "ratio": 0.233,
-   "compress_mbps": 73.85,
-   "decompress_mbps": 236.28
+   "compress_mbps": 73.25,
+   "decompress_mbps": 245.53
   },
   {
    "compressor": "native",
@@ -554,8 +554,8 @@
    "level": 5,
    "out_size": 218565,
    "ratio": 0.2123,
-   "compress_mbps": 49.86,
-   "decompress_mbps": 232.2
+   "compress_mbps": 48.71,
+   "decompress_mbps": 243.95
   },
   {
    "compressor": "native",
@@ -564,8 +564,8 @@
    "level": 6,
    "out_size": 202676,
    "ratio": 0.1968,
-   "compress_mbps": 37.69,
-   "decompress_mbps": 238.56
+   "compress_mbps": 37.46,
+   "decompress_mbps": 251.44
   },
   {
    "compressor": "native",
@@ -574,8 +574,8 @@
    "level": 7,
    "out_size": 201403,
    "ratio": 0.1956,
-   "compress_mbps": 28.01,
-   "decompress_mbps": 241.08
+   "compress_mbps": 27.67,
+   "decompress_mbps": 252.72
   },
   {
    "compressor": "native",
@@ -584,8 +584,8 @@
    "level": 8,
    "out_size": 200798,
    "ratio": 0.195,
-   "compress_mbps": 21.14,
-   "decompress_mbps": 243.51
+   "compress_mbps": 20.96,
+   "decompress_mbps": 257.86
   },
   {
    "compressor": "native",
@@ -594,8 +594,8 @@
    "level": 9,
    "out_size": 182508,
    "ratio": 0.1772,
-   "compress_mbps": 3.36,
-   "decompress_mbps": 244.31
+   "compress_mbps": 3.3,
+   "decompress_mbps": 257.37
   },
   {
    "compressor": "native",
@@ -604,7 +604,7 @@
    "level": 10,
    "out_size": 178067,
    "ratio": 0.1729,
-   "compress_mbps": 1.41,
+   "compress_mbps": 1.39,
    "decompress_mbps": null
   },
   {
@@ -614,8 +614,8 @@
    "level": 1,
    "out_size": 160674,
    "ratio": 0.3765,
-   "compress_mbps": 72.97,
-   "decompress_mbps": 117.65
+   "compress_mbps": 72.58,
+   "decompress_mbps": 121.4
   },
   {
    "compressor": "native",
@@ -624,8 +624,8 @@
    "level": 2,
    "out_size": 149787,
    "ratio": 0.351,
-   "compress_mbps": 52.46,
-   "decompress_mbps": 126.41
+   "compress_mbps": 52.08,
+   "decompress_mbps": 131.48
   },
   {
    "compressor": "native",
@@ -634,8 +634,8 @@
    "level": 3,
    "out_size": 148055,
    "ratio": 0.3469,
-   "compress_mbps": 46.56,
-   "decompress_mbps": 139.13
+   "compress_mbps": 46.16,
+   "decompress_mbps": 143.32
   },
   {
    "compressor": "native",
@@ -644,8 +644,8 @@
    "level": 4,
    "out_size": 144750,
    "ratio": 0.3392,
-   "compress_mbps": 36.69,
-   "decompress_mbps": 144.01
+   "compress_mbps": 36.63,
+   "decompress_mbps": 148.65
   },
   {
    "compressor": "native",
@@ -654,8 +654,8 @@
    "level": 5,
    "out_size": 144408,
    "ratio": 0.3384,
-   "compress_mbps": 29.71,
-   "decompress_mbps": 151.45
+   "compress_mbps": 29.57,
+   "decompress_mbps": 155.16
   },
   {
    "compressor": "native",
@@ -664,8 +664,8 @@
    "level": 6,
    "out_size": 144070,
    "ratio": 0.3376,
-   "compress_mbps": 28.4,
-   "decompress_mbps": 154.78
+   "compress_mbps": 28.63,
+   "decompress_mbps": 159.1
   },
   {
    "compressor": "native",
@@ -674,8 +674,8 @@
    "level": 7,
    "out_size": 143628,
    "ratio": 0.3366,
-   "compress_mbps": 24.33,
-   "decompress_mbps": 155.66
+   "compress_mbps": 24.35,
+   "decompress_mbps": 160.94
   },
   {
    "compressor": "native",
@@ -684,8 +684,8 @@
    "level": 8,
    "out_size": 143569,
    "ratio": 0.3364,
-   "compress_mbps": 23.49,
-   "decompress_mbps": 155.78
+   "compress_mbps": 23.54,
+   "decompress_mbps": 161.72
   },
   {
    "compressor": "native",
@@ -694,8 +694,8 @@
    "level": 9,
    "out_size": 140322,
    "ratio": 0.3288,
-   "compress_mbps": 4.12,
-   "decompress_mbps": 155.58
+   "compress_mbps": 4.05,
+   "decompress_mbps": 161.14
   },
   {
    "compressor": "native",
@@ -704,7 +704,7 @@
    "level": 10,
    "out_size": 138830,
    "ratio": 0.3253,
-   "compress_mbps": 2.42,
+   "compress_mbps": 2.37,
    "decompress_mbps": null
   },
   {
@@ -714,8 +714,8 @@
    "level": 1,
    "out_size": 212588,
    "ratio": 0.4412,
-   "compress_mbps": 61.98,
-   "decompress_mbps": 98.41
+   "compress_mbps": 61.77,
+   "decompress_mbps": 101.39
   },
   {
    "compressor": "native",
@@ -724,8 +724,8 @@
    "level": 2,
    "out_size": 199981,
    "ratio": 0.415,
-   "compress_mbps": 44.57,
-   "decompress_mbps": 107.07
+   "compress_mbps": 44.31,
+   "decompress_mbps": 110.63
   },
   {
    "compressor": "native",
@@ -734,8 +734,8 @@
    "level": 3,
    "out_size": 198551,
    "ratio": 0.4121,
-   "compress_mbps": 39.73,
-   "decompress_mbps": 117.19
+   "compress_mbps": 39.43,
+   "decompress_mbps": 121.14
   },
   {
    "compressor": "native",
@@ -744,8 +744,8 @@
    "level": 4,
    "out_size": 193783,
    "ratio": 0.4022,
-   "compress_mbps": 29.14,
-   "decompress_mbps": 121.01
+   "compress_mbps": 29.47,
+   "decompress_mbps": 125.12
   },
   {
    "compressor": "native",
@@ -754,8 +754,8 @@
    "level": 5,
    "out_size": 193223,
    "ratio": 0.401,
-   "compress_mbps": 24.47,
-   "decompress_mbps": 127.1
+   "compress_mbps": 24.53,
+   "decompress_mbps": 131.78
   },
   {
    "compressor": "native",
@@ -764,8 +764,8 @@
    "level": 6,
    "out_size": 193416,
    "ratio": 0.4014,
-   "compress_mbps": 24.56,
-   "decompress_mbps": 130.54
+   "compress_mbps": 24.77,
+   "decompress_mbps": 135.08
   },
   {
    "compressor": "native",
@@ -774,8 +774,8 @@
    "level": 7,
    "out_size": 192664,
    "ratio": 0.3998,
-   "compress_mbps": 20.51,
-   "decompress_mbps": 130.68
+   "compress_mbps": 20.84,
+   "decompress_mbps": 135.67
   },
   {
    "compressor": "native",
@@ -784,8 +784,8 @@
    "level": 8,
    "out_size": 192638,
    "ratio": 0.3998,
-   "compress_mbps": 19.69,
-   "decompress_mbps": 131.14
+   "compress_mbps": 20.1,
+   "decompress_mbps": 136.18
   },
   {
    "compressor": "native",
@@ -794,8 +794,8 @@
    "level": 9,
    "out_size": 189365,
    "ratio": 0.393,
-   "compress_mbps": 3.88,
-   "decompress_mbps": 131.46
+   "compress_mbps": 3.95,
+   "decompress_mbps": 136.09
   },
   {
    "compressor": "native",
@@ -804,7 +804,7 @@
    "level": 10,
    "out_size": 186147,
    "ratio": 0.3863,
-   "compress_mbps": 2.34,
+   "compress_mbps": 2.32,
    "decompress_mbps": null
   },
   {
@@ -814,8 +814,8 @@
    "level": 1,
    "out_size": 60161,
    "ratio": 0.1172,
-   "compress_mbps": 206.72,
-   "decompress_mbps": 343.32
+   "compress_mbps": 207.74,
+   "decompress_mbps": 353.32
   },
   {
    "compressor": "native",
@@ -824,8 +824,8 @@
    "level": 2,
    "out_size": 58873,
    "ratio": 0.1147,
-   "compress_mbps": 153.38,
-   "decompress_mbps": 359.42
+   "compress_mbps": 153.59,
+   "decompress_mbps": 371.3
   },
   {
    "compressor": "native",
@@ -834,8 +834,8 @@
    "level": 3,
    "out_size": 58327,
    "ratio": 0.1137,
-   "compress_mbps": 133.21,
-   "decompress_mbps": 382.0
+   "compress_mbps": 133.1,
+   "decompress_mbps": 395.92
   },
   {
    "compressor": "native",
@@ -844,8 +844,8 @@
    "level": 4,
    "out_size": 55588,
    "ratio": 0.1083,
-   "compress_mbps": 89.71,
-   "decompress_mbps": 355.0
+   "compress_mbps": 89.51,
+   "decompress_mbps": 368.88
   },
   {
    "compressor": "native",
@@ -854,8 +854,8 @@
    "level": 5,
    "out_size": 55097,
    "ratio": 0.1074,
-   "compress_mbps": 67.78,
-   "decompress_mbps": 378.1
+   "compress_mbps": 67.7,
+   "decompress_mbps": 390.45
   },
   {
    "compressor": "native",
@@ -864,8 +864,8 @@
    "level": 6,
    "out_size": 55195,
    "ratio": 0.1075,
-   "compress_mbps": 55.89,
-   "decompress_mbps": 404.07
+   "compress_mbps": 56.55,
+   "decompress_mbps": 419.37
   },
   {
    "compressor": "native",
@@ -874,8 +874,8 @@
    "level": 7,
    "out_size": 54316,
    "ratio": 0.1058,
-   "compress_mbps": 43.71,
-   "decompress_mbps": 423.41
+   "compress_mbps": 43.91,
+   "decompress_mbps": 446.43
   },
   {
    "compressor": "native",
@@ -884,8 +884,8 @@
    "level": 8,
    "out_size": 53091,
    "ratio": 0.1034,
-   "compress_mbps": 35.1,
-   "decompress_mbps": 456.62
+   "compress_mbps": 35.43,
+   "decompress_mbps": 477.62
   },
   {
    "compressor": "native",
@@ -894,8 +894,8 @@
    "level": 9,
    "out_size": 52605,
    "ratio": 0.1025,
-   "compress_mbps": 5.44,
-   "decompress_mbps": 463.22
+   "compress_mbps": 5.35,
+   "decompress_mbps": 488.18
   },
   {
    "compressor": "native",
@@ -904,7 +904,7 @@
    "level": 10,
    "out_size": 52234,
    "ratio": 0.1018,
-   "compress_mbps": 3.54,
+   "compress_mbps": 3.49,
    "decompress_mbps": null
   },
   {
@@ -914,8 +914,8 @@
    "level": 1,
    "out_size": 14249,
    "ratio": 0.3726,
-   "compress_mbps": 51.7,
-   "decompress_mbps": 112.65
+   "compress_mbps": 35.94,
+   "decompress_mbps": 119.1
   },
   {
    "compressor": "native",
@@ -924,8 +924,8 @@
    "level": 2,
    "out_size": 13825,
    "ratio": 0.3615,
-   "compress_mbps": 44.96,
-   "decompress_mbps": 115.26
+   "compress_mbps": 44.46,
+   "decompress_mbps": 122.12
   },
   {
    "compressor": "native",
@@ -934,8 +934,8 @@
    "level": 3,
    "out_size": 13751,
    "ratio": 0.3596,
-   "compress_mbps": 43.1,
-   "decompress_mbps": 116.87
+   "compress_mbps": 42.93,
+   "decompress_mbps": 124.18
   },
   {
    "compressor": "native",
@@ -944,8 +944,8 @@
    "level": 4,
    "out_size": 13287,
    "ratio": 0.3475,
-   "compress_mbps": 38.62,
-   "decompress_mbps": 122.72
+   "compress_mbps": 38.11,
+   "decompress_mbps": 130.61
   },
   {
    "compressor": "native",
@@ -954,8 +954,8 @@
    "level": 5,
    "out_size": 13240,
    "ratio": 0.3462,
-   "compress_mbps": 34.25,
-   "decompress_mbps": 128.84
+   "compress_mbps": 33.83,
+   "decompress_mbps": 137.29
   },
   {
    "compressor": "native",
@@ -964,8 +964,8 @@
    "level": 6,
    "out_size": 12944,
    "ratio": 0.3385,
-   "compress_mbps": 18.77,
-   "decompress_mbps": 131.45
+   "compress_mbps": 18.61,
+   "decompress_mbps": 140.36
   },
   {
    "compressor": "native",
@@ -974,8 +974,8 @@
    "level": 7,
    "out_size": 12929,
    "ratio": 0.3381,
-   "compress_mbps": 17.39,
-   "decompress_mbps": 132.08
+   "compress_mbps": 17.31,
+   "decompress_mbps": 140.84
   },
   {
    "compressor": "native",
@@ -984,8 +984,8 @@
    "level": 8,
    "out_size": 12921,
    "ratio": 0.3379,
-   "compress_mbps": 16.14,
-   "decompress_mbps": 133.69
+   "compress_mbps": 15.99,
+   "decompress_mbps": 142.51
   },
   {
    "compressor": "native",
@@ -994,8 +994,8 @@
    "level": 9,
    "out_size": 12427,
    "ratio": 0.325,
-   "compress_mbps": 5.17,
-   "decompress_mbps": 135.14
+   "compress_mbps": 5.11,
+   "decompress_mbps": 144.71
   },
   {
    "compressor": "native",
@@ -1014,8 +1014,8 @@
    "level": 1,
    "out_size": 1800,
    "ratio": 0.4258,
-   "compress_mbps": 24.85,
-   "decompress_mbps": 57.19
+   "compress_mbps": 25.73,
+   "decompress_mbps": 65.78
   },
   {
    "compressor": "native",
@@ -1024,8 +1024,8 @@
    "level": 2,
    "out_size": 1750,
    "ratio": 0.414,
-   "compress_mbps": 23.47,
-   "decompress_mbps": 57.84
+   "compress_mbps": 23.91,
+   "decompress_mbps": 66.76
   },
   {
    "compressor": "native",
@@ -1034,8 +1034,8 @@
    "level": 3,
    "out_size": 1742,
    "ratio": 0.4121,
-   "compress_mbps": 23.3,
-   "decompress_mbps": 58.03
+   "compress_mbps": 24.13,
+   "decompress_mbps": 66.5
   },
   {
    "compressor": "native",
@@ -1044,8 +1044,8 @@
    "level": 4,
    "out_size": 1726,
    "ratio": 0.4083,
-   "compress_mbps": 22.99,
-   "decompress_mbps": 59.22
+   "compress_mbps": 23.6,
+   "decompress_mbps": 68.5
   },
   {
    "compressor": "native",
@@ -1054,8 +1054,8 @@
    "level": 5,
    "out_size": 1722,
    "ratio": 0.4074,
-   "compress_mbps": 22.58,
-   "decompress_mbps": 59.44
+   "compress_mbps": 23.19,
+   "decompress_mbps": 68.73
   },
   {
    "compressor": "native",
@@ -1064,8 +1064,8 @@
    "level": 6,
    "out_size": 1722,
    "ratio": 0.4074,
-   "compress_mbps": 21.67,
-   "decompress_mbps": 59.35
+   "compress_mbps": 22.18,
+   "decompress_mbps": 69.05
   },
   {
    "compressor": "native",
@@ -1074,8 +1074,8 @@
    "level": 7,
    "out_size": 1722,
    "ratio": 0.4074,
-   "compress_mbps": 21.71,
-   "decompress_mbps": 59.38
+   "compress_mbps": 22.02,
+   "decompress_mbps": 68.54
   },
   {
    "compressor": "native",
@@ -1084,8 +1084,8 @@
    "level": 8,
    "out_size": 1722,
    "ratio": 0.4074,
-   "compress_mbps": 21.74,
-   "decompress_mbps": 59.51
+   "compress_mbps": 22.15,
+   "decompress_mbps": 69.2
   },
   {
    "compressor": "native",
@@ -1095,7 +1095,7 @@
    "out_size": 1708,
    "ratio": 0.4041,
    "compress_mbps": 5.23,
-   "decompress_mbps": 59.52
+   "decompress_mbps": 68.93
   },
   {
    "compressor": "native",
@@ -1104,7 +1104,7 @@
    "level": 10,
    "out_size": 1693,
    "ratio": 0.4005,
-   "compress_mbps": 3.12,
+   "compress_mbps": 3.17,
    "decompress_mbps": null
   },
   {
@@ -4414,8 +4414,8 @@
    "level": 1,
    "out_size": 4259644,
    "ratio": 0.4179,
-   "compress_mbps": 64.23,
-   "decompress_mbps": 103.46
+   "compress_mbps": 64.75,
+   "decompress_mbps": 105.94
   },
   {
    "compressor": "native",
@@ -4424,8 +4424,8 @@
    "level": 2,
    "out_size": 3977395,
    "ratio": 0.3902,
-   "compress_mbps": 46.36,
-   "decompress_mbps": 111.59
+   "compress_mbps": 46.15,
+   "decompress_mbps": 114.7
   },
   {
    "compressor": "native",
@@ -4434,8 +4434,8 @@
    "level": 3,
    "out_size": 3945296,
    "ratio": 0.3871,
-   "compress_mbps": 40.94,
-   "decompress_mbps": 121.93
+   "compress_mbps": 40.72,
+   "decompress_mbps": 125.91
   },
   {
    "compressor": "native",
@@ -4444,8 +4444,8 @@
    "level": 4,
    "out_size": 3851998,
    "ratio": 0.3779,
-   "compress_mbps": 31.24,
-   "decompress_mbps": 125.55
+   "compress_mbps": 30.92,
+   "decompress_mbps": 129.05
   },
   {
    "compressor": "native",
@@ -4454,8 +4454,8 @@
    "level": 5,
    "out_size": 3840481,
    "ratio": 0.3768,
-   "compress_mbps": 26.32,
-   "decompress_mbps": 131.73
+   "compress_mbps": 26.22,
+   "decompress_mbps": 133.97
   },
   {
    "compressor": "native",
@@ -4464,8 +4464,8 @@
    "level": 6,
    "out_size": 3847941,
    "ratio": 0.3775,
-   "compress_mbps": 26.51,
-   "decompress_mbps": 136.03
+   "compress_mbps": 26.48,
+   "decompress_mbps": 139.02
   },
   {
    "compressor": "native",
@@ -4474,8 +4474,8 @@
    "level": 7,
    "out_size": 3834802,
    "ratio": 0.3762,
-   "compress_mbps": 22.23,
-   "decompress_mbps": 136.55
+   "compress_mbps": 22.17,
+   "decompress_mbps": 139.54
   },
   {
    "compressor": "native",
@@ -4484,8 +4484,8 @@
    "level": 8,
    "out_size": 3833946,
    "ratio": 0.3762,
-   "compress_mbps": 21.45,
-   "decompress_mbps": 136.56
+   "compress_mbps": 21.43,
+   "decompress_mbps": 139.22
   },
   {
    "compressor": "native",
@@ -4494,8 +4494,8 @@
    "level": 9,
    "out_size": 3766584,
    "ratio": 0.3695,
-   "compress_mbps": 4.0,
-   "decompress_mbps": 139.1
+   "compress_mbps": 3.96,
+   "decompress_mbps": 143.62
   },
   {
    "compressor": "native",
@@ -4504,7 +4504,7 @@
    "level": 10,
    "out_size": 3711172,
    "ratio": 0.3641,
-   "compress_mbps": 2.36,
+   "compress_mbps": 2.33,
    "decompress_mbps": null
   },
   {
@@ -4514,8 +4514,8 @@
    "level": 1,
    "out_size": 21267086,
    "ratio": 0.4152,
-   "compress_mbps": 78.9,
-   "decompress_mbps": 131.77
+   "compress_mbps": 79.77,
+   "decompress_mbps": 138.05
   },
   {
    "compressor": "native",
@@ -4524,8 +4524,8 @@
    "level": 2,
    "out_size": 20802983,
    "ratio": 0.4061,
-   "compress_mbps": 63.24,
-   "decompress_mbps": 138.99
+   "compress_mbps": 62.71,
+   "decompress_mbps": 145.87
   },
   {
    "compressor": "native",
@@ -4534,8 +4534,8 @@
    "level": 3,
    "out_size": 20665485,
    "ratio": 0.4035,
-   "compress_mbps": 58.81,
-   "decompress_mbps": 142.71
+   "compress_mbps": 58.83,
+   "decompress_mbps": 150.96
   },
   {
    "compressor": "native",
@@ -4544,8 +4544,8 @@
    "level": 4,
    "out_size": 20356893,
    "ratio": 0.3974,
-   "compress_mbps": 48.64,
-   "decompress_mbps": 145.81
+   "compress_mbps": 48.27,
+   "decompress_mbps": 155.81
   },
   {
    "compressor": "native",
@@ -4554,8 +4554,8 @@
    "level": 5,
    "out_size": 20209289,
    "ratio": 0.3946,
-   "compress_mbps": 38.41,
-   "decompress_mbps": 157.36
+   "compress_mbps": 37.91,
+   "decompress_mbps": 168.37
   },
   {
    "compressor": "native",
@@ -4564,8 +4564,8 @@
    "level": 6,
    "out_size": 19174181,
    "ratio": 0.3743,
-   "compress_mbps": 26.13,
-   "decompress_mbps": 161.08
+   "compress_mbps": 26.01,
+   "decompress_mbps": 171.79
   },
   {
    "compressor": "native",
@@ -4574,8 +4574,8 @@
    "level": 7,
    "out_size": 19127630,
    "ratio": 0.3734,
-   "compress_mbps": 21.52,
-   "decompress_mbps": 161.44
+   "compress_mbps": 21.62,
+   "decompress_mbps": 172.25
   },
   {
    "compressor": "native",
@@ -4584,8 +4584,8 @@
    "level": 8,
    "out_size": 19117840,
    "ratio": 0.3732,
-   "compress_mbps": 18.67,
-   "decompress_mbps": 163.06
+   "compress_mbps": 18.7,
+   "decompress_mbps": 173.32
   },
   {
    "compressor": "native",
@@ -4594,8 +4594,8 @@
    "level": 9,
    "out_size": 18686872,
    "ratio": 0.3648,
-   "compress_mbps": 4.18,
-   "decompress_mbps": 158.87
+   "compress_mbps": 4.14,
+   "decompress_mbps": 141.24
   },
   {
    "compressor": "native",
@@ -4604,7 +4604,7 @@
    "level": 10,
    "out_size": 18539905,
    "ratio": 0.362,
-   "compress_mbps": 1.82,
+   "compress_mbps": 2.24,
    "decompress_mbps": null
   },
   {
@@ -4614,8 +4614,8 @@
    "level": 1,
    "out_size": 3864163,
    "ratio": 0.3876,
-   "compress_mbps": 78.37,
-   "decompress_mbps": 120.98
+   "compress_mbps": 79.39,
+   "decompress_mbps": 122.86
   },
   {
    "compressor": "native",
@@ -4624,8 +4624,8 @@
    "level": 2,
    "out_size": 3734957,
    "ratio": 0.3746,
-   "compress_mbps": 60.61,
-   "decompress_mbps": 126.38
+   "compress_mbps": 60.6,
+   "decompress_mbps": 130.79
   },
   {
    "compressor": "native",
@@ -4634,8 +4634,8 @@
    "level": 3,
    "out_size": 3708443,
    "ratio": 0.3719,
-   "compress_mbps": 51.98,
-   "decompress_mbps": 135.59
+   "compress_mbps": 51.96,
+   "decompress_mbps": 140.02
   },
   {
    "compressor": "native",
@@ -4644,8 +4644,8 @@
    "level": 4,
    "out_size": 3683603,
    "ratio": 0.3694,
-   "compress_mbps": 37.27,
-   "decompress_mbps": 130.12
+   "compress_mbps": 37.1,
+   "decompress_mbps": 135.0
   },
   {
    "compressor": "native",
@@ -4654,8 +4654,8 @@
    "level": 5,
    "out_size": 3677014,
    "ratio": 0.3688,
-   "compress_mbps": 30.22,
-   "decompress_mbps": 136.28
+   "compress_mbps": 29.98,
+   "decompress_mbps": 142.33
   },
   {
    "compressor": "native",
@@ -4664,8 +4664,8 @@
    "level": 6,
    "out_size": 3588221,
    "ratio": 0.3599,
-   "compress_mbps": 27.71,
-   "decompress_mbps": 141.5
+   "compress_mbps": 27.52,
+   "decompress_mbps": 148.43
   },
   {
    "compressor": "native",
@@ -4674,8 +4674,8 @@
    "level": 7,
    "out_size": 3581006,
    "ratio": 0.3592,
-   "compress_mbps": 22.57,
-   "decompress_mbps": 143.39
+   "compress_mbps": 22.45,
+   "decompress_mbps": 149.38
   },
   {
    "compressor": "native",
@@ -4684,8 +4684,8 @@
    "level": 8,
    "out_size": 3580944,
    "ratio": 0.3592,
-   "compress_mbps": 20.43,
-   "decompress_mbps": 145.92
+   "compress_mbps": 20.32,
+   "decompress_mbps": 153.82
   },
   {
    "compressor": "native",
@@ -4694,8 +4694,8 @@
    "level": 9,
    "out_size": 3581441,
    "ratio": 0.3592,
-   "compress_mbps": 4.54,
-   "decompress_mbps": 150.67
+   "compress_mbps": 4.48,
+   "decompress_mbps": 157.58
   },
   {
    "compressor": "native",
@@ -4714,8 +4714,8 @@
    "level": 1,
    "out_size": 3785443,
    "ratio": 0.1128,
-   "compress_mbps": 230.34,
-   "decompress_mbps": 358.02
+   "compress_mbps": 231.37,
+   "decompress_mbps": 370.28
   },
   {
    "compressor": "native",
@@ -4724,8 +4724,8 @@
    "level": 2,
    "out_size": 3761560,
    "ratio": 0.1121,
-   "compress_mbps": 146.79,
-   "decompress_mbps": 401.47
+   "compress_mbps": 145.65,
+   "decompress_mbps": 416.11
   },
   {
    "compressor": "native",
@@ -4734,8 +4734,8 @@
    "level": 3,
    "out_size": 3606997,
    "ratio": 0.1075,
-   "compress_mbps": 125.51,
-   "decompress_mbps": 448.53
+   "compress_mbps": 123.84,
+   "decompress_mbps": 463.77
   },
   {
    "compressor": "native",
@@ -4744,8 +4744,8 @@
    "level": 4,
    "out_size": 3201209,
    "ratio": 0.0954,
-   "compress_mbps": 96.02,
-   "decompress_mbps": 461.8
+   "compress_mbps": 94.76,
+   "decompress_mbps": 476.45
   },
   {
    "compressor": "native",
@@ -4754,8 +4754,8 @@
    "level": 5,
    "out_size": 3091564,
    "ratio": 0.0921,
-   "compress_mbps": 73.13,
-   "decompress_mbps": 525.58
+   "compress_mbps": 72.43,
+   "decompress_mbps": 536.28
   },
   {
    "compressor": "native",
@@ -4764,8 +4764,8 @@
    "level": 6,
    "out_size": 3112756,
    "ratio": 0.0928,
-   "compress_mbps": 71.57,
-   "decompress_mbps": 563.64
+   "compress_mbps": 71.55,
+   "decompress_mbps": 583.32
   },
   {
    "compressor": "native",
@@ -4774,8 +4774,8 @@
    "level": 7,
    "out_size": 3062314,
    "ratio": 0.0913,
-   "compress_mbps": 55.5,
-   "decompress_mbps": 576.8
+   "compress_mbps": 54.91,
+   "decompress_mbps": 595.51
   },
   {
    "compressor": "native",
@@ -4784,8 +4784,8 @@
    "level": 8,
    "out_size": 3045348,
    "ratio": 0.0908,
-   "compress_mbps": 46.91,
-   "decompress_mbps": 599.55
+   "compress_mbps": 46.45,
+   "decompress_mbps": 615.73
   },
   {
    "compressor": "native",
@@ -4794,8 +4794,8 @@
    "level": 9,
    "out_size": 3031645,
    "ratio": 0.0904,
-   "compress_mbps": 3.17,
-   "decompress_mbps": 601.36
+   "compress_mbps": 2.84,
+   "decompress_mbps": 621.2
   },
   {
    "compressor": "native",
@@ -4804,7 +4804,7 @@
    "level": 10,
    "out_size": 2902186,
    "ratio": 0.0865,
-   "compress_mbps": 1.85,
+   "compress_mbps": 1.48,
    "decompress_mbps": null
   },
   {
@@ -4814,8 +4814,8 @@
    "level": 1,
    "out_size": 3357083,
    "ratio": 0.5457,
-   "compress_mbps": 56.24,
-   "decompress_mbps": 92.0
+   "compress_mbps": 56.26,
+   "decompress_mbps": 95.43
   },
   {
    "compressor": "native",
@@ -4824,8 +4824,8 @@
    "level": 2,
    "out_size": 3285077,
    "ratio": 0.534,
-   "compress_mbps": 46.35,
-   "decompress_mbps": 92.68
+   "compress_mbps": 46.9,
+   "decompress_mbps": 96.94
   },
   {
    "compressor": "native",
@@ -4834,8 +4834,8 @@
    "level": 3,
    "out_size": 3272746,
    "ratio": 0.532,
-   "compress_mbps": 45.0,
-   "decompress_mbps": 95.23
+   "compress_mbps": 45.02,
+   "decompress_mbps": 100.18
   },
   {
    "compressor": "native",
@@ -4844,8 +4844,8 @@
    "level": 4,
    "out_size": 3228052,
    "ratio": 0.5247,
-   "compress_mbps": 38.1,
-   "decompress_mbps": 103.31
+   "compress_mbps": 37.81,
+   "decompress_mbps": 108.83
   },
   {
    "compressor": "native",
@@ -4854,8 +4854,8 @@
    "level": 5,
    "out_size": 3223415,
    "ratio": 0.5239,
-   "compress_mbps": 34.4,
-   "decompress_mbps": 107.25
+   "compress_mbps": 34.08,
+   "decompress_mbps": 113.17
   },
   {
    "compressor": "native",
@@ -4864,8 +4864,8 @@
    "level": 6,
    "out_size": 3159522,
    "ratio": 0.5136,
-   "compress_mbps": 23.94,
-   "decompress_mbps": 108.81
+   "compress_mbps": 24.37,
+   "decompress_mbps": 112.81
   },
   {
    "compressor": "native",
@@ -4874,8 +4874,8 @@
    "level": 7,
    "out_size": 3156358,
    "ratio": 0.513,
-   "compress_mbps": 22.4,
-   "decompress_mbps": 109.6
+   "compress_mbps": 22.35,
+   "decompress_mbps": 114.65
   },
   {
    "compressor": "native",
@@ -4884,8 +4884,8 @@
    "level": 8,
    "out_size": 3155368,
    "ratio": 0.5129,
-   "compress_mbps": 21.32,
-   "decompress_mbps": 109.86
+   "compress_mbps": 21.66,
+   "decompress_mbps": 116.56
   },
   {
    "compressor": "native",
@@ -4894,8 +4894,8 @@
    "level": 9,
    "out_size": 3048772,
    "ratio": 0.4956,
-   "compress_mbps": 4.87,
-   "decompress_mbps": 109.2
+   "compress_mbps": 4.89,
+   "decompress_mbps": 117.55
   },
   {
    "compressor": "native",
@@ -4904,7 +4904,7 @@
    "level": 10,
    "out_size": 3021986,
    "ratio": 0.4912,
-   "compress_mbps": 3.06,
+   "compress_mbps": 3.04,
    "decompress_mbps": null
   },
   {
@@ -4914,8 +4914,8 @@
    "level": 1,
    "out_size": 3838828,
    "ratio": 0.3806,
-   "compress_mbps": 89.33,
-   "decompress_mbps": 156.27
+   "compress_mbps": 89.37,
+   "decompress_mbps": 165.47
   },
   {
    "compressor": "native",
@@ -4924,8 +4924,8 @@
    "level": 2,
    "out_size": 3792520,
    "ratio": 0.376,
-   "compress_mbps": 66.59,
-   "decompress_mbps": 161.7
+   "compress_mbps": 66.27,
+   "decompress_mbps": 170.49
   },
   {
    "compressor": "native",
@@ -4934,8 +4934,8 @@
    "level": 3,
    "out_size": 3783171,
    "ratio": 0.3751,
-   "compress_mbps": 64.53,
-   "decompress_mbps": 165.55
+   "compress_mbps": 64.25,
+   "decompress_mbps": 174.9
   },
   {
    "compressor": "native",
@@ -4944,8 +4944,8 @@
    "level": 4,
    "out_size": 3648458,
    "ratio": 0.3617,
-   "compress_mbps": 57.75,
-   "decompress_mbps": 176.79
+   "compress_mbps": 57.05,
+   "decompress_mbps": 181.69
   },
   {
    "compressor": "native",
@@ -4954,8 +4954,8 @@
    "level": 5,
    "out_size": 3648472,
    "ratio": 0.3617,
-   "compress_mbps": 53.53,
-   "decompress_mbps": 183.0
+   "compress_mbps": 53.21,
+   "decompress_mbps": 186.7
   },
   {
    "compressor": "native",
@@ -4964,8 +4964,8 @@
    "level": 6,
    "out_size": 3648595,
    "ratio": 0.3618,
-   "compress_mbps": 43.69,
-   "decompress_mbps": 184.18
+   "compress_mbps": 43.34,
+   "decompress_mbps": 195.87
   },
   {
    "compressor": "native",
@@ -4974,8 +4974,8 @@
    "level": 7,
    "out_size": 3648160,
    "ratio": 0.3617,
-   "compress_mbps": 43.5,
-   "decompress_mbps": 187.01
+   "compress_mbps": 43.27,
+   "decompress_mbps": 197.07
   },
   {
    "compressor": "native",
@@ -4984,8 +4984,8 @@
    "level": 8,
    "out_size": 3648156,
    "ratio": 0.3617,
-   "compress_mbps": 43.27,
-   "decompress_mbps": 188.07
+   "compress_mbps": 43.17,
+   "decompress_mbps": 199.41
   },
   {
    "compressor": "native",
@@ -4994,8 +4994,8 @@
    "level": 9,
    "out_size": 3648156,
    "ratio": 0.3617,
-   "compress_mbps": 5.71,
-   "decompress_mbps": 191.93
+   "compress_mbps": 5.63,
+   "decompress_mbps": 204.98
   },
   {
    "compressor": "native",
@@ -5014,8 +5014,8 @@
    "level": 1,
    "out_size": 2254442,
    "ratio": 0.3402,
-   "compress_mbps": 82.52,
-   "decompress_mbps": 124.77
+   "compress_mbps": 82.97,
+   "decompress_mbps": 127.54
   },
   {
    "compressor": "native",
@@ -5024,8 +5024,8 @@
    "level": 2,
    "out_size": 2044843,
    "ratio": 0.3086,
-   "compress_mbps": 55.86,
-   "decompress_mbps": 140.79
+   "compress_mbps": 55.83,
+   "decompress_mbps": 147.39
   },
   {
    "compressor": "native",
@@ -5034,8 +5034,8 @@
    "level": 3,
    "out_size": 1992105,
    "ratio": 0.3006,
-   "compress_mbps": 43.0,
-   "decompress_mbps": 156.45
+   "compress_mbps": 45.62,
+   "decompress_mbps": 160.68
   },
   {
    "compressor": "native",
@@ -5044,8 +5044,8 @@
    "level": 4,
    "out_size": 1890729,
    "ratio": 0.2853,
-   "compress_mbps": 32.1,
-   "decompress_mbps": 159.15
+   "compress_mbps": 31.96,
+   "decompress_mbps": 168.5
   },
   {
    "compressor": "native",
@@ -5054,8 +5054,8 @@
    "level": 5,
    "out_size": 1858234,
    "ratio": 0.2804,
-   "compress_mbps": 21.09,
-   "decompress_mbps": 171.37
+   "compress_mbps": 20.98,
+   "decompress_mbps": 174.78
   },
   {
    "compressor": "native",
@@ -5064,8 +5064,8 @@
    "level": 6,
    "out_size": 1856235,
    "ratio": 0.2801,
-   "compress_mbps": 25.32,
-   "decompress_mbps": 185.73
+   "compress_mbps": 25.34,
+   "decompress_mbps": 187.44
   },
   {
    "compressor": "native",
@@ -5074,8 +5074,8 @@
    "level": 7,
    "out_size": 1823963,
    "ratio": 0.2752,
-   "compress_mbps": 16.37,
-   "decompress_mbps": 185.59
+   "compress_mbps": 16.35,
+   "decompress_mbps": 191.19
   },
   {
    "compressor": "native",
@@ -5084,8 +5084,8 @@
    "level": 8,
    "out_size": 1820112,
    "ratio": 0.2746,
-   "compress_mbps": 14.29,
-   "decompress_mbps": 192.09
+   "compress_mbps": 14.21,
+   "decompress_mbps": 193.13
   },
   {
    "compressor": "native",
@@ -5094,8 +5094,8 @@
    "level": 9,
    "out_size": 1773447,
    "ratio": 0.2676,
-   "compress_mbps": 2.87,
-   "decompress_mbps": 191.95
+   "compress_mbps": 2.82,
+   "decompress_mbps": 195.14
   },
   {
    "compressor": "native",
@@ -5104,7 +5104,7 @@
    "level": 10,
    "out_size": 1718500,
    "ratio": 0.2593,
-   "compress_mbps": 1.52,
+   "compress_mbps": 1.51,
    "decompress_mbps": null
   },
   {
@@ -5114,8 +5114,8 @@
    "level": 1,
    "out_size": 6406301,
    "ratio": 0.2965,
-   "compress_mbps": 109.31,
-   "decompress_mbps": 195.21
+   "compress_mbps": 109.99,
+   "decompress_mbps": 203.67
   },
   {
    "compressor": "native",
@@ -5124,8 +5124,8 @@
    "level": 2,
    "out_size": 6102377,
    "ratio": 0.2824,
-   "compress_mbps": 80.54,
-   "decompress_mbps": 206.7
+   "compress_mbps": 80.92,
+   "decompress_mbps": 216.41
   },
   {
    "compressor": "native",
@@ -5134,8 +5134,8 @@
    "level": 3,
    "out_size": 6022184,
    "ratio": 0.2787,
-   "compress_mbps": 73.49,
-   "decompress_mbps": 215.64
+   "compress_mbps": 73.7,
+   "decompress_mbps": 226.26
   },
   {
    "compressor": "native",
@@ -5144,8 +5144,8 @@
    "level": 4,
    "out_size": 5880892,
    "ratio": 0.2722,
-   "compress_mbps": 57.23,
-   "decompress_mbps": 225.43
+   "compress_mbps": 57.16,
+   "decompress_mbps": 237.07
   },
   {
    "compressor": "native",
@@ -5154,8 +5154,8 @@
    "level": 5,
    "out_size": 5834363,
    "ratio": 0.27,
-   "compress_mbps": 45.3,
-   "decompress_mbps": 237.39
+   "compress_mbps": 45.03,
+   "decompress_mbps": 249.04
   },
   {
    "compressor": "native",
@@ -5164,8 +5164,8 @@
    "level": 6,
    "out_size": 5409792,
    "ratio": 0.2504,
-   "compress_mbps": 38.01,
-   "decompress_mbps": 242.08
+   "compress_mbps": 37.82,
+   "decompress_mbps": 255.63
   },
   {
    "compressor": "native",
@@ -5174,8 +5174,8 @@
    "level": 7,
    "out_size": 5393735,
    "ratio": 0.2496,
-   "compress_mbps": 32.64,
-   "decompress_mbps": 244.99
+   "compress_mbps": 32.5,
+   "decompress_mbps": 255.37
   },
   {
    "compressor": "native",
@@ -5184,8 +5184,8 @@
    "level": 8,
    "out_size": 5389952,
    "ratio": 0.2495,
-   "compress_mbps": 30.52,
-   "decompress_mbps": 246.15
+   "compress_mbps": 30.26,
+   "decompress_mbps": 258.97
   },
   {
    "compressor": "native",
@@ -5194,8 +5194,8 @@
    "level": 9,
    "out_size": 5235865,
    "ratio": 0.2423,
-   "compress_mbps": 4.52,
-   "decompress_mbps": 246.53
+   "compress_mbps": 4.49,
+   "decompress_mbps": 259.8
   },
   {
    "compressor": "native",
@@ -5204,7 +5204,7 @@
    "level": 10,
    "out_size": 5177560,
    "ratio": 0.2396,
-   "compress_mbps": 2.48,
+   "compress_mbps": 2.45,
    "decompress_mbps": null
   },
   {
@@ -5214,8 +5214,8 @@
    "level": 1,
    "out_size": 5612204,
    "ratio": 0.7739,
-   "compress_mbps": 46.68,
-   "decompress_mbps": 91.69
+   "compress_mbps": 47.9,
+   "decompress_mbps": 96.84
   },
   {
    "compressor": "native",
@@ -5224,8 +5224,8 @@
    "level": 2,
    "out_size": 5533875,
    "ratio": 0.7631,
-   "compress_mbps": 38.99,
-   "decompress_mbps": 93.38
+   "compress_mbps": 39.29,
+   "decompress_mbps": 100.99
   },
   {
    "compressor": "native",
@@ -5234,8 +5234,8 @@
    "level": 3,
    "out_size": 5522436,
    "ratio": 0.7615,
-   "compress_mbps": 36.79,
-   "decompress_mbps": 97.13
+   "compress_mbps": 36.58,
+   "decompress_mbps": 104.92
   },
   {
    "compressor": "native",
@@ -5244,8 +5244,8 @@
    "level": 4,
    "out_size": 5494383,
    "ratio": 0.7576,
-   "compress_mbps": 31.74,
-   "decompress_mbps": 100.46
+   "compress_mbps": 31.8,
+   "decompress_mbps": 108.75
   },
   {
    "compressor": "native",
@@ -5254,8 +5254,8 @@
    "level": 5,
    "out_size": 5489807,
    "ratio": 0.757,
-   "compress_mbps": 30.06,
-   "decompress_mbps": 103.92
+   "compress_mbps": 29.96,
+   "decompress_mbps": 111.32
   },
   {
    "compressor": "native",
@@ -5264,8 +5264,8 @@
    "level": 6,
    "out_size": 5470520,
    "ratio": 0.7544,
-   "compress_mbps": 22.8,
-   "decompress_mbps": 104.41
+   "compress_mbps": 22.74,
+   "decompress_mbps": 113.14
   },
   {
    "compressor": "native",
@@ -5274,8 +5274,8 @@
    "level": 7,
    "out_size": 5463682,
    "ratio": 0.7534,
-   "compress_mbps": 21.89,
-   "decompress_mbps": 104.98
+   "compress_mbps": 21.83,
+   "decompress_mbps": 115.0
   },
   {
    "compressor": "native",
@@ -5284,8 +5284,8 @@
    "level": 8,
    "out_size": 5463761,
    "ratio": 0.7534,
-   "compress_mbps": 21.33,
-   "decompress_mbps": 104.82
+   "compress_mbps": 21.4,
+   "decompress_mbps": 114.5
   },
   {
    "compressor": "native",
@@ -5294,8 +5294,8 @@
    "level": 9,
    "out_size": 5284536,
    "ratio": 0.7287,
-   "compress_mbps": 4.92,
-   "decompress_mbps": 104.71
+   "compress_mbps": 4.87,
+   "decompress_mbps": 114.85
   },
   {
    "compressor": "native",
@@ -5304,7 +5304,7 @@
    "level": 10,
    "out_size": 5262319,
    "ratio": 0.7256,
-   "compress_mbps": 3.4,
+   "compress_mbps": 3.46,
    "decompress_mbps": null
   },
   {
@@ -5314,8 +5314,8 @@
    "level": 1,
    "out_size": 13727247,
    "ratio": 0.3311,
-   "compress_mbps": 82.87,
-   "decompress_mbps": 135.52
+   "compress_mbps": 82.59,
+   "decompress_mbps": 140.42
   },
   {
    "compressor": "native",
@@ -5324,8 +5324,8 @@
    "level": 2,
    "out_size": 12940398,
    "ratio": 0.3121,
-   "compress_mbps": 60.83,
-   "decompress_mbps": 145.83
+   "compress_mbps": 60.54,
+   "decompress_mbps": 152.13
   },
   {
    "compressor": "native",
@@ -5334,8 +5334,8 @@
    "level": 3,
    "out_size": 12703756,
    "ratio": 0.3064,
-   "compress_mbps": 55.32,
-   "decompress_mbps": 158.9
+   "compress_mbps": 54.29,
+   "decompress_mbps": 163.62
   },
   {
    "compressor": "native",
@@ -5344,8 +5344,8 @@
    "level": 4,
    "out_size": 12177338,
    "ratio": 0.2937,
-   "compress_mbps": 43.13,
-   "decompress_mbps": 165.37
+   "compress_mbps": 43.07,
+   "decompress_mbps": 171.17
   },
   {
    "compressor": "native",
@@ -5355,7 +5355,7 @@
    "out_size": 12051075,
    "ratio": 0.2907,
    "compress_mbps": 33.35,
-   "decompress_mbps": 174.01
+   "decompress_mbps": 180.31
   },
   {
    "compressor": "native",
@@ -5364,8 +5364,8 @@
    "level": 6,
    "out_size": 12103573,
    "ratio": 0.2919,
-   "compress_mbps": 34.7,
-   "decompress_mbps": 179.27
+   "compress_mbps": 34.81,
+   "decompress_mbps": 185.35
   },
   {
    "compressor": "native",
@@ -5374,8 +5374,8 @@
    "level": 7,
    "out_size": 12027976,
    "ratio": 0.2901,
-   "compress_mbps": 27.78,
-   "decompress_mbps": 180.01
+   "compress_mbps": 27.43,
+   "decompress_mbps": 187.23
   },
   {
    "compressor": "native",
@@ -5384,8 +5384,8 @@
    "level": 8,
    "out_size": 12019953,
    "ratio": 0.2899,
-   "compress_mbps": 21.7,
-   "decompress_mbps": 132.44
+   "compress_mbps": 26.4,
+   "decompress_mbps": 187.58
   },
   {
    "compressor": "native",
@@ -5394,8 +5394,8 @@
    "level": 9,
    "out_size": 11806466,
    "ratio": 0.2848,
-   "compress_mbps": 3.68,
-   "decompress_mbps": 179.99
+   "compress_mbps": 3.67,
+   "decompress_mbps": 187.69
   },
   {
    "compressor": "native",
@@ -5404,7 +5404,7 @@
    "level": 10,
    "out_size": 11636727,
    "ratio": 0.2807,
-   "compress_mbps": 1.94,
+   "compress_mbps": 1.92,
    "decompress_mbps": null
   },
   {
@@ -5414,8 +5414,8 @@
    "level": 1,
    "out_size": 6438176,
    "ratio": 0.7597,
-   "compress_mbps": 43.68,
-   "decompress_mbps": 77.76
+   "compress_mbps": 43.6,
+   "decompress_mbps": 80.52
   },
   {
    "compressor": "native",
@@ -5424,8 +5424,8 @@
    "level": 2,
    "out_size": 6392101,
    "ratio": 0.7543,
-   "compress_mbps": 41.52,
-   "decompress_mbps": 78.07
+   "compress_mbps": 41.68,
+   "decompress_mbps": 81.87
   },
   {
    "compressor": "native",
@@ -5434,8 +5434,8 @@
    "level": 3,
    "out_size": 6392124,
    "ratio": 0.7543,
-   "compress_mbps": 40.88,
-   "decompress_mbps": 80.53
+   "compress_mbps": 41.87,
+   "decompress_mbps": 82.94
   },
   {
    "compressor": "native",
@@ -5444,8 +5444,8 @@
    "level": 4,
    "out_size": 6360604,
    "ratio": 0.7506,
-   "compress_mbps": 39.16,
-   "decompress_mbps": 79.68
+   "compress_mbps": 38.86,
+   "decompress_mbps": 84.05
   },
   {
    "compressor": "native",
@@ -5454,8 +5454,8 @@
    "level": 5,
    "out_size": 6360567,
    "ratio": 0.7506,
-   "compress_mbps": 39.04,
-   "decompress_mbps": 82.97
+   "compress_mbps": 38.89,
+   "decompress_mbps": 86.31
   },
   {
    "compressor": "native",
@@ -5464,8 +5464,8 @@
    "level": 6,
    "out_size": 6271453,
    "ratio": 0.7401,
-   "compress_mbps": 16.59,
-   "decompress_mbps": 82.89
+   "compress_mbps": 16.45,
+   "decompress_mbps": 86.51
   },
   {
    "compressor": "native",
@@ -5474,8 +5474,8 @@
    "level": 7,
    "out_size": 6271447,
    "ratio": 0.7401,
-   "compress_mbps": 16.76,
-   "decompress_mbps": 82.27
+   "compress_mbps": 16.34,
+   "decompress_mbps": 86.5
   },
   {
    "compressor": "native",
@@ -5484,8 +5484,8 @@
    "level": 8,
    "out_size": 6271447,
    "ratio": 0.7401,
-   "compress_mbps": 17.42,
-   "decompress_mbps": 82.78
+   "compress_mbps": 16.41,
+   "decompress_mbps": 87.03
   },
   {
    "compressor": "native",
@@ -5494,8 +5494,8 @@
    "level": 9,
    "out_size": 5952505,
    "ratio": 0.7024,
-   "compress_mbps": 5.85,
-   "decompress_mbps": 82.83
+   "compress_mbps": 5.75,
+   "decompress_mbps": 87.39
   },
   {
    "compressor": "native",
@@ -5504,7 +5504,7 @@
    "level": 10,
    "out_size": 5848663,
    "ratio": 0.6902,
-   "compress_mbps": 4.29,
+   "compress_mbps": 4.22,
    "decompress_mbps": null
   },
   {
@@ -5514,8 +5514,8 @@
    "level": 1,
    "out_size": 858525,
    "ratio": 0.1606,
-   "compress_mbps": 174.37,
-   "decompress_mbps": 265.62
+   "compress_mbps": 175.3,
+   "decompress_mbps": 268.16
   },
   {
    "compressor": "native",
@@ -5524,8 +5524,8 @@
    "level": 2,
    "out_size": 846807,
    "ratio": 0.1584,
-   "compress_mbps": 112.46,
-   "decompress_mbps": 300.43
+   "compress_mbps": 112.85,
+   "decompress_mbps": 306.05
   },
   {
    "compressor": "native",
@@ -5534,8 +5534,8 @@
    "level": 3,
    "out_size": 806798,
    "ratio": 0.1509,
-   "compress_mbps": 103.12,
-   "decompress_mbps": 350.6
+   "compress_mbps": 103.15,
+   "decompress_mbps": 358.21
   },
   {
    "compressor": "native",
@@ -5544,8 +5544,8 @@
    "level": 4,
    "out_size": 717301,
    "ratio": 0.1342,
-   "compress_mbps": 77.34,
-   "decompress_mbps": 332.55
+   "compress_mbps": 76.43,
+   "decompress_mbps": 340.71
   },
   {
    "compressor": "native",
@@ -5554,8 +5554,8 @@
    "level": 5,
    "out_size": 701552,
    "ratio": 0.1312,
-   "compress_mbps": 60.91,
-   "decompress_mbps": 391.92
+   "compress_mbps": 60.19,
+   "decompress_mbps": 405.37
   },
   {
    "compressor": "native",
@@ -5564,8 +5564,8 @@
    "level": 6,
    "out_size": 678544,
    "ratio": 0.1269,
-   "compress_mbps": 58.17,
-   "decompress_mbps": 403.14
+   "compress_mbps": 57.48,
+   "decompress_mbps": 397.42
   },
   {
    "compressor": "native",
@@ -5574,8 +5574,8 @@
    "level": 7,
    "out_size": 663716,
    "ratio": 0.1242,
-   "compress_mbps": 47.1,
-   "decompress_mbps": 402.26
+   "compress_mbps": 46.59,
+   "decompress_mbps": 414.16
   },
   {
    "compressor": "native",
@@ -5584,8 +5584,8 @@
    "level": 8,
    "out_size": 660481,
    "ratio": 0.1236,
-   "compress_mbps": 41.79,
-   "decompress_mbps": 415.15
+   "compress_mbps": 41.47,
+   "decompress_mbps": 426.65
   },
   {
    "compressor": "native",
@@ -5594,8 +5594,8 @@
    "level": 9,
    "out_size": 659417,
    "ratio": 0.1234,
-   "compress_mbps": 4.3,
-   "decompress_mbps": 439.25
+   "compress_mbps": 4.23,
+   "decompress_mbps": 401.55
   },
   {
    "compressor": "native",
@@ -5604,7 +5604,7 @@
    "level": 10,
    "out_size": 643093,
    "ratio": 0.1203,
-   "compress_mbps": 2.88,
+   "compress_mbps": 2.86,
    "decompress_mbps": null
   },
   {


### PR DESCRIPTION
This PR cheapens the per-block Huffman decode-table build with three independent, individually-measurable changes, keeping every equivalence proof holding, and closes https://github.com/kim-em/lean-zip/issues/2797 "perf(decode): cheapen the per-block table build (shift-based Kraft, constant fixed tables, unchecked fillSlots)".

Replace runtime `2 ^ k` with `1 <<< k` shifts in the canonical table build — the `fillSlots` stride/count (`2^len`, `2^(fastBits-len)`), the Kraft term `2^(maxBits-b)` in `kraftSumFast`, and the `2^maxBits` bound in `validateLengths`. These were the `Nat.pow` calls that reached GMP (`__gmpz_n_pow_ui`); the generated C now emits `lean_nat_shiftl` for all of them. The equivalence proofs bridge `1 <<< k = 2 ^ k` via `Nat.shiftLeft_eq`.

Add `fillSlotsU`, an unchecked variant of `fillSlots` that writes each slot with the proof-carrying `Array.set` (compiles to `lean_array_fset`, no per-slot bounds branch) instead of `set!` (`lean_array_set`, checked). `buildCanonicalLoop` calls it behind a single per-codeword bounds guard, so a length-`len` codeword pays one bounds check for its `2^(fastBits-len)` slot writes instead of one per write, falling back to the checked `fillSlots` if the guard ever fails. `fillSlotsU_eq` proves the two equal, so every downstream decode proof transfers unchanged.

Precompute the RFC 1951 §3.2.6 fixed lit/length and distance decode tables (both the canonical fast tables and the long-code tables) as top-level nullary `def`s. As closed terms they compile to `lean_obj_once` cells: the runtime builds each once on first use and caches it, so the fixed-Huffman path no longer rebuilds both tables every fixed block. The table-agnostic loop is factored into `decodeHuffmanFastBufTables`, and the fixed path routes through `decodeHuffmanFastBufFixed`; `decodeHuffmanFastBufFixed_eq` proves it definitionally equal to the per-block build specialised to the fixed lengths, so the fixed-block correctness step still goes through `decodeHuffmanFastBufTreeFree_ok_iff`.

The residual 19-symbol `HuffTree` on the code-length path (`fromLengths`, the remaining `Nat.pow` site) is the issue's optional step 4 and is left for a follow-up. `sorry` count stays 0; `lake exe test` passes.

🤖 Prepared with Claude Code