### PR TITLE
perf(decode): bind the packed Huffman table entry once per symbol

### DIFF
--- a/Zip/Native/Inflate.lean
+++ b/Zip/Native/Inflate.lean
@@ -160,14 +160,16 @@ where
 
 /-- Pack a slot's `(symbol, codeLen)` into one `UInt32` word: the codeword length
     in the low byte (bits 0–7), the 16-bit symbol in bits 8–23. libdeflate-style
-    single-word entry (libdeflate also uses a `u32`). The source reads the slot
-    through `lenAt`/`symAt`, which name the same `packed[idx]!` element; the
-    compiler CSEs the shared read, so a per-symbol decode lowers to **one**
-    `lean_array_get` plus register shifts (verified in the generated C for the
-    fastloop literal path), rather than two reads into the parallel `syms`/`lens`
-    arrays of #2650 (which also touched two cache lines). Even without the CSE it
-    is two reads of one tagged-scalar array, never the old two-array / two-cache-
-    line shape.
+    single-word entry (libdeflate also uses a `u32`). The hot decode loops read the
+    slot **once** per symbol via `entryAt` (a single guarded `packed[idx]` load) and
+    extract `len`/`sym` from that one word with `unpackLen`/`unpackSym` (a low-byte
+    truncation and a shift, register-only), so a per-symbol decode lowers to one
+    `lean_array_get` plus register ops. The
+    compiler does **not** CSE separate `lenAt`/`symAt` calls — each `dite` read
+    lowers to its own `lean_array_get_size` + `lean_nat_dec_lt` — so binding the
+    entry once in the source is what collapses the four reads (see `entryAt`). This
+    is one read of one tagged-scalar array, never the two reads into the parallel
+    `syms`/`lens` arrays of #2650 (which also touched two cache lines).
 
     **`UInt32`, not `UInt64`.** On a 64-bit target `lean_box_uint32` is a tagged
     scalar stored inline in the array (no allocation), exactly like the old
@@ -199,8 +201,11 @@ where
     `Array (UInt16 × UInt8)` boxes every slot as a heap pair, so each per-symbol
     read pointer-chases through `lean_ctor_get` twice; #2650 split the fields into
     two parallel scalar arrays to de-box; this folds them back into one packed
-    word so a per-symbol read is a single `lean_array_fget` plus shifts (`symAt` /
-    `lenAt`) touching one tagged-scalar array / one cache line instead of two.
+    word so a per-symbol read is a single `lean_array_fget` plus shifts (via
+    `entryAt`, bound once) touching one tagged-scalar array / one cache line instead
+    of two. Reading through `lenAt`/`symAt` separately does **not** collapse to one
+    load — the compiler does not CSE the two `dite` reads — so the loops bind the
+    word once with `entryAt`.
 
     The only packed field on the well-founded recursions' termination measure is
     the length, and `lenAt` extracts it shift-free (`toUInt8` of the low byte), so
@@ -241,6 +246,28 @@ theorem DecodeTable.symAt_def (t : DecodeTable) (idx : Nat) :
   split
   · rw [getElem!_pos t.packed idx ‹_›]
   · rw [getElem!_neg t.packed idx ‹_›]; rfl
+
+/-- The raw packed word of slot `idx` (out-of-bounds → `0`). The hot decode loops
+    bind this **once** per symbol and read `len`/`sym` from the single word
+    (`unpackLen` is a low-byte truncation, `unpackSym` a shift — both register-only,
+    no memory), so the compiled loop performs one
+    `lean_array_get` plus one bounds check per literal instead of the four the
+    `lenAt`/`symAt` guards lowered to (each `dite` read is a separate, un-CSE'd
+    `lean_array_get_size` + `lean_nat_dec_lt`). `lenAt`/`symAt` factor through this
+    (`lenAt_eq_unpackLen_entryAt` / `symAt_eq_unpackSym_entryAt`), so every existing
+    decode proof transfers. -/
+@[inline] def DecodeTable.entryAt (t : DecodeTable) (idx : Nat) : UInt32 :=
+  if h : idx < t.packed.size then t.packed[idx]'h else 0
+
+theorem DecodeTable.lenAt_eq_unpackLen_entryAt (t : DecodeTable) (idx : Nat) :
+    t.lenAt idx = unpackLen (t.entryAt idx) := by
+  unfold DecodeTable.lenAt DecodeTable.entryAt
+  split <;> rfl
+
+theorem DecodeTable.symAt_eq_unpackSym_entryAt (t : DecodeTable) (idx : Nat) :
+    t.symAt idx = unpackSym (t.entryAt idx) := by
+  unfold DecodeTable.symAt DecodeTable.entryAt
+  split <;> rfl
 
 /-- Build the `2^fastBits`-entry decode table for `tree`: slot `i` holds
     `packEntry sym codeLen` for the `(sym, codeLen)` reached by walking `tree` on
@@ -848,6 +875,19 @@ theorem usize_toUInt64_toNat (c : USize) : c.toUInt64 = c.toNat.toUInt64 := by
   rw [USize.toNat_toUInt64, Nat.toUInt64_eq, UInt64.toNat_ofNat']
   exact (Nat.mod_eq_of_lt c.toNat_lt).symm
 
+/-- The `UInt8→UInt64` conversion factors through `Nat` (both keep `toNat`); the
+    packed loops shift `bitBuf` by the raw `UInt8` length, the boxed reference by
+    `len.toNat.toUInt64`, so the two shift amounts agree. -/
+theorem uint8_toUInt64_toNat (x : UInt8) : x.toUInt64 = x.toNat.toUInt64 := by
+  apply UInt64.toNat.inj
+  rw [UInt8.toNat_toUInt64, Nat.toUInt64_eq, UInt64.toNat_ofNat']
+  exact (Nat.mod_eq_of_lt (Nat.lt_trans x.toNat_lt (by decide))).symm
+
+/-- A `UInt8` is nonzero iff its `Nat` value is: the packed loops test `len ≠ 0` in
+    `UInt8`, the boxed reference in `Nat`. -/
+theorem uint8_ne_zero_iff_toNat (x : UInt8) : x ≠ 0 ↔ x.toNat ≠ 0 := by
+  rw [Ne, Ne, ← UInt8.toNat_inj]; rfl
+
 /-- The fused refill guard read in `USize` matches the `Nat` guard once the buffer
     is `USize`-addressable. -/
 theorem refillGuard_usize (data : ByteArray) (pos cnt : USize) (hsz : data.size < USize.size) :
@@ -856,16 +896,21 @@ theorem refillGuard_usize (data : ByteArray) (pos cnt : USize) (hsz : data.size 
   rw [USize.le_iff_toNat_le, USize.lt_iff_toNat_lt, toUSize_toNat_of_lt hsz,
       USize.toNat_ofNat_of_lt (Nat.lt_of_lt_of_le (by decide) USize.le_size)]
 
-/-- The inline-literal guard read in `USize` matches the `Nat` guard (the length
-    field round-trips since it is a `UInt8`). -/
+/-- The inline-literal guard reads the packed entry **once** (`entryAt`) and tests
+    `len`/`sym` in their native `UInt8`/`UInt16` widths; this matches the boxed
+    reference's `lenAt`/`symAt` `Nat` guard (the length field round-trips since it is
+    a `UInt8`). -/
 theorem litGuard_usize (table : HuffTree.DecodeTable) (bitBuf : UInt64) (cnt : USize) :
-    ((table.lenAt (bitBuf &&& 0x7FF).toNat).toNat ≠ 0
-        ∧ ((table.lenAt (bitBuf &&& 0x7FF).toNat).toNat).toUSize ≤ cnt
-        ∧ table.symAt (bitBuf &&& 0x7FF).toNat < 256)
+    (HuffTree.unpackLen (table.entryAt (bitBuf &&& 0x7FF).toNat) ≠ 0
+        ∧ (HuffTree.unpackLen (table.entryAt (bitBuf &&& 0x7FF).toNat)).toUSize ≤ cnt
+        ∧ HuffTree.unpackSym (table.entryAt (bitBuf &&& 0x7FF).toNat) < 256)
       ↔ ((table.lenAt (bitBuf &&& 0x7FF).toNat).toNat ≠ 0
         ∧ (table.lenAt (bitBuf &&& 0x7FF).toNat).toNat ≤ cnt.toNat
         ∧ table.symAt (bitBuf &&& 0x7FF).toNat < 256) := by
-  rw [USize.le_iff_toNat_le, toUSize_toNat_of_lt (UInt8.toNat_lt_usizeSize _)]
+  rw [table.lenAt_eq_unpackLen_entryAt, table.symAt_eq_unpackSym_entryAt]
+  refine and_congr ?_ (and_congr ?_ Iff.rfl)
+  · rw [Ne, Ne, ← UInt8.toNat_inj]; rfl
+  · rw [USize.le_iff_toNat_le, UInt8.toNat_toUSize]
 
 /-- Load whole bytes into the high end of `bitBuf` until it holds > 56 bits or
     the input is exhausted. Preserves the consumed bit position `pos*8 - cnt`. -/
@@ -1140,16 +1185,17 @@ def goFusedPU (litTable distTable : HuffTree.DecodeTable)
           rwa [toUSize_toNat_of_lt hsz] at h)).toUInt64 <<< cnt.toUInt64))
       (cnt + 8) hsz output
   else
-  if hlit : (litTable.lenAt (bitBuf &&& 0x7FF).toNat).toNat ≠ 0
-      ∧ ((litTable.lenAt (bitBuf &&& 0x7FF).toNat).toNat).toUSize ≤ cnt
-      ∧ litTable.symAt (bitBuf &&& 0x7FF).toNat < 256 then
+  let e := litTable.entryAt (bitBuf &&& 0x7FF).toNat
+  if hlit : HuffTree.unpackLen e ≠ 0
+      ∧ (HuffTree.unpackLen e).toUSize ≤ cnt
+      ∧ HuffTree.unpackSym e < 256 then
     if output.size ≥ maxOut then throw "Inflate: output exceeds maximum size"
     else
       goFusedPU litTable distTable data litTree distTree maxOut pos
-        (bitBuf >>> ((litTable.lenAt (bitBuf &&& 0x7FF).toNat).toNat).toUInt64)
-        (cnt - ((litTable.lenAt (bitBuf &&& 0x7FF).toNat).toNat).toUSize)
+        (bitBuf >>> (HuffTree.unpackLen e).toUInt64)
+        (cnt - (HuffTree.unpackLen e).toUSize)
         hsz
-        (output.push (litTable.symAt (bitBuf &&& 0x7FF).toNat).toUInt8)
+        (output.push (HuffTree.unpackSym e).toUInt8)
   else
   let cnt0 := cnt.toNat
   match decodeSym litTree litTable bitBuf cnt.toNat with
@@ -1211,13 +1257,13 @@ def goFusedPU (litTable distTable : HuffTree.DecodeTable)
       rw [hpa, hca]; omega
     · -- inline literal: cnt drops by len ≥ 1
       obtain ⟨hne, hle, _⟩ := hlit
-      have hlen : ((litTable.lenAt (bitBuf &&& 0x7FF).toNat).toNat).toUSize.toNat
-          = (litTable.lenAt (bitBuf &&& 0x7FF).toNat).toNat :=
-        toUSize_toNat_of_lt (UInt8.toNat_lt_usizeSize _)
-      have hsub : (cnt - ((litTable.lenAt (bitBuf &&& 0x7FF).toNat).toNat).toUSize).toNat
-          = cnt.toNat - (litTable.lenAt (bitBuf &&& 0x7FF).toNat).toNat := by
+      have hne' : (HuffTree.unpackLen e).toNat ≠ 0 := (uint8_ne_zero_iff_toNat _).mp hne
+      have hlen : ((HuffTree.unpackLen e).toUSize).toNat = (HuffTree.unpackLen e).toNat :=
+        UInt8.toNat_toUSize _
+      have hsub : (cnt - (HuffTree.unpackLen e).toUSize).toNat
+          = cnt.toNat - (HuffTree.unpackLen e).toNat := by
         rw [USize.toNat_sub_of_le _ _ hle, hlen]
-      have hlecnt : (litTable.lenAt (bitBuf &&& 0x7FF).toNat).toNat ≤ cnt.toNat :=
+      have hlecnt : (HuffTree.unpackLen e).toNat ≤ cnt.toNat :=
         hlen ▸ USize.le_iff_toNat_le.mp hle
       rw [hsub]; omega
     · -- slow literal: cnt' < cnt0 = cnt.toNat from the no-progress guard

--- a/Zip/Native/InflateTreeFree.lean
+++ b/Zip/Native/InflateTreeFree.lean
@@ -137,9 +137,10 @@ where
 @[inline] def decodeSymCanon (ld : LongDecode) (table : DecodeTable) (maxBits : Nat)
     (bitBuf : UInt64) (cnt : Nat) : Except String (UInt16 × UInt64 × Nat × Nat) :=
   let idx := (bitBuf &&& 0x7FF).toNat
-  let len := (table.lenAt idx).toNat
+  let e := table.entryAt idx
+  let len := (unpackLen e).toNat
   if len == 0 || len > cnt then walkCanonical ld maxBits bitBuf cnt
-  else .ok (table.symAt idx, bitBuf >>> len.toUInt64, cnt - len, len)
+  else .ok (unpackSym e, bitBuf >>> len.toUInt64, cnt - len, len)
 
 end HuffTree
 
@@ -226,16 +227,17 @@ def goTreeFreeU (litTable distTable : DecodeTable) (litLD distLD : LongDecode)
           rwa [toUSize_toNat_of_lt hsz] at h)).toUInt64 <<< cnt.toUInt64))
       (cnt + 8) hsz output
   else
-  if hlit : (litTable.lenAt (bitBuf &&& 0x7FF).toNat).toNat ≠ 0
-      ∧ ((litTable.lenAt (bitBuf &&& 0x7FF).toNat).toNat).toUSize ≤ cnt
-      ∧ litTable.symAt (bitBuf &&& 0x7FF).toNat < 256 then
+  let e := litTable.entryAt (bitBuf &&& 0x7FF).toNat
+  if hlit : HuffTree.unpackLen e ≠ 0
+      ∧ (HuffTree.unpackLen e).toUSize ≤ cnt
+      ∧ HuffTree.unpackSym e < 256 then
     if output.size ≥ maxOut then throw "Inflate: output exceeds maximum size"
     else
       goTreeFreeU litTable distTable litLD distLD maxBits data maxOut pos
-        (bitBuf >>> ((litTable.lenAt (bitBuf &&& 0x7FF).toNat).toNat).toUInt64)
-        (cnt - ((litTable.lenAt (bitBuf &&& 0x7FF).toNat).toNat).toUSize)
+        (bitBuf >>> (HuffTree.unpackLen e).toUInt64)
+        (cnt - (HuffTree.unpackLen e).toUSize)
         hsz
-        (output.push (litTable.symAt (bitBuf &&& 0x7FF).toNat).toUInt8)
+        (output.push (HuffTree.unpackSym e).toUInt8)
   else
   let cnt0 := cnt.toNat
   match decodeSymCanon litLD litTable maxBits bitBuf cnt.toNat with
@@ -296,13 +298,13 @@ def goTreeFreeU (litTable distTable : DecodeTable) (litLD distLD : LongDecode)
         rw [USize.toNat_add, h8]; apply Nat.mod_eq_of_lt; omega
       rw [hpa, hca]; omega
     · obtain ⟨hne, hle, _⟩ := hlit
-      have hlen : ((litTable.lenAt (bitBuf &&& 0x7FF).toNat).toNat).toUSize.toNat
-          = (litTable.lenAt (bitBuf &&& 0x7FF).toNat).toNat :=
-        toUSize_toNat_of_lt (UInt8.toNat_lt_usizeSize _)
-      have hsub : (cnt - ((litTable.lenAt (bitBuf &&& 0x7FF).toNat).toNat).toUSize).toNat
-          = cnt.toNat - (litTable.lenAt (bitBuf &&& 0x7FF).toNat).toNat := by
+      have hne' : (HuffTree.unpackLen e).toNat ≠ 0 := (uint8_ne_zero_iff_toNat _).mp hne
+      have hlen : ((HuffTree.unpackLen e).toUSize).toNat = (HuffTree.unpackLen e).toNat :=
+        UInt8.toNat_toUSize _
+      have hsub : (cnt - (HuffTree.unpackLen e).toUSize).toNat
+          = cnt.toNat - (HuffTree.unpackLen e).toNat := by
         rw [USize.toNat_sub_of_le _ _ hle, hlen]
-      have hlecnt : (litTable.lenAt (bitBuf &&& 0x7FF).toNat).toNat ≤ cnt.toNat :=
+      have hlecnt : (HuffTree.unpackLen e).toNat ≤ cnt.toNat :=
         hlen ▸ USize.le_iff_toNat_le.mp hle
       rw [hsub]; omega
     · have hcsz : cnt.toNat < USize.size := cnt.toNat_lt_two_pow_numBits

--- a/Zip/Spec/InflateBufCorrect.lean
+++ b/Zip/Spec/InflateBufCorrect.lean
@@ -1499,39 +1499,40 @@ theorem goFusedPU_eq (litTable distTable : HuffTree.DecodeTable) (data : ByteArr
       rw [InflateBuf.goFusedPU, dif_pos hrc, InflateBuf.goFusedP, dif_pos hgN,
           ih (by rw [e1]; omega), e1, e2,
           InflateBuf.uget_eq_getElem data pos hpn, InflateBuf.usize_toUInt64_toNat]
-  | case2 pos bitBuf cnt output hrc hlit hmax =>
+  | case2 pos bitBuf cnt output hrc ent hlit hmax =>
       intro hpos
       rw [InflateBuf.goFusedPU, dif_neg hrc, dif_pos hlit, if_pos hmax,
           InflateBuf.goFusedP, dif_neg (fun h => hrc ((InflateBuf.refillGuard_usize data pos cnt hsz).mpr h)),
           dif_pos ((InflateBuf.litGuard_usize litTable bitBuf cnt).mp hlit), if_pos hmax]
       rfl
-  | case3 pos bitBuf cnt output hrc hlit hmax ih =>
+  | case3 pos bitBuf cnt output hrc ent hlit hmax ih =>
       intro hpos
       obtain ⟨hl0, hl1, hl2⟩ := hlit
-      have hlen : ((litTable.lenAt (bitBuf &&& 0x7FF).toNat).toNat).toUSize.toNat
-          = (litTable.lenAt (bitBuf &&& 0x7FF).toNat).toNat :=
-        InflateBuf.toUSize_toNat_of_lt (UInt8.toNat_lt_usizeSize _)
-      have hsub : (cnt - ((litTable.lenAt (bitBuf &&& 0x7FF).toNat).toNat).toUSize).toNat
-          = cnt.toNat - (litTable.lenAt (bitBuf &&& 0x7FF).toNat).toNat := by
-        rw [USize.toNat_sub_of_le _ _ hl1, hlen]
+      have hle : litTable.lenAt (bitBuf &&& 0x7FF).toNat = HuffTree.unpackLen ent :=
+        litTable.lenAt_eq_unpackLen_entryAt _
+      have hse : litTable.symAt (bitBuf &&& 0x7FF).toNat = HuffTree.unpackSym ent :=
+        litTable.symAt_eq_unpackSym_entryAt _
+      have hsub : (cnt - (HuffTree.unpackLen ent).toUSize).toNat
+          = cnt.toNat - (HuffTree.unpackLen ent).toNat := by
+        rw [USize.toNat_sub_of_le _ _ hl1, UInt8.toNat_toUSize]
       rw [InflateBuf.goFusedPU, dif_neg hrc, dif_pos ⟨hl0, hl1, hl2⟩, if_neg hmax,
           InflateBuf.goFusedP, dif_neg (fun h => hrc ((InflateBuf.refillGuard_usize data pos cnt hsz).mpr h)),
           dif_pos ((InflateBuf.litGuard_usize litTable bitBuf cnt).mp ⟨hl0, hl1, hl2⟩), if_neg hmax,
-          ih hpos, hsub]
-  | case4 pos bitBuf cnt output hrc hlit e hde =>
+          ih hpos, hsub, hle, hse, uint8_toUInt64_toNat]
+  | case4 pos bitBuf cnt output hrc ent hlit e hde =>
       intro hpos
       rw [InflateBuf.goFusedPU, dif_neg hrc, dif_neg hlit,
           InflateBuf.goFusedP, dif_neg (fun h => hrc ((InflateBuf.refillGuard_usize data pos cnt hsz).mpr h)),
           dif_neg (fun h => hlit ((InflateBuf.litGuard_usize litTable bitBuf cnt).mpr h))]
       simp only [hde, Except.map]
-  | case5 pos bitBuf cnt output hrc hlit sym bb c used hde hsym hmax =>
+  | case5 pos bitBuf cnt output hrc ent hlit sym bb c used hde hsym hmax =>
       intro hpos
       rw [InflateBuf.goFusedPU, dif_neg hrc, dif_neg hlit,
           InflateBuf.goFusedP, dif_neg (fun h => hrc ((InflateBuf.refillGuard_usize data pos cnt hsz).mpr h)),
           dif_neg (fun h => hlit ((InflateBuf.litGuard_usize litTable bitBuf cnt).mpr h))]
       simp only [hde, if_pos hsym, if_pos hmax]
       rfl
-  | case6 pos bitBuf cnt output hrc hlit cnt0 sym bb c used hde hsym hmax hnp =>
+  | case6 pos bitBuf cnt output hrc ent hlit cnt0 sym bb c used hde hsym hmax hnp =>
       intro hpos
       have hnp' : cnt.toNat ≤ c := hnp
       rw [InflateBuf.goFusedPU, dif_neg hrc, dif_neg hlit,
@@ -1539,7 +1540,7 @@ theorem goFusedPU_eq (litTable distTable : HuffTree.DecodeTable) (data : ByteArr
           dif_neg (fun h => hlit ((InflateBuf.litGuard_usize litTable bitBuf cnt).mpr h))]
       simp only [hde, if_pos hsym, if_neg hmax, dif_pos hnp']
       rfl
-  | case7 pos bitBuf cnt output hrc hlit cnt0 sym bb c used hde hsym hmax hnp ih =>
+  | case7 pos bitBuf cnt output hrc ent hlit cnt0 sym bb c used hde hsym hmax hnp ih =>
       intro hpos
       have hnp' : ¬ cnt.toNat ≤ c := hnp
       have hcle : c ≤ cnt.toNat := decodeSym_cnt_le litTree litTable bitBuf cnt.toNat hde
@@ -1550,7 +1551,7 @@ theorem goFusedPU_eq (litTable distTable : HuffTree.DecodeTable) (data : ByteArr
           dif_neg (fun h => hlit ((InflateBuf.litGuard_usize litTable bitBuf cnt).mpr h))]
       simp only [hde, if_pos hsym, if_neg hmax, dif_neg hnp']
       rw [ih hpos, hcrt]
-  | case8 pos bitBuf cnt output hrc hlit sym bb c used hde hsym heob =>
+  | case8 pos bitBuf cnt output hrc ent hlit sym bb c used hde hsym heob =>
       intro hpos
       have hcle : c ≤ cnt.toNat := decodeSym_cnt_le litTree litTable bitBuf cnt.toNat hde
       have hcrt : c.toUSize.toNat = c :=
@@ -1559,7 +1560,7 @@ theorem goFusedPU_eq (litTable distTable : HuffTree.DecodeTable) (data : ByteArr
           InflateBuf.goFusedP, dif_neg (fun h => hrc ((InflateBuf.refillGuard_usize data pos cnt hsz).mpr h)),
           dif_neg (fun h => hlit ((InflateBuf.litGuard_usize litTable bitBuf cnt).mpr h))]
       simp only [hde, if_neg hsym, if_pos heob, Except.map, hcrt]
-  | case9 pos bitBuf cnt output hrc hlit sym bb c used hde hsym hneob idx hidx =>
+  | case9 pos bitBuf cnt output hrc ent hlit sym bb c used hde hsym hneob idx hidx =>
       intro hpos
       have hidxc : sym.toNat - 257 ≥ Inflate.lengthBase.size := hidx
       rw [InflateBuf.goFusedPU, dif_neg hrc, dif_neg hlit,
@@ -1567,7 +1568,7 @@ theorem goFusedPU_eq (litTable distTable : HuffTree.DecodeTable) (data : ByteArr
           dif_neg (fun h => hlit ((InflateBuf.litGuard_usize litTable bitBuf cnt).mpr h))]
       simp only [hde, if_neg hsym, if_neg hneob, dif_pos hidxc]
       rfl
-  | case10 pos bitBuf cnt output hrc hlit cnt0 sym bb c used hde hsym hneob idx hh base ih =>
+  | case10 pos bitBuf cnt output hrc ent hlit cnt0 sym bb c used hde hsym hneob idx hh base ih =>
       intro hpos
       have hhc : ¬ sym.toNat - 257 ≥ Inflate.lengthBase.size := hh
       rw [InflateBuf.goFusedPU, dif_neg hrc, dif_neg hlit,

--- a/Zip/Spec/InflateTreeFreeCorrect.lean
+++ b/Zip/Spec/InflateTreeFreeCorrect.lean
@@ -1138,7 +1138,8 @@ theorem decodeSymCanon_ok_iff_decodeSym (lengths : Array UInt8) (maxBits : Nat)
     (table : DecodeTable) (buf : UInt64) (cnt : Nat) (r : UInt16 × UInt64 × Nat × Nat) :
     decodeSymCanon (buildLongDecode lengths maxBits) table maxBits buf cnt = .ok r ↔
       decodeSym (fromLengthsTree lengths maxBits) table buf cnt = .ok r := by
-  simp only [decodeSymCanon, decodeSym]
+  simp only [decodeSymCanon, decodeSym, DecodeTable.lenAt_eq_unpackLen_entryAt,
+    DecodeTable.symAt_eq_unpackSym_entryAt]
   split
   · exact walkCanonical_ok_iff_walkTree lengths maxBits hmb hmb15 hv hbound buf cnt r
   · exact Iff.rfl
@@ -1316,10 +1317,12 @@ theorem decodeSymCanon_withCount_ok_iff_decodeSym (lengths : Array UInt8)
   · rw [buildLongDecodeWithCount_eq lengths 15 hlong]
     exact decodeSymCanon_ok_iff_decodeSym lengths 15 (by omega) (by omega) hv hbound _ buf cnt r
   · simp only [Bool.not_eq_true] at hlong
-    simp only [decodeSymCanon, decodeSym]
+    simp only [decodeSymCanon, decodeSym, DecodeTable.lenAt_eq_unpackLen_entryAt,
+      DecodeTable.symAt_eq_unpackSym_entryAt]
     split
     · rename_i hguard
-      simp only [Bool.or_eq_true, beq_iff_eq, decide_eq_true_eq] at hguard
+      simp only [Bool.or_eq_true, beq_iff_eq, decide_eq_true_eq,
+        ← DecodeTable.lenAt_eq_unpackLen_entryAt] at hguard
       constructor
       · intro h
         obtain ⟨r', hr'⟩ := walkCanonical_ok_of_count_eq _ (buildLongDecode lengths 15) 15
@@ -1546,39 +1549,40 @@ theorem goTreeFreeU_eq (litTable distTable : HuffTree.DecodeTable) (data : ByteA
       rw [goTreeFreeU, dif_pos hrc, goTreeFree, dif_pos hgN,
           ih (by rw [e1]; omega), e1, e2,
           uget_eq_getElem! data pos hpn, usize_toUInt64_toNat]
-  | case2 pos bitBuf cnt output hrc hlit hmax =>
+  | case2 pos bitBuf cnt output hrc ent hlit hmax =>
       intro hpos
       rw [goTreeFreeU, dif_neg hrc, dif_pos hlit, if_pos hmax,
           goTreeFree, dif_neg (fun h => hrc ((refillGuard_usize data pos cnt hsz).mpr h)),
           dif_pos ((litGuard_usize litTable bitBuf cnt).mp hlit), if_pos hmax]
       rfl
-  | case3 pos bitBuf cnt output hrc hlit hmax ih =>
+  | case3 pos bitBuf cnt output hrc ent hlit hmax ih =>
       intro hpos
       obtain ⟨hl0, hl1, hl2⟩ := hlit
-      have hlen : ((litTable.lenAt (bitBuf &&& 0x7FF).toNat).toNat).toUSize.toNat
-          = (litTable.lenAt (bitBuf &&& 0x7FF).toNat).toNat :=
-        toUSize_toNat_of_lt (UInt8.toNat_lt_usizeSize _)
-      have hsub : (cnt - ((litTable.lenAt (bitBuf &&& 0x7FF).toNat).toNat).toUSize).toNat
-          = cnt.toNat - (litTable.lenAt (bitBuf &&& 0x7FF).toNat).toNat := by
-        rw [USize.toNat_sub_of_le _ _ hl1, hlen]
+      have hle : litTable.lenAt (bitBuf &&& 0x7FF).toNat = HuffTree.unpackLen ent :=
+        litTable.lenAt_eq_unpackLen_entryAt _
+      have hse : litTable.symAt (bitBuf &&& 0x7FF).toNat = HuffTree.unpackSym ent :=
+        litTable.symAt_eq_unpackSym_entryAt _
+      have hsub : (cnt - (HuffTree.unpackLen ent).toUSize).toNat
+          = cnt.toNat - (HuffTree.unpackLen ent).toNat := by
+        rw [USize.toNat_sub_of_le _ _ hl1, UInt8.toNat_toUSize]
       rw [goTreeFreeU, dif_neg hrc, dif_pos ⟨hl0, hl1, hl2⟩, if_neg hmax,
           goTreeFree, dif_neg (fun h => hrc ((refillGuard_usize data pos cnt hsz).mpr h)),
           dif_pos ((litGuard_usize litTable bitBuf cnt).mp ⟨hl0, hl1, hl2⟩), if_neg hmax,
-          ih hpos, hsub]
-  | case4 pos bitBuf cnt output hrc hlit e hde =>
+          ih hpos, hsub, hle, hse, uint8_toUInt64_toNat]
+  | case4 pos bitBuf cnt output hrc ent hlit e hde =>
       intro hpos
       rw [goTreeFreeU, dif_neg hrc, dif_neg hlit,
           goTreeFree, dif_neg (fun h => hrc ((refillGuard_usize data pos cnt hsz).mpr h)),
           dif_neg (fun h => hlit ((litGuard_usize litTable bitBuf cnt).mpr h))]
       simp only [hde, Except.map]
-  | case5 pos bitBuf cnt output hrc hlit sym bb c used hde hsym hmax =>
+  | case5 pos bitBuf cnt output hrc ent hlit sym bb c used hde hsym hmax =>
       intro hpos
       rw [goTreeFreeU, dif_neg hrc, dif_neg hlit,
           goTreeFree, dif_neg (fun h => hrc ((refillGuard_usize data pos cnt hsz).mpr h)),
           dif_neg (fun h => hlit ((litGuard_usize litTable bitBuf cnt).mpr h))]
       simp only [hde, if_pos hsym, if_pos hmax]
       rfl
-  | case6 pos bitBuf cnt output hrc hlit cnt0 sym bb c used hde hsym hmax hnp =>
+  | case6 pos bitBuf cnt output hrc ent hlit cnt0 sym bb c used hde hsym hmax hnp =>
       intro hpos
       have hnp' : cnt.toNat ≤ c := hnp
       rw [goTreeFreeU, dif_neg hrc, dif_neg hlit,
@@ -1586,7 +1590,7 @@ theorem goTreeFreeU_eq (litTable distTable : HuffTree.DecodeTable) (data : ByteA
           dif_neg (fun h => hlit ((litGuard_usize litTable bitBuf cnt).mpr h))]
       simp only [hde, if_pos hsym, if_neg hmax, dif_pos hnp']
       rfl
-  | case7 pos bitBuf cnt output hrc hlit cnt0 sym bb c used hde hsym hmax hnp ih =>
+  | case7 pos bitBuf cnt output hrc ent hlit cnt0 sym bb c used hde hsym hmax hnp ih =>
       intro hpos
       have hnp' : ¬ cnt.toNat ≤ c := hnp
       have hcle : c ≤ cnt.toNat := HuffTree.decodeSymCanon_cnt_le litLD litTable maxBits bitBuf cnt.toNat hde
@@ -1597,7 +1601,7 @@ theorem goTreeFreeU_eq (litTable distTable : HuffTree.DecodeTable) (data : ByteA
           dif_neg (fun h => hlit ((litGuard_usize litTable bitBuf cnt).mpr h))]
       simp only [hde, if_pos hsym, if_neg hmax, dif_neg hnp']
       rw [ih hpos, hcrt]
-  | case8 pos bitBuf cnt output hrc hlit sym bb c used hde hsym heob =>
+  | case8 pos bitBuf cnt output hrc ent hlit sym bb c used hde hsym heob =>
       intro hpos
       have hcle : c ≤ cnt.toNat := HuffTree.decodeSymCanon_cnt_le litLD litTable maxBits bitBuf cnt.toNat hde
       have hcrt : c.toUSize.toNat = c :=
@@ -1606,7 +1610,7 @@ theorem goTreeFreeU_eq (litTable distTable : HuffTree.DecodeTable) (data : ByteA
           goTreeFree, dif_neg (fun h => hrc ((refillGuard_usize data pos cnt hsz).mpr h)),
           dif_neg (fun h => hlit ((litGuard_usize litTable bitBuf cnt).mpr h))]
       simp only [hde, if_neg hsym, if_pos heob, Except.map, hcrt]
-  | case9 pos bitBuf cnt output hrc hlit sym bb c used hde hsym hneob idx hidx =>
+  | case9 pos bitBuf cnt output hrc ent hlit sym bb c used hde hsym hneob idx hidx =>
       intro hpos
       have hidxc : sym.toNat - 257 ≥ Inflate.lengthBase.size := hidx
       rw [goTreeFreeU, dif_neg hrc, dif_neg hlit,
@@ -1614,7 +1618,7 @@ theorem goTreeFreeU_eq (litTable distTable : HuffTree.DecodeTable) (data : ByteA
           dif_neg (fun h => hlit ((litGuard_usize litTable bitBuf cnt).mpr h))]
       simp only [hde, if_neg hsym, if_neg hneob, dif_pos hidxc]
       rfl
-  | case10 pos bitBuf cnt output hrc hlit cnt0 sym bb c used hde hsym hneob idx hh base ih =>
+  | case10 pos bitBuf cnt output hrc ent hlit cnt0 sym bb c used hde hsym hneob idx hh base ih =>
       intro hpos
       have hhc : ¬ sym.toNat - 257 ≥ Inflate.lengthBase.size := hh
       rw [goTreeFreeU, dif_neg hrc, dif_neg hlit,


### PR DESCRIPTION
This PR binds the packed Huffman decode-table entry **once** per symbol and reads `len`/`sym` out of that single word, replacing the four separate `lenAt`/`symAt` reads — each a guarded `dite` with its own bounds check — the shipped decode loop performed per literal. A new `DecodeTable.entryAt` does one guarded `packed[idx]` load returning the raw `UInt32`; `unpackLen`/`unpackSym` then extract the fields in native `UInt8`/`UInt16`/`USize` widths, so the compiled literal path lowers to one `lean_array_get` plus register ops instead of four reads and four boxed bounds checks with tagged-`Nat` round-trips. The change lands in the production `goTreeFreeU`, its tree-based twin `goFusedPU`, and `decodeSymCanon`; the boxed reference loops `goTreeFree`/`goFusedP` are left unchanged as the correctness anchor, and equivalence transfers through the `lenAt`/`symAt` = `unpackLen`/`unpackSym` ∘ `entryAt` bridge lemmas plus the restated `litGuard_usize`. It also corrects the `Inflate.lean` docstring that falsely claimed the compiler CSEs the shared read into one load — the generated C shows it does not, which is exactly why binding the entry once in the source is what collapses the four reads.

Measured with deterministic `perf stat` (same worktree, dispatch target the only difference) on Silesia and Canterbury payloads: roughly **5% fewer retired instructions and 1-2% fewer cycles** on the decode across `x-ray`, `ooffice`, `sao`, `alice29`, and `plrabn12`, never a regression. This is a real but modest win, well below the +40-80% the issue estimated: the read-count reduction is genuine, but the reads were cheap (cache-resident, tagged-scalar bounds checks), so the wall-clock gain is small. A follow-up will thread the `packed.size = 2^fastBits` invariant so the remaining guarded read becomes a proven-bounds `uget`, dropping the last per-literal bounds check.

Full library builds with no `sorry`; all tests pass. A second opinion (Codex) found no correctness or soundness concern in the definitions or the equivalence bridging.

🤖 Prepared with Claude Code
