### PR TITLE
perf: enable -flto so the wide-load stopgap externs inline into the hot loops

### DIFF
--- a/bench/graphs/canterbury_compress_heatmap.svg
+++ b/bench/graphs/canterbury_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#paf08724384)">
+   <g clip-path="url(#p2cec6f8756)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJB0lEQVR4nO3YvYpdVQCG4TmZM5qYMQyCMRgIgjaCYKWN9vZeiFdg4zV4ByLYi2BhbWMpNgqCRAmKkmh+ZiaT82Mh2AvvYpnN81zBt1nsfd6zVru/Ptsf8HQ5fzh7wTiPl/ls+4vz2ROGWV27PnvCGM8+N3vBOKtLsxeM8WS579lSz2x/95fZE4ZZ5okBAEwksAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYuvbq7uzNwxxsT2fPWGYGyevzJ4wzPHu+uwJQ6zO7s+eMMzXZ9/PnjDEy8+8OHvCMNvdZvaEIR5sTmdPGGaz386eMMRbz9+cPWEYN1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQWx8fnczeMMRuvZs9YZjjg8uzJ4zz5+3ZC4bYn92fPWGYt2+9M3vCEKeb5Z7Zo4U+22vHb8yeMMzFajN7whD7n76dPWEYN1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQW185PJ69YYjz7ensCeOsFtzFl6/NXjDEasFndrTZzJ4wxJLP7Op6me/Zbxd3Zk8YZrO7mD1hiJtXT2ZPGGa5XxAAgEkEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMRW2+8+2s8eAf/a7WYvgH9c8v/zqeP7wf+ILwgAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDE1h/8fnv2hiHuP97OnjDMN3cezJ4wzBfvvzt7whAvXbk1e8Iwb37y6ewJQ7z36guzJwzz472z2ROGuLI+nD1hmM+//GH2hCFOP/5w9oRh3GABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBAbLXZfbWfPWKE7W4ze8Iwl1bL7eLD89PZE8Y4XM9eMM6ju7MXDLE9uTF7wjC7/W72hCGOVst9z57sl/mbdrRZ5nMdHLjBAgDICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgNh69oBR9ge72ROGObz36+wJ4zz8Y/aCIfYXT2ZPGGZ18/XZE/iPHm9PZ08Y4mi5r9nB0cUyz2z/x8+zJwzjBgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABifwNgWILmYcDVwgAAAABJRU5ErkJggg==" id="imagedddfef3877" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJFUlEQVR4nO3YzaqdZx2H4b2StWtjd0MqNBYLQdChpSM7aefOPRCPwEmPwTMQwbkIDhx30qE4sSBIlEBbSdN87L2zsz4cFDyC++HfLK7rCH4vD++77vVsDt/+8XjG6+X6+fSCdV6e5rMdb66nJyyzuXt/esIaP/jh9IJ1NremF6zx6nTfs1M9s+Pj/0xPWOY0TwwAYJDAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCIbR9uHk9vWOJmfz09YZn37v10esIyF4f70xOW2Fw9nZ6wzGdX/5iesMRP3nh3esIy+8NuesISz3aX0xOW2R330xOW+OXb709PWMYNFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMS2F+f3pjcscdgepicsc3H25vSEdZ48nF6wxPHq6fSEZT568PH0hCUud6d7Zi9O9Nl+fvGL6QnL3Gx20xOWOP7rb9MTlnGDBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAALHtndsX0xuWuN5fTk9YZ3PCXfzm3ekFS2xO+MzOd7vpCUuc8pm9tT3N9+zLm0fTE5bZHW6mJyzx/lv3picsc7pfEACAIQILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYpv93z89To+A/zscphfAd275//na8f3ge8QXBAAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGLb33z9cHrDEk9f7qcnLPP5o2fTE5b5868/mZ6wxI/vPJiesMyHv//D9IQlfvWzH01PWOaf31xNT1jizvb29IRl/vSXL6YnLHH5u99OT1jGDRYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDENrvDX4/TI1bYH3bTE5a5tTndLr59fTk9YY3b2+kF67x4PL1gif2996YnLHM4HqYnLHG+Od337NXxNH/Tznen+VxnZ26wAAByAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAILbdH3bTG5bYHW6mJyxz5/nT6QnrPPtqesESx5cvpycss3nwwfSEJV6d8Dfkavd8esIS72wupicsc375ZHrCEsf//nt6wjJusAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACD2P33ciOxuxBeUAAAAAElFTkSuQmCC" id="imageb380e94aee" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m7eed3b631e" d="M 0 0 
+       <path id="m097ee1ac93" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m7eed3b631e" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m097ee1ac93" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m7eed3b631e" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m097ee1ac93" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m7eed3b631e" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m097ee1ac93" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m7eed3b631e" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m097ee1ac93" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m7eed3b631e" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m097ee1ac93" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m7eed3b631e" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m097ee1ac93" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m7eed3b631e" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m097ee1ac93" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m7eed3b631e" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m097ee1ac93" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m7eed3b631e" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m097ee1ac93" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m7eed3b631e" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m097ee1ac93" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m7eed3b631e" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m097ee1ac93" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="m73f3f81f79" d="M 0 0 
+       <path id="me2dd1e684b" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m73f3f81f79" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me2dd1e684b" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m73f3f81f79" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me2dd1e684b" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m73f3f81f79" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me2dd1e684b" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m73f3f81f79" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me2dd1e684b" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m73f3f81f79" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me2dd1e684b" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m73f3f81f79" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me2dd1e684b" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m73f3f81f79" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me2dd1e684b" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m73f3f81f79" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me2dd1e684b" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1303,8 +1303,8 @@ L 527.435033 49.4355
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_20">
-    <!-- +6 -->
-    <g transform="translate(110.510438 68.904519) scale(0.065 -0.065)">
+    <!-- +11 -->
+    <g transform="translate(108.442626 68.904519) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-2b" d="M 2944 4013 
 L 2944 2272 
@@ -1321,51 +1321,22 @@ L 2419 4013
 L 2944 4013 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-36" d="M 2113 2584 
-Q 1688 2584 1439 2293 
-Q 1191 2003 1191 1497 
-Q 1191 994 1439 701 
-Q 1688 409 2113 409 
-Q 2538 409 2786 701 
-Q 3034 994 3034 1497 
-Q 3034 2003 2786 2293 
-Q 2538 2584 2113 2584 
-z
-M 3366 4563 
-L 3366 3988 
-Q 3128 4100 2886 4159 
-Q 2644 4219 2406 4219 
-Q 1781 4219 1451 3797 
-Q 1122 3375 1075 2522 
-Q 1259 2794 1537 2939 
-Q 1816 3084 2150 3084 
-Q 2853 3084 3261 2657 
-Q 3669 2231 3669 1497 
-Q 3669 778 3244 343 
-Q 2819 -91 2113 -91 
-Q 1303 -91 875 529 
-Q 447 1150 447 2328 
-Q 447 3434 972 4092 
-Q 1497 4750 2381 4750 
-Q 2619 4750 2861 4703 
-Q 3103 4656 3366 4563 
-z
-" transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_21">
-    <!-- +15 -->
+    <!-- +20 -->
     <g transform="translate(147.693424 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_22">
-    <!-- -47 -->
+    <!-- -43 -->
     <g transform="translate(188.495082 68.904519) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
@@ -1387,6 +1358,48 @@ L 313 1709
 L 2253 4666 
 z
 " transform="scale(0.015625)"/>
+      <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_23">
+    <!-- -77 -->
+    <g transform="translate(227.74588 68.904519) scale(0.065 -0.065)">
+     <defs>
       <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
 L 3525 4397 
@@ -1399,16 +1412,8 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_23">
-    <!-- -79 -->
-    <g transform="translate(227.74588 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_24">
@@ -1461,84 +1466,83 @@ z
     </g>
    </g>
    <g id="text_25">
-    <!-- -23 -->
+    <!-- -16 -->
     <g transform="translate(306.247477 68.904519) scale(0.065 -0.065)">
      <defs>
-      <path id="DejaVuSans-33" d="M 2597 2516 
-Q 3050 2419 3304 2112 
-Q 3559 1806 3559 1356 
-Q 3559 666 3084 287 
-Q 2609 -91 1734 -91 
-Q 1441 -91 1130 -33 
-Q 819 25 488 141 
-L 488 750 
-Q 750 597 1062 519 
-Q 1375 441 1716 441 
-Q 2309 441 2620 675 
-Q 2931 909 2931 1356 
-Q 2931 1769 2642 2001 
-Q 2353 2234 1838 2234 
-L 1294 2234 
-L 1294 2753 
-L 1863 2753 
-Q 2328 2753 2575 2939 
-Q 2822 3125 2822 3475 
-Q 2822 3834 2567 4026 
-Q 2313 4219 1838 4219 
-Q 1578 4219 1281 4162 
-Q 984 4106 628 3988 
-L 628 4550 
-Q 988 4650 1302 4700 
-Q 1616 4750 1894 4750 
-Q 2613 4750 3031 4423 
-Q 3450 4097 3450 3541 
-Q 3450 3153 3228 2886 
-Q 3006 2619 2597 2516 
+      <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_26">
-    <!-- +7 -->
-    <g transform="translate(346.015229 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_27">
-    <!-- +27 -->
-    <g transform="translate(383.198215 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_28">
-    <!-- -26 -->
-    <g transform="translate(423.999873 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
     </g>
    </g>
+   <g id="text_26">
+    <!-- +16 -->
+    <g transform="translate(343.947416 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_27">
+    <!-- +36 -->
+    <g transform="translate(383.198215 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_28">
+    <!-- -17 -->
+    <g transform="translate(423.999873 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
    <g id="text_29">
-    <!-- -42 -->
+    <!-- -41 -->
     <g transform="translate(463.250671 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_30">
-    <!-- -89 -->
+    <!-- -88 -->
     <g transform="translate(502.50147 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_31">
@@ -2177,18 +2181,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="image7436233bce" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
+iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="image3f11eb0739" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="me584de6e14" d="M 0 0 
+       <path id="m909d6473aa" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#me584de6e14" x="547.779688" y="276.293905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m909d6473aa" x="547.779688" y="276.293905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
@@ -2211,7 +2215,7 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#me584de6e14" x="547.779688" y="247.808905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m909d6473aa" x="547.779688" y="247.808905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
@@ -2225,7 +2229,7 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#me584de6e14" x="547.779688" y="219.323905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m909d6473aa" x="547.779688" y="219.323905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
@@ -2239,7 +2243,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#me584de6e14" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m909d6473aa" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
@@ -2252,7 +2256,7 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#me584de6e14" x="547.779688" y="162.353904" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m909d6473aa" x="547.779688" y="162.353904" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_112">
@@ -2265,7 +2269,7 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#me584de6e14" x="547.779688" y="133.868904" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m909d6473aa" x="547.779688" y="133.868904" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
@@ -2278,7 +2282,7 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#me584de6e14" x="547.779688" y="105.383904" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m909d6473aa" x="547.779688" y="105.383904" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
@@ -2939,8 +2943,8 @@ z
    </g>
   </g>
   <g id="text_117">
-   <!-- 2026-07-08T06:11:08Z  ·  Linux chungus2 x86_64  ·  commit 28336125  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(16.380391 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-08T15:47:33Z  ·  Linux chungus2 x86_64  ·  commit f2026e66  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(17.448437 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -3009,14 +3013,14 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-38" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3056,109 +3060,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3262.744141 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3326.367188 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3389.990234 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3453.613281 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3517.236328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3580.859375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3612.646484 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3644.433594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3676.220703 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3708.007812 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3739.794922 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3767.578125 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3829.101562 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3890.380859 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3953.759766 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4017.236328 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4056.099609 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4117.28125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4176.460938 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4237.984375 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4279.097656 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4312.789062 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4340.572266 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4402.095703 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4463.375 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4526.753906 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4590.376953 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4624.068359 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4683.248047 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4746.871094 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4778.658203 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4842.28125 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4905.904297 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4937.691406 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(5001.314453 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5037.398438 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5076.261719 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5131.242188 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5194.865234 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5226.652344 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5258.439453 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5290.226562 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5322.013672 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5353.800781 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5393.009766 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5456.388672 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5495.251953 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5556.433594 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5619.8125 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5683.289062 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5746.667969 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5810.144531 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5873.523438 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5912.732422 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5944.519531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6028.308594 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6060.095703 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6157.507812 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6219.03125 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6282.507812 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6310.291016 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6371.570312 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6434.949219 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6466.736328 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6518.835938 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6582.214844 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6643.494141 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6706.970703 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6759.070312 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6822.449219 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6883.630859 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6922.839844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6956.53125 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6988.318359 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7029.431641 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7090.710938 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7129.919922 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7157.703125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7218.884766 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7250.671875 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7278.455078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7330.554688 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7362.341797 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7425.818359 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7487.341797 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7526.550781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7588.074219 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7627.4375 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7724.849609 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7752.632812 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7816.011719 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7843.794922 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7895.894531 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7935.103516 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7962.886719 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3107.080078 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3170.703125 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3234.326172 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3297.949219 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3361.572266 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3423.095703 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3486.71875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3550.341797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3582.128906 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3613.916016 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3645.703125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3677.490234 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3709.277344 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3737.060547 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3798.583984 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3859.863281 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3923.242188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3986.71875 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4025.582031 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4086.763672 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4145.943359 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4207.466797 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4248.580078 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4282.271484 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4310.054688 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4371.578125 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4432.857422 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4496.236328 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4559.859375 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4593.550781 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4652.730469 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4716.353516 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4748.140625 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4811.763672 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4875.386719 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4907.173828 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4970.796875 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5006.880859 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5045.744141 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5100.724609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5164.347656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5196.134766 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5227.921875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5259.708984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5291.496094 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5323.283203 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5362.492188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5425.871094 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5464.734375 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5525.916016 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5589.294922 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5652.771484 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5716.150391 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5779.626953 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5843.005859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5882.214844 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5914.001953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5997.791016 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6029.578125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6126.990234 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6188.513672 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6251.990234 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6279.773438 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6341.052734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6404.431641 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6436.21875 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6488.318359 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6551.697266 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6612.976562 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6676.453125 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6728.552734 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6791.931641 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6853.113281 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6892.322266 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6926.013672 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6957.800781 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6998.914062 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7060.193359 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7099.402344 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7127.185547 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7188.367188 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7220.154297 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7247.9375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7300.037109 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7331.824219 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7395.300781 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7456.824219 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7496.033203 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7557.556641 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7596.919922 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7694.332031 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7722.115234 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7785.494141 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7813.277344 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7865.376953 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7904.585938 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7932.369141 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="paf08724384">
+  <clipPath id="p2cec6f8756">
    <rect x="95.67625" y="49.4355" width="431.758783" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_compress_pareto.svg
+++ b/bench/graphs/canterbury_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 79.118387 412.80375 
 L 79.118387 48.323125 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="mcd64ee64cf" d="M 0 0 
+       <path id="mb2667e4cd3" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mcd64ee64cf" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb2667e4cd3" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -161,11 +161,11 @@ z
      <g id="line2d_3">
       <path d="M 166.481434 412.80375 
 L 166.481434 48.323125 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mcd64ee64cf" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb2667e4cd3" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -216,11 +216,11 @@ z
      <g id="line2d_5">
       <path d="M 253.844481 412.80375 
 L 253.844481 48.323125 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#mcd64ee64cf" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb2667e4cd3" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -237,11 +237,11 @@ L 253.844481 48.323125
      <g id="line2d_7">
       <path d="M 341.207528 412.80375 
 L 341.207528 48.323125 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#mcd64ee64cf" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb2667e4cd3" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -279,11 +279,11 @@ z
      <g id="line2d_9">
       <path d="M 428.570575 412.80375 
 L 428.570575 48.323125 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#mcd64ee64cf" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb2667e4cd3" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -332,11 +332,11 @@ z
      <g id="line2d_11">
       <path d="M 515.933622 412.80375 
 L 515.933622 48.323125 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#mcd64ee64cf" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb2667e4cd3" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -353,11 +353,11 @@ L 515.933622 48.323125
      <g id="line2d_13">
       <path d="M 603.296669 412.80375 
 L 603.296669 48.323125 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mcd64ee64cf" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb2667e4cd3" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -854,16 +854,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 347.786382 
 L 637.2 347.786382 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="m7c82985a79" d="M 0 0 
+       <path id="m43496cbc69" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m7c82985a79" x="49.078125" y="347.786382" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m43496cbc69" x="49.078125" y="347.786382" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -895,11 +895,11 @@ z
      <g id="line2d_17">
       <path d="M 49.078125 238.646289 
 L 637.2 238.646289 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m7c82985a79" x="49.078125" y="238.646289" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m43496cbc69" x="49.078125" y="238.646289" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -915,11 +915,11 @@ L 637.2 238.646289
      <g id="line2d_19">
       <path d="M 49.078125 129.506196 
 L 637.2 129.506196 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m7c82985a79" x="49.078125" y="129.506196" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m43496cbc69" x="49.078125" y="129.506196" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -935,16 +935,16 @@ L 637.2 129.506196
      <g id="line2d_21">
       <path d="M 49.078125 404.853417 
 L 637.2 404.853417 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="m0439fb0555" d="M 0 0 
+       <path id="mb058e9b162" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m0439fb0555" x="49.078125" y="404.853417" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb058e9b162" x="49.078125" y="404.853417" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -952,11 +952,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 391.217592 
 L 637.2 391.217592 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m0439fb0555" x="49.078125" y="391.217592" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb058e9b162" x="49.078125" y="391.217592" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -964,11 +964,11 @@ L 637.2 391.217592
      <g id="line2d_25">
       <path d="M 49.078125 380.640824 
 L 637.2 380.640824 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m0439fb0555" x="49.078125" y="380.640824" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb058e9b162" x="49.078125" y="380.640824" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -976,11 +976,11 @@ L 637.2 380.640824
      <g id="line2d_27">
       <path d="M 49.078125 371.998975 
 L 637.2 371.998975 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m0439fb0555" x="49.078125" y="371.998975" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb058e9b162" x="49.078125" y="371.998975" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -988,11 +988,11 @@ L 637.2 371.998975
      <g id="line2d_29">
       <path d="M 49.078125 364.692396 
 L 637.2 364.692396 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m0439fb0555" x="49.078125" y="364.692396" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb058e9b162" x="49.078125" y="364.692396" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1000,11 +1000,11 @@ L 637.2 364.692396
      <g id="line2d_31">
       <path d="M 49.078125 358.36315 
 L 637.2 358.36315 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m0439fb0555" x="49.078125" y="358.36315" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb058e9b162" x="49.078125" y="358.36315" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1012,11 +1012,11 @@ L 637.2 358.36315
      <g id="line2d_33">
       <path d="M 49.078125 352.780359 
 L 637.2 352.780359 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m0439fb0555" x="49.078125" y="352.780359" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb058e9b162" x="49.078125" y="352.780359" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1024,11 +1024,11 @@ L 637.2 352.780359
      <g id="line2d_35">
       <path d="M 49.078125 314.93194 
 L 637.2 314.93194 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m0439fb0555" x="49.078125" y="314.93194" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb058e9b162" x="49.078125" y="314.93194" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1036,11 +1036,11 @@ L 637.2 314.93194
      <g id="line2d_37">
       <path d="M 49.078125 295.713324 
 L 637.2 295.713324 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m0439fb0555" x="49.078125" y="295.713324" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb058e9b162" x="49.078125" y="295.713324" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1048,11 +1048,11 @@ L 637.2 295.713324
      <g id="line2d_39">
       <path d="M 49.078125 282.077499 
 L 637.2 282.077499 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m0439fb0555" x="49.078125" y="282.077499" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb058e9b162" x="49.078125" y="282.077499" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1060,11 +1060,11 @@ L 637.2 282.077499
      <g id="line2d_41">
       <path d="M 49.078125 271.500731 
 L 637.2 271.500731 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m0439fb0555" x="49.078125" y="271.500731" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb058e9b162" x="49.078125" y="271.500731" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1072,11 +1072,11 @@ L 637.2 271.500731
      <g id="line2d_43">
       <path d="M 49.078125 262.858882 
 L 637.2 262.858882 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m0439fb0555" x="49.078125" y="262.858882" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb058e9b162" x="49.078125" y="262.858882" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1084,11 +1084,11 @@ L 637.2 262.858882
      <g id="line2d_45">
       <path d="M 49.078125 255.552304 
 L 637.2 255.552304 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m0439fb0555" x="49.078125" y="255.552304" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb058e9b162" x="49.078125" y="255.552304" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1096,11 +1096,11 @@ L 637.2 255.552304
      <g id="line2d_47">
       <path d="M 49.078125 249.223057 
 L 637.2 249.223057 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m0439fb0555" x="49.078125" y="249.223057" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb058e9b162" x="49.078125" y="249.223057" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1108,11 +1108,11 @@ L 637.2 249.223057
      <g id="line2d_49">
       <path d="M 49.078125 243.640266 
 L 637.2 243.640266 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m0439fb0555" x="49.078125" y="243.640266" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb058e9b162" x="49.078125" y="243.640266" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1120,11 +1120,11 @@ L 637.2 243.640266
      <g id="line2d_51">
       <path d="M 49.078125 205.791848 
 L 637.2 205.791848 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m0439fb0555" x="49.078125" y="205.791848" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb058e9b162" x="49.078125" y="205.791848" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1132,11 +1132,11 @@ L 637.2 205.791848
      <g id="line2d_53">
       <path d="M 49.078125 186.573231 
 L 637.2 186.573231 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#m0439fb0555" x="49.078125" y="186.573231" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb058e9b162" x="49.078125" y="186.573231" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1144,11 +1144,11 @@ L 637.2 186.573231
      <g id="line2d_55">
       <path d="M 49.078125 172.937406 
 L 637.2 172.937406 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#m0439fb0555" x="49.078125" y="172.937406" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb058e9b162" x="49.078125" y="172.937406" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1156,11 +1156,11 @@ L 637.2 172.937406
      <g id="line2d_57">
       <path d="M 49.078125 162.360638 
 L 637.2 162.360638 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#m0439fb0555" x="49.078125" y="162.360638" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb058e9b162" x="49.078125" y="162.360638" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1168,11 +1168,11 @@ L 637.2 162.360638
      <g id="line2d_59">
       <path d="M 49.078125 153.71879 
 L 637.2 153.71879 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#m0439fb0555" x="49.078125" y="153.71879" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb058e9b162" x="49.078125" y="153.71879" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1180,11 +1180,11 @@ L 637.2 153.71879
      <g id="line2d_61">
       <path d="M 49.078125 146.412211 
 L 637.2 146.412211 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#m0439fb0555" x="49.078125" y="146.412211" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb058e9b162" x="49.078125" y="146.412211" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1192,11 +1192,11 @@ L 637.2 146.412211
      <g id="line2d_63">
       <path d="M 49.078125 140.082964 
 L 637.2 140.082964 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#m0439fb0555" x="49.078125" y="140.082964" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb058e9b162" x="49.078125" y="140.082964" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1204,11 +1204,11 @@ L 637.2 140.082964
      <g id="line2d_65">
       <path d="M 49.078125 134.500173 
 L 637.2 134.500173 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#m0439fb0555" x="49.078125" y="134.500173" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb058e9b162" x="49.078125" y="134.500173" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1216,11 +1216,11 @@ L 637.2 134.500173
      <g id="line2d_67">
       <path d="M 49.078125 96.651755 
 L 637.2 96.651755 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_68">
       <g>
-       <use xlink:href="#m0439fb0555" x="49.078125" y="96.651755" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb058e9b162" x="49.078125" y="96.651755" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1228,11 +1228,11 @@ L 637.2 96.651755
      <g id="line2d_69">
       <path d="M 49.078125 77.433138 
 L 637.2 77.433138 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_70">
       <g>
-       <use xlink:href="#m0439fb0555" x="49.078125" y="77.433138" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb058e9b162" x="49.078125" y="77.433138" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1240,11 +1240,11 @@ L 637.2 77.433138
      <g id="line2d_71">
       <path d="M 49.078125 63.797313 
 L 637.2 63.797313 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_72">
       <g>
-       <use xlink:href="#m0439fb0555" x="49.078125" y="63.797313" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb058e9b162" x="49.078125" y="63.797313" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1252,11 +1252,11 @@ L 637.2 63.797313
      <g id="line2d_73">
       <path d="M 49.078125 53.220545 
 L 637.2 53.220545 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_74">
       <g>
-       <use xlink:href="#m0439fb0555" x="49.078125" y="53.220545" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb058e9b162" x="49.078125" y="53.220545" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1378,7 +1378,7 @@ L 637.2 48.323125
    </g>
    <g id="text_13">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(294.669676 147.452522) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(294.669676 144.610306) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1410,7 +1410,7 @@ z
    </g>
    <g id="text_14">
     <!-- L10 -->
-    <g style="fill: #d62728" transform="translate(104.852312 296.898328) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(104.852312 295.336792) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1732,23 +1732,23 @@ z
    </g>
    <g id="line2d_75">
     <defs>
-     <path id="mb68b9316c8" d="M -2.5 2.5 
+     <path id="ma6a4cfb2c2" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p870c1441f5)">
-     <use xlink:href="#mb68b9316c8" x="355.479835" y="95.382063" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb68b9316c8" x="308.273931" y="102.754513" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb68b9316c8" x="271.230161" y="116.528062" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb68b9316c8" x="217.83458" y="120.013651" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb68b9316c8" x="177.077692" y="138.43462" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb68b9316c8" x="162.880539" y="157.778627" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb68b9316c8" x="160.741445" y="165.196647" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb68b9316c8" x="153.966678" y="183.405761" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb68b9316c8" x="151.589614" y="194.488118" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p6652a911cf)">
+     <use xlink:href="#ma6a4cfb2c2" x="355.479835" y="95.382063" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma6a4cfb2c2" x="308.273931" y="102.754513" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma6a4cfb2c2" x="271.230161" y="116.528062" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma6a4cfb2c2" x="217.83458" y="120.013651" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma6a4cfb2c2" x="177.077692" y="138.43462" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma6a4cfb2c2" x="162.880539" y="157.778627" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma6a4cfb2c2" x="160.741445" y="165.196647" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma6a4cfb2c2" x="153.966678" y="183.405761" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma6a4cfb2c2" x="151.589614" y="194.488118" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_76">
@@ -1801,7 +1801,7 @@ L 311.2243 102.325849
 L 310.240844 102.469168 
 L 309.257387 102.612055 
 L 308.273931 102.754513 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_77">
     <path d="M 308.273931 102.754513 
@@ -1853,7 +1853,7 @@ L 273.545396 115.775058
 L 272.773651 116.027391 
 L 272.001906 116.278388 
 L 271.230161 116.528062 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_78">
     <path d="M 271.230161 116.528062 
@@ -1905,7 +1905,7 @@ L 221.171803 119.803152
 L 220.059395 119.873422 
 L 218.946988 119.943588 
 L 217.83458 120.013651 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_79">
     <path d="M 217.83458 120.013651 
@@ -1957,7 +1957,7 @@ L 179.624997 137.470928
 L 178.775895 137.79434 
 L 177.926794 138.115561 
 L 177.077692 138.43462 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_80">
     <path d="M 177.077692 138.43462 
@@ -2009,7 +2009,7 @@ L 163.767861 156.775388
 L 163.472087 157.112166 
 L 163.176313 157.446568 
 L 162.880539 157.778627 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_81">
     <path d="M 162.880539 157.778627 
@@ -2061,7 +2061,7 @@ L 160.875139 164.765525
 L 160.830574 164.909668 
 L 160.78601 165.053375 
 L 160.741445 165.196647 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_82">
     <path d="M 160.741445 165.196647 
@@ -2113,7 +2113,7 @@ L 154.390101 182.45125
 L 154.24896 182.771561 
 L 154.107819 183.089721 
 L 153.966678 183.405761 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_83">
     <path d="M 153.966678 183.405761 
@@ -2165,26 +2165,26 @@ L 151.73818 193.866427
 L 151.688658 194.074564 
 L 151.639136 194.281792 
 L 151.589614 194.488118 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_84">
     <defs>
-     <path id="m52931cc3f4" d="M 0 -2.5 
+     <path id="mddee50189a" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p870c1441f5)">
-     <use xlink:href="#m52931cc3f4" x="531.649087" y="75.963093" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m52931cc3f4" x="283.721324" y="99.020035" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m52931cc3f4" x="218.882044" y="121.069315" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m52931cc3f4" x="187.447228" y="127.10685" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m52931cc3f4" x="176.342474" y="138.36311" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m52931cc3f4" x="163.054314" y="161.312135" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m52931cc3f4" x="162.210539" y="168.753955" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m52931cc3f4" x="159.303811" y="175.753345" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m52931cc3f4" x="157.793928" y="179.494802" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p6652a911cf)">
+     <use xlink:href="#mddee50189a" x="531.649087" y="75.963093" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mddee50189a" x="283.721324" y="99.020035" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mddee50189a" x="218.882044" y="121.069315" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mddee50189a" x="187.447228" y="127.10685" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mddee50189a" x="176.342474" y="138.36311" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mddee50189a" x="163.054314" y="161.312135" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mddee50189a" x="162.210539" y="168.753955" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mddee50189a" x="159.303811" y="175.753345" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mddee50189a" x="157.793928" y="179.494802" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_85">
@@ -2237,7 +2237,7 @@ L 299.21681 97.864971
 L 294.051648 98.253128 
 L 288.886486 98.638133 
 L 283.721324 99.020035 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_86">
     <path d="M 283.721324 99.020035 
@@ -2289,7 +2289,7 @@ L 222.934499 119.954333
 L 221.583681 120.328916 
 L 220.232863 120.700561 
 L 218.882044 121.069315 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_87">
     <path d="M 218.882044 121.069315 
@@ -2341,7 +2341,7 @@ L 189.411904 126.751217
 L 188.757012 126.870058 
 L 188.10212 126.988602 
 L 187.447228 127.10685 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_88">
     <path d="M 187.447228 127.10685 
@@ -2393,7 +2393,7 @@ L 177.036521 137.732718
 L 176.805172 137.943781 
 L 176.573823 138.153909 
 L 176.342474 138.36311 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_89">
     <path d="M 176.342474 138.36311 
@@ -2445,7 +2445,7 @@ L 163.884824 160.161325
 L 163.607987 160.548041 
 L 163.33115 160.931628 
 L 163.054314 161.312135 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_90">
     <path d="M 163.054314 161.312135 
@@ -2497,7 +2497,7 @@ L 162.263275 168.321549
 L 162.245696 168.466124 
 L 162.228118 168.610258 
 L 162.210539 168.753955 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_91">
     <path d="M 162.210539 168.753955 
@@ -2549,7 +2549,7 @@ L 159.485481 175.344896
 L 159.424925 175.481437 
 L 159.364368 175.617586 
 L 159.303811 175.753345 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_92">
     <path d="M 159.303811 175.753345 
@@ -2601,30 +2601,30 @@ L 157.888296 179.269417
 L 157.85684 179.344665 
 L 157.825384 179.419793 
 L 157.793928 179.494802 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_93">
     <defs>
-     <path id="mdf417f3473" d="M -0 3.535534 
+     <path id="m77b5932206" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p870c1441f5)">
-     <use xlink:href="#mdf417f3473" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdf417f3473" x="203.775848" y="81.750179" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdf417f3473" x="186.982691" y="88.344921" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdf417f3473" x="179.779306" y="91.045312" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdf417f3473" x="157.610419" y="99.395085" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdf417f3473" x="148.722526" y="107.864022" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdf417f3473" x="144.388162" y="121.237794" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdf417f3473" x="127.071247" y="144.560664" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdf417f3473" x="124.491988" y="152.083585" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdf417f3473" x="92.613662" y="207.637263" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdf417f3473" x="87.348715" y="225.457654" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdf417f3473" x="86.053433" y="242.017529" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p6652a911cf)">
+     <use xlink:href="#m77b5932206" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m77b5932206" x="203.775848" y="81.750179" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m77b5932206" x="186.982691" y="88.344921" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m77b5932206" x="179.779306" y="91.045312" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m77b5932206" x="157.610419" y="99.395085" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m77b5932206" x="148.722526" y="107.864022" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m77b5932206" x="144.388162" y="121.237794" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m77b5932206" x="127.071247" y="144.560664" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m77b5932206" x="124.491988" y="152.083585" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m77b5932206" x="92.613662" y="207.637263" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m77b5932206" x="87.348715" y="225.457654" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m77b5932206" x="86.053433" y="242.017529" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_94">
@@ -2677,7 +2677,7 @@ L 206.762331 80.855075
 L 205.766837 81.155325 
 L 204.771342 81.453685 
 L 203.775848 81.750179 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_95">
     <path d="M 203.775848 81.750179 
@@ -2729,7 +2729,7 @@ L 188.032264 87.958568
 L 187.682406 88.087703 
 L 187.332549 88.216487 
 L 186.982691 88.344921 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_96">
     <path d="M 186.982691 88.344921 
@@ -2781,7 +2781,7 @@ L 180.229518 90.88097
 L 180.079447 90.935814 
 L 179.929376 90.990595 
 L 179.779306 91.045312 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_97">
     <path d="M 179.779306 91.045312 
@@ -2833,7 +2833,7 @@ L 158.995974 98.914174
 L 158.534122 99.075021 
 L 158.07227 99.235323 
 L 157.610419 99.395085 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_98">
     <path d="M 157.610419 99.395085 
@@ -2885,7 +2885,7 @@ L 149.27802 107.37681
 L 149.092855 107.539771 
 L 148.907691 107.702174 
 L 148.722526 107.864022 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_99">
     <path d="M 148.722526 107.864022 
@@ -2937,7 +2937,7 @@ L 144.65906 120.50385
 L 144.568761 120.749763 
 L 144.478462 120.994407 
 L 144.388162 121.237794 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_100">
     <path d="M 144.388162 121.237794 
@@ -2989,7 +2989,7 @@ L 128.153555 143.395158
 L 127.792786 143.786853 
 L 127.432016 144.175338 
 L 127.071247 144.560664 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_101">
     <path d="M 127.071247 144.560664 
@@ -3041,7 +3041,7 @@ L 124.653192 151.646811
 L 124.599457 151.79285 
 L 124.545723 151.93844 
 L 124.491988 152.083585 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_102">
     <path d="M 124.491988 152.083585 
@@ -3093,7 +3093,7 @@ L 94.606058 205.546972
 L 93.941926 206.254028 
 L 93.277794 206.950691 
 L 92.613662 207.637263 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_103">
     <path d="M 92.613662 207.637263 
@@ -3145,7 +3145,7 @@ L 87.677774 224.520091
 L 87.568088 224.834677 
 L 87.458402 225.147189 
 L 87.348715 225.457654 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_104">
     <path d="M 87.348715 225.457654 
@@ -3197,23 +3197,23 @@ L 86.134388 241.135848
 L 86.107403 241.431568 
 L 86.080418 241.725454 
 L 86.053433 242.017529 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_105">
     <defs>
-     <path id="ma07ddbcbfd" d="M -0 2.5 
+     <path id="ma7c25d9a97" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p870c1441f5)">
-     <use xlink:href="#ma07ddbcbfd" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p6652a911cf)">
+     <use xlink:href="#ma7c25d9a97" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_106">
     <defs>
-     <path id="m8f79101622" d="M -0.833333 2.5 
+     <path id="m79b355ad29" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -3228,16 +3228,16 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p870c1441f5)">
-     <use xlink:href="#m8f79101622" x="362.865999" y="115.428618" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8f79101622" x="278.798176" y="122.858526" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8f79101622" x="251.17632" y="128.261574" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8f79101622" x="200.806828" y="131.522849" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8f79101622" x="169.803221" y="147.931404" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8f79101622" x="161.916638" y="160.718659" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8f79101622" x="158.697104" y="167.705569" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8f79101622" x="154.26679" y="181.026105" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8f79101622" x="153.096464" y="191.924265" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p6652a911cf)">
+     <use xlink:href="#m79b355ad29" x="362.865999" y="115.428618" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m79b355ad29" x="278.798176" y="122.858526" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m79b355ad29" x="251.17632" y="128.261574" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m79b355ad29" x="200.806828" y="131.522849" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m79b355ad29" x="169.803221" y="147.931404" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m79b355ad29" x="161.916638" y="160.718659" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m79b355ad29" x="158.697104" y="167.705569" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m79b355ad29" x="154.26679" y="181.026105" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m79b355ad29" x="153.096464" y="191.924265" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_107">
@@ -3290,7 +3290,7 @@ L 284.052415 122.426763
 L 282.301002 122.571121 
 L 280.549589 122.715042 
 L 278.798176 122.858526 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_108">
     <path d="M 278.798176 122.858526 
@@ -3342,7 +3342,7 @@ L 252.902686 127.94134
 L 252.327231 128.048325 
 L 251.751776 128.155069 
 L 251.17632 128.261574 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_109">
     <path d="M 251.17632 128.261574 
@@ -3394,7 +3394,7 @@ L 203.954921 131.325463
 L 202.905557 131.39135 
 L 201.856192 131.457145 
 L 200.806828 131.522849 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_110">
     <path d="M 200.806828 131.522849 
@@ -3446,7 +3446,7 @@ L 171.740947 147.056528
 L 171.095038 147.349951 
 L 170.44913 147.64157 
 L 169.803221 147.931404 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_111">
     <path d="M 169.803221 147.931404 
@@ -3498,7 +3498,7 @@ L 162.409549 160.012958
 L 162.245246 160.249361 
 L 162.080942 160.484591 
 L 161.916638 160.718659 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_112">
     <path d="M 161.916638 160.718659 
@@ -3550,7 +3550,7 @@ L 158.898325 167.297798
 L 158.831251 167.434112 
 L 158.764178 167.570034 
 L 158.697104 167.705569 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_113">
     <path d="M 158.697104 167.705569 
@@ -3602,7 +3602,7 @@ L 154.543684 180.294711
 L 154.451386 180.539765 
 L 154.359088 180.783558 
 L 154.26679 181.026105 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_114">
     <path d="M 154.26679 181.026105 
@@ -3654,11 +3654,11 @@ L 153.16961 191.311823
 L 153.145228 191.516851 
 L 153.120846 191.720996 
 L 153.096464 191.924265 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_115">
     <defs>
-     <path id="m82bc1365e3" d="M -1.25 2.5 
+     <path id="m353579a97d" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -3673,16 +3673,16 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p870c1441f5)">
-     <use xlink:href="#m82bc1365e3" x="301.619021" y="150.561849" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m82bc1365e3" x="250.236474" y="156.671134" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m82bc1365e3" x="225.418659" y="160.842551" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m82bc1365e3" x="212.328936" y="161.382211" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m82bc1365e3" x="209.030149" y="166.25091" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m82bc1365e3" x="197.547749" y="171.432451" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m82bc1365e3" x="194.819287" y="175.129495" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m82bc1365e3" x="193.12279" y="181.606362" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m82bc1365e3" x="192.79794" y="189.451167" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p6652a911cf)">
+     <use xlink:href="#m353579a97d" x="301.619021" y="150.561849" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m353579a97d" x="250.236474" y="156.671134" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m353579a97d" x="225.418659" y="160.842551" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m353579a97d" x="212.328936" y="161.382211" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m353579a97d" x="209.030149" y="166.25091" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m353579a97d" x="197.547749" y="171.432451" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m353579a97d" x="194.819287" y="175.129495" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m353579a97d" x="193.12279" y="181.606362" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m353579a97d" x="192.79794" y="189.451167" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_116">
@@ -3735,7 +3735,7 @@ L 253.447883 156.311526
 L 252.377414 156.431699 
 L 251.306944 156.551567 
 L 250.236474 156.671134 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_117">
     <path d="M 250.236474 156.671134 
@@ -3787,7 +3787,7 @@ L 226.969772 160.592321
 L 226.452735 160.675878 
 L 225.935697 160.759287 
 L 225.418659 160.842551 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_118">
     <path d="M 225.418659 160.842551 
@@ -3839,7 +3839,7 @@ L 213.147044 161.348661
 L 212.874341 161.359847 
 L 212.601639 161.37103 
 L 212.328936 161.382211 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_119">
     <path d="M 212.328936 161.382211 
@@ -3891,7 +3891,7 @@ L 209.236323 165.960837
 L 209.167599 166.057725 
 L 209.098874 166.154416 
 L 209.030149 166.25091 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_120">
     <path d="M 209.030149 166.25091 
@@ -3943,7 +3943,7 @@ L 198.265399 171.124681
 L 198.026182 171.227493 
 L 197.786966 171.330083 
 L 197.547749 171.432451 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_121">
     <path d="M 197.547749 171.432451 
@@ -3995,7 +3995,7 @@ L 194.989815 174.906688
 L 194.932972 174.981074 
 L 194.876129 175.055342 
 L 194.819287 175.129495 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_122">
     <path d="M 194.819287 175.129495 
@@ -4047,7 +4047,7 @@ L 193.228821 181.226479
 L 193.193478 181.353445 
 L 193.158134 181.480072 
 L 193.12279 181.606362 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_123">
     <path d="M 193.12279 181.606362 
@@ -4099,11 +4099,11 @@ L 192.818243 188.997124
 L 192.811475 189.148955 
 L 192.804707 189.300302 
 L 192.79794 189.451167 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_124">
     <defs>
-     <path id="mcedf235565" d="M 0 -2.5 
+     <path id="m3ed957900c" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -4116,16 +4116,16 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p870c1441f5)">
-     <use xlink:href="#mcedf235565" x="206.45578" y="118.584066" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mcedf235565" x="206.45578" y="118.258949" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mcedf235565" x="206.45578" y="118.759361" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mcedf235565" x="206.45578" y="118.234957" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mcedf235565" x="171.767499" y="134.097889" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mcedf235565" x="163.54283" y="144.663903" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mcedf235565" x="160.174881" y="151.505345" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mcedf235565" x="154.179217" y="169.303726" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mcedf235565" x="152.4406" y="178.584542" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p6652a911cf)">
+     <use xlink:href="#m3ed957900c" x="206.45578" y="118.584066" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m3ed957900c" x="206.45578" y="118.258949" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m3ed957900c" x="206.45578" y="118.759361" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m3ed957900c" x="206.45578" y="118.234957" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m3ed957900c" x="171.767499" y="134.097889" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m3ed957900c" x="163.54283" y="144.663903" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m3ed957900c" x="160.174881" y="151.505345" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m3ed957900c" x="154.179217" y="169.303726" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m3ed957900c" x="152.4406" y="178.584542" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_125">
@@ -4178,7 +4178,7 @@ L 206.45578 118.279335
 L 206.45578 118.27254 
 L 206.45578 118.265745 
 L 206.45578 118.258949 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_126">
     <path d="M 206.45578 118.258949 
@@ -4230,7 +4230,7 @@ L 206.45578 118.728239
 L 206.45578 118.738615 
 L 206.45578 118.748989 
 L 206.45578 118.759361 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_127">
     <path d="M 206.45578 118.759361 
@@ -4282,7 +4282,7 @@ L 206.45578 118.267903
 L 206.45578 118.256924 
 L 206.45578 118.245942 
 L 206.45578 118.234957 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_128">
     <path d="M 206.45578 118.234957 
@@ -4334,7 +4334,7 @@ L 173.935517 133.247721
 L 173.212844 133.532808 
 L 172.490172 133.816191 
 L 171.767499 134.097889 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_129">
     <path d="M 171.767499 134.097889 
@@ -4386,7 +4386,7 @@ L 164.056872 144.068227
 L 163.885524 144.267619 
 L 163.714177 144.466175 
 L 163.54283 144.663903 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_130">
     <path d="M 163.54283 144.663903 
@@ -4438,7 +4438,7 @@ L 160.385378 151.105499
 L 160.315212 151.239156 
 L 160.245047 151.372438 
 L 160.174881 151.505345 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_131">
     <path d="M 160.174881 151.505345 
@@ -4490,7 +4490,7 @@ L 154.553946 168.367127
 L 154.429036 168.681387 
 L 154.304126 168.993578 
 L 154.179217 169.303726 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_132">
     <path d="M 154.179217 169.303726 
@@ -4542,11 +4542,11 @@ L 152.549264 178.054798
 L 152.513043 178.232038 
 L 152.476822 178.408618 
 L 152.4406 178.584542 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_133">
     <defs>
-     <path id="mb035a0cf5e" d="M 0 -2.5 
+     <path id="mfee84be412" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -4555,16 +4555,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p870c1441f5)">
-     <use xlink:href="#mb035a0cf5e" x="610.467188" y="172.829682" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb035a0cf5e" x="592.067397" y="173.763838" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb035a0cf5e" x="534.807821" y="180.385179" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb035a0cf5e" x="327.802209" y="176.172104" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb035a0cf5e" x="275.83761" y="186.734601" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb035a0cf5e" x="258.25125" y="198.783148" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb035a0cf5e" x="256.777056" y="203.737732" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb035a0cf5e" x="248.769854" y="217.74136" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb035a0cf5e" x="246.264594" y="227.740017" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p6652a911cf)">
+     <use xlink:href="#mfee84be412" x="610.467188" y="172.829682" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfee84be412" x="592.067397" y="173.763838" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfee84be412" x="534.807821" y="180.385179" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfee84be412" x="327.802209" y="176.172104" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfee84be412" x="275.83761" y="186.734601" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfee84be412" x="258.25125" y="198.783148" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfee84be412" x="256.777056" y="203.737732" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfee84be412" x="248.769854" y="217.74136" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfee84be412" x="246.264594" y="227.740017" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_134">
@@ -4617,7 +4617,7 @@ L 593.217384 173.705989
 L 592.834055 173.72528 
 L 592.450726 173.744563 
 L 592.067397 173.763838 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_135">
     <path d="M 592.067397 173.763838 
@@ -4669,7 +4669,7 @@ L 538.386544 179.997367
 L 537.193636 180.126991 
 L 536.000728 180.25626 
 L 534.807821 180.385179 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_136">
     <path d="M 534.807821 180.385179 
@@ -4721,7 +4721,7 @@ L 340.74006 176.446681
 L 336.427443 176.355332 
 L 332.114826 176.263806 
 L 327.802209 176.172104 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_137">
     <path d="M 327.802209 176.172104 
@@ -4773,7 +4773,7 @@ L 279.085397 186.139102
 L 278.002801 186.338434 
 L 276.920205 186.536931 
 L 275.83761 186.734601 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_138">
     <path d="M 275.83761 186.734601 
@@ -4825,7 +4825,7 @@ L 259.350398 198.113494
 L 258.984015 198.337765 
 L 258.617633 198.560979 
 L 258.25125 198.783148 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_139">
     <path d="M 258.25125 198.783148 
@@ -4877,7 +4877,7 @@ L 256.869193 203.442789
 L 256.838481 203.541307 
 L 256.807768 203.639621 
 L 256.777056 203.737732 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_140">
     <path d="M 256.777056 203.737732 
@@ -4929,7 +4929,7 @@ L 249.270304 216.977455
 L 249.103487 217.23346 
 L 248.93667 217.48809 
 L 248.769854 217.74136 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_141">
     <path d="M 248.769854 217.74136 
@@ -4981,7 +4981,7 @@ L 246.421172 227.173237
 L 246.368979 227.362918 
 L 246.316786 227.551842 
 L 246.264594 227.740017 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="legend_1">
     <g id="patch_7">
@@ -4999,7 +4999,7 @@ z
     </g>
     <g id="line2d_142">
      <defs>
-      <path id="mec1c3bb732" d="M 0 3.5 
+      <path id="m456359a00c" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -5012,7 +5012,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#mec1c3bb732" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m456359a00c" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -5071,7 +5071,7 @@ z
     </g>
     <g id="line2d_143">
      <g>
-      <use xlink:href="#mb68b9316c8" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#ma6a4cfb2c2" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -5085,7 +5085,7 @@ z
     </g>
     <g id="line2d_144">
      <g>
-      <use xlink:href="#m52931cc3f4" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mddee50189a" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -5130,7 +5130,7 @@ z
     </g>
     <g id="line2d_145">
      <g>
-      <use xlink:href="#mdf417f3473" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m77b5932206" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -5173,7 +5173,7 @@ z
     </g>
     <g id="line2d_146">
      <g>
-      <use xlink:href="#ma07ddbcbfd" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#ma7c25d9a97" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -5189,7 +5189,7 @@ z
     </g>
     <g id="line2d_147">
      <g>
-      <use xlink:href="#m8f79101622" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m79b355ad29" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -5243,7 +5243,7 @@ z
     </g>
     <g id="line2d_148">
      <g>
-      <use xlink:href="#m82bc1365e3" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m353579a97d" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -5308,7 +5308,7 @@ z
     </g>
     <g id="line2d_149">
      <g>
-      <use xlink:href="#mcedf235565" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#m3ed957900c" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -5346,7 +5346,7 @@ z
     </g>
     <g id="line2d_150">
      <g>
-      <use xlink:href="#mb035a0cf5e" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mfee84be412" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -5416,486 +5416,486 @@ z
     </g>
    </g>
    <g id="line2d_151">
-    <g clip-path="url(#p870c1441f5)">
-     <use xlink:href="#mec1c3bb732" x="289.669676" y="152.452522" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mec1c3bb732" x="223.847406" y="163.616764" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mec1c3bb732" x="212.215046" y="167.355312" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mec1c3bb732" x="181.367844" y="175.254349" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mec1c3bb732" x="165.231972" y="183.015764" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mec1c3bb732" x="153.327587" y="188.352968" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mec1c3bb732" x="148.576453" y="194.377723" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mec1c3bb732" x="145.287154" y="197.356361" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mec1c3bb732" x="115.00257" y="275.425589" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mec1c3bb732" x="99.852312" y="301.898328" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <g clip-path="url(#p6652a911cf)">
+     <use xlink:href="#m456359a00c" x="289.669676" y="149.610306" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m456359a00c" x="223.847406" y="159.886151" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m456359a00c" x="212.215046" y="163.98228" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m456359a00c" x="181.367844" y="171.586964" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m456359a00c" x="165.231972" y="179.494638" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m456359a00c" x="153.327587" y="185.380514" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m456359a00c" x="148.576453" y="191.342448" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m456359a00c" x="145.287154" y="194.257162" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m456359a00c" x="115.00257" y="273.95723" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m456359a00c" x="99.852312" y="300.336792" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
    <g id="line2d_152">
-    <path d="M 289.669676 152.452522 
-L 288.298379 152.714062 
-L 286.927082 152.974168 
-L 285.555784 153.232853 
-L 284.184487 153.490135 
-L 282.81319 153.746028 
-L 281.441892 154.000546 
-L 280.070595 154.253706 
-L 278.699298 154.50552 
-L 277.328 154.756003 
-L 275.956703 155.00517 
-L 274.585406 155.253034 
-L 273.214109 155.499608 
-L 271.842811 155.744906 
-L 270.471514 155.988942 
-L 269.100217 156.231727 
-L 267.728919 156.473275 
-L 266.357622 156.713599 
-L 264.986325 156.95271 
-L 263.615028 157.190621 
-L 262.24373 157.427343 
-L 260.872433 157.66289 
-L 259.501136 157.897271 
-L 258.129838 158.130499 
-L 256.758541 158.362586 
-L 255.387244 158.593541 
-L 254.015947 158.823377 
-L 252.644649 159.052103 
-L 251.273352 159.279731 
-L 249.902055 159.506271 
-L 248.530757 159.731734 
-L 247.15946 159.956129 
-L 245.788163 160.179467 
-L 244.416866 160.401757 
-L 243.045568 160.62301 
-L 241.674271 160.843234 
-L 240.302974 161.062441 
-L 238.931676 161.280638 
-L 237.560379 161.497835 
-L 236.189082 161.714042 
-L 234.817784 161.929267 
-L 233.446487 162.143519 
-L 232.07519 162.356807 
-L 230.703893 162.569139 
-L 229.332595 162.780524 
-L 227.961298 162.990971 
-L 226.590001 163.200488 
-L 225.218703 163.409083 
-L 223.847406 163.616764 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 289.669676 149.610306 
+L 288.298379 149.848763 
+L 286.927082 150.086026 
+L 285.555784 150.322108 
+L 284.184487 150.557019 
+L 282.81319 150.790772 
+L 281.441892 151.023378 
+L 280.070595 151.254848 
+L 278.699298 151.485193 
+L 277.328 151.714424 
+L 275.956703 151.942552 
+L 274.585406 152.169587 
+L 273.214109 152.39554 
+L 271.842811 152.620421 
+L 270.471514 152.84424 
+L 269.100217 153.067007 
+L 267.728919 153.288732 
+L 266.357622 153.509424 
+L 264.986325 153.729094 
+L 263.615028 153.947751 
+L 262.24373 154.165403 
+L 260.872433 154.38206 
+L 259.501136 154.597732 
+L 258.129838 154.812427 
+L 256.758541 155.026153 
+L 255.387244 155.238921 
+L 254.015947 155.450737 
+L 252.644649 155.661611 
+L 251.273352 155.871551 
+L 249.902055 156.080566 
+L 248.530757 156.288662 
+L 247.15946 156.495849 
+L 245.788163 156.702135 
+L 244.416866 156.907526 
+L 243.045568 157.112032 
+L 241.674271 157.315658 
+L 240.302974 157.518414 
+L 238.931676 157.720306 
+L 237.560379 157.921342 
+L 236.189082 158.121529 
+L 234.817784 158.320873 
+L 233.446487 158.519383 
+L 232.07519 158.717065 
+L 230.703893 158.913926 
+L 229.332595 159.109973 
+L 227.961298 159.305212 
+L 226.590001 159.499651 
+L 225.218703 159.693294 
+L 223.847406 159.886151 
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_153">
-    <path d="M 223.847406 163.616764 
-L 223.605065 163.697735 
-L 223.362724 163.778568 
-L 223.120384 163.859263 
-L 222.878043 163.939822 
-L 222.635702 164.020243 
-L 222.393361 164.100529 
-L 222.15102 164.180679 
-L 221.908679 164.260693 
-L 221.666339 164.340573 
-L 221.423998 164.420318 
-L 221.181657 164.499929 
-L 220.939316 164.579407 
-L 220.696975 164.658751 
-L 220.454635 164.737963 
-L 220.212294 164.817043 
-L 219.969953 164.895992 
-L 219.727612 164.974808 
-L 219.485271 165.053495 
-L 219.24293 165.13205 
-L 219.00059 165.210476 
-L 218.758249 165.288772 
-L 218.515908 165.366939 
-L 218.273567 165.444977 
-L 218.031226 165.522888 
-L 217.788885 165.60067 
-L 217.546545 165.678325 
-L 217.304204 165.755852 
-L 217.061863 165.833253 
-L 216.819522 165.910528 
-L 216.577181 165.987678 
-L 216.33484 166.064702 
-L 216.0925 166.1416 
-L 215.850159 166.218375 
-L 215.607818 166.295025 
-L 215.365477 166.371551 
-L 215.123136 166.447954 
-L 214.880795 166.524234 
-L 214.638455 166.600392 
-L 214.396114 166.676427 
-L 214.153773 166.752341 
-L 213.911432 166.828133 
-L 213.669091 166.903804 
-L 213.42675 166.979355 
-L 213.18441 167.054785 
-L 212.942069 167.130096 
-L 212.699728 167.205287 
-L 212.457387 167.280359 
-L 212.215046 167.355312 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 223.847406 159.886151 
+L 223.605065 159.975199 
+L 223.362724 160.06408 
+L 223.120384 160.152795 
+L 222.878043 160.241344 
+L 222.635702 160.329728 
+L 222.393361 160.417947 
+L 222.15102 160.506003 
+L 221.908679 160.593895 
+L 221.666339 160.681625 
+L 221.423998 160.769192 
+L 221.181657 160.856599 
+L 220.939316 160.943844 
+L 220.696975 161.030929 
+L 220.454635 161.117854 
+L 220.212294 161.20462 
+L 219.969953 161.291227 
+L 219.727612 161.377677 
+L 219.485271 161.463969 
+L 219.24293 161.550105 
+L 219.00059 161.636084 
+L 218.758249 161.721907 
+L 218.515908 161.807576 
+L 218.273567 161.893089 
+L 218.031226 161.978449 
+L 217.788885 162.063655 
+L 217.546545 162.148709 
+L 217.304204 162.23361 
+L 217.061863 162.318359 
+L 216.819522 162.402957 
+L 216.577181 162.487405 
+L 216.33484 162.571702 
+L 216.0925 162.655849 
+L 215.850159 162.739847 
+L 215.607818 162.823697 
+L 215.365477 162.907399 
+L 215.123136 162.990953 
+L 214.880795 163.07436 
+L 214.638455 163.157621 
+L 214.396114 163.240735 
+L 214.153773 163.323704 
+L 213.911432 163.406529 
+L 213.669091 163.489208 
+L 213.42675 163.571744 
+L 213.18441 163.654136 
+L 212.942069 163.736385 
+L 212.699728 163.818492 
+L 212.457387 163.900457 
+L 212.215046 163.98228 
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_154">
-    <path d="M 212.215046 167.355312 
-L 211.572396 167.534045 
-L 210.929746 167.712106 
-L 210.287096 167.889501 
-L 209.644446 168.066234 
-L 209.001796 168.242311 
-L 208.359146 168.417736 
-L 207.716496 168.592514 
-L 207.073846 168.76665 
-L 206.431196 168.940149 
-L 205.788546 169.113015 
-L 205.145896 169.285253 
-L 204.503246 169.456867 
-L 203.860596 169.627863 
-L 203.217946 169.798243 
-L 202.575296 169.968013 
-L 201.932645 170.137178 
-L 201.289995 170.30574 
-L 200.647345 170.473706 
-L 200.004695 170.641078 
-L 199.362045 170.807861 
-L 198.719395 170.97406 
-L 198.076745 171.139678 
-L 197.434095 171.304719 
-L 196.791445 171.469187 
-L 196.148795 171.633087 
-L 195.506145 171.796422 
-L 194.863495 171.959196 
-L 194.220845 172.121413 
-L 193.578195 172.283077 
-L 192.935545 172.444191 
-L 192.292895 172.604759 
-L 191.650245 172.764786 
-L 191.007595 172.924273 
-L 190.364945 173.083226 
-L 189.722294 173.241648 
-L 189.079644 173.399542 
-L 188.436994 173.556912 
-L 187.794344 173.713761 
-L 187.151694 173.870093 
-L 186.509044 174.02591 
-L 185.866394 174.181218 
-L 185.223744 174.336018 
-L 184.581094 174.490314 
-L 183.938444 174.644109 
-L 183.295794 174.797407 
-L 182.653144 174.950211 
-L 182.010494 175.102524 
-L 181.367844 175.254349 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 212.215046 163.98228 
+L 211.572396 164.153817 
+L 210.929746 164.324736 
+L 210.287096 164.495041 
+L 209.644446 164.664736 
+L 209.001796 164.833825 
+L 208.359146 165.002314 
+L 207.716496 165.170206 
+L 207.073846 165.337505 
+L 206.431196 165.504215 
+L 205.788546 165.670342 
+L 205.145896 165.835888 
+L 204.503246 166.000858 
+L 203.860596 166.165256 
+L 203.217946 166.329086 
+L 202.575296 166.492351 
+L 201.932645 166.655056 
+L 201.289995 166.817204 
+L 200.647345 166.978799 
+L 200.004695 167.139846 
+L 199.362045 167.300347 
+L 198.719395 167.460306 
+L 198.076745 167.619728 
+L 197.434095 167.778615 
+L 196.791445 167.936971 
+L 196.148795 168.0948 
+L 195.506145 168.252105 
+L 194.863495 168.40889 
+L 194.220845 168.565157 
+L 193.578195 168.720912 
+L 192.935545 168.876156 
+L 192.292895 169.030893 
+L 191.650245 169.185127 
+L 191.007595 169.338861 
+L 190.364945 169.492098 
+L 189.722294 169.644841 
+L 189.079644 169.797093 
+L 188.436994 169.948858 
+L 187.794344 170.100138 
+L 187.151694 170.250937 
+L 186.509044 170.401258 
+L 185.866394 170.551103 
+L 185.223744 170.700477 
+L 184.581094 170.849381 
+L 183.938444 170.997819 
+L 183.295794 171.145793 
+L 182.653144 171.293307 
+L 182.010494 171.440363 
+L 181.367844 171.586964 
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_155">
-    <path d="M 181.367844 175.254349 
-L 181.03168 175.429712 
-L 180.695516 175.604429 
-L 180.359352 175.778504 
-L 180.023188 175.951942 
-L 179.687024 176.124748 
-L 179.35086 176.296926 
-L 179.014696 176.46848 
-L 178.678532 176.639417 
-L 178.342368 176.809739 
-L 178.006204 176.979451 
-L 177.67004 177.148557 
-L 177.333876 177.317063 
-L 176.997712 177.484971 
-L 176.661548 177.652287 
-L 176.325384 177.819014 
-L 175.98922 177.985157 
-L 175.653056 178.15072 
-L 175.316892 178.315706 
-L 174.980728 178.48012 
-L 174.644564 178.643966 
-L 174.3084 178.807247 
-L 173.972236 178.969967 
-L 173.636072 179.132131 
-L 173.299908 179.293742 
-L 172.963744 179.454804 
-L 172.62758 179.615321 
-L 172.291416 179.775295 
-L 171.955252 179.934732 
-L 171.619088 180.093634 
-L 171.282924 180.252005 
-L 170.94676 180.409849 
-L 170.610596 180.567169 
-L 170.274432 180.723968 
-L 169.938268 180.88025 
-L 169.602104 181.036019 
-L 169.26594 181.191278 
-L 168.929776 181.34603 
-L 168.593612 181.500278 
-L 168.257448 181.654025 
-L 167.921284 181.807276 
-L 167.58512 181.960033 
-L 167.248956 182.112299 
-L 166.912792 182.264077 
-L 166.576628 182.415371 
-L 166.240464 182.566184 
-L 165.9043 182.716518 
-L 165.568136 182.866377 
-L 165.231972 183.015764 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 181.367844 171.586964 
+L 181.03168 171.765909 
+L 180.695516 171.94418 
+L 180.359352 172.121784 
+L 180.023188 172.298724 
+L 179.687024 172.475006 
+L 179.35086 172.650636 
+L 179.014696 172.825616 
+L 178.678532 172.999954 
+L 178.342368 173.173652 
+L 178.006204 173.346716 
+L 177.67004 173.51915 
+L 177.333876 173.69096 
+L 176.997712 173.862149 
+L 176.661548 174.032722 
+L 176.325384 174.202683 
+L 175.98922 174.372037 
+L 175.653056 174.540788 
+L 175.316892 174.708941 
+L 174.980728 174.876499 
+L 174.644564 175.043466 
+L 174.3084 175.209848 
+L 173.972236 175.375648 
+L 173.636072 175.540869 
+L 173.299908 175.705517 
+L 172.963744 175.869595 
+L 172.62758 176.033107 
+L 172.291416 176.196056 
+L 171.955252 176.358448 
+L 171.619088 176.520285 
+L 171.282924 176.681571 
+L 170.94676 176.84231 
+L 170.610596 177.002506 
+L 170.274432 177.162163 
+L 169.938268 177.321283 
+L 169.602104 177.479871 
+L 169.26594 177.637931 
+L 168.929776 177.795465 
+L 168.593612 177.952477 
+L 168.257448 178.10897 
+L 167.921284 178.264949 
+L 167.58512 178.420416 
+L 167.248956 178.575375 
+L 166.912792 178.729829 
+L 166.576628 178.883781 
+L 166.240464 179.037235 
+L 165.9043 179.190194 
+L 165.568136 179.34266 
+L 165.231972 179.494638 
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_156">
-    <path d="M 165.231972 183.015764 
-L 164.983964 183.133312 
-L 164.735956 183.250569 
-L 164.487948 183.367536 
-L 164.23994 183.484216 
-L 163.991932 183.600609 
-L 163.743924 183.716717 
-L 163.495916 183.832542 
-L 163.247908 183.948084 
-L 162.9999 184.063345 
-L 162.751892 184.178326 
-L 162.503884 184.293029 
-L 162.255876 184.407456 
-L 162.007868 184.521606 
-L 161.75986 184.635483 
-L 161.511852 184.749086 
-L 161.263844 184.862418 
-L 161.015836 184.97548 
-L 160.767828 185.088272 
-L 160.51982 185.200797 
-L 160.271812 185.313055 
-L 160.023804 185.425048 
-L 159.775796 185.536777 
-L 159.527788 185.648244 
-L 159.27978 185.759449 
-L 159.031772 185.870393 
-L 158.783764 185.981078 
-L 158.535756 186.091506 
-L 158.287748 186.201677 
-L 158.03974 186.311592 
-L 157.791732 186.421253 
-L 157.543724 186.530661 
-L 157.295716 186.639817 
-L 157.047708 186.748722 
-L 156.7997 186.857378 
-L 156.551691 186.965785 
-L 156.303683 187.073945 
-L 156.055675 187.181858 
-L 155.807667 187.289526 
-L 155.559659 187.396951 
-L 155.311651 187.504132 
-L 155.063643 187.611072 
-L 154.815635 187.71777 
-L 154.567627 187.824229 
-L 154.319619 187.93045 
-L 154.071611 188.036433 
-L 153.823603 188.14218 
-L 153.575595 188.247691 
-L 153.327587 188.352968 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 165.231972 179.494638 
+L 164.983964 179.625019 
+L 164.735956 179.755043 
+L 164.487948 179.884711 
+L 164.23994 180.014026 
+L 163.991932 180.142989 
+L 163.743924 180.271601 
+L 163.495916 180.399866 
+L 163.247908 180.527784 
+L 162.9999 180.655359 
+L 162.751892 180.78259 
+L 162.503884 180.909481 
+L 162.255876 181.036034 
+L 162.007868 181.162249 
+L 161.75986 181.288129 
+L 161.511852 181.413676 
+L 161.263844 181.538891 
+L 161.015836 181.663776 
+L 160.767828 181.788333 
+L 160.51982 181.912564 
+L 160.271812 182.03647 
+L 160.023804 182.160052 
+L 159.775796 182.283314 
+L 159.527788 182.406255 
+L 159.27978 182.528879 
+L 159.031772 182.651186 
+L 158.783764 182.773178 
+L 158.535756 182.894858 
+L 158.287748 183.016225 
+L 158.03974 183.137283 
+L 157.791732 183.258032 
+L 157.543724 183.378475 
+L 157.295716 183.498612 
+L 157.047708 183.618445 
+L 156.7997 183.737976 
+L 156.551691 183.857207 
+L 156.303683 183.976138 
+L 156.055675 184.094772 
+L 155.807667 184.21311 
+L 155.559659 184.331152 
+L 155.311651 184.448902 
+L 155.063643 184.56636 
+L 154.815635 184.683527 
+L 154.567627 184.800406 
+L 154.319619 184.916997 
+L 154.071611 185.033302 
+L 153.823603 185.149322 
+L 153.575595 185.265059 
+L 153.327587 185.380514 
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_157">
-    <path d="M 153.327587 188.352968 
-L 153.228605 188.486621 
-L 153.129623 188.619898 
-L 153.030641 188.752802 
-L 152.931659 188.885334 
-L 152.832678 189.017496 
-L 152.733696 189.149291 
-L 152.634714 189.280721 
-L 152.535732 189.411787 
-L 152.43675 189.542492 
-L 152.337768 189.672837 
-L 152.238786 189.802825 
-L 152.139804 189.932457 
-L 152.040822 190.061736 
-L 151.94184 190.190663 
-L 151.842858 190.31924 
-L 151.743876 190.447469 
-L 151.644894 190.575353 
-L 151.545912 190.702892 
-L 151.44693 190.83009 
-L 151.347948 190.956946 
-L 151.248966 191.083464 
-L 151.149984 191.209646 
-L 151.051002 191.335492 
-L 150.95202 191.461005 
-L 150.853038 191.586187 
-L 150.754056 191.711038 
-L 150.655074 191.835562 
-L 150.556093 191.95976 
-L 150.457111 192.083633 
-L 150.358129 192.207183 
-L 150.259147 192.330412 
-L 150.160165 192.453321 
-L 150.061183 192.575912 
-L 149.962201 192.698188 
-L 149.863219 192.820148 
-L 149.764237 192.941796 
-L 149.665255 193.063132 
-L 149.566273 193.184158 
-L 149.467291 193.304876 
-L 149.368309 193.425288 
-L 149.269327 193.545394 
-L 149.170345 193.665197 
-L 149.071363 193.784698 
-L 148.972381 193.903898 
-L 148.873399 194.022799 
-L 148.774417 194.141403 
-L 148.675435 194.25971 
-L 148.576453 194.377723 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 153.327587 185.380514 
+L 153.228605 185.512686 
+L 153.129623 185.644491 
+L 153.030641 185.77593 
+L 152.931659 185.907005 
+L 152.832678 186.037719 
+L 152.733696 186.168074 
+L 152.634714 186.298071 
+L 152.535732 186.427713 
+L 152.43675 186.557001 
+L 152.337768 186.685937 
+L 152.238786 186.814523 
+L 152.139804 186.942762 
+L 152.040822 187.070654 
+L 151.94184 187.198203 
+L 151.842858 187.325409 
+L 151.743876 187.452274 
+L 151.644894 187.578801 
+L 151.545912 187.704991 
+L 151.44693 187.830846 
+L 151.347948 187.956368 
+L 151.248966 188.081558 
+L 151.149984 188.206419 
+L 151.051002 188.330951 
+L 150.95202 188.455157 
+L 150.853038 188.579039 
+L 150.754056 188.702597 
+L 150.655074 188.825834 
+L 150.556093 188.948752 
+L 150.457111 189.071352 
+L 150.358129 189.193635 
+L 150.259147 189.315604 
+L 150.160165 189.43726 
+L 150.061183 189.558604 
+L 149.962201 189.679638 
+L 149.863219 189.800365 
+L 149.764237 189.920784 
+L 149.665255 190.040898 
+L 149.566273 190.160709 
+L 149.467291 190.280218 
+L 149.368309 190.399426 
+L 149.269327 190.518334 
+L 149.170345 190.636946 
+L 149.071363 190.755261 
+L 148.972381 190.873282 
+L 148.873399 190.99101 
+L 148.774417 191.108445 
+L 148.675435 191.225591 
+L 148.576453 191.342448 
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_158">
-    <path d="M 148.576453 194.377723 
-L 148.507926 194.441726 
-L 148.439399 194.505643 
-L 148.370872 194.569474 
-L 148.302345 194.633218 
-L 148.233818 194.696878 
-L 148.165291 194.760451 
-L 148.096764 194.82394 
-L 148.028237 194.887344 
-L 147.95971 194.950663 
-L 147.891183 195.013897 
-L 147.822656 195.077048 
-L 147.754129 195.140114 
-L 147.685602 195.203097 
-L 147.617074 195.265995 
-L 147.548547 195.328811 
-L 147.48002 195.391543 
-L 147.411493 195.454193 
-L 147.342966 195.51676 
-L 147.274439 195.579244 
-L 147.205912 195.641646 
-L 147.137385 195.703966 
-L 147.068858 195.766204 
-L 147.000331 195.828361 
-L 146.931804 195.890436 
-L 146.863277 195.95243 
-L 146.79475 196.014343 
-L 146.726223 196.076175 
-L 146.657696 196.137927 
-L 146.589169 196.199598 
-L 146.520641 196.26119 
-L 146.452114 196.322701 
-L 146.383587 196.384132 
-L 146.31506 196.445484 
-L 146.246533 196.506757 
-L 146.178006 196.567951 
-L 146.109479 196.629065 
-L 146.040952 196.690101 
-L 145.972425 196.751059 
-L 145.903898 196.811938 
-L 145.835371 196.872739 
-L 145.766844 196.933463 
-L 145.698317 196.994108 
-L 145.62979 197.054676 
-L 145.561263 197.115167 
-L 145.492735 197.175581 
-L 145.424208 197.235917 
-L 145.355681 197.296177 
-L 145.287154 197.356361 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 148.576453 191.342448 
+L 148.507926 191.405036 
+L 148.439399 191.467541 
+L 148.370872 191.529964 
+L 148.302345 191.592305 
+L 148.233818 191.654564 
+L 148.165291 191.716741 
+L 148.096764 191.778837 
+L 148.028237 191.840851 
+L 147.95971 191.902785 
+L 147.891183 191.964637 
+L 147.822656 192.02641 
+L 147.754129 192.088101 
+L 147.685602 192.149713 
+L 147.617074 192.211244 
+L 147.548547 192.272696 
+L 147.48002 192.334068 
+L 147.411493 192.395361 
+L 147.342966 192.456575 
+L 147.274439 192.517709 
+L 147.205912 192.578765 
+L 147.137385 192.639743 
+L 147.068858 192.700642 
+L 147.000331 192.761463 
+L 146.931804 192.822206 
+L 146.863277 192.882871 
+L 146.79475 192.943459 
+L 146.726223 193.003969 
+L 146.657696 193.064402 
+L 146.589169 193.124759 
+L 146.520641 193.185038 
+L 146.452114 193.245241 
+L 146.383587 193.305368 
+L 146.31506 193.365418 
+L 146.246533 193.425392 
+L 146.178006 193.485291 
+L 146.109479 193.545114 
+L 146.040952 193.604862 
+L 145.972425 193.664534 
+L 145.903898 193.724131 
+L 145.835371 193.783654 
+L 145.766844 193.843102 
+L 145.698317 193.902475 
+L 145.62979 193.961774 
+L 145.561263 194.020999 
+L 145.492735 194.08015 
+L 145.424208 194.139228 
+L 145.355681 194.198231 
+L 145.287154 194.257162 
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_159">
-    <path d="M 145.287154 197.356361 
-L 144.656225 201.324744 
-L 144.025297 204.986398 
-L 143.394368 208.385354 
-L 142.763439 211.556797 
-L 142.13251 214.529283 
-L 141.501581 217.326307 
-L 140.870652 219.967435 
-L 140.239723 222.469132 
-L 139.608795 224.845383 
-L 138.977866 227.108171 
-L 138.346937 229.267839 
-L 137.716008 231.333378 
-L 137.085079 233.312652 
-L 136.45415 235.212579 
-L 135.823222 237.039275 
-L 135.192293 238.798177 
-L 134.561364 240.494137 
-L 133.930435 242.131506 
-L 133.299506 243.714196 
-L 132.668577 245.245742 
-L 132.037648 246.729346 
-L 131.40672 248.167919 
-L 130.775791 249.564113 
-L 130.144862 250.920355 
-L 129.513933 252.238868 
-L 128.883004 253.521693 
-L 128.252075 254.770712 
-L 127.621147 255.987662 
-L 126.990218 257.174147 
-L 126.359289 258.331656 
-L 125.72836 259.461571 
-L 125.097431 260.565176 
-L 124.466502 261.643669 
-L 123.835573 262.698168 
-L 123.204645 263.729717 
-L 122.573716 264.739293 
-L 121.942787 265.727813 
-L 121.311858 266.696138 
-L 120.680929 267.645076 
-L 120.05 268.575389 
-L 119.419071 269.487793 
-L 118.788143 270.382965 
-L 118.157214 271.261543 
-L 117.526285 272.124132 
-L 116.895356 272.971304 
-L 116.264427 273.803599 
-L 115.633498 274.621532 
-L 115.00257 275.425589 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 145.287154 194.257162 
+L 144.656225 198.390308 
+L 144.025297 202.191777 
+L 143.394368 205.710868 
+L 142.763439 208.986648 
+L 142.13251 212.050598 
+L 141.501581 214.928457 
+L 140.870652 217.641541 
+L 140.239723 220.207702 
+L 139.608795 222.642038 
+L 138.977866 224.957434 
+L 138.346937 227.164974 
+L 137.716008 229.274259 
+L 137.085079 231.293666 
+L 136.45415 233.230541 
+L 135.823222 235.091366 
+L 135.192293 236.881889 
+L 134.561364 238.607228 
+L 133.930435 240.271965 
+L 133.299506 241.880211 
+L 132.668577 243.435675 
+L 132.037648 244.941712 
+L 131.40672 246.401367 
+L 130.775791 247.817411 
+L 130.144862 249.192376 
+L 129.513933 250.528576 
+L 128.883004 251.828139 
+L 128.252075 253.09302 
+L 127.621147 254.325022 
+L 126.990218 255.525811 
+L 126.359289 256.69693 
+L 125.72836 257.839809 
+L 125.097431 258.95578 
+L 124.466502 260.046078 
+L 123.835573 261.11186 
+L 123.204645 262.154204 
+L 122.573716 263.174117 
+L 121.942787 264.172546 
+L 121.311858 265.150377 
+L 120.680929 266.108443 
+L 120.05 267.047526 
+L 119.419071 267.968365 
+L 118.788143 268.871655 
+L 118.157214 269.758052 
+L 117.526285 270.628177 
+L 116.895356 271.482616 
+L 116.264427 272.321924 
+L 115.633498 273.146629 
+L 115.00257 273.95723 
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_160">
-    <path d="M 115.00257 275.425589 
-L 114.686939 276.158589 
-L 114.371309 276.880426 
-L 114.055678 277.591435 
-L 113.740048 278.291936 
-L 113.424418 278.982235 
-L 113.108787 279.662624 
-L 112.793157 280.333385 
-L 112.477527 280.994786 
-L 112.161896 281.647085 
-L 111.846266 282.290529 
-L 111.530636 282.925355 
-L 111.215005 283.55179 
-L 110.899375 284.170055 
-L 110.583745 284.780358 
-L 110.268114 285.382903 
-L 109.952484 285.977885 
-L 109.636853 286.56549 
-L 109.321223 287.1459 
-L 109.005593 287.719289 
-L 108.689962 288.285824 
-L 108.374332 288.845668 
-L 108.058702 289.398976 
-L 107.743071 289.945899 
-L 107.427441 290.486584 
-L 107.111811 291.021171 
-L 106.79618 291.549795 
-L 106.48055 292.072589 
-L 106.16492 292.58968 
-L 105.849289 293.10119 
-L 105.533659 293.607239 
-L 105.218028 294.107942 
-L 104.902398 294.603411 
-L 104.586768 295.093755 
-L 104.271137 295.579078 
-L 103.955507 296.059482 
-L 103.639877 296.535066 
-L 103.324246 297.005925 
-L 103.008616 297.472153 
-L 102.692986 297.933839 
-L 102.377355 298.391072 
-L 102.061725 298.843936 
-L 101.746095 299.292514 
-L 101.430464 299.736887 
-L 101.114834 300.177132 
-L 100.799203 300.613326 
-L 100.483573 301.045543 
-L 100.167943 301.473853 
-L 99.852312 301.898328 
-" clip-path="url(#p870c1441f5)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 115.00257 273.95723 
+L 114.686939 274.686892 
+L 114.371309 275.405491 
+L 114.055678 276.113359 
+L 113.740048 276.81081 
+L 113.424418 277.498148 
+L 113.108787 278.17566 
+L 112.793157 278.843625 
+L 112.477527 279.502307 
+L 112.161896 280.151961 
+L 111.846266 280.792831 
+L 111.530636 281.425152 
+L 111.215005 282.049148 
+L 110.899375 282.665035 
+L 110.583745 283.273023 
+L 110.268114 283.873311 
+L 109.952484 284.466091 
+L 109.636853 285.051549 
+L 109.321223 285.629865 
+L 109.005593 286.201209 
+L 108.689962 286.765748 
+L 108.374332 287.323642 
+L 108.058702 287.875046 
+L 107.743071 288.420109 
+L 107.427441 288.958975 
+L 107.111811 289.491784 
+L 106.79618 290.01867 
+L 106.48055 290.539764 
+L 106.16492 291.055191 
+L 105.849289 291.565073 
+L 105.533659 292.069529 
+L 105.218028 292.568673 
+L 104.902398 293.062615 
+L 104.586768 293.551462 
+L 104.271137 294.03532 
+L 103.955507 294.514287 
+L 103.639877 294.988464 
+L 103.324246 295.457943 
+L 103.008616 295.922818 
+L 102.692986 296.383178 
+L 102.377355 296.83911 
+L 102.061725 297.290698 
+L 101.746095 297.738024 
+L 101.430464 298.181167 
+L 101.114834 298.620206 
+L 100.799203 299.055216 
+L 100.483573 299.48627 
+L 100.167943 299.913438 
+L 99.852312 300.336792 
+" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
   </g>
   <g id="text_25">
@@ -6254,8 +6254,8 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-07-08T06:11:08Z  ·  Linux chungus2 x86_64  ·  commit 28336125  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(43.380391 465.66) scale(0.07 -0.07)">
+   <!-- 2026-07-08T15:47:33Z  ·  Linux chungus2 x86_64  ·  commit f2026e66  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(44.448437 465.66) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -6276,6 +6276,31 @@ L 1638 0
 L 1638 4134 
 L -19 4134 
 L -19 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-3a" d="M 750 794 
@@ -6348,31 +6373,6 @@ Q 2894 3584 3203 3211
 Q 3513 2838 3513 2113 
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
-z
-" transform="scale(0.015625)"/>
      <path id="DejaVuSans-3d" d="M 678 2906 
 L 4684 2906 
 L 4684 2381 
@@ -6413,14 +6413,14 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-38" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -6460,109 +6460,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3262.744141 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3326.367188 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3389.990234 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3453.613281 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3517.236328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3580.859375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3612.646484 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3644.433594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3676.220703 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3708.007812 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3739.794922 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3767.578125 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3829.101562 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3890.380859 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3953.759766 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4017.236328 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4056.099609 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4117.28125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4176.460938 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4237.984375 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4279.097656 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4312.789062 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4340.572266 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4402.095703 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4463.375 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4526.753906 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4590.376953 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4624.068359 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4683.248047 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4746.871094 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4778.658203 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4842.28125 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4905.904297 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4937.691406 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(5001.314453 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5037.398438 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5076.261719 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5131.242188 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5194.865234 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5226.652344 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5258.439453 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5290.226562 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5322.013672 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5353.800781 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5393.009766 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5456.388672 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5495.251953 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5556.433594 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5619.8125 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5683.289062 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5746.667969 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5810.144531 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5873.523438 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5912.732422 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5944.519531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6028.308594 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6060.095703 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6157.507812 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6219.03125 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6282.507812 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6310.291016 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6371.570312 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6434.949219 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6466.736328 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6518.835938 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6582.214844 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6643.494141 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6706.970703 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6759.070312 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6822.449219 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6883.630859 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6922.839844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6956.53125 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6988.318359 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7029.431641 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7090.710938 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7129.919922 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7157.703125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7218.884766 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7250.671875 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7278.455078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7330.554688 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7362.341797 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7425.818359 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7487.341797 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7526.550781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7588.074219 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7627.4375 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7724.849609 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7752.632812 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7816.011719 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7843.794922 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7895.894531 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7935.103516 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7962.886719 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3107.080078 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3170.703125 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3234.326172 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3297.949219 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3361.572266 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3423.095703 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3486.71875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3550.341797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3582.128906 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3613.916016 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3645.703125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3677.490234 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3709.277344 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3737.060547 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3798.583984 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3859.863281 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3923.242188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3986.71875 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4025.582031 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4086.763672 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4145.943359 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4207.466797 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4248.580078 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4282.271484 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4310.054688 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4371.578125 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4432.857422 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4496.236328 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4559.859375 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4593.550781 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4652.730469 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4716.353516 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4748.140625 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4811.763672 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4875.386719 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4907.173828 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4970.796875 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5006.880859 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5045.744141 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5100.724609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5164.347656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5196.134766 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5227.921875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5259.708984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5291.496094 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5323.283203 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5362.492188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5425.871094 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5464.734375 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5525.916016 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5589.294922 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5652.771484 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5716.150391 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5779.626953 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5843.005859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5882.214844 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5914.001953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5997.791016 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6029.578125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6126.990234 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6188.513672 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6251.990234 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6279.773438 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6341.052734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6404.431641 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6436.21875 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6488.318359 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6551.697266 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6612.976562 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6676.453125 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6728.552734 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6791.931641 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6853.113281 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6892.322266 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6926.013672 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6957.800781 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6998.914062 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7060.193359 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7099.402344 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7127.185547 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7188.367188 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7220.154297 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7247.9375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7300.037109 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7331.824219 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7395.300781 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7456.824219 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7496.033203 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7557.556641 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7596.919922 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7694.332031 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7722.115234 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7785.494141 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7813.277344 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7865.376953 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7904.585938 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7932.369141 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p870c1441f5">
+  <clipPath id="p6652a911cf">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_ratio_heatmap.svg
+++ b/bench/graphs/canterbury_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#pfd599db94e)">
+   <g clip-path="url(#pd295bb7cec)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAI/UlEQVR4nO3YwYqkVx2H4aqe7qYn4oAyashScCfBhRtn49o7yRW4DNl7HcYbEEQk2Yjixo24E3ciISRjnMyE7p7q78sljMKRv9T7PFfwO3zUqZdz3P71y/1wbl5+Nr1gqf3z8zrP4XA4/OPnv56esNTf//JqesJyP/3wZ9MTljv+6MfTE9Y6XkwvWO/FJ9ML1rt5Mr1gqV997xfTE5Y7w18SAMB/TgwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKQd706/2adHrLYftukJSx3PsFmvLq6nJyx1v91OT1ju6q9/mp6w3OmHz6YnLHXa7qcnLPfq9GJ6wnJPz+x6eP3k6fSE5c7vXxYA4L8ghgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0i6vXn0xvWG9u6+mF6y1b9ML1nv8ZHrBUtfTA/4H9hevpicsd/Xl8+kJS11tp+kJyz0+x/vu9uX0gqWuLs/vxvMyBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgLTjafvdPj1itX3fpicstZ3ZeQ6Hw+Hq4np6wlIP+2l6wnKPXj6fnrDeN787vWCp19v99ITlPr/95/SE5d6+u5yesNT2rXemJyznZQgASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASLv886d/mN6w3MXhOD1hqe+89XR6wnIP22l6wlLXj26mJyz33se/n56w3Ac/+cH0hKVO+zY9Ybn3//i36QnLPXvnG9MTlnrv3WfTE5bzMgQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIC04+uH3+7TI1a7f7idnrDU4+PN9ATe4P54mp6w3L/vPpuesNy3b96enrDUtm/TE5b74u7T6QnLPb/7ZHrCUt9/8u70hOW8DAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACDtuG0f7dMjgP9Dp/vpBetdXk8v4A1uH76anrDczaO3pifwBl6GAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkHZ5v91Ob1juYTtNT1jq8uJ6esJyV2d2ptfb/fSE5faLbXrCcscz+04P+3nddYfD4fDl/fPpCctdP76ZnrDUvp/f3eBlCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGlfA43TkfjdNPLgAAAAAElFTkSuQmCC" id="image24d1cf7531" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAI/UlEQVR4nO3YwYqkVx2H4aqe7qYn4oAyashScCfBhRtn49o7yRW4DNl7HcYbEEQk2Yjixo24E3ciISRjnMyE7p7q78sljMKRv9T7PFfwO3zUqZdz3P71y/1wbl5+Nr1gqf3z8zrP4XA4/OPnv56esNTf//JqesJyP/3wZ9MTljv+6MfTE9Y6XkwvWO/FJ9ML1rt5Mr1gqV997xfTE5Y7w18SAMB/TgwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKQd706/2adHrLYftukJSx3PsFmvLq6nJyx1v91OT1ju6q9/mp6w3OmHz6YnLHXa7qcnLPfq9GJ6wnJPz+x6eP3k6fSE5c7vXxYA4L8ghgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0i6vXn0xvWG9u6+mF6y1b9ML1nv8ZHrBUtfTA/4H9hevpicsd/Xl8+kJS11tp+kJyz0+x/vu9uX0gqWuLs/vxvMyBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgLTjafvdPj1itX3fpicstZ3ZeQ6Hw+Hq4np6wlIP+2l6wnKPXj6fnrDeN787vWCp19v99ITlPr/95/SE5d6+u5yesNT2rXemJyznZQgASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASLv886d/mN6w3MXhOD1hqe+89XR6wnIP22l6wlLXj26mJyz33se/n56w3Ac/+cH0hKVO+zY9Ybn3//i36QnLPXvnG9MTlnrv3WfTE5bzMgQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIC04+uH3+7TI1a7f7idnrDU4+PN9ATe4P54mp6w3L/vPpuesNy3b96enrDUtm/TE5b74u7T6QnLPb/7ZHrCUt9/8u70hOW8DAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACDtuG0f7dMjgP9Dp/vpBetdXk8v4A1uH76anrDczaO3pifwBl6GAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkHZ5v91Ob1juYTtNT1jq8uJ6esJyV2d2ptfb/fSE5faLbXrCcscz+04P+3nddYfD4fDl/fPpCctdP76ZnrDUvp/f3eBlCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGlfA43TkfjdNPLgAAAAAElFTkSuQmCC" id="imageaa90d1f60d" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m298804456b" d="M 0 0 
+       <path id="m5bf989e3b0" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m298804456b" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5bf989e3b0" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m298804456b" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5bf989e3b0" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m298804456b" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5bf989e3b0" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m298804456b" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5bf989e3b0" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m298804456b" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5bf989e3b0" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m298804456b" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5bf989e3b0" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m298804456b" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5bf989e3b0" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m298804456b" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5bf989e3b0" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m298804456b" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5bf989e3b0" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m298804456b" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5bf989e3b0" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m298804456b" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5bf989e3b0" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="m11c1c9545a" d="M 0 0 
+       <path id="mf611572638" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m11c1c9545a" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf611572638" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m11c1c9545a" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf611572638" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m11c1c9545a" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf611572638" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m11c1c9545a" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf611572638" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m11c1c9545a" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf611572638" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m11c1c9545a" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf611572638" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m11c1c9545a" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf611572638" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m11c1c9545a" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf611572638" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -2092,18 +2092,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="imagec87d77c940" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
+iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="image6dd72eee2a" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="m9d4d53922e" d="M 0 0 
+       <path id="m6b46d0cd4d" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m9d4d53922e" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6b46d0cd4d" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
@@ -2129,7 +2129,7 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m9d4d53922e" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6b46d0cd4d" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
@@ -2146,7 +2146,7 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m9d4d53922e" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6b46d0cd4d" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
@@ -2163,7 +2163,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m9d4d53922e" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6b46d0cd4d" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
@@ -2180,7 +2180,7 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m9d4d53922e" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6b46d0cd4d" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_112">
@@ -2196,7 +2196,7 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m9d4d53922e" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6b46d0cd4d" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
@@ -2212,7 +2212,7 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m9d4d53922e" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6b46d0cd4d" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
@@ -2228,7 +2228,7 @@ z
     <g id="ytick_16">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#m9d4d53922e" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6b46d0cd4d" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_115">
@@ -2244,7 +2244,7 @@ z
     <g id="ytick_17">
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m9d4d53922e" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6b46d0cd4d" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_116">
@@ -2882,8 +2882,8 @@ z
    </g>
   </g>
   <g id="text_119">
-   <!-- 2026-07-08T06:11:08Z  ·  Linux chungus2 x86_64  ·  commit 28336125  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(16.380391 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-08T15:47:33Z  ·  Linux chungus2 x86_64  ·  commit f2026e66  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(17.448437 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2952,14 +2952,14 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-38" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2999,109 +2999,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3262.744141 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3326.367188 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3389.990234 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3453.613281 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3517.236328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3580.859375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3612.646484 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3644.433594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3676.220703 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3708.007812 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3739.794922 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3767.578125 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3829.101562 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3890.380859 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3953.759766 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4017.236328 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4056.099609 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4117.28125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4176.460938 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4237.984375 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4279.097656 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4312.789062 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4340.572266 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4402.095703 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4463.375 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4526.753906 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4590.376953 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4624.068359 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4683.248047 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4746.871094 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4778.658203 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4842.28125 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4905.904297 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4937.691406 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(5001.314453 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5037.398438 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5076.261719 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5131.242188 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5194.865234 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5226.652344 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5258.439453 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5290.226562 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5322.013672 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5353.800781 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5393.009766 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5456.388672 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5495.251953 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5556.433594 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5619.8125 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5683.289062 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5746.667969 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5810.144531 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5873.523438 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5912.732422 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5944.519531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6028.308594 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6060.095703 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6157.507812 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6219.03125 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6282.507812 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6310.291016 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6371.570312 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6434.949219 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6466.736328 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6518.835938 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6582.214844 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6643.494141 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6706.970703 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6759.070312 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6822.449219 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6883.630859 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6922.839844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6956.53125 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6988.318359 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7029.431641 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7090.710938 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7129.919922 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7157.703125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7218.884766 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7250.671875 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7278.455078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7330.554688 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7362.341797 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7425.818359 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7487.341797 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7526.550781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7588.074219 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7627.4375 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7724.849609 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7752.632812 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7816.011719 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7843.794922 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7895.894531 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7935.103516 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7962.886719 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3107.080078 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3170.703125 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3234.326172 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3297.949219 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3361.572266 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3423.095703 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3486.71875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3550.341797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3582.128906 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3613.916016 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3645.703125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3677.490234 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3709.277344 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3737.060547 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3798.583984 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3859.863281 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3923.242188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3986.71875 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4025.582031 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4086.763672 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4145.943359 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4207.466797 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4248.580078 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4282.271484 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4310.054688 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4371.578125 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4432.857422 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4496.236328 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4559.859375 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4593.550781 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4652.730469 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4716.353516 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4748.140625 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4811.763672 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4875.386719 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4907.173828 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4970.796875 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5006.880859 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5045.744141 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5100.724609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5164.347656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5196.134766 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5227.921875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5259.708984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5291.496094 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5323.283203 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5362.492188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5425.871094 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5464.734375 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5525.916016 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5589.294922 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5652.771484 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5716.150391 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5779.626953 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5843.005859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5882.214844 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5914.001953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5997.791016 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6029.578125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6126.990234 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6188.513672 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6251.990234 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6279.773438 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6341.052734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6404.431641 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6436.21875 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6488.318359 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6551.697266 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6612.976562 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6676.453125 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6728.552734 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6791.931641 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6853.113281 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6892.322266 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6926.013672 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6957.800781 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6998.914062 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7060.193359 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7099.402344 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7127.185547 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7188.367188 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7220.154297 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7247.9375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7300.037109 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7331.824219 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7395.300781 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7456.824219 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7496.033203 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7557.556641 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7596.919922 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7694.332031 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7722.115234 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7785.494141 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7813.277344 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7865.376953 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7904.585938 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7932.369141 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pfd599db94e">
+  <clipPath id="pd295bb7cec">
    <rect x="95.67625" y="49.4355" width="416.571298" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_summary.svg
+++ b/bench/graphs/canterbury_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="575.639219pt" height="386.202469pt" viewBox="0 0 575.639219 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="573.503125pt" height="386.202469pt" viewBox="0 0 573.503125 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,232 +22,232 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 386.202469 
-L 575.639219 386.202469 
-L 575.639219 0 
+L 573.503125 386.202469 
+L 573.503125 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 189.944609 104.1264 
-L 294.569609 104.1264 
-L 294.569609 74.7432 
-L 189.944609 74.7432 
+    <path d="M 188.876563 104.1264 
+L 293.501563 104.1264 
+L 293.501563 74.7432 
+L 188.876563 74.7432 
 z
-" clip-path="url(#pe2b833f815)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p25d2ad8c0f)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 294.569609 104.1264 
-L 399.194609 104.1264 
-L 399.194609 74.7432 
-L 294.569609 74.7432 
+    <path d="M 293.501563 104.1264 
+L 398.126563 104.1264 
+L 398.126563 74.7432 
+L 293.501563 74.7432 
 z
-" clip-path="url(#pe2b833f815)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p25d2ad8c0f)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 399.194609 104.1264 
-L 503.819609 104.1264 
-L 503.819609 74.7432 
-L 399.194609 74.7432 
+    <path d="M 398.126563 104.1264 
+L 502.751563 104.1264 
+L 502.751563 74.7432 
+L 398.126563 74.7432 
 z
-" clip-path="url(#pe2b833f815)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p25d2ad8c0f)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 189.944609 133.5096 
-L 294.569609 133.5096 
-L 294.569609 104.1264 
-L 189.944609 104.1264 
+    <path d="M 188.876563 133.5096 
+L 293.501563 133.5096 
+L 293.501563 104.1264 
+L 188.876563 104.1264 
 z
-" clip-path="url(#pe2b833f815)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p25d2ad8c0f)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 294.569609 133.5096 
-L 399.194609 133.5096 
-L 399.194609 104.1264 
-L 294.569609 104.1264 
+    <path d="M 293.501563 133.5096 
+L 398.126563 133.5096 
+L 398.126563 104.1264 
+L 293.501563 104.1264 
 z
-" clip-path="url(#pe2b833f815)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p25d2ad8c0f)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 399.194609 133.5096 
-L 503.819609 133.5096 
-L 503.819609 104.1264 
-L 399.194609 104.1264 
+    <path d="M 398.126563 133.5096 
+L 502.751563 133.5096 
+L 502.751563 104.1264 
+L 398.126563 104.1264 
 z
-" clip-path="url(#pe2b833f815)" style="fill: #fdb768; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p25d2ad8c0f)" style="fill: #fdb768; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 189.944609 162.8928 
-L 294.569609 162.8928 
-L 294.569609 133.5096 
-L 189.944609 133.5096 
+    <path d="M 188.876563 162.8928 
+L 293.501563 162.8928 
+L 293.501563 133.5096 
+L 188.876563 133.5096 
 z
-" clip-path="url(#pe2b833f815)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p25d2ad8c0f)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 294.569609 162.8928 
-L 399.194609 162.8928 
-L 399.194609 133.5096 
-L 294.569609 133.5096 
+    <path d="M 293.501563 162.8928 
+L 398.126563 162.8928 
+L 398.126563 133.5096 
+L 293.501563 133.5096 
 z
-" clip-path="url(#pe2b833f815)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p25d2ad8c0f)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 399.194609 162.8928 
-L 503.819609 162.8928 
-L 503.819609 133.5096 
-L 399.194609 133.5096 
+    <path d="M 398.126563 162.8928 
+L 502.751563 162.8928 
+L 502.751563 133.5096 
+L 398.126563 133.5096 
 z
-" clip-path="url(#pe2b833f815)" style="fill: #bbe278; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p25d2ad8c0f)" style="fill: #bbe278; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 189.944609 192.276 
-L 294.569609 192.276 
-L 294.569609 162.8928 
-L 189.944609 162.8928 
+    <path d="M 188.876563 192.276 
+L 293.501563 192.276 
+L 293.501563 162.8928 
+L 188.876563 162.8928 
 z
-" clip-path="url(#pe2b833f815)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p25d2ad8c0f)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 294.569609 192.276 
-L 399.194609 192.276 
-L 399.194609 162.8928 
-L 294.569609 162.8928 
+    <path d="M 293.501563 192.276 
+L 398.126563 192.276 
+L 398.126563 162.8928 
+L 293.501563 162.8928 
 z
-" clip-path="url(#pe2b833f815)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p25d2ad8c0f)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 399.194609 192.276 
-L 503.819609 192.276 
-L 503.819609 162.8928 
-L 399.194609 162.8928 
+    <path d="M 398.126563 192.276 
+L 502.751563 192.276 
+L 502.751563 162.8928 
+L 398.126563 162.8928 
 z
-" clip-path="url(#pe2b833f815)" style="fill: #fdc776; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p25d2ad8c0f)" style="fill: #fdc776; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 189.944609 221.6592 
-L 294.569609 221.6592 
-L 294.569609 192.276 
-L 189.944609 192.276 
+    <path d="M 188.876563 221.6592 
+L 293.501563 221.6592 
+L 293.501563 192.276 
+L 188.876563 192.276 
 z
-" clip-path="url(#pe2b833f815)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p25d2ad8c0f)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 294.569609 221.6592 
-L 399.194609 221.6592 
-L 399.194609 192.276 
-L 294.569609 192.276 
+    <path d="M 293.501563 221.6592 
+L 398.126563 221.6592 
+L 398.126563 192.276 
+L 293.501563 192.276 
 z
-" clip-path="url(#pe2b833f815)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p25d2ad8c0f)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 399.194609 221.6592 
-L 503.819609 221.6592 
-L 503.819609 192.276 
-L 399.194609 192.276 
+    <path d="M 398.126563 221.6592 
+L 502.751563 221.6592 
+L 502.751563 192.276 
+L 398.126563 192.276 
 z
-" clip-path="url(#pe2b833f815)" style="fill: #addc6f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p25d2ad8c0f)" style="fill: #addc6f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 189.944609 251.0424 
-L 294.569609 251.0424 
-L 294.569609 221.6592 
-L 189.944609 221.6592 
+    <path d="M 188.876563 251.0424 
+L 293.501563 251.0424 
+L 293.501563 221.6592 
+L 188.876563 221.6592 
 z
-" clip-path="url(#pe2b833f815)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p25d2ad8c0f)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 294.569609 251.0424 
-L 399.194609 251.0424 
-L 399.194609 221.6592 
-L 294.569609 221.6592 
+    <path d="M 293.501563 251.0424 
+L 398.126563 251.0424 
+L 398.126563 221.6592 
+L 293.501563 221.6592 
 z
-" clip-path="url(#pe2b833f815)" style="fill: #fdbd6d; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p25d2ad8c0f)" style="fill: #fdbd6d; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 399.194609 251.0424 
-L 503.819609 251.0424 
-L 503.819609 221.6592 
-L 399.194609 221.6592 
+    <path d="M 398.126563 251.0424 
+L 502.751563 251.0424 
+L 502.751563 221.6592 
+L 398.126563 221.6592 
 z
-" clip-path="url(#pe2b833f815)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p25d2ad8c0f)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 189.944609 280.4256 
-L 294.569609 280.4256 
-L 294.569609 251.0424 
-L 189.944609 251.0424 
+    <path d="M 188.876563 280.4256 
+L 293.501563 280.4256 
+L 293.501563 251.0424 
+L 188.876563 251.0424 
 z
-" clip-path="url(#pe2b833f815)" style="fill: #ebf7a3; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p25d2ad8c0f)" style="fill: #ebf7a3; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 294.569609 280.4256 
-L 399.194609 280.4256 
-L 399.194609 251.0424 
-L 294.569609 251.0424 
+    <path d="M 293.501563 280.4256 
+L 398.126563 280.4256 
+L 398.126563 251.0424 
+L 293.501563 251.0424 
 z
-" clip-path="url(#pe2b833f815)" style="fill: #fb9d59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p25d2ad8c0f)" style="fill: #fba35c; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 399.194609 280.4256 
-L 503.819609 280.4256 
-L 503.819609 251.0424 
-L 399.194609 251.0424 
+    <path d="M 398.126563 280.4256 
+L 502.751563 280.4256 
+L 502.751563 251.0424 
+L 398.126563 251.0424 
 z
-" clip-path="url(#pe2b833f815)" style="fill: #f47044; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p25d2ad8c0f)" style="fill: #fba35c; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 189.944609 309.8088 
-L 294.569609 309.8088 
-L 294.569609 280.4256 
-L 189.944609 280.4256 
+    <path d="M 188.876563 309.8088 
+L 293.501563 309.8088 
+L 293.501563 280.4256 
+L 188.876563 280.4256 
 z
-" clip-path="url(#pe2b833f815)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p25d2ad8c0f)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 294.569609 309.8088 
-L 399.194609 309.8088 
-L 399.194609 280.4256 
-L 294.569609 280.4256 
+    <path d="M 293.501563 309.8088 
+L 398.126563 309.8088 
+L 398.126563 280.4256 
+L 293.501563 280.4256 
 z
-" clip-path="url(#pe2b833f815)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p25d2ad8c0f)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 399.194609 309.8088 
-L 503.819609 309.8088 
-L 503.819609 280.4256 
-L 399.194609 280.4256 
+    <path d="M 398.126563 309.8088 
+L 502.751563 309.8088 
+L 502.751563 280.4256 
+L 398.126563 280.4256 
 z
-" clip-path="url(#pe2b833f815)" style="fill: #ee613e; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p25d2ad8c0f)" style="fill: #ee613e; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 189.944609 339.192 
-L 294.569609 339.192 
-L 294.569609 309.8088 
-L 189.944609 309.8088 
+    <path d="M 188.876563 339.192 
+L 293.501563 339.192 
+L 293.501563 309.8088 
+L 188.876563 309.8088 
 z
-" clip-path="url(#pe2b833f815)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p25d2ad8c0f)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 294.569609 339.192 
-L 399.194609 339.192 
-L 399.194609 309.8088 
-L 294.569609 309.8088 
+    <path d="M 293.501563 339.192 
+L 398.126563 339.192 
+L 398.126563 309.8088 
+L 293.501563 309.8088 
 z
-" clip-path="url(#pe2b833f815)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p25d2ad8c0f)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 399.194609 339.192 
-L 503.819609 339.192 
-L 503.819609 309.8088 
-L 399.194609 309.8088 
+    <path d="M 398.126563 339.192 
+L 502.751563 339.192 
+L 502.751563 309.8088 
+L 398.126563 309.8088 
 z
-" clip-path="url(#pe2b833f815)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p25d2ad8c0f)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(122.931875 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(121.863828 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(230.216094 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(229.148047 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(308.788203 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(307.720156 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(407.139922 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(406.071875 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(118.869609 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(117.801563 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.296 -->
-    <g transform="translate(230.805859 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(229.737813 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -946,7 +946,7 @@ z
    </g>
    <g id="text_7">
     <!-- 158 -->
-    <g transform="translate(339.247109 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(338.179063 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -1034,7 +1034,7 @@ z
    </g>
    <g id="text_8">
     <!-- 925 -->
-    <g transform="translate(443.872109 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(442.804063 91.6423) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-39"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
@@ -1042,7 +1042,7 @@ z
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(113.507734 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(112.439688 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1141,7 +1141,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.299 -->
-    <g transform="translate(230.805859 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(229.737813 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1151,7 +1151,7 @@ z
    </g>
    <g id="text_11">
     <!-- 73 -->
-    <g transform="translate(341.792109 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(340.724063 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -1202,7 +1202,7 @@ z
    </g>
    <g id="text_12">
     <!-- 283 -->
-    <g transform="translate(443.872109 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(442.804063 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(127.246094 0)"/>
@@ -1210,7 +1210,7 @@ z
    </g>
    <g id="text_13">
     <!-- zlib -->
-    <g transform="translate(130.770859 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(129.702813 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1234,7 +1234,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.299 -->
-    <g transform="translate(230.805859 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(229.737813 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1244,14 +1244,14 @@ z
    </g>
    <g id="text_15">
     <!-- 55 -->
-    <g transform="translate(341.792109 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(340.724063 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
     <!-- 692 -->
-    <g transform="translate(443.872109 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(442.804063 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-36"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
@@ -1259,7 +1259,7 @@ z
    </g>
    <g id="text_17">
     <!-- Go compress/flate -->
-    <g transform="translate(101.200859 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(100.132813 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -1430,7 +1430,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.299 -->
-    <g transform="translate(230.805859 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(229.737813 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1440,14 +1440,14 @@ z
    </g>
    <g id="text_19">
     <!-- 52 -->
-    <g transform="translate(341.792109 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(340.724063 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
     <!-- 323 -->
-    <g transform="translate(443.872109 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(442.804063 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(127.246094 0)"/>
@@ -1455,7 +1455,7 @@ z
    </g>
    <g id="text_21">
     <!-- miniz_oxide -->
-    <g transform="translate(114.077109 209.06385) scale(0.08 -0.08)">
+    <g transform="translate(113.009063 209.06385) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6e" d="M 3513 2113 
 L 3513 0 
@@ -1514,7 +1514,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.299 -->
-    <g transform="translate(230.805859 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(229.737813 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1524,14 +1524,14 @@ z
    </g>
    <g id="text_23">
     <!-- 51 -->
-    <g transform="translate(341.792109 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(340.724063 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_24">
     <!-- 729 -->
-    <g transform="translate(443.872109 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(442.804063 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-37"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(127.246094 0)"/>
@@ -1539,7 +1539,7 @@ z
    </g>
    <g id="text_25">
     <!-- JS fflate -->
-    <g transform="translate(122.233359 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(121.165313 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1599,7 +1599,7 @@ z
    </g>
    <g id="text_26">
     <!-- 0.307 -->
-    <g transform="translate(230.805859 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(229.737813 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1609,7 +1609,7 @@ z
    </g>
    <g id="text_27">
     <!-- 41 -->
-    <g transform="translate(341.792109 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(340.724063 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1637,14 +1637,14 @@ z
    </g>
    <g id="text_28">
     <!-- 80 -->
-    <g transform="translate(446.417109 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(445.349063 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-38"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_29">
     <!-- lean-zip (native) -->
-    <g transform="translate(100.578984 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(99.510938 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1753,7 +1753,7 @@ z
    </g>
    <g id="text_30">
     <!-- 0.297 -->
-    <g transform="translate(229.605234 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(228.537188 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1854,16 +1854,41 @@ z
     </g>
    </g>
    <g id="text_31">
-    <!-- 29 -->
-    <g transform="translate(341.315859 267.9415) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-Bold-32"/>
-     <use xlink:href="#DejaVuSans-Bold-39" transform="translate(69.580078 0)"/>
-    </g>
-   </g>
-   <g id="text_32">
-    <!-- 148 -->
-    <g transform="translate(443.157734 267.9415) scale(0.08 -0.08)">
+    <!-- 31 -->
+    <g transform="translate(340.247813 267.9415) scale(0.08 -0.08)">
      <defs>
+      <path id="DejaVuSans-Bold-33" d="M 2981 2516 
+Q 3453 2394 3698 2092 
+Q 3944 1791 3944 1325 
+Q 3944 631 3412 270 
+Q 2881 -91 1863 -91 
+Q 1503 -91 1142 -33 
+Q 781 25 428 141 
+L 428 1069 
+Q 766 900 1098 814 
+Q 1431 728 1753 728 
+Q 2231 728 2486 893 
+Q 2741 1059 2741 1369 
+Q 2741 1688 2480 1852 
+Q 2219 2016 1709 2016 
+L 1228 2016 
+L 1228 2791 
+L 1734 2791 
+Q 2188 2791 2409 2933 
+Q 2631 3075 2631 3366 
+Q 2631 3634 2415 3781 
+Q 2200 3928 1806 3928 
+Q 1516 3928 1219 3862 
+Q 922 3797 628 3669 
+L 628 4550 
+Q 984 4650 1334 4700 
+Q 1684 4750 2022 4750 
+Q 2931 4750 3382 4451 
+Q 3834 4153 3834 3553 
+Q 3834 3144 3618 2883 
+Q 3403 2622 2981 2516 
+z
+" transform="scale(0.015625)"/>
       <path id="DejaVuSans-Bold-31" d="M 750 831 
 L 1813 831 
 L 1813 3847 
@@ -1878,73 +1903,22 @@ L 750 0
 L 750 831 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-34" d="M 2356 3675 
-L 1038 1722 
-L 2356 1722 
-L 2356 3675 
-z
-M 2156 4666 
-L 3494 4666 
-L 3494 1722 
-L 4159 1722 
-L 4159 850 
-L 3494 850 
-L 3494 0 
-L 2356 0 
-L 2356 850 
-L 288 850 
-L 288 1881 
-L 2156 4666 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-38" d="M 2228 2088 
-Q 1891 2088 1709 1903 
-Q 1528 1719 1528 1375 
-Q 1528 1031 1709 848 
-Q 1891 666 2228 666 
-Q 2563 666 2741 848 
-Q 2919 1031 2919 1375 
-Q 2919 1722 2741 1905 
-Q 2563 2088 2228 2088 
-z
-M 1350 2484 
-Q 925 2613 709 2878 
-Q 494 3144 494 3541 
-Q 494 4131 934 4440 
-Q 1375 4750 2228 4750 
-Q 3075 4750 3515 4442 
-Q 3956 4134 3956 3541 
-Q 3956 3144 3739 2878 
-Q 3522 2613 3097 2484 
-Q 3572 2353 3814 2058 
-Q 4056 1763 4056 1313 
-Q 4056 619 3595 264 
-Q 3134 -91 2228 -91 
-Q 1319 -91 855 264 
-Q 391 619 391 1313 
-Q 391 1763 633 2058 
-Q 875 2353 1350 2484 
-z
-M 1631 3419 
-Q 1631 3141 1786 2991 
-Q 1941 2841 2228 2841 
-Q 2509 2841 2662 2991 
-Q 2816 3141 2816 3419 
-Q 2816 3697 2662 3845 
-Q 2509 3994 2228 3994 
-Q 1941 3994 1786 3844 
-Q 1631 3694 1631 3419 
-z
-" transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-Bold-31"/>
-     <use xlink:href="#DejaVuSans-Bold-34" transform="translate(69.580078 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-38" transform="translate(139.160156 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-33"/>
+     <use xlink:href="#DejaVuSans-Bold-31" transform="translate(69.580078 0)"/>
+    </g>
+   </g>
+   <g id="text_32">
+    <!-- 239 -->
+    <g transform="translate(442.089688 267.9415) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-Bold-32"/>
+     <use xlink:href="#DejaVuSans-Bold-33" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-39" transform="translate(139.160156 0)"/>
     </g>
    </g>
    <g id="text_33">
     <!-- OCaml decompress -->
-    <g transform="translate(98.693984 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(97.625938 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -2009,7 +1983,7 @@ z
    </g>
    <g id="text_34">
     <!-- 0.321 -->
-    <g transform="translate(230.805859 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(229.737813 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -2019,14 +1993,14 @@ z
    </g>
    <g id="text_35">
     <!-- 23 -->
-    <g transform="translate(341.792109 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(340.724063 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_36">
     <!-- 117 -->
-    <g transform="translate(443.872109 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(442.804063 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
@@ -2034,7 +2008,7 @@ z
    </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(126.915234 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(125.847188 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -2045,7 +2019,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.279 -->
-    <g transform="translate(230.805859 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(229.737813 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -2055,13 +2029,13 @@ z
    </g>
    <g id="text_39">
     <!-- 0 -->
-    <g transform="translate(344.337109 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(343.269063 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(447.507109 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(446.439063 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2077,7 +2051,7 @@ z
   </g>
   <g id="text_41">
    <!-- canterbury — geomean over files, level 6 -->
-   <g transform="translate(137.328359 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(136.260313 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-62" d="M 2400 722 
 Q 2759 722 2948 984 
@@ -2290,7 +2264,7 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-07-08T06:11:08Z  ·  Linux chungus2 x86_64  ·  commit 28336125  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-07-08T15:47:33Z  ·  Linux chungus2 x86_64  ·  commit f2026e66  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2431,14 +2405,14 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-38" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2478,110 +2452,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3262.744141 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3326.367188 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3389.990234 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3453.613281 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3517.236328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3580.859375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3612.646484 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3644.433594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3676.220703 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3708.007812 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3739.794922 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3767.578125 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3829.101562 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3890.380859 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3953.759766 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4017.236328 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4056.099609 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4117.28125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4176.460938 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4237.984375 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4279.097656 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4312.789062 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4340.572266 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4402.095703 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4463.375 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4526.753906 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4590.376953 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4624.068359 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4683.248047 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4746.871094 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4778.658203 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4842.28125 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4905.904297 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4937.691406 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(5001.314453 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5037.398438 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5076.261719 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5131.242188 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5194.865234 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5226.652344 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5258.439453 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5290.226562 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5322.013672 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5353.800781 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5393.009766 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5456.388672 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5495.251953 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5556.433594 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5619.8125 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5683.289062 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5746.667969 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5810.144531 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5873.523438 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5912.732422 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5944.519531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6028.308594 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6060.095703 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6157.507812 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6219.03125 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6282.507812 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6310.291016 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6371.570312 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6434.949219 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6466.736328 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6518.835938 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6582.214844 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6643.494141 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6706.970703 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6759.070312 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6822.449219 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6883.630859 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6922.839844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6956.53125 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6988.318359 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7029.431641 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7090.710938 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7129.919922 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7157.703125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7218.884766 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7250.671875 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7278.455078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7330.554688 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7362.341797 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7425.818359 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7487.341797 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7526.550781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7588.074219 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7627.4375 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7724.849609 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7752.632812 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7816.011719 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7843.794922 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7895.894531 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7935.103516 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7962.886719 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3107.080078 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3170.703125 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3234.326172 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3297.949219 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3361.572266 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3423.095703 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3486.71875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3550.341797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3582.128906 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3613.916016 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3645.703125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3677.490234 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3709.277344 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3737.060547 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3798.583984 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3859.863281 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3923.242188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3986.71875 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4025.582031 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4086.763672 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4145.943359 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4207.466797 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4248.580078 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4282.271484 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4310.054688 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4371.578125 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4432.857422 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4496.236328 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4559.859375 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4593.550781 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4652.730469 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4716.353516 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4748.140625 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4811.763672 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4875.386719 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4907.173828 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4970.796875 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5006.880859 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5045.744141 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5100.724609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5164.347656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5196.134766 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5227.921875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5259.708984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5291.496094 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5323.283203 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5362.492188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5425.871094 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5464.734375 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5525.916016 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5589.294922 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5652.771484 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5716.150391 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5779.626953 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5843.005859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5882.214844 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5914.001953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5997.791016 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6029.578125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6126.990234 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6188.513672 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6251.990234 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6279.773438 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6341.052734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6404.431641 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6436.21875 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6488.318359 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6551.697266 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6612.976562 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6676.453125 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6728.552734 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6791.931641 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6853.113281 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6892.322266 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6926.013672 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6957.800781 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6998.914062 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7060.193359 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7099.402344 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7127.185547 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7188.367188 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7220.154297 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7247.9375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7300.037109 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7331.824219 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7395.300781 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7456.824219 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7496.033203 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7557.556641 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7596.919922 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7694.332031 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7722.115234 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7785.494141 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7813.277344 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7865.376953 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7904.585938 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7932.369141 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pe2b833f815">
-   <rect x="85.319609" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="p25d2ad8c0f">
+   <rect x="84.251563" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/graphs/silesia_compress_heatmap.svg
+++ b/bench/graphs/silesia_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.34175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p02dbaa5e36)">
+   <g clip-path="url(#p18e35a4b65)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAqAAAAGaCAYAAADQNfGTAAAJ90lEQVR4nO3YT46sZR2GYbqruulzjMcDaIdDmODEGAcEEmLcButwxJQ1uAFnDl2AAyYMHJjghCEJiSSARsK/HPGkaburu1kEee9f++W6VvBU3nq/uus7uv3mT3fPbdnVxfSCtY6OpxesdXuYXrDW1s/vcDW9YK2Hj6cXrPW/Z9ML+DF2p9ML1tr69/PkbHrBUhv/9QMA4L4RoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApPYfHj6b3rDU6cl+esJSl4er6QlLPXn0yvSEpT797vPpCUsdjm6mJyz16wcvTk9Y6vD82fSEpf717J/TE5Y6f3A+PWGpy9PD9ISljp67mJ6wlDegAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBAan/+8Hx6w1JPfvLL6QlLfXnx2fSEpV6+3PZ/pEcvvT49YanT3dn0hKVubg/TE5ba+vlt/vMdb/vz7Y9fnZ6w1Nnl5fSEpbb96w4AwL0jQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASO2f3z2c3rDUt5dfTE9Yauvnd/PCi9MTlvr86YfTE5Z6dn05PWGpt154a3rCUld3h+kJS3363SfTE5b6zUtvTk9Y6oMv/jY9Yak3frHt8/MGFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACB1dPPXd+6mRyx1ezu9gB9j6+d37D8gjNn6/fP8/P92OEwvWGrjpwcAwH0jQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASO3PP/hoesNSu9Pd9ISlvvzoq+kJS/3x929MT1jqD3/f9vn97tVH0xOW+vP7n0xPWOrdt381PWGpv/zjP9MTlnrt8YPpCUt9+/319ISlfvvk4fSEpbwBBQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUkfXN+/dTY9YaXd9NT1hrd3p9IK1DpfTC9ban00vWGu3n16w1t3t9IK1rjd+/442/g7meNv37/po2/fv5HCYnrDUxm8fAAD3jQAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACC1f3b9dHrDUj+73nZj35ycTk9Yavffr6cnrPX4lekFa11dTC9Y6mq/7efL6cXT6Qlrbf3+3d1OL1jq5N8fT09Y66c/n16w1LafngAA3DsCFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACA1A+Ps3vKrJhbuQAAAABJRU5ErkJggg==" id="imaged2898d7735" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="483.84" height="295.2"/>
+iVBORw0KGgoAAAANSUhEUgAAAqAAAAGaCAYAAADQNfGTAAAJ90lEQVR4nO3YP25l5R3H4bF9x3iMNAyQWBlEQxqEUiCQEGIbrCNV2qwhG6CjZAEUaSgoIpGGDqog8ScIDQISNAzGvrZZBHo/P3P0PCv4Hr3n3Ps55+D6u3dv7mzZxZPpBWsdHE4vWOt6P71gra2f3/5iesFapw+mF6z1y+PpBfwWR8fTC9ba+v1592R6wVIb//cDAOC2EaAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKR2H++/mN6w1PHd3fSEpc73F9MTlnp4/4XpCUt9/uOX0xOW2h9cTU9Y6pV7z01PWGr/1Mn0hKX++/ir6QlLnd07m56w1PnxfnrCUgd3nkxPWMoXUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAILU7Oz2b3rDUw6f/PD1hqUdPvpiesNSfzrf9jnT/+VenJyx1fHQyPWGpq+v99ISltn5+m7++w21f3+7wxekJS52cn09PWGrb/+4AANw6AhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgNTuqaPT6Q1LfX/+zfSEpbZ+flfPPjc9Yakv//fx9ISlHl+eT09Y6o1n35iesNTFzX56wlKf//jZ9ISl/vL869MTlvrom39NT1jqtT9u+/x8AQUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBIHVx9+Leb6RFLXV9PL+C32Pr5HXoHhDFbf/78fv6+7ffTC5ba+OkBAHDbCFAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFK7s48+nd6w1NHx0fSEpR59+u30hKXe+etr0xOW+se/t31+b714f3rCUu998Nn0hKX+/vbL0xOWev8//5+esNRLD+5NT1jq+58vpycs9ebD0+kJS/kCCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApA4ur/55Mz1ipaPLi+kJax0dTy9Ya38+vWCt3cn0grWOdtML1rq5nl6w1uXGn7+DjX+DOdz283d5sO3n7+5+Pz1hqY0/fQAA3DYCFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACA1O6HXx5Nb1jqD9en0xOWutht+x3i+OLJ9IS1jrd9f9652k8vWOqnm23fn0//vO3ru37mbHrCUocb/8Z09+tPpies9eCF6QVLbfvuBADg1hGgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkfgXanHzC+rW0OAAAAABJRU5ErkJggg==" id="imaged1c9e1fee9" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="483.84" height="295.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="md8def93227" d="M 0 0 
+       <path id="me9908c3d04" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#md8def93227" x="115.814949" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me9908c3d04" x="115.814949" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#md8def93227" x="156.092348" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me9908c3d04" x="156.092348" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#md8def93227" x="196.369746" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me9908c3d04" x="196.369746" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#md8def93227" x="236.647145" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me9908c3d04" x="236.647145" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#md8def93227" x="276.924544" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me9908c3d04" x="276.924544" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#md8def93227" x="317.201942" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me9908c3d04" x="317.201942" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#md8def93227" x="357.479341" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me9908c3d04" x="357.479341" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#md8def93227" x="397.756739" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me9908c3d04" x="397.756739" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#md8def93227" x="438.034138" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me9908c3d04" x="438.034138" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#md8def93227" x="478.311536" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me9908c3d04" x="478.311536" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#md8def93227" x="518.588935" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me9908c3d04" x="518.588935" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#md8def93227" x="558.866334" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me9908c3d04" x="558.866334" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="md12e6800de" d="M 0 0 
+       <path id="m0f870b9436" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#md12e6800de" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0f870b9436" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#md12e6800de" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0f870b9436" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#md12e6800de" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0f870b9436" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#md12e6800de" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0f870b9436" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -836,7 +836,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#md12e6800de" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0f870b9436" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -899,7 +899,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#md12e6800de" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0f870b9436" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -966,7 +966,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#md12e6800de" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0f870b9436" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1047,7 +1047,7 @@ z
     <g id="ytick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#md12e6800de" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0f870b9436" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -1138,7 +1138,7 @@ L 579.005033 49.34175
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_21">
-    <!-- +25 -->
+    <!-- +33 -->
     <g transform="translate(108.955926 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-2b" d="M 2944 4013 
@@ -1156,65 +1156,6 @@ L 2419 4013
 L 2944 4013 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-32" d="M 1228 531 
-L 3431 531 
-L 3431 0 
-L 469 0 
-L 469 531 
-Q 828 903 1448 1529 
-Q 2069 2156 2228 2338 
-Q 2531 2678 2651 2914 
-Q 2772 3150 2772 3378 
-Q 2772 3750 2511 3984 
-Q 2250 4219 1831 4219 
-Q 1534 4219 1204 4116 
-Q 875 4013 500 3803 
-L 500 4441 
-Q 881 4594 1212 4672 
-Q 1544 4750 1819 4750 
-Q 2544 4750 2975 4387 
-Q 3406 4025 3406 3419 
-Q 3406 3131 3298 2873 
-Q 3191 2616 2906 2266 
-Q 2828 2175 2409 1742 
-Q 1991 1309 1228 531 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_22">
-    <!-- -23 -->
-    <g transform="translate(150.784184 69.553235) scale(0.065 -0.065)">
-     <defs>
       <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
 Q 3559 1806 3559 1356 
@@ -1248,20 +1189,92 @@ Q 3006 2619 2597 2516
 z
 " transform="scale(0.015625)"/>
      </defs>
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_22">
+    <!-- -20 -->
+    <g transform="translate(150.784184 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_23">
-    <!-- +5 -->
-    <g transform="translate(191.578535 69.553235) scale(0.065 -0.065)">
+    <!-- +12 -->
+    <g transform="translate(189.510723 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_24">
-    <!-- -38 -->
+    <!-- -28 -->
     <g transform="translate(231.338981 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
@@ -1305,90 +1318,13 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_25">
-    <!-- -8 -->
-    <g transform="translate(273.684192 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_26">
-    <!-- -12 -->
-    <g transform="translate(311.893778 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-31" d="M 794 531 
-L 1825 531 
-L 1825 4091 
-L 703 3866 
-L 703 4441 
-L 1819 4666 
-L 2450 4666 
-L 2450 531 
-L 3481 531 
-L 3481 0 
-L 794 0 
-L 794 531 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_27">
-    <!-- +11 -->
-    <g transform="translate(350.620317 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_28">
-    <!-- -32 -->
-    <g transform="translate(392.448575 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_29">
-    <!-- +0 -->
-    <g transform="translate(433.242927 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-30" d="M 2034 4250 
-Q 1547 4250 1301 3770 
-Q 1056 3291 1056 2328 
-Q 1056 1369 1301 889 
-Q 1547 409 2034 409 
-Q 2525 409 2770 889 
-Q 3016 1369 3016 2328 
-Q 3016 3291 2770 3770 
-Q 2525 4250 2034 4250 
-z
-M 2034 4750 
-Q 2819 4750 3233 4129 
-Q 3647 3509 3647 2328 
-Q 3647 1150 3233 529 
-Q 2819 -91 2034 -91 
-Q 1250 -91 836 529 
-Q 422 1150 422 2328 
-Q 422 3509 836 4129 
-Q 1250 4750 2034 4750 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_30">
     <!-- -4 -->
-    <g transform="translate(475.071185 69.553235) scale(0.065 -0.065)">
+    <g transform="translate(273.684192 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1414,17 +1350,121 @@ z
      <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
     </g>
    </g>
+   <g id="text_26">
+    <!-- -5 -->
+    <g transform="translate(313.961591 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_27">
+    <!-- +18 -->
+    <g transform="translate(350.620317 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_28">
+    <!-- -29 -->
+    <g transform="translate(392.448575 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_29">
+    <!-- +4 -->
+    <g transform="translate(433.242927 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_30">
+    <!-- +2 -->
+    <g transform="translate(473.520325 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
    <g id="text_31">
-    <!-- -51 -->
+    <!-- -50 -->
     <g transform="translate(513.280771 69.553235) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_32">
-    <!-- -27 -->
+    <!-- -20 -->
     <g transform="translate(553.558169 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_33">
+    <!-- +7 -->
+    <g transform="translate(111.023738 106.389018) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -1437,14 +1477,6 @@ L 525 4666
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_33">
-    <!-- +7 -->
-    <g transform="translate(111.023738 106.389018) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
     </g>
@@ -1551,38 +1583,6 @@ z
    <g id="text_43">
     <!-- +9 -->
     <g transform="translate(513.797724 106.389018) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-39" d="M 703 97 
-L 703 672 
-Q 941 559 1184 500 
-Q 1428 441 1663 441 
-Q 2288 441 2617 861 
-Q 2947 1281 2994 2138 
-Q 2813 1869 2534 1725 
-Q 2256 1581 1919 1581 
-Q 1219 1581 811 2004 
-Q 403 2428 403 3163 
-Q 403 3881 828 4315 
-Q 1253 4750 1959 4750 
-Q 2769 4750 3195 4129 
-Q 3622 3509 3622 2328 
-Q 3622 1225 3098 567 
-Q 2575 -91 1691 -91 
-Q 1453 -91 1209 -44 
-Q 966 3 703 97 
-z
-M 1959 2075 
-Q 2384 2075 2632 2365 
-Q 2881 2656 2881 3163 
-Q 2881 3666 2632 3958 
-Q 2384 4250 1959 4250 
-Q 1534 4250 1286 3958 
-Q 1038 3666 1038 3163 
-Q 1038 2656 1286 2365 
-Q 1534 2075 1959 2075 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(83.789062 0)"/>
     </g>
@@ -2192,18 +2192,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB1ElEQVR4nO2b0a3DMAwD7cSzvM3fmI47gvpxCK6ENABhnkQ5aZH5P/7OAGpdFyEzBiQDnija2qSEghnZhIIZCa3NyWQkmZFOKJhRsDXsOopmJJwjaEPOmxHirE3MWjOqhSBr2EAGMyKtMVpc+ynYwe3viNQVbA0LrZDRFbxGbNbWyM3auG0RGbo1Qp0IZCSMiG2OgtNvbL+Oke6BvddIWaQ1qP3RjGSTLXypwdaIMP2ctWb0olAzKkr4LhLMCPvnOJiRbo6CrTWjF4WCGYHWJtU1TKgZvSZkfNAKZhRsDftFa96MkJCRrf29ausyWrOtWiMjmxDH6FAfDJzzIEKctQc60ToDEqJOBLbfZs04RxQjobWOSFXrjM0IdURqIaG1jkhVPmvGOUqOCPLJMdh+6kRk+zFGMtjKOdK13zbZ2EBGMxLOkSz90YygK9tozSbUa6Qu4RxtRifZ2np0jDY32YiOc44gIQo2aI1ZkB2Rb4SiIyJbtcr0Q0IPdCQyIpCQDnZHpC5uQ27uOtJFBBptH2zlHOnab+uaMSK29htXrW2NKK0hOtlrxLaPjIxys4a99x9dRKgTgUK69gsZ9RxVFWzNyIi6RZIZtbXfE+qI1BU8R5i1D2e5X2tFkZmlAAAAAElFTkSuQmCC" id="image441eda2005" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-69.84" width="12.96" height="253.44"/>
+iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB1ElEQVR4nO2b0a3DMAwD7cSzvM3fmI47gvpxCK6ENABhnkQ5aZH5P/7OAGpdFyEzBiQDnija2qSEghnZhIIZCa3NyWQkmZFOKJhRsDXsOopmJJwjaEPOmxHirE3MWjOqhSBr2EAGMyKtMVpc+ynYwe3viNQVbA0LrZDRFbxGbNbWyM3auG0RGbo1Qp0IZCSMiG2OgtNvbL+Oke6BvddIWaQ1qP3RjGSTLXypwdaIMP2ctWb0olAzKkr4LhLMCPvnOJiRbo6CrTWjF4WCGYHWJtU1TKgZvSZkfNAKZhRsDftFa96MkJCRrf29ausyWrOtWiMjmxDH6FAfDJzzIEKctQc60ToDEqJOBLbfZs04RxQjobWOSFXrjM0IdURqIaG1jkhVPmvGOUqOCPLJMdh+6kRk+zFGMtjKOdK13zbZ2EBGMxLOkSz90YygK9tozSbUa6Qu4RxtRifZ2np0jDY32YiOc44gIQo2aI1ZkB2Rb4SiIyJbtcr0Q0IPdCQyIpCQDnZHpC5uQ27uOtJFBBptH2zlHOnab+uaMSK29htXrW2NKK0hOtlrxLaPjIxys4a99x9dRKgTgUK69gsZ9RxVFWzNyIi6RZIZtbXfE+qI1BU8R5i1D2e5X2tFkZmlAAAAAElFTkSuQmCC" id="image1c38bdd3c7" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-69.84" width="12.96" height="253.44"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_21">
       <defs>
-       <path id="m5c20abfc64" d="M 0 0 
+       <path id="m4cdb40f425" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m5c20abfc64" x="601.779688" y="322.507463" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4cdb40f425" x="601.779688" y="322.507463" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_117">
@@ -2226,7 +2226,7 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m5c20abfc64" x="601.779688" y="280.566603" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4cdb40f425" x="601.779688" y="280.566603" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_118">
@@ -2240,7 +2240,7 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m5c20abfc64" x="601.779688" y="238.625742" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4cdb40f425" x="601.779688" y="238.625742" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_119">
@@ -2254,7 +2254,7 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m5c20abfc64" x="601.779688" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4cdb40f425" x="601.779688" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_120">
@@ -2267,7 +2267,7 @@ z
     <g id="ytick_13">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m5c20abfc64" x="601.779688" y="154.74402" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4cdb40f425" x="601.779688" y="154.74402" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_121">
@@ -2280,7 +2280,7 @@ z
     <g id="ytick_14">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m5c20abfc64" x="601.779688" y="112.803159" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4cdb40f425" x="601.779688" y="112.803159" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_122">
@@ -2293,7 +2293,7 @@ z
     <g id="ytick_15">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#m5c20abfc64" x="601.779688" y="70.862298" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4cdb40f425" x="601.779688" y="70.862298" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_123">
@@ -2909,8 +2909,8 @@ z
    </g>
   </g>
   <g id="text_126">
-   <!-- 2026-07-08T06:11:08Z  ·  Linux chungus2 x86_64  ·  commit 28336125  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(43.380391 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-08T15:47:33Z  ·  Linux chungus2 x86_64  ·  commit f2026e66  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(44.448437 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -3001,14 +3001,14 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-38" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3048,109 +3048,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3262.744141 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3326.367188 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3389.990234 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3453.613281 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3517.236328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3580.859375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3612.646484 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3644.433594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3676.220703 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3708.007812 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3739.794922 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3767.578125 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3829.101562 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3890.380859 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3953.759766 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4017.236328 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4056.099609 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4117.28125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4176.460938 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4237.984375 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4279.097656 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4312.789062 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4340.572266 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4402.095703 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4463.375 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4526.753906 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4590.376953 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4624.068359 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4683.248047 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4746.871094 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4778.658203 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4842.28125 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4905.904297 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4937.691406 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(5001.314453 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5037.398438 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5076.261719 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5131.242188 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5194.865234 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5226.652344 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5258.439453 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5290.226562 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5322.013672 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5353.800781 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5393.009766 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5456.388672 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5495.251953 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5556.433594 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5619.8125 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5683.289062 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5746.667969 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5810.144531 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5873.523438 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5912.732422 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5944.519531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6028.308594 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6060.095703 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6157.507812 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6219.03125 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6282.507812 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6310.291016 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6371.570312 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6434.949219 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6466.736328 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6518.835938 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6582.214844 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6643.494141 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6706.970703 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6759.070312 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6822.449219 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6883.630859 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6922.839844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6956.53125 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6988.318359 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7029.431641 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7090.710938 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7129.919922 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7157.703125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7218.884766 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7250.671875 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7278.455078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7330.554688 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7362.341797 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7425.818359 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7487.341797 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7526.550781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7588.074219 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7627.4375 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7724.849609 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7752.632812 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7816.011719 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7843.794922 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7895.894531 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7935.103516 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7962.886719 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3107.080078 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3170.703125 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3234.326172 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3297.949219 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3361.572266 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3423.095703 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3486.71875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3550.341797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3582.128906 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3613.916016 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3645.703125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3677.490234 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3709.277344 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3737.060547 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3798.583984 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3859.863281 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3923.242188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3986.71875 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4025.582031 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4086.763672 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4145.943359 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4207.466797 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4248.580078 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4282.271484 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4310.054688 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4371.578125 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4432.857422 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4496.236328 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4559.859375 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4593.550781 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4652.730469 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4716.353516 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4748.140625 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4811.763672 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4875.386719 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4907.173828 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4970.796875 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5006.880859 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5045.744141 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5100.724609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5164.347656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5196.134766 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5227.921875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5259.708984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5291.496094 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5323.283203 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5362.492188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5425.871094 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5464.734375 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5525.916016 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5589.294922 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5652.771484 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5716.150391 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5779.626953 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5843.005859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5882.214844 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5914.001953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5997.791016 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6029.578125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6126.990234 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6188.513672 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6251.990234 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6279.773438 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6341.052734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6404.431641 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6436.21875 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6488.318359 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6551.697266 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6612.976562 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6676.453125 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6728.552734 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6791.931641 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6853.113281 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6892.322266 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6926.013672 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6957.800781 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6998.914062 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7060.193359 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7099.402344 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7127.185547 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7188.367188 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7220.154297 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7247.9375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7300.037109 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7331.824219 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7395.300781 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7456.824219 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7496.033203 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7557.556641 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7596.919922 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7694.332031 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7722.115234 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7785.494141 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7813.277344 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7865.376953 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7904.585938 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7932.369141 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p02dbaa5e36">
+  <clipPath id="p18e35a4b65">
    <rect x="95.67625" y="49.34175" width="483.328783" height="294.686261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_compress_pareto.svg
+++ b/bench/graphs/silesia_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 61.085542 412.80375 
 L 61.085542 48.323125 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m07e3c24419" d="M 0 0 
+       <path id="m79f87d447f" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m07e3c24419" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m79f87d447f" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -130,11 +130,11 @@ z
      <g id="line2d_3">
       <path d="M 145.270284 412.80375 
 L 145.270284 48.323125 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m07e3c24419" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m79f87d447f" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -177,11 +177,11 @@ z
      <g id="line2d_5">
       <path d="M 229.455026 412.80375 
 L 229.455026 48.323125 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m07e3c24419" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m79f87d447f" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -219,11 +219,11 @@ z
      <g id="line2d_7">
       <path d="M 313.639768 412.80375 
 L 313.639768 48.323125 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m07e3c24419" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m79f87d447f" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -272,11 +272,11 @@ z
      <g id="line2d_9">
       <path d="M 397.82451 412.80375 
 L 397.82451 48.323125 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m07e3c24419" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m79f87d447f" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -334,11 +334,11 @@ z
      <g id="line2d_11">
       <path d="M 482.009253 412.80375 
 L 482.009253 48.323125 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m07e3c24419" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m79f87d447f" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -355,11 +355,11 @@ L 482.009253 48.323125
      <g id="line2d_13">
       <path d="M 566.193995 412.80375 
 L 566.193995 48.323125 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m07e3c24419" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m79f87d447f" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -856,16 +856,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 368.08164 
 L 637.2 368.08164 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="m6c0f2cc344" d="M 0 0 
+       <path id="m9c677cfa76" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m6c0f2cc344" x="49.078125" y="368.08164" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9c677cfa76" x="49.078125" y="368.08164" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -897,11 +897,11 @@ z
      <g id="line2d_17">
       <path d="M 49.078125 243.439835 
 L 637.2 243.439835 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m6c0f2cc344" x="49.078125" y="243.439835" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9c677cfa76" x="49.078125" y="243.439835" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -917,11 +917,11 @@ L 637.2 243.439835
      <g id="line2d_19">
       <path d="M 49.078125 118.798029 
 L 637.2 118.798029 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m6c0f2cc344" x="49.078125" y="118.798029" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9c677cfa76" x="49.078125" y="118.798029" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -937,16 +937,16 @@ L 637.2 118.798029
      <g id="line2d_21">
       <path d="M 49.078125 405.602562 
 L 637.2 405.602562 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="m9387aed3df" d="M 0 0 
+       <path id="maca583f6d6" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m9387aed3df" x="49.078125" y="405.602562" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#maca583f6d6" x="49.078125" y="405.602562" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -954,11 +954,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 395.733268 
 L 637.2 395.733268 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m9387aed3df" x="49.078125" y="395.733268" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#maca583f6d6" x="49.078125" y="395.733268" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -966,11 +966,11 @@ L 637.2 395.733268
      <g id="line2d_25">
       <path d="M 49.078125 387.3889 
 L 637.2 387.3889 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m9387aed3df" x="49.078125" y="387.3889" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#maca583f6d6" x="49.078125" y="387.3889" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -978,11 +978,11 @@ L 637.2 387.3889
      <g id="line2d_27">
       <path d="M 49.078125 380.160679 
 L 637.2 380.160679 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m9387aed3df" x="49.078125" y="380.160679" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#maca583f6d6" x="49.078125" y="380.160679" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -990,11 +990,11 @@ L 637.2 380.160679
      <g id="line2d_29">
       <path d="M 49.078125 373.784936 
 L 637.2 373.784936 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m9387aed3df" x="49.078125" y="373.784936" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#maca583f6d6" x="49.078125" y="373.784936" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1002,11 +1002,11 @@ L 637.2 373.784936
      <g id="line2d_31">
       <path d="M 49.078125 330.560718 
 L 637.2 330.560718 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m9387aed3df" x="49.078125" y="330.560718" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#maca583f6d6" x="49.078125" y="330.560718" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1014,11 +1014,11 @@ L 637.2 330.560718
      <g id="line2d_33">
       <path d="M 49.078125 308.612385 
 L 637.2 308.612385 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m9387aed3df" x="49.078125" y="308.612385" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#maca583f6d6" x="49.078125" y="308.612385" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1026,11 +1026,11 @@ L 637.2 308.612385
      <g id="line2d_35">
       <path d="M 49.078125 293.039796 
 L 637.2 293.039796 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m9387aed3df" x="49.078125" y="293.039796" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#maca583f6d6" x="49.078125" y="293.039796" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1038,11 +1038,11 @@ L 637.2 293.039796
      <g id="line2d_37">
       <path d="M 49.078125 280.960757 
 L 637.2 280.960757 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m9387aed3df" x="49.078125" y="280.960757" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#maca583f6d6" x="49.078125" y="280.960757" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1050,11 +1050,11 @@ L 637.2 280.960757
      <g id="line2d_39">
       <path d="M 49.078125 271.091463 
 L 637.2 271.091463 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m9387aed3df" x="49.078125" y="271.091463" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#maca583f6d6" x="49.078125" y="271.091463" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1062,11 +1062,11 @@ L 637.2 271.091463
      <g id="line2d_41">
       <path d="M 49.078125 262.747094 
 L 637.2 262.747094 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m9387aed3df" x="49.078125" y="262.747094" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#maca583f6d6" x="49.078125" y="262.747094" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1074,11 +1074,11 @@ L 637.2 262.747094
      <g id="line2d_43">
       <path d="M 49.078125 255.518874 
 L 637.2 255.518874 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m9387aed3df" x="49.078125" y="255.518874" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#maca583f6d6" x="49.078125" y="255.518874" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1086,11 +1086,11 @@ L 637.2 255.518874
      <g id="line2d_45">
       <path d="M 49.078125 249.143131 
 L 637.2 249.143131 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m9387aed3df" x="49.078125" y="249.143131" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#maca583f6d6" x="49.078125" y="249.143131" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1098,11 +1098,11 @@ L 637.2 249.143131
      <g id="line2d_47">
       <path d="M 49.078125 205.918912 
 L 637.2 205.918912 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m9387aed3df" x="49.078125" y="205.918912" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#maca583f6d6" x="49.078125" y="205.918912" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1110,11 +1110,11 @@ L 637.2 205.918912
      <g id="line2d_49">
       <path d="M 49.078125 183.97058 
 L 637.2 183.97058 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m9387aed3df" x="49.078125" y="183.97058" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#maca583f6d6" x="49.078125" y="183.97058" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1122,11 +1122,11 @@ L 637.2 183.97058
      <g id="line2d_51">
       <path d="M 49.078125 168.39799 
 L 637.2 168.39799 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m9387aed3df" x="49.078125" y="168.39799" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#maca583f6d6" x="49.078125" y="168.39799" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1134,11 +1134,11 @@ L 637.2 168.39799
      <g id="line2d_53">
       <path d="M 49.078125 156.318951 
 L 637.2 156.318951 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#m9387aed3df" x="49.078125" y="156.318951" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#maca583f6d6" x="49.078125" y="156.318951" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1146,11 +1146,11 @@ L 637.2 156.318951
      <g id="line2d_55">
       <path d="M 49.078125 146.449658 
 L 637.2 146.449658 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#m9387aed3df" x="49.078125" y="146.449658" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#maca583f6d6" x="49.078125" y="146.449658" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1158,11 +1158,11 @@ L 637.2 146.449658
      <g id="line2d_57">
       <path d="M 49.078125 138.105289 
 L 637.2 138.105289 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#m9387aed3df" x="49.078125" y="138.105289" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#maca583f6d6" x="49.078125" y="138.105289" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1170,11 +1170,11 @@ L 637.2 138.105289
      <g id="line2d_59">
       <path d="M 49.078125 130.877068 
 L 637.2 130.877068 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#m9387aed3df" x="49.078125" y="130.877068" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#maca583f6d6" x="49.078125" y="130.877068" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1182,11 +1182,11 @@ L 637.2 130.877068
      <g id="line2d_61">
       <path d="M 49.078125 124.501326 
 L 637.2 124.501326 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#m9387aed3df" x="49.078125" y="124.501326" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#maca583f6d6" x="49.078125" y="124.501326" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1194,11 +1194,11 @@ L 637.2 124.501326
      <g id="line2d_63">
       <path d="M 49.078125 81.277107 
 L 637.2 81.277107 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#m9387aed3df" x="49.078125" y="81.277107" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#maca583f6d6" x="49.078125" y="81.277107" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1206,11 +1206,11 @@ L 637.2 81.277107
      <g id="line2d_65">
       <path d="M 49.078125 59.328775 
 L 637.2 59.328775 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#m9387aed3df" x="49.078125" y="59.328775" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#maca583f6d6" x="49.078125" y="59.328775" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1332,7 +1332,7 @@ L 637.2 48.323125
    </g>
    <g id="text_13">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(324.643112 123.107026) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(324.643112 118.779184) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1364,7 +1364,7 @@ z
    </g>
    <g id="text_14">
     <!-- L10 -->
-    <g style="fill: #d62728" transform="translate(102.799363 311.5192) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(102.799363 309.724011) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1686,23 +1686,23 @@ z
    </g>
    <g id="line2d_67">
     <defs>
-     <path id="m62136bef61" d="M -2.5 2.5 
+     <path id="m8021e33023" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pbea61dadc3)">
-     <use xlink:href="#m62136bef61" x="377.110281" y="104.685421" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m62136bef61" x="323.801439" y="110.409833" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m62136bef61" x="272.665744" y="126.308323" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m62136bef61" x="235.168828" y="128.026741" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m62136bef61" x="186.228265" y="149.377587" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m62136bef61" x="158.303164" y="171.457731" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m62136bef61" x="149.489547" y="182.192614" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m62136bef61" x="140.563162" y="202.482797" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m62136bef61" x="138.984853" y="209.328911" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p21d9583499)">
+     <use xlink:href="#m8021e33023" x="377.110281" y="104.685421" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8021e33023" x="323.801439" y="110.409833" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8021e33023" x="272.665744" y="126.308323" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8021e33023" x="235.168828" y="128.026741" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8021e33023" x="186.228265" y="149.377587" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8021e33023" x="158.303164" y="171.457731" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8021e33023" x="149.489547" y="182.192614" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8021e33023" x="140.563162" y="202.482797" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8021e33023" x="138.984853" y="209.328911" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_68">
@@ -1755,7 +1755,7 @@ L 327.133241 110.069256
 L 326.02264 110.18302 
 L 324.91204 110.296545 
 L 323.801439 110.409833 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_69">
     <path d="M 323.801439 110.409833 
@@ -1807,7 +1807,7 @@ L 275.861725 125.44037
 L 274.796398 125.731236 
 L 273.731071 126.020548 
 L 272.665744 126.308323 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_70">
     <path d="M 272.665744 126.308323 
@@ -1859,7 +1859,7 @@ L 237.512385 127.920923
 L 236.7312 127.956219 
 L 235.950014 127.991491 
 L 235.168828 128.026741 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_71">
     <path d="M 235.168828 128.026741 
@@ -1911,7 +1911,7 @@ L 189.28705 148.263499
 L 188.267455 148.637415 
 L 187.24786 149.008766 
 L 186.228265 149.377587 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_72">
     <path d="M 186.228265 149.377587 
@@ -1963,7 +1963,7 @@ L 160.048483 170.312481
 L 159.46671 170.696929 
 L 158.884937 171.078667 
 L 158.303164 171.457731 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_73">
     <path d="M 158.303164 171.457731 
@@ -2015,7 +2015,7 @@ L 150.040398 181.580576
 L 149.856781 181.785359 
 L 149.673164 181.989369 
 L 149.489547 182.192614 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_74">
     <path d="M 149.489547 182.192614 
@@ -2067,7 +2067,7 @@ L 141.121061 201.414753
 L 140.935095 201.773114 
 L 140.749129 202.129119 
 L 140.563162 202.482797 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_75">
     <path d="M 140.563162 202.482797 
@@ -2119,26 +2119,26 @@ L 139.083497 208.925481
 L 139.050616 209.060292 
 L 139.017734 209.194768 
 L 138.984853 209.328911 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_76">
     <defs>
-     <path id="m1ffa8fa975" d="M 0 -2.5 
+     <path id="m1e1abfc02b" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pbea61dadc3)">
-     <use xlink:href="#m1ffa8fa975" x="610.467187" y="71.939349" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1ffa8fa975" x="319.880958" y="101.884157" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1ffa8fa975" x="210.281253" y="129.778154" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1ffa8fa975" x="196.287076" y="133.586625" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1ffa8fa975" x="176.054419" y="147.38645" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1ffa8fa975" x="152.161413" y="174.753272" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1ffa8fa975" x="146.720208" y="186.587648" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1ffa8fa975" x="143.994022" y="196.356323" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1ffa8fa975" x="142.666037" y="200.180971" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p21d9583499)">
+     <use xlink:href="#m1e1abfc02b" x="610.467187" y="71.939349" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1e1abfc02b" x="319.880958" y="101.884157" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1e1abfc02b" x="210.281253" y="129.778154" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1e1abfc02b" x="196.287076" y="133.586625" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1e1abfc02b" x="176.054419" y="147.38645" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1e1abfc02b" x="152.161413" y="174.753272" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1e1abfc02b" x="146.720208" y="186.587648" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1e1abfc02b" x="143.994022" y="196.356323" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1e1abfc02b" x="142.666037" y="200.180971" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_77">
@@ -2191,7 +2191,7 @@ L 338.042598 100.427247
 L 331.988718 100.917253 
 L 325.934838 101.402864 
 L 319.880958 101.884157 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_78">
     <path d="M 319.880958 101.884157 
@@ -2243,7 +2243,7 @@ L 217.131235 128.398367
 L 214.847908 128.862215 
 L 212.564581 129.322122 
 L 210.281253 129.778154 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_79">
     <path d="M 210.281253 129.778154 
@@ -2295,7 +2295,7 @@ L 197.161712 133.356286
 L 196.870166 133.433175 
 L 196.578621 133.509954 
 L 196.287076 133.586625 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_80">
     <path d="M 196.287076 133.586625 
@@ -2347,7 +2347,7 @@ L 177.31896 146.619719
 L 176.897447 146.876504 
 L 176.475933 147.132078 
 L 176.054419 147.38645 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_81">
     <path d="M 176.054419 147.38645 
@@ -2399,7 +2399,7 @@ L 153.654726 173.393769
 L 153.156955 173.850741 
 L 152.659184 174.303887 
 L 152.161413 174.753272 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_82">
     <path d="M 152.161413 174.753272 
@@ -2451,7 +2451,7 @@ L 147.060283 185.919158
 L 146.946925 186.142906 
 L 146.833566 186.365734 
 L 146.720208 186.587648 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_83">
     <path d="M 146.720208 186.587648 
@@ -2503,7 +2503,7 @@ L 144.164409 195.794799
 L 144.107613 195.982622 
 L 144.050817 196.169795 
 L 143.994022 196.356323 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_84">
     <path d="M 143.994022 196.356323 
@@ -2555,30 +2555,30 @@ L 142.749036 199.949687
 L 142.72137 200.026891 
 L 142.693704 200.103986 
 L 142.666037 200.180971 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_85">
     <defs>
-     <path id="m2915dfd003" d="M -0 3.535534 
+     <path id="m5a7f2031e7" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pbea61dadc3)">
-     <use xlink:href="#m2915dfd003" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2915dfd003" x="242.839153" y="80.778898" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2915dfd003" x="218.251194" y="86.377096" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2915dfd003" x="197.814984" y="90.309617" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2915dfd003" x="166.378359" y="99.066934" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2915dfd003" x="145.830392" y="110.431955" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2915dfd003" x="134.598477" y="126.026287" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2915dfd003" x="124.077268" y="149.033155" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2915dfd003" x="122.462976" y="157.476606" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2915dfd003" x="81.012077" y="220.06889" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2915dfd003" x="77.44276" y="239.652656" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2915dfd003" x="76.953425" y="252.706566" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p21d9583499)">
+     <use xlink:href="#m5a7f2031e7" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5a7f2031e7" x="242.839153" y="80.778898" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5a7f2031e7" x="218.251194" y="86.377096" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5a7f2031e7" x="197.814984" y="90.309617" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5a7f2031e7" x="166.378359" y="99.066934" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5a7f2031e7" x="145.830392" y="110.431955" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5a7f2031e7" x="134.598477" y="126.026287" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5a7f2031e7" x="124.077268" y="149.033155" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5a7f2031e7" x="122.462976" y="157.476606" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5a7f2031e7" x="81.012077" y="220.06889" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5a7f2031e7" x="77.44276" y="239.652656" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5a7f2031e7" x="76.953425" y="252.706566" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_86">
@@ -2631,7 +2631,7 @@ L 245.91379 79.91142
 L 244.888911 80.202126 
 L 243.864032 80.49128 
 L 242.839153 80.778898 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_87">
     <path d="M 242.839153 80.778898 
@@ -2683,7 +2683,7 @@ L 219.787941 86.043669
 L 219.275692 86.155039 
 L 218.763443 86.266182 
 L 218.251194 86.377096 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_88">
     <path d="M 218.251194 86.377096 
@@ -2735,7 +2735,7 @@ L 199.092247 90.072029
 L 198.666492 90.151341 
 L 198.240738 90.230537 
 L 197.814984 90.309617 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_89">
     <path d="M 197.814984 90.309617 
@@ -2787,7 +2787,7 @@ L 168.343148 98.559208
 L 167.688219 98.72898 
 L 167.033289 98.898221 
 L 166.378359 99.066934 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_90">
     <path d="M 166.378359 99.066934 
@@ -2839,7 +2839,7 @@ L 147.11464 109.78743
 L 146.686557 110.003126 
 L 146.258475 110.217965 
 L 145.830392 110.431955 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_91">
     <path d="M 145.830392 110.431955 
@@ -2891,7 +2891,7 @@ L 135.300472 125.172774
 L 135.066474 125.458776 
 L 134.832476 125.743276 
 L 134.598477 126.026287 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_92">
     <path d="M 134.598477 126.026287 
@@ -2943,7 +2943,7 @@ L 124.734843 147.848882
 L 124.515652 148.246526 
 L 124.29646 148.641269 
 L 124.077268 149.033155 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_93">
     <path d="M 124.077268 149.033155 
@@ -2995,7 +2995,7 @@ L 122.56387 156.985769
 L 122.530239 157.149876 
 L 122.496607 157.313488 
 L 122.462976 157.476606 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_94">
     <path d="M 122.462976 157.476606 
@@ -3047,7 +3047,7 @@ L 83.602758 217.699074
 L 82.739198 218.500595 
 L 81.875637 219.290422 
 L 81.012077 220.06889 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_95">
     <path d="M 81.012077 220.06889 
@@ -3099,7 +3099,7 @@ L 77.665842 238.615761
 L 77.591481 238.963605 
 L 77.517121 239.309227 
 L 77.44276 239.652656 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_96">
     <path d="M 77.44276 239.652656 
@@ -3151,23 +3151,23 @@ L 76.984008 251.97672
 L 76.973814 252.221097 
 L 76.96362 252.464376 
 L 76.953425 252.706566 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_97">
     <defs>
-     <path id="m6e21457418" d="M -0 2.5 
+     <path id="m39d336fd0f" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pbea61dadc3)">
-     <use xlink:href="#m6e21457418" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p21d9583499)">
+     <use xlink:href="#m39d336fd0f" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_98">
     <defs>
-     <path id="m74cfb33100" d="M -0.833333 2.5 
+     <path id="mc70085bc84" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -3182,16 +3182,16 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pbea61dadc3)">
-     <use xlink:href="#m74cfb33100" x="432.495268" y="96.067622" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m74cfb33100" x="300.62247" y="112.493412" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m74cfb33100" x="266.967623" y="120.8136" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m74cfb33100" x="226.040946" y="122.099593" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m74cfb33100" x="180.985721" y="141.85872" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m74cfb33100" x="164.441833" y="156.106179" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m74cfb33100" x="157.761315" y="165.23787" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m74cfb33100" x="151.269082" y="178.700983" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m74cfb33100" x="150.327087" y="185.23695" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p21d9583499)">
+     <use xlink:href="#mc70085bc84" x="432.495268" y="96.067622" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc70085bc84" x="300.62247" y="112.493412" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc70085bc84" x="266.967623" y="120.8136" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc70085bc84" x="226.040946" y="122.099593" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc70085bc84" x="180.985721" y="141.85872" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc70085bc84" x="164.441833" y="156.106179" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc70085bc84" x="157.761315" y="165.23787" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc70085bc84" x="151.269082" y="178.700983" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc70085bc84" x="150.327087" y="185.23695" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_99">
@@ -3244,7 +3244,7 @@ L 308.86452 111.600609
 L 306.11717 111.899849 
 L 303.36982 112.197444 
 L 300.62247 112.493412 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_100">
     <path d="M 300.62247 112.493412 
@@ -3296,7 +3296,7 @@ L 269.071051 120.329422
 L 268.369908 120.491297 
 L 267.668766 120.652688 
 L 266.967623 120.8136 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_101">
     <path d="M 266.967623 120.8136 
@@ -3348,7 +3348,7 @@ L 228.598863 122.020108
 L 227.746224 122.046616 
 L 226.893585 122.073111 
 L 226.040946 122.099593 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_102">
     <path d="M 226.040946 122.099593 
@@ -3400,7 +3400,7 @@ L 183.801673 140.814056
 L 182.863022 141.164522 
 L 181.924372 141.512734 
 L 180.985721 141.85872 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_103">
     <path d="M 180.985721 141.85872 
@@ -3452,7 +3452,7 @@ L 165.475826 155.317544
 L 165.131161 155.581701 
 L 164.786497 155.844575 
 L 164.441833 156.106179 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_104">
     <path d="M 164.441833 156.106179 
@@ -3504,7 +3504,7 @@ L 158.178848 164.710119
 L 158.03967 164.886608 
 L 157.900493 165.062524 
 L 157.761315 165.23787 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_105">
     <path d="M 157.761315 165.23787 
@@ -3556,7 +3556,7 @@ L 151.674847 177.950842
 L 151.539592 178.202046 
 L 151.404337 178.452089 
 L 151.269082 178.700983 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_106">
     <path d="M 151.269082 178.700983 
@@ -3608,11 +3608,11 @@ L 150.385962 184.850776
 L 150.366337 184.979807 
 L 150.346712 185.108531 
 L 150.327087 185.23695 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_107">
     <defs>
-     <path id="m52d536e5b4" d="M -1.25 2.5 
+     <path id="mee1785d91c" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -3627,16 +3627,16 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pbea61dadc3)">
-     <use xlink:href="#m52d536e5b4" x="345.030867" y="136.859359" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m52d536e5b4" x="273.364924" y="143.571257" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m52d536e5b4" x="240.719951" y="149.310846" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m52d536e5b4" x="221.353978" y="154.160538" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m52d536e5b4" x="207.129625" y="156.092215" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m52d536e5b4" x="181.064802" y="166.758473" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m52d536e5b4" x="179.282169" y="170.289343" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m52d536e5b4" x="177.719335" y="175.489948" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m52d536e5b4" x="177.643939" y="181.552088" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p21d9583499)">
+     <use xlink:href="#mee1785d91c" x="345.030867" y="136.859359" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mee1785d91c" x="273.364924" y="143.571257" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mee1785d91c" x="240.719951" y="149.310846" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mee1785d91c" x="221.353978" y="154.160538" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mee1785d91c" x="207.129625" y="156.092215" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mee1785d91c" x="181.064802" y="166.758473" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mee1785d91c" x="179.282169" y="170.289343" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mee1785d91c" x="177.719335" y="175.489948" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mee1785d91c" x="177.643939" y="181.552088" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_108">
@@ -3689,7 +3689,7 @@ L 277.844045 143.175283
 L 276.351005 143.307597 
 L 274.857964 143.439587 
 L 273.364924 143.571257 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_109">
     <path d="M 273.364924 143.571257 
@@ -3741,7 +3741,7 @@ L 242.760262 148.96941
 L 242.080158 149.083462 
 L 241.400055 149.197273 
 L 240.719951 149.310846 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_110">
     <path d="M 240.719951 149.310846 
@@ -3793,7 +3793,7 @@ L 222.564351 153.869835
 L 222.160893 153.966909 
 L 221.757435 154.06381 
 L 221.353978 154.160538 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_111">
     <path d="M 221.353978 154.160538 
@@ -3845,7 +3845,7 @@ L 208.018647 155.973483
 L 207.722306 156.013089 
 L 207.425965 156.052666 
 L 207.129625 156.092215 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_112">
     <path d="M 207.129625 156.092215 
@@ -3897,7 +3897,7 @@ L 182.693853 166.149994
 L 182.150836 166.353581 
 L 181.607819 166.556405 
 L 181.064802 166.758473 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_113">
     <path d="M 181.064802 166.758473 
@@ -3949,7 +3949,7 @@ L 179.393584 170.075284
 L 179.356445 170.146731 
 L 179.319307 170.218084 
 L 179.282169 170.289343 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_114">
     <path d="M 179.282169 170.289343 
@@ -4001,7 +4001,7 @@ L 177.817012 175.179146
 L 177.784453 175.282945 
 L 177.751894 175.386546 
 L 177.719335 175.489948 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_115">
     <path d="M 177.719335 175.489948 
@@ -4053,11 +4053,11 @@ L 177.648651 181.192458
 L 177.64708 181.3126 
 L 177.645509 181.432477 
 L 177.643939 181.552088 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_116">
     <defs>
-     <path id="m00f7baae95" d="M 0 -2.5 
+     <path id="m6a5ab4ae5d" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -4070,16 +4070,16 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#pbea61dadc3)">
-     <use xlink:href="#m00f7baae95" x="226.871027" y="113.224491" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m00f7baae95" x="226.871027" y="113.066324" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m00f7baae95" x="226.871027" y="113.178221" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m00f7baae95" x="226.871027" y="113.089884" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m00f7baae95" x="177.768423" y="132.327899" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m00f7baae95" x="160.37503" y="145.652356" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m00f7baae95" x="153.995779" y="152.678629" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m00f7baae95" x="147.106887" y="168.143801" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m00f7baae95" x="145.871703" y="175.118358" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p21d9583499)">
+     <use xlink:href="#m6a5ab4ae5d" x="226.871027" y="113.224491" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m6a5ab4ae5d" x="226.871027" y="113.066324" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m6a5ab4ae5d" x="226.871027" y="113.178221" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m6a5ab4ae5d" x="226.871027" y="113.089884" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m6a5ab4ae5d" x="177.768423" y="132.327899" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m6a5ab4ae5d" x="160.37503" y="145.652356" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m6a5ab4ae5d" x="153.995779" y="152.678629" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m6a5ab4ae5d" x="147.106887" y="168.143801" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m6a5ab4ae5d" x="145.871703" y="175.118358" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_117">
@@ -4132,7 +4132,7 @@ L 226.871027 113.076223
 L 226.871027 113.072924 
 L 226.871027 113.069624 
 L 226.871027 113.066324 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_118">
     <path d="M 226.871027 113.066324 
@@ -4184,7 +4184,7 @@ L 226.871027 113.171234
 L 226.871027 113.173563 
 L 226.871027 113.175892 
 L 226.871027 113.178221 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_119">
     <path d="M 226.871027 113.178221 
@@ -4236,7 +4236,7 @@ L 226.871027 113.09541
 L 226.871027 113.093568 
 L 226.871027 113.091726 
 L 226.871027 113.089884 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_120">
     <path d="M 226.871027 113.089884 
@@ -4288,7 +4288,7 @@ L 180.837336 131.306392
 L 179.814365 131.649041 
 L 178.791394 131.989534 
 L 177.768423 132.327899 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_121">
     <path d="M 177.768423 132.327899 
@@ -4340,7 +4340,7 @@ L 161.462117 144.909076
 L 161.099755 145.157972 
 L 160.737393 145.405728 
 L 160.37503 145.652356 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_122">
     <path d="M 160.37503 145.652356 
@@ -4392,7 +4392,7 @@ L 154.394483 152.265218
 L 154.261581 152.403373 
 L 154.12868 152.541176 
 L 153.995779 152.678629 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_123">
     <path d="M 153.995779 152.678629 
@@ -4444,7 +4444,7 @@ L 147.537442 167.296442
 L 147.393924 167.580372 
 L 147.250405 167.862819 
 L 147.106887 168.143801 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_124">
     <path d="M 147.106887 168.143801 
@@ -4496,11 +4496,11 @@ L 145.948902 174.70781
 L 145.923169 174.845005 
 L 145.897436 174.981854 
 L 145.871703 175.118358 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_125">
     <defs>
-     <path id="m1528a399dc" d="M 0 -2.5 
+     <path id="m1d2551259d" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -4509,16 +4509,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pbea61dadc3)">
-     <use xlink:href="#m1528a399dc" x="585.66883" y="173.051371" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1528a399dc" x="527.144592" y="175.326465" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1528a399dc" x="457.339427" y="183.688849" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1528a399dc" x="292.124837" y="178.486631" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1528a399dc" x="243.129344" y="190.369032" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1528a399dc" x="213.541392" y="204.43395" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1528a399dc" x="204.551957" y="212.140784" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1528a399dc" x="195.860087" y="228.582256" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1528a399dc" x="194.019853" y="234.294862" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p21d9583499)">
+     <use xlink:href="#m1d2551259d" x="585.66883" y="173.051371" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1d2551259d" x="527.144592" y="175.326465" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1d2551259d" x="457.339427" y="183.688849" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1d2551259d" x="292.124837" y="178.486631" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1d2551259d" x="243.129344" y="190.369032" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1d2551259d" x="213.541392" y="204.43395" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1d2551259d" x="204.551957" y="212.140784" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1d2551259d" x="195.860087" y="228.582256" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1d2551259d" x="194.019853" y="234.294862" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_126">
@@ -4571,7 +4571,7 @@ L 530.802357 175.187039
 L 529.583102 175.233554 
 L 528.363847 175.28003 
 L 527.144592 175.326465 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_127">
     <path d="M 527.144592 175.326465 
@@ -4623,7 +4623,7 @@ L 461.70225 183.20239
 L 460.247976 183.36503 
 L 458.793701 183.527182 
 L 457.339427 183.688849 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_128">
     <path d="M 457.339427 183.688849 
@@ -4675,7 +4675,7 @@ L 302.450749 178.826834
 L 299.008779 178.713671 
 L 295.566808 178.60027 
 L 292.124837 178.486631 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_129">
     <path d="M 292.124837 178.486631 
@@ -4727,7 +4727,7 @@ L 246.191563 189.6981
 L 245.170823 189.922669 
 L 244.150084 190.146311 
 L 243.129344 190.369032 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_130">
     <path d="M 243.129344 190.369032 
@@ -4779,7 +4779,7 @@ L 215.390639 203.654226
 L 214.774224 203.915384 
 L 214.157808 204.175288 
 L 213.541392 204.43395 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_131">
     <path d="M 213.541392 204.43395 
@@ -4831,7 +4831,7 @@ L 205.113797 211.689953
 L 204.926517 211.840648 
 L 204.739237 211.990924 
 L 204.551957 212.140784 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_132">
     <path d="M 204.551957 212.140784 
@@ -4883,7 +4883,7 @@ L 196.403329 227.688717
 L 196.222248 227.988205 
 L 196.041168 228.286045 
 L 195.860087 228.582256 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_133">
     <path d="M 195.860087 228.582256 
@@ -4935,7 +4935,7 @@ L 194.134867 233.954953
 L 194.096529 234.068494 
 L 194.058191 234.181796 
 L 194.019853 234.294862 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="legend_1">
     <g id="patch_7">
@@ -4953,7 +4953,7 @@ z
     </g>
     <g id="line2d_134">
      <defs>
-      <path id="m3e43abbbac" d="M 0 3.5 
+      <path id="m7af52bbf39" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -4966,7 +4966,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m3e43abbbac" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m7af52bbf39" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -5025,7 +5025,7 @@ z
     </g>
     <g id="line2d_135">
      <g>
-      <use xlink:href="#m62136bef61" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m8021e33023" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -5039,7 +5039,7 @@ z
     </g>
     <g id="line2d_136">
      <g>
-      <use xlink:href="#m1ffa8fa975" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m1e1abfc02b" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -5084,7 +5084,7 @@ z
     </g>
     <g id="line2d_137">
      <g>
-      <use xlink:href="#m2915dfd003" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m5a7f2031e7" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -5127,7 +5127,7 @@ z
     </g>
     <g id="line2d_138">
      <g>
-      <use xlink:href="#m6e21457418" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m39d336fd0f" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -5143,7 +5143,7 @@ z
     </g>
     <g id="line2d_139">
      <g>
-      <use xlink:href="#m74cfb33100" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mc70085bc84" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -5197,7 +5197,7 @@ z
     </g>
     <g id="line2d_140">
      <g>
-      <use xlink:href="#m52d536e5b4" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mee1785d91c" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -5262,7 +5262,7 @@ z
     </g>
     <g id="line2d_141">
      <g>
-      <use xlink:href="#m00f7baae95" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#m6a5ab4ae5d" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -5300,7 +5300,7 @@ z
     </g>
     <g id="line2d_142">
      <g>
-      <use xlink:href="#m1528a399dc" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m1d2551259d" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -5370,486 +5370,486 @@ z
     </g>
    </g>
    <g id="line2d_143">
-    <g clip-path="url(#pbea61dadc3)">
-     <use xlink:href="#m3e43abbbac" x="319.643112" y="128.107026" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m3e43abbbac" x="269.129958" y="143.921076" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m3e43abbbac" x="247.452898" y="148.934277" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m3e43abbbac" x="192.820547" y="160.90313" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m3e43abbbac" x="180.389901" y="170.909251" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m3e43abbbac" x="156.350594" y="180.616864" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m3e43abbbac" x="147.843012" y="189.600549" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m3e43abbbac" x="146.231533" y="193.578961" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m3e43abbbac" x="119.590386" y="288.745993" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m3e43abbbac" x="97.799363" y="316.5192" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <g clip-path="url(#p21d9583499)">
+     <use xlink:href="#m7af52bbf39" x="319.643112" y="123.779184" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m7af52bbf39" x="269.129958" y="139.427151" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m7af52bbf39" x="247.452898" y="144.401126" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m7af52bbf39" x="192.820547" y="156.792234" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m7af52bbf39" x="180.389901" y="167.242695" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m7af52bbf39" x="156.350594" y="177.250032" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m7af52bbf39" x="147.843012" y="186.309462" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m7af52bbf39" x="146.231533" y="190.194023" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m7af52bbf39" x="119.590386" y="286.756333" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m7af52bbf39" x="97.799363" y="314.724011" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
    <g id="line2d_144">
-    <path d="M 319.643112 128.107026 
-L 318.590755 128.488314 
-L 317.538397 128.866934 
-L 316.48604 129.242925 
-L 315.433682 129.616323 
-L 314.381325 129.987162 
-L 313.328968 130.355478 
-L 312.27661 130.721305 
-L 311.224253 131.084676 
-L 310.171896 131.445624 
-L 309.119538 131.804181 
-L 308.067181 132.160379 
-L 307.014823 132.514248 
-L 305.962466 132.865819 
-L 304.910109 133.215121 
-L 303.857751 133.562184 
-L 302.805394 133.907036 
-L 301.753037 134.249704 
-L 300.700679 134.590218 
-L 299.648322 134.928602 
-L 298.595965 135.264884 
-L 297.543607 135.599091 
-L 296.49125 135.931246 
-L 295.438892 136.261376 
-L 294.386535 136.589504 
-L 293.334178 136.915656 
-L 292.28182 137.239854 
-L 291.229463 137.562122 
-L 290.177106 137.882482 
-L 289.124748 138.200958 
-L 288.072391 138.517571 
-L 287.020033 138.832343 
-L 285.967676 139.145296 
-L 284.915319 139.456449 
-L 283.862961 139.765824 
-L 282.810604 140.073441 
-L 281.758247 140.37932 
-L 280.705889 140.683479 
-L 279.653532 140.98594 
-L 278.601175 141.28672 
-L 277.548817 141.585837 
-L 276.49646 141.883311 
-L 275.444102 142.179159 
-L 274.391745 142.473399 
-L 273.339388 142.766049 
-L 272.28703 143.057124 
-L 271.234673 143.346643 
-L 270.182316 143.634622 
-L 269.129958 143.921076 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 319.643112 123.779184 
+L 318.590755 124.155877 
+L 317.538397 124.529967 
+L 316.48604 124.901489 
+L 315.433682 125.270479 
+L 314.381325 125.63697 
+L 313.328968 126.000997 
+L 312.27661 126.362592 
+L 311.224253 126.721788 
+L 310.171896 127.078616 
+L 309.119538 127.433107 
+L 308.067181 127.785292 
+L 307.014823 128.1352 
+L 305.962466 128.482861 
+L 304.910109 128.828303 
+L 303.857751 129.171555 
+L 302.805394 129.512644 
+L 301.753037 129.851597 
+L 300.700679 130.188441 
+L 299.648322 130.523202 
+L 298.595965 130.855905 
+L 297.543607 131.186576 
+L 296.49125 131.515239 
+L 295.438892 131.841919 
+L 294.386535 132.166639 
+L 293.334178 132.489422 
+L 292.28182 132.810293 
+L 291.229463 133.129272 
+L 290.177106 133.446383 
+L 289.124748 133.761647 
+L 288.072391 134.075086 
+L 287.020033 134.38672 
+L 285.967676 134.69657 
+L 284.915319 135.004657 
+L 283.862961 135.311 
+L 282.810604 135.615619 
+L 281.758247 135.918534 
+L 280.705889 136.219763 
+L 279.653532 136.519324 
+L 278.601175 136.817238 
+L 277.548817 137.11352 
+L 276.49646 137.40819 
+L 275.444102 137.701265 
+L 274.391745 137.992761 
+L 273.339388 138.282696 
+L 272.28703 138.571086 
+L 271.234673 138.857948 
+L 270.182316 139.143298 
+L 269.129958 139.427151 
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_145">
-    <path d="M 269.129958 143.921076 
-L 268.678353 144.030397 
-L 268.226747 144.139497 
-L 267.775142 144.248377 
-L 267.323537 144.357039 
-L 266.871931 144.465483 
-L 266.420326 144.573711 
-L 265.96872 144.681722 
-L 265.517115 144.789519 
-L 265.065509 144.897101 
-L 264.613904 145.00447 
-L 264.162299 145.111626 
-L 263.710693 145.21857 
-L 263.259088 145.325304 
-L 262.807482 145.431828 
-L 262.355877 145.538142 
-L 261.904271 145.644248 
-L 261.452666 145.750147 
-L 261.001061 145.855838 
-L 260.549455 145.961324 
-L 260.09785 146.066605 
-L 259.646244 146.171681 
-L 259.194639 146.276553 
-L 258.743034 146.381223 
-L 258.291428 146.485691 
-L 257.839823 146.589958 
-L 257.388217 146.694024 
-L 256.936612 146.79789 
-L 256.485006 146.901558 
-L 256.033401 147.005027 
-L 255.581796 147.108299 
-L 255.13019 147.211375 
-L 254.678585 147.314254 
-L 254.226979 147.416938 
-L 253.775374 147.519428 
-L 253.323769 147.621724 
-L 252.872163 147.723828 
-L 252.420558 147.825739 
-L 251.968952 147.927458 
-L 251.517347 148.028987 
-L 251.065741 148.130326 
-L 250.614136 148.231475 
-L 250.162531 148.332436 
-L 249.710925 148.433208 
-L 249.25932 148.533794 
-L 248.807714 148.634193 
-L 248.356109 148.734406 
-L 247.904503 148.834433 
-L 247.452898 148.934277 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 269.129958 139.427151 
+L 268.678353 139.535577 
+L 268.226747 139.643786 
+L 267.775142 139.75178 
+L 267.323537 139.859558 
+L 266.871931 139.967122 
+L 266.420326 140.074473 
+L 265.96872 140.181611 
+L 265.517115 140.288538 
+L 265.065509 140.395254 
+L 264.613904 140.50176 
+L 264.162299 140.608057 
+L 263.710693 140.714145 
+L 263.259088 140.820026 
+L 262.807482 140.9257 
+L 262.355877 141.031169 
+L 261.904271 141.136432 
+L 261.452666 141.241491 
+L 261.001061 141.346346 
+L 260.549455 141.450999 
+L 260.09785 141.55545 
+L 259.646244 141.659699 
+L 259.194639 141.763749 
+L 258.743034 141.867598 
+L 258.291428 141.971249 
+L 257.839823 142.074702 
+L 257.388217 142.177957 
+L 256.936612 142.281016 
+L 256.485006 142.383879 
+L 256.033401 142.486547 
+L 255.581796 142.58902 
+L 255.13019 142.6913 
+L 254.678585 142.793387 
+L 254.226979 142.895282 
+L 253.775374 142.996985 
+L 253.323769 143.098498 
+L 252.872163 143.19982 
+L 252.420558 143.300954 
+L 251.968952 143.401899 
+L 251.517347 143.502655 
+L 251.065741 143.603225 
+L 250.614136 143.703608 
+L 250.162531 143.803806 
+L 249.710925 143.903818 
+L 249.25932 144.003646 
+L 248.807714 144.10329 
+L 248.356109 144.20275 
+L 247.904503 144.302029 
+L 247.452898 144.401126 
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_146">
-    <path d="M 247.452898 148.934277 
-L 246.314724 149.212627 
-L 245.17655 149.489553 
-L 244.038376 149.76507 
-L 242.900202 150.039191 
-L 241.762028 150.311932 
-L 240.623854 150.583305 
-L 239.48568 150.853324 
-L 238.347506 151.122003 
-L 237.209332 151.389355 
-L 236.071158 151.655393 
-L 234.932984 151.92013 
-L 233.79481 152.183579 
-L 232.656636 152.445752 
-L 231.518462 152.706661 
-L 230.380288 152.966318 
-L 229.242114 153.224736 
-L 228.10394 153.481926 
-L 226.965766 153.7379 
-L 225.827592 153.992669 
-L 224.689418 154.246245 
-L 223.551244 154.498638 
-L 222.41307 154.74986 
-L 221.274896 154.999921 
-L 220.136722 155.248833 
-L 218.998548 155.496605 
-L 217.860374 155.743248 
-L 216.7222 155.988773 
-L 215.584026 156.233189 
-L 214.445852 156.476506 
-L 213.307678 156.718735 
-L 212.169505 156.959884 
-L 211.031331 157.199964 
-L 209.893157 157.438984 
-L 208.754983 157.676953 
-L 207.616809 157.913881 
-L 206.478635 158.149776 
-L 205.340461 158.384647 
-L 204.202287 158.618504 
-L 203.064113 158.851355 
-L 201.925939 159.083208 
-L 200.787765 159.314073 
-L 199.649591 159.543957 
-L 198.511417 159.772869 
-L 197.373243 160.000817 
-L 196.235069 160.227809 
-L 195.096895 160.453853 
-L 193.958721 160.678958 
-L 192.820547 160.90313 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 247.452898 144.401126 
+L 246.314724 144.690435 
+L 245.17655 144.978206 
+L 244.038376 145.264456 
+L 242.900202 145.5492 
+L 241.762028 145.832454 
+L 240.623854 146.114233 
+L 239.48568 146.394553 
+L 238.347506 146.673429 
+L 237.209332 146.950876 
+L 236.071158 147.226908 
+L 234.932984 147.501539 
+L 233.79481 147.774784 
+L 232.656636 148.046657 
+L 231.518462 148.317171 
+L 230.380288 148.58634 
+L 229.242114 148.854177 
+L 228.10394 149.120696 
+L 226.965766 149.385908 
+L 225.827592 149.649828 
+L 224.689418 149.912467 
+L 223.551244 150.173838 
+L 222.41307 150.433953 
+L 221.274896 150.692824 
+L 220.136722 150.950463 
+L 218.998548 151.206881 
+L 217.860374 151.462091 
+L 216.7222 151.716103 
+L 215.584026 151.968928 
+L 214.445852 152.220578 
+L 213.307678 152.471064 
+L 212.169505 152.720396 
+L 211.031331 152.968585 
+L 209.893157 153.215641 
+L 208.754983 153.461574 
+L 207.616809 153.706396 
+L 206.478635 153.950115 
+L 205.340461 154.192741 
+L 204.202287 154.434285 
+L 203.064113 154.674756 
+L 201.925939 154.914164 
+L 200.787765 155.152517 
+L 199.649591 155.389825 
+L 198.511417 155.626098 
+L 197.373243 155.861344 
+L 196.235069 156.095571 
+L 195.096895 156.32879 
+L 193.958721 156.561008 
+L 192.820547 156.792234 
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_147">
-    <path d="M 192.820547 160.90313 
-L 192.561575 161.131619 
-L 192.302603 161.359147 
-L 192.043631 161.585724 
-L 191.78466 161.811355 
-L 191.525688 162.036051 
-L 191.266716 162.259817 
-L 191.007744 162.482662 
-L 190.748773 162.704594 
-L 190.489801 162.925619 
-L 190.230829 163.145746 
-L 189.971857 163.364981 
-L 189.712885 163.583331 
-L 189.453914 163.800805 
-L 189.194942 164.017408 
-L 188.93597 164.233148 
-L 188.676998 164.448031 
-L 188.418027 164.662065 
-L 188.159055 164.875256 
-L 187.900083 165.087611 
-L 187.641111 165.299136 
-L 187.382139 165.509837 
-L 187.123168 165.719722 
-L 186.864196 165.928795 
-L 186.605224 166.137065 
-L 186.346252 166.344536 
-L 186.087281 166.551215 
-L 185.828309 166.757108 
-L 185.569337 166.962221 
-L 185.310365 167.166559 
-L 185.051393 167.370129 
-L 184.792422 167.572937 
-L 184.53345 167.774987 
-L 184.274478 167.976286 
-L 184.015506 168.176839 
-L 183.756535 168.376652 
-L 183.497563 168.57573 
-L 183.238591 168.774078 
-L 182.979619 168.971703 
-L 182.720647 169.168608 
-L 182.461676 169.3648 
-L 182.202704 169.560284 
-L 181.943732 169.755064 
-L 181.68476 169.949145 
-L 181.425789 170.142534 
-L 181.166817 170.335233 
-L 180.907845 170.52725 
-L 180.648873 170.718587 
-L 180.389901 170.909251 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 192.820547 156.792234 
+L 192.561575 157.031858 
+L 192.302603 157.270425 
+L 192.043631 157.507945 
+L 191.78466 157.744428 
+L 191.525688 157.979882 
+L 191.266716 158.214316 
+L 191.007744 158.447739 
+L 190.748773 158.68016 
+L 190.489801 158.911588 
+L 190.230829 159.14203 
+L 189.971857 159.371495 
+L 189.712885 159.599992 
+L 189.453914 159.827529 
+L 189.194942 160.054112 
+L 188.93597 160.279752 
+L 188.676998 160.504455 
+L 188.418027 160.728228 
+L 188.159055 160.951081 
+L 187.900083 161.17302 
+L 187.641111 161.394052 
+L 187.382139 161.614186 
+L 187.123168 161.833428 
+L 186.864196 162.051786 
+L 186.605224 162.269267 
+L 186.346252 162.485877 
+L 186.087281 162.701624 
+L 185.828309 162.916514 
+L 185.569337 163.130555 
+L 185.310365 163.343753 
+L 185.051393 163.556114 
+L 184.792422 163.767646 
+L 184.53345 163.978354 
+L 184.274478 164.188245 
+L 184.015506 164.397325 
+L 183.756535 164.605601 
+L 183.497563 164.813079 
+L 183.238591 165.019764 
+L 182.979619 165.225663 
+L 182.720647 165.430782 
+L 182.461676 165.635127 
+L 182.202704 165.838703 
+L 181.943732 166.041517 
+L 181.68476 166.243573 
+L 181.425789 166.444878 
+L 181.166817 166.645437 
+L 180.907845 166.845256 
+L 180.648873 167.04434 
+L 180.389901 167.242695 
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_148">
-    <path d="M 180.389901 170.909251 
-L 179.889083 171.13031 
-L 179.388264 171.350469 
-L 178.887445 171.569737 
-L 178.386626 171.788121 
-L 177.885807 172.005627 
-L 177.384988 172.222262 
-L 176.884169 172.438034 
-L 176.38335 172.652949 
-L 175.882531 172.867015 
-L 175.381713 173.080237 
-L 174.880894 173.292623 
-L 174.380075 173.504178 
-L 173.879256 173.71491 
-L 173.378437 173.924825 
-L 172.877618 174.133929 
-L 172.376799 174.342228 
-L 171.87598 174.549729 
-L 171.375161 174.756437 
-L 170.874342 174.962359 
-L 170.373524 175.167501 
-L 169.872705 175.371868 
-L 169.371886 175.575466 
-L 168.871067 175.778302 
-L 168.370248 175.98038 
-L 167.869429 176.181707 
-L 167.36861 176.382288 
-L 166.867791 176.582128 
-L 166.366972 176.781234 
-L 165.866154 176.979609 
-L 165.365335 177.17726 
-L 164.864516 177.374193 
-L 164.363697 177.570411 
-L 163.862878 177.76592 
-L 163.362059 177.960727 
-L 162.86124 178.154834 
-L 162.360421 178.348248 
-L 161.859602 178.540973 
-L 161.358783 178.733015 
-L 160.857965 178.924377 
-L 160.357146 179.115066 
-L 159.856327 179.305085 
-L 159.355508 179.49444 
-L 158.854689 179.683134 
-L 158.35387 179.871173 
-L 157.853051 180.058561 
-L 157.352232 180.245303 
-L 156.851413 180.431402 
-L 156.350594 180.616864 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 180.389901 167.242695 
+L 179.889083 167.471214 
+L 179.388264 167.698773 
+L 178.887445 167.925379 
+L 178.386626 168.15104 
+L 177.885807 168.375765 
+L 177.384988 168.59956 
+L 176.884169 168.822434 
+L 176.38335 169.044394 
+L 175.882531 169.265448 
+L 175.381713 169.485603 
+L 174.880894 169.704866 
+L 174.380075 169.923244 
+L 173.879256 170.140745 
+L 173.378437 170.357376 
+L 172.877618 170.573143 
+L 172.376799 170.788053 
+L 171.87598 171.002114 
+L 171.375161 171.215331 
+L 170.874342 171.427712 
+L 170.373524 171.639263 
+L 169.872705 171.84999 
+L 169.371886 172.0599 
+L 168.871067 172.268999 
+L 168.370248 172.477294 
+L 167.869429 172.68479 
+L 167.36861 172.891494 
+L 166.867791 173.097412 
+L 166.366972 173.302549 
+L 165.866154 173.506912 
+L 165.365335 173.710506 
+L 164.864516 173.913337 
+L 164.363697 174.115411 
+L 163.862878 174.316734 
+L 163.362059 174.51731 
+L 162.86124 174.717146 
+L 162.360421 174.916247 
+L 161.859602 175.114619 
+L 161.358783 175.312266 
+L 160.857965 175.509194 
+L 160.357146 175.705408 
+L 159.856327 175.900914 
+L 159.355508 176.095716 
+L 158.854689 176.28982 
+L 158.35387 176.48323 
+L 157.853051 176.675951 
+L 157.352232 176.867989 
+L 156.851413 177.059347 
+L 156.350594 177.250032 
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_149">
-    <path d="M 156.350594 180.616864 
-L 156.173353 180.820069 
-L 155.996112 181.022514 
-L 155.818871 181.224205 
-L 155.641629 181.425146 
-L 155.464388 181.625345 
-L 155.287147 181.824806 
-L 155.109905 182.023535 
-L 154.932664 182.221537 
-L 154.755423 182.418817 
-L 154.578182 182.615381 
-L 154.40094 182.811234 
-L 154.223699 183.006381 
-L 154.046458 183.200826 
-L 153.869216 183.394576 
-L 153.691975 183.587635 
-L 153.514734 183.780007 
-L 153.337492 183.971699 
-L 153.160251 184.162714 
-L 152.98301 184.353057 
-L 152.805769 184.542733 
-L 152.628527 184.731747 
-L 152.451286 184.920103 
-L 152.274045 185.107807 
-L 152.096803 185.294861 
-L 151.919562 185.481272 
-L 151.742321 185.667042 
-L 151.56508 185.852177 
-L 151.387838 186.036682 
-L 151.210597 186.220559 
-L 151.033356 186.403814 
-L 150.856114 186.586451 
-L 150.678873 186.768474 
-L 150.501632 186.949886 
-L 150.32439 187.130693 
-L 150.147149 187.310897 
-L 149.969908 187.490504 
-L 149.792667 187.669517 
-L 149.615425 187.84794 
-L 149.438184 188.025776 
-L 149.260943 188.203031 
-L 149.083701 188.379706 
-L 148.90646 188.555807 
-L 148.729219 188.731337 
-L 148.551977 188.9063 
-L 148.374736 189.080699 
-L 148.197495 189.254538 
-L 148.020254 189.42782 
-L 147.843012 189.600549 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 156.350594 177.250032 
+L 156.173353 177.455094 
+L 155.996112 177.659382 
+L 155.818871 177.862903 
+L 155.641629 178.06566 
+L 155.464388 178.267661 
+L 155.287147 178.468912 
+L 155.109905 178.669416 
+L 154.932664 178.869181 
+L 154.755423 179.068211 
+L 154.578182 179.266513 
+L 154.40094 179.46409 
+L 154.223699 179.660949 
+L 154.046458 179.857094 
+L 153.869216 180.052532 
+L 153.691975 180.247266 
+L 153.514734 180.441302 
+L 153.337492 180.634645 
+L 153.160251 180.8273 
+L 152.98301 181.019272 
+L 152.805769 181.210566 
+L 152.628527 181.401185 
+L 152.451286 181.591136 
+L 152.274045 181.780423 
+L 152.096803 181.96905 
+L 151.919562 182.157022 
+L 151.742321 182.344344 
+L 151.56508 182.531019 
+L 151.387838 182.717053 
+L 151.210597 182.90245 
+L 151.033356 183.087214 
+L 150.856114 183.27135 
+L 150.678873 183.454861 
+L 150.501632 183.637753 
+L 150.32439 183.820028 
+L 150.147149 184.001692 
+L 149.969908 184.182748 
+L 149.792667 184.3632 
+L 149.615425 184.543053 
+L 149.438184 184.722311 
+L 149.260943 184.900977 
+L 149.083701 185.079055 
+L 148.90646 185.256549 
+L 148.729219 185.433463 
+L 148.551977 185.6098 
+L 148.374736 185.785565 
+L 148.197495 185.960762 
+L 148.020254 186.135393 
+L 147.843012 186.309462 
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_150">
-    <path d="M 147.843012 189.600549 
-L 147.80944 189.686487 
-L 147.775867 189.772288 
-L 147.742295 189.857953 
-L 147.708722 189.943482 
-L 147.67515 190.028877 
-L 147.641577 190.114138 
-L 147.608005 190.199264 
-L 147.574432 190.284256 
-L 147.54086 190.369116 
-L 147.507287 190.453842 
-L 147.473715 190.538437 
-L 147.440142 190.622899 
-L 147.40657 190.707229 
-L 147.372997 190.791429 
-L 147.339425 190.875497 
-L 147.305852 190.959436 
-L 147.27228 191.043244 
-L 147.238707 191.126923 
-L 147.205135 191.210472 
-L 147.171562 191.293893 
-L 147.13799 191.377185 
-L 147.104417 191.46035 
-L 147.070845 191.543387 
-L 147.037273 191.626297 
-L 147.0037 191.70908 
-L 146.970128 191.791736 
-L 146.936555 191.874267 
-L 146.902983 191.956672 
-L 146.86941 192.038951 
-L 146.835838 192.121106 
-L 146.802265 192.203136 
-L 146.768693 192.285042 
-L 146.73512 192.366825 
-L 146.701548 192.448484 
-L 146.667975 192.53002 
-L 146.634403 192.611433 
-L 146.60083 192.692724 
-L 146.567258 192.773894 
-L 146.533685 192.854941 
-L 146.500113 192.935868 
-L 146.46654 193.016674 
-L 146.432968 193.097359 
-L 146.399395 193.177924 
-L 146.365823 193.25837 
-L 146.33225 193.338696 
-L 146.298678 193.418903 
-L 146.265105 193.498991 
-L 146.231533 193.578961 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 147.843012 186.309462 
+L 147.80944 186.3933 
+L 147.775867 186.477008 
+L 147.742295 186.560587 
+L 147.708722 186.644037 
+L 147.67515 186.727359 
+L 147.641577 186.810553 
+L 147.608005 186.893619 
+L 147.574432 186.976558 
+L 147.54086 187.059369 
+L 147.507287 187.142055 
+L 147.473715 187.224614 
+L 147.440142 187.307047 
+L 147.40657 187.389356 
+L 147.372997 187.471539 
+L 147.339425 187.553597 
+L 147.305852 187.635532 
+L 147.27228 187.717342 
+L 147.238707 187.79903 
+L 147.205135 187.880594 
+L 147.171562 187.962035 
+L 147.13799 188.043354 
+L 147.104417 188.124551 
+L 147.070845 188.205626 
+L 147.037273 188.286581 
+L 147.0037 188.367414 
+L 146.970128 188.448127 
+L 146.936555 188.528719 
+L 146.902983 188.609192 
+L 146.86941 188.689545 
+L 146.835838 188.769779 
+L 146.802265 188.849895 
+L 146.768693 188.929892 
+L 146.73512 189.009771 
+L 146.701548 189.089532 
+L 146.667975 189.169176 
+L 146.634403 189.248703 
+L 146.60083 189.328113 
+L 146.567258 189.407407 
+L 146.533685 189.486585 
+L 146.500113 189.565647 
+L 146.46654 189.644595 
+L 146.432968 189.723427 
+L 146.399395 189.802144 
+L 146.365823 189.880747 
+L 146.33225 189.959236 
+L 146.298678 190.037612 
+L 146.265105 190.115874 
+L 146.231533 190.194023 
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_151">
-    <path d="M 146.231533 193.578961 
-L 145.676509 198.739537 
-L 145.121485 203.450669 
-L 144.566461 207.78441 
-L 144.011437 211.796763 
-L 143.456413 215.532123 
-L 142.901389 219.026277 
-L 142.346365 222.308496 
-L 141.791342 225.403026 
-L 141.236318 228.330176 
-L 140.681294 231.107127 
-L 140.12627 233.748544 
-L 139.571246 236.267044 
-L 139.016222 238.67356 
-L 138.461198 240.977628 
-L 137.906174 243.187614 
-L 137.35115 245.310904 
-L 136.796126 247.354041 
-L 136.241103 249.322858 
-L 135.686079 251.222574 
-L 135.131055 253.057874 
-L 134.576031 254.832983 
-L 134.021007 256.551726 
-L 133.465983 258.217572 
-L 132.910959 259.833679 
-L 132.355935 261.402932 
-L 131.800911 262.927972 
-L 131.245887 264.411221 
-L 130.690864 265.85491 
-L 130.13584 267.261093 
-L 129.580816 268.63167 
-L 129.025792 269.968401 
-L 128.470768 271.272915 
-L 127.915744 272.546731 
-L 127.36072 273.791259 
-L 126.805696 275.007816 
-L 126.250672 276.197631 
-L 125.695648 277.361856 
-L 125.140625 278.501567 
-L 124.585601 279.617777 
-L 124.030577 280.711434 
-L 123.475553 281.783431 
-L 122.920529 282.834611 
-L 122.365505 283.865766 
-L 121.810481 284.877645 
-L 121.255457 285.870956 
-L 120.700433 286.846367 
-L 120.145409 287.804513 
-L 119.590386 288.745993 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 146.231533 190.194023 
+L 145.676509 195.509669 
+L 145.121485 200.349682 
+L 144.566461 204.792231 
+L 144.011437 208.897673 
+L 143.456413 212.713579 
+L 142.901389 216.27811 
+L 142.346365 219.62235 
+L 141.791342 222.771948 
+L 141.236318 225.748321 
+L 140.681294 228.569535 
+L 140.12627 231.250968 
+L 139.571246 233.805819 
+L 139.016222 236.245504 
+L 138.461198 238.579958 
+L 137.906174 240.817885 
+L 137.35115 242.966952 
+L 136.796126 245.033947 
+L 136.241103 247.024908 
+L 135.686079 248.945232 
+L 135.131055 250.799759 
+L 134.576031 252.592849 
+L 134.021007 254.328443 
+L 133.465983 256.010113 
+L 132.910959 257.641111 
+L 132.355935 259.224399 
+L 131.800911 260.762691 
+L 131.245887 262.258473 
+L 130.690864 263.714032 
+L 130.13584 265.131474 
+L 129.580816 266.512746 
+L 129.025792 267.859646 
+L 128.470768 269.173845 
+L 127.915744 270.456893 
+L 127.36072 271.710232 
+L 126.805696 272.935207 
+L 126.250672 274.133073 
+L 125.695648 275.305005 
+L 125.140625 276.452101 
+L 124.585601 277.575393 
+L 124.030577 278.675848 
+L 123.475553 279.754377 
+L 122.920529 280.811836 
+L 122.365505 281.849032 
+L 121.810481 282.866728 
+L 121.255457 283.865644 
+L 120.700433 284.846459 
+L 120.145409 285.809818 
+L 119.590386 286.756333 
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_152">
-    <path d="M 119.590386 288.745993 
-L 119.136406 289.496811 
-L 118.682426 290.237357 
-L 118.228447 290.967909 
-L 117.774467 291.688732 
-L 117.320487 292.400083 
-L 116.866508 293.102207 
-L 116.412528 293.79534 
-L 115.958549 294.47971 
-L 115.504569 295.155535 
-L 115.050589 295.823027 
-L 114.59661 296.482388 
-L 114.14263 297.133814 
-L 113.68865 297.777494 
-L 113.234671 298.413609 
-L 112.780691 299.042337 
-L 112.326712 299.663845 
-L 111.872732 300.278298 
-L 111.418752 300.885855 
-L 110.964773 301.486669 
-L 110.510793 302.080887 
-L 110.056813 302.668652 
-L 109.602834 303.250105 
-L 109.148854 303.825378 
-L 108.694874 304.394601 
-L 108.240895 304.957901 
-L 107.786915 305.515399 
-L 107.332936 306.067215 
-L 106.878956 306.613461 
-L 106.424976 307.154251 
-L 105.970997 307.689691 
-L 105.517017 308.219887 
-L 105.063037 308.74494 
-L 104.609058 309.264949 
-L 104.155078 309.78001 
-L 103.701099 310.290217 
-L 103.247119 310.795659 
-L 102.793139 311.296426 
-L 102.33916 311.792602 
-L 101.88518 312.284272 
-L 101.4312 312.771516 
-L 100.977221 313.254414 
-L 100.523241 313.733041 
-L 100.069262 314.207474 
-L 99.615282 314.677784 
-L 99.161302 315.144044 
-L 98.707323 315.606322 
-L 98.253343 316.064685 
-L 97.799363 316.5192 
-" clip-path="url(#pbea61dadc3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 119.590386 286.756333 
+L 119.136406 287.513837 
+L 118.682426 288.260886 
+L 118.228447 288.997766 
+L 117.774467 289.72475 
+L 117.320487 290.442099 
+L 116.866508 291.150067 
+L 116.412528 291.848894 
+L 115.958549 292.538814 
+L 115.504569 293.220052 
+L 115.050589 293.892823 
+L 114.59661 294.557335 
+L 114.14263 295.213788 
+L 113.68865 295.862376 
+L 113.234671 296.503284 
+L 112.780691 297.136693 
+L 112.326712 297.762776 
+L 111.872732 298.3817 
+L 111.418752 298.993627 
+L 110.964773 299.598714 
+L 110.510793 300.197112 
+L 110.056813 300.788967 
+L 109.602834 301.374421 
+L 109.148854 301.953611 
+L 108.694874 302.526669 
+L 108.240895 303.093724 
+L 107.786915 303.654901 
+L 107.332936 304.210319 
+L 106.878956 304.760096 
+L 106.424976 305.304346 
+L 105.970997 305.843178 
+L 105.517017 306.376699 
+L 105.063037 306.905013 
+L 104.609058 307.42822 
+L 104.155078 307.946419 
+L 103.701099 308.459704 
+L 103.247119 308.968168 
+L 102.793139 309.4719 
+L 102.33916 309.970987 
+L 101.88518 310.465515 
+L 101.4312 310.955566 
+L 100.977221 311.441221 
+L 100.523241 311.922556 
+L 100.069262 312.39965 
+L 99.615282 312.872575 
+L 99.161302 313.341405 
+L 98.707323 313.806208 
+L 98.253343 314.267055 
+L 97.799363 314.724011 
+" clip-path="url(#p21d9583499)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
   </g>
   <g id="text_25">
@@ -6166,8 +6166,8 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-07-08T06:11:08Z  ·  Linux chungus2 x86_64  ·  commit 28336125  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(43.380391 465.66) scale(0.07 -0.07)">
+   <!-- 2026-07-08T15:47:33Z  ·  Linux chungus2 x86_64  ·  commit f2026e66  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(44.448437 465.66) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -6188,6 +6188,31 @@ L 1638 0
 L 1638 4134 
 L -19 4134 
 L -19 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-3a" d="M 750 794 
@@ -6260,31 +6285,6 @@ Q 2894 3584 3203 3211
 Q 3513 2838 3513 2113 
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
-z
-" transform="scale(0.015625)"/>
      <path id="DejaVuSans-3d" d="M 678 2906 
 L 4684 2906 
 L 4684 2381 
@@ -6325,14 +6325,14 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-38" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -6372,109 +6372,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3262.744141 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3326.367188 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3389.990234 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3453.613281 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3517.236328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3580.859375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3612.646484 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3644.433594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3676.220703 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3708.007812 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3739.794922 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3767.578125 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3829.101562 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3890.380859 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3953.759766 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4017.236328 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4056.099609 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4117.28125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4176.460938 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4237.984375 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4279.097656 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4312.789062 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4340.572266 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4402.095703 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4463.375 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4526.753906 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4590.376953 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4624.068359 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4683.248047 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4746.871094 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4778.658203 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4842.28125 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4905.904297 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4937.691406 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(5001.314453 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5037.398438 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5076.261719 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5131.242188 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5194.865234 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5226.652344 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5258.439453 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5290.226562 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5322.013672 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5353.800781 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5393.009766 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5456.388672 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5495.251953 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5556.433594 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5619.8125 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5683.289062 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5746.667969 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5810.144531 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5873.523438 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5912.732422 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5944.519531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6028.308594 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6060.095703 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6157.507812 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6219.03125 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6282.507812 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6310.291016 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6371.570312 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6434.949219 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6466.736328 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6518.835938 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6582.214844 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6643.494141 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6706.970703 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6759.070312 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6822.449219 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6883.630859 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6922.839844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6956.53125 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6988.318359 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7029.431641 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7090.710938 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7129.919922 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7157.703125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7218.884766 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7250.671875 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7278.455078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7330.554688 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7362.341797 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7425.818359 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7487.341797 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7526.550781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7588.074219 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7627.4375 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7724.849609 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7752.632812 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7816.011719 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7843.794922 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7895.894531 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7935.103516 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7962.886719 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3107.080078 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3170.703125 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3234.326172 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3297.949219 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3361.572266 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3423.095703 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3486.71875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3550.341797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3582.128906 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3613.916016 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3645.703125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3677.490234 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3709.277344 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3737.060547 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3798.583984 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3859.863281 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3923.242188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3986.71875 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4025.582031 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4086.763672 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4145.943359 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4207.466797 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4248.580078 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4282.271484 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4310.054688 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4371.578125 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4432.857422 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4496.236328 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4559.859375 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4593.550781 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4652.730469 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4716.353516 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4748.140625 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4811.763672 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4875.386719 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4907.173828 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4970.796875 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5006.880859 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5045.744141 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5100.724609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5164.347656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5196.134766 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5227.921875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5259.708984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5291.496094 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5323.283203 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5362.492188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5425.871094 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5464.734375 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5525.916016 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5589.294922 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5652.771484 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5716.150391 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5779.626953 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5843.005859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5882.214844 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5914.001953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5997.791016 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6029.578125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6126.990234 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6188.513672 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6251.990234 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6279.773438 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6341.052734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6404.431641 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6436.21875 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6488.318359 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6551.697266 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6612.976562 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6676.453125 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6728.552734 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6791.931641 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6853.113281 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6892.322266 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6926.013672 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6957.800781 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6998.914062 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7060.193359 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7099.402344 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7127.185547 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7188.367188 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7220.154297 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7247.9375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7300.037109 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7331.824219 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7395.300781 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7456.824219 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7496.033203 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7557.556641 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7596.919922 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7694.332031 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7722.115234 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7785.494141 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7813.277344 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7865.376953 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7904.585938 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7932.369141 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pbea61dadc3">
+  <clipPath id="p21d9583499">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_decode_density.svg
+++ b/bench/graphs/silesia_decode_density.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 82.373685 412.80375 
 L 82.373685 47.3475 
-" clip-path="url(#p0db99e05ab)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p89333ce73e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m6a4ec14abd" d="M 0 0 
+       <path id="m9aac86e160" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m6a4ec14abd" x="82.373685" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9aac86e160" x="82.373685" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -111,11 +111,11 @@ z
      <g id="line2d_3">
       <path d="M 165.44644 412.80375 
 L 165.44644 47.3475 
-" clip-path="url(#p0db99e05ab)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p89333ce73e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m6a4ec14abd" x="165.44644" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9aac86e160" x="165.44644" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -157,11 +157,11 @@ z
      <g id="line2d_5">
       <path d="M 248.519195 412.80375 
 L 248.519195 47.3475 
-" clip-path="url(#p0db99e05ab)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p89333ce73e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m6a4ec14abd" x="248.519195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9aac86e160" x="248.519195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -211,11 +211,11 @@ z
      <g id="line2d_7">
       <path d="M 331.59195 412.80375 
 L 331.59195 47.3475 
-" clip-path="url(#p0db99e05ab)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p89333ce73e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m6a4ec14abd" x="331.59195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9aac86e160" x="331.59195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -252,11 +252,11 @@ z
      <g id="line2d_9">
       <path d="M 414.664704 412.80375 
 L 414.664704 47.3475 
-" clip-path="url(#p0db99e05ab)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p89333ce73e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m6a4ec14abd" x="414.664704" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9aac86e160" x="414.664704" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -299,11 +299,11 @@ z
      <g id="line2d_11">
       <path d="M 497.737459 412.80375 
 L 497.737459 47.3475 
-" clip-path="url(#p0db99e05ab)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p89333ce73e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m6a4ec14abd" x="497.737459" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9aac86e160" x="497.737459" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -351,11 +351,11 @@ z
      <g id="line2d_13">
       <path d="M 580.810214 412.80375 
 L 580.810214 47.3475 
-" clip-path="url(#p0db99e05ab)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p89333ce73e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m6a4ec14abd" x="580.810214" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9aac86e160" x="580.810214" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -897,16 +897,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 392.557757 
 L 637.2 392.557757 
-" clip-path="url(#p0db99e05ab)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p89333ce73e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="mf1996cff56" d="M 0 0 
+       <path id="m5e681aa6cf" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mf1996cff56" x="49.078125" y="392.557757" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5e681aa6cf" x="49.078125" y="392.557757" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -922,11 +922,11 @@ L -3.5 0
      <g id="line2d_17">
       <path d="M 49.078125 265.209319 
 L 637.2 265.209319 
-" clip-path="url(#p0db99e05ab)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p89333ce73e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mf1996cff56" x="49.078125" y="265.209319" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5e681aa6cf" x="49.078125" y="265.209319" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -942,11 +942,11 @@ L 637.2 265.209319
      <g id="line2d_19">
       <path d="M 49.078125 137.860881 
 L 637.2 137.860881 
-" clip-path="url(#p0db99e05ab)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p89333ce73e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#mf1996cff56" x="49.078125" y="137.860881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5e681aa6cf" x="49.078125" y="137.860881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -962,16 +962,16 @@ L 637.2 137.860881
      <g id="line2d_21">
       <path d="M 49.078125 412.284279 
 L 637.2 412.284279 
-" clip-path="url(#p0db99e05ab)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p89333ce73e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="m5fed76f5f0" d="M 0 0 
+       <path id="m340ca10544" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m5fed76f5f0" x="49.078125" y="412.284279" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m340ca10544" x="49.078125" y="412.284279" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -979,11 +979,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 404.899096 
 L 637.2 404.899096 
-" clip-path="url(#p0db99e05ab)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p89333ce73e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m5fed76f5f0" x="49.078125" y="404.899096" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m340ca10544" x="49.078125" y="404.899096" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -991,11 +991,11 @@ L 637.2 404.899096
      <g id="line2d_25">
       <path d="M 49.078125 398.384902 
 L 637.2 398.384902 
-" clip-path="url(#p0db99e05ab)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p89333ce73e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m5fed76f5f0" x="49.078125" y="398.384902" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m340ca10544" x="49.078125" y="398.384902" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1003,11 +1003,11 @@ L 637.2 398.384902
      <g id="line2d_27">
       <path d="M 49.078125 354.222057 
 L 637.2 354.222057 
-" clip-path="url(#p0db99e05ab)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p89333ce73e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m5fed76f5f0" x="49.078125" y="354.222057" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m340ca10544" x="49.078125" y="354.222057" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1015,11 +1015,11 @@ L 637.2 354.222057
      <g id="line2d_29">
       <path d="M 49.078125 331.79711 
 L 637.2 331.79711 
-" clip-path="url(#p0db99e05ab)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p89333ce73e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m5fed76f5f0" x="49.078125" y="331.79711" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m340ca10544" x="49.078125" y="331.79711" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1027,11 +1027,11 @@ L 637.2 331.79711
      <g id="line2d_31">
       <path d="M 49.078125 315.886357 
 L 637.2 315.886357 
-" clip-path="url(#p0db99e05ab)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p89333ce73e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m5fed76f5f0" x="49.078125" y="315.886357" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m340ca10544" x="49.078125" y="315.886357" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1039,11 +1039,11 @@ L 637.2 315.886357
      <g id="line2d_33">
       <path d="M 49.078125 303.545019 
 L 637.2 303.545019 
-" clip-path="url(#p0db99e05ab)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p89333ce73e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m5fed76f5f0" x="49.078125" y="303.545019" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m340ca10544" x="49.078125" y="303.545019" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1051,11 +1051,11 @@ L 637.2 303.545019
      <g id="line2d_35">
       <path d="M 49.078125 293.461411 
 L 637.2 293.461411 
-" clip-path="url(#p0db99e05ab)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p89333ce73e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m5fed76f5f0" x="49.078125" y="293.461411" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m340ca10544" x="49.078125" y="293.461411" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1063,11 +1063,11 @@ L 637.2 293.461411
      <g id="line2d_37">
       <path d="M 49.078125 284.935842 
 L 637.2 284.935842 
-" clip-path="url(#p0db99e05ab)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p89333ce73e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m5fed76f5f0" x="49.078125" y="284.935842" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m340ca10544" x="49.078125" y="284.935842" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1075,11 +1075,11 @@ L 637.2 284.935842
      <g id="line2d_39">
       <path d="M 49.078125 277.550658 
 L 637.2 277.550658 
-" clip-path="url(#p0db99e05ab)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p89333ce73e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m5fed76f5f0" x="49.078125" y="277.550658" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m340ca10544" x="49.078125" y="277.550658" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1087,11 +1087,11 @@ L 637.2 277.550658
      <g id="line2d_41">
       <path d="M 49.078125 271.036464 
 L 637.2 271.036464 
-" clip-path="url(#p0db99e05ab)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p89333ce73e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m5fed76f5f0" x="49.078125" y="271.036464" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m340ca10544" x="49.078125" y="271.036464" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1099,11 +1099,11 @@ L 637.2 271.036464
      <g id="line2d_43">
       <path d="M 49.078125 226.873619 
 L 637.2 226.873619 
-" clip-path="url(#p0db99e05ab)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p89333ce73e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m5fed76f5f0" x="49.078125" y="226.873619" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m340ca10544" x="49.078125" y="226.873619" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1111,11 +1111,11 @@ L 637.2 226.873619
      <g id="line2d_45">
       <path d="M 49.078125 204.448672 
 L 637.2 204.448672 
-" clip-path="url(#p0db99e05ab)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p89333ce73e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m5fed76f5f0" x="49.078125" y="204.448672" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m340ca10544" x="49.078125" y="204.448672" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1123,11 +1123,11 @@ L 637.2 204.448672
      <g id="line2d_47">
       <path d="M 49.078125 188.53792 
 L 637.2 188.53792 
-" clip-path="url(#p0db99e05ab)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p89333ce73e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m5fed76f5f0" x="49.078125" y="188.53792" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m340ca10544" x="49.078125" y="188.53792" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1135,11 +1135,11 @@ L 637.2 188.53792
      <g id="line2d_49">
       <path d="M 49.078125 176.196581 
 L 637.2 176.196581 
-" clip-path="url(#p0db99e05ab)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p89333ce73e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m5fed76f5f0" x="49.078125" y="176.196581" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m340ca10544" x="49.078125" y="176.196581" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1147,11 +1147,11 @@ L 637.2 176.196581
      <g id="line2d_51">
       <path d="M 49.078125 166.112973 
 L 637.2 166.112973 
-" clip-path="url(#p0db99e05ab)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p89333ce73e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m5fed76f5f0" x="49.078125" y="166.112973" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m340ca10544" x="49.078125" y="166.112973" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1159,11 +1159,11 @@ L 637.2 166.112973
      <g id="line2d_53">
       <path d="M 49.078125 157.587404 
 L 637.2 157.587404 
-" clip-path="url(#p0db99e05ab)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p89333ce73e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#m5fed76f5f0" x="49.078125" y="157.587404" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m340ca10544" x="49.078125" y="157.587404" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1171,11 +1171,11 @@ L 637.2 157.587404
      <g id="line2d_55">
       <path d="M 49.078125 150.20222 
 L 637.2 150.20222 
-" clip-path="url(#p0db99e05ab)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p89333ce73e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#m5fed76f5f0" x="49.078125" y="150.20222" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m340ca10544" x="49.078125" y="150.20222" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1183,11 +1183,11 @@ L 637.2 150.20222
      <g id="line2d_57">
       <path d="M 49.078125 143.688026 
 L 637.2 143.688026 
-" clip-path="url(#p0db99e05ab)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p89333ce73e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#m5fed76f5f0" x="49.078125" y="143.688026" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m340ca10544" x="49.078125" y="143.688026" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1195,11 +1195,11 @@ L 637.2 143.688026
      <g id="line2d_59">
       <path d="M 49.078125 99.525181 
 L 637.2 99.525181 
-" clip-path="url(#p0db99e05ab)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p89333ce73e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#m5fed76f5f0" x="49.078125" y="99.525181" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m340ca10544" x="49.078125" y="99.525181" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1207,11 +1207,11 @@ L 637.2 99.525181
      <g id="line2d_61">
       <path d="M 49.078125 77.100235 
 L 637.2 77.100235 
-" clip-path="url(#p0db99e05ab)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p89333ce73e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#m5fed76f5f0" x="49.078125" y="77.100235" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m340ca10544" x="49.078125" y="77.100235" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1219,11 +1219,11 @@ L 637.2 77.100235
      <g id="line2d_63">
       <path d="M 49.078125 61.189482 
 L 637.2 61.189482 
-" clip-path="url(#p0db99e05ab)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p89333ce73e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#m5fed76f5f0" x="49.078125" y="61.189482" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m340ca10544" x="49.078125" y="61.189482" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1231,11 +1231,11 @@ L 637.2 61.189482
      <g id="line2d_65">
       <path d="M 49.078125 48.848143 
 L 637.2 48.848143 
-" clip-path="url(#p0db99e05ab)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p89333ce73e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#m5fed76f5f0" x="49.078125" y="48.848143" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m340ca10544" x="49.078125" y="48.848143" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1398,7 +1398,7 @@ z
    <g id="line2d_67">
     <path d="M 49.078125 63.959148 
 L 637.2 63.959148 
-" clip-path="url(#p0db99e05ab)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
+" clip-path="url(#p89333ce73e)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
    </g>
    <g id="patch_3">
     <path d="M 49.078125 412.80375 
@@ -1801,78 +1801,78 @@ z
    </g>
    <g id="line2d_68">
     <defs>
-     <path id="m584f3a17e6" d="M -2.5 2.5 
+     <path id="mce9b992f32" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p0db99e05ab)">
-     <use xlink:href="#m584f3a17e6" x="75.810937" y="262.071247" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m584f3a17e6" x="105.634056" y="268.596154" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m584f3a17e6" x="204.490635" y="300.845541" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m584f3a17e6" x="234.479899" y="306.8179" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m584f3a17e6" x="242.537956" y="314.611143" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m584f3a17e6" x="300.771958" y="297.295948" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m584f3a17e6" x="303.26414" y="309.008338" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m584f3a17e6" x="304.261013" y="317.489766" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m584f3a17e6" x="313.897453" y="317.717971" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m584f3a17e6" x="414.166268" y="334.585481" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m584f3a17e6" x="587.289889" y="328.108569" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m584f3a17e6" x="610.467187" y="319.417439" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p89333ce73e)">
+     <use xlink:href="#mce9b992f32" x="75.810937" y="262.071247" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mce9b992f32" x="105.634056" y="268.596154" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mce9b992f32" x="204.490635" y="300.845541" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mce9b992f32" x="234.479899" y="306.8179" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mce9b992f32" x="242.537956" y="314.611143" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mce9b992f32" x="300.771958" y="297.295948" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mce9b992f32" x="303.26414" y="309.008338" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mce9b992f32" x="304.261013" y="317.489766" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mce9b992f32" x="313.897453" y="317.717971" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mce9b992f32" x="414.166268" y="334.585481" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mce9b992f32" x="587.289889" y="328.108569" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mce9b992f32" x="610.467187" y="319.417439" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_69">
     <defs>
-     <path id="m8ea1332d51" d="M 0 -2.5 
+     <path id="m304420e3e0" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p0db99e05ab)">
-     <use xlink:href="#m8ea1332d51" x="75.810937" y="260.356415" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8ea1332d51" x="105.634056" y="255.335352" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8ea1332d51" x="204.490635" y="300.329661" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8ea1332d51" x="234.479899" y="298.16824" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8ea1332d51" x="242.537956" y="305.868465" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8ea1332d51" x="300.771958" y="286.449653" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8ea1332d51" x="303.26414" y="299.806142" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8ea1332d51" x="304.261013" y="313.982391" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8ea1332d51" x="313.897453" y="307.348543" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8ea1332d51" x="414.166268" y="326.105079" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8ea1332d51" x="587.289889" y="328.229425" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8ea1332d51" x="610.467187" y="317.702252" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p89333ce73e)">
+     <use xlink:href="#m304420e3e0" x="75.810937" y="260.356415" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m304420e3e0" x="105.634056" y="255.335352" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m304420e3e0" x="204.490635" y="300.329661" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m304420e3e0" x="234.479899" y="298.16824" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m304420e3e0" x="242.537956" y="305.868465" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m304420e3e0" x="300.771958" y="286.449653" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m304420e3e0" x="303.26414" y="299.806142" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m304420e3e0" x="304.261013" y="313.982391" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m304420e3e0" x="313.897453" y="307.348543" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m304420e3e0" x="414.166268" y="326.105079" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m304420e3e0" x="587.289889" y="328.229425" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m304420e3e0" x="610.467187" y="317.702252" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_70">
     <defs>
-     <path id="md205d2f9e5" d="M -0 3.535534 
+     <path id="m95a95bc721" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p0db99e05ab)">
-     <use xlink:href="#md205d2f9e5" x="75.810937" y="228.571334" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md205d2f9e5" x="105.634056" y="231.338394" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md205d2f9e5" x="204.490635" y="257.724879" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md205d2f9e5" x="234.479899" y="258.806342" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md205d2f9e5" x="242.537956" y="270.393131" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md205d2f9e5" x="300.771958" y="258.431756" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md205d2f9e5" x="303.26414" y="269.129678" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md205d2f9e5" x="304.261013" y="279.340839" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md205d2f9e5" x="313.897453" y="274.978134" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md205d2f9e5" x="414.166268" y="294.726626" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md205d2f9e5" x="587.289889" y="300.153563" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md205d2f9e5" x="610.467187" y="298.472179" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p89333ce73e)">
+     <use xlink:href="#m95a95bc721" x="75.810937" y="228.571334" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m95a95bc721" x="105.634056" y="231.338394" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m95a95bc721" x="204.490635" y="257.724879" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m95a95bc721" x="234.479899" y="258.806342" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m95a95bc721" x="242.537956" y="270.393131" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m95a95bc721" x="300.771958" y="258.431756" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m95a95bc721" x="303.26414" y="269.129678" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m95a95bc721" x="304.261013" y="279.340839" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m95a95bc721" x="313.897453" y="274.978134" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m95a95bc721" x="414.166268" y="294.726626" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m95a95bc721" x="587.289889" y="300.153563" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m95a95bc721" x="610.467187" y="298.472179" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_71">
     <defs>
-     <path id="m7c100d36b7" d="M -0.833333 2.5 
+     <path id="mb48fad6a09" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -1887,24 +1887,24 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p0db99e05ab)">
-     <use xlink:href="#m7c100d36b7" x="75.810937" y="280.974255" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7c100d36b7" x="105.634056" y="299.415702" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7c100d36b7" x="204.490635" y="326.068499" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7c100d36b7" x="234.479899" y="340.121484" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7c100d36b7" x="242.537956" y="342.329412" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7c100d36b7" x="300.771958" y="338.660143" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7c100d36b7" x="303.26414" y="346.44421" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7c100d36b7" x="304.261013" y="346.535582" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7c100d36b7" x="313.897453" y="352.154021" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7c100d36b7" x="414.166268" y="366.002809" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7c100d36b7" x="587.289889" y="371.46125" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7c100d36b7" x="610.467187" y="359.767243" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p89333ce73e)">
+     <use xlink:href="#mb48fad6a09" x="75.810937" y="280.974255" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb48fad6a09" x="105.634056" y="299.415702" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb48fad6a09" x="204.490635" y="326.068499" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb48fad6a09" x="234.479899" y="340.121484" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb48fad6a09" x="242.537956" y="342.329412" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb48fad6a09" x="300.771958" y="338.660143" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb48fad6a09" x="303.26414" y="346.44421" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb48fad6a09" x="304.261013" y="346.535582" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb48fad6a09" x="313.897453" y="352.154021" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb48fad6a09" x="414.166268" y="366.002809" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb48fad6a09" x="587.289889" y="371.46125" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb48fad6a09" x="610.467187" y="359.767243" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_72">
     <defs>
-     <path id="mec2c7140d2" d="M -1.25 2.5 
+     <path id="m419565db1a" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -1919,24 +1919,24 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p0db99e05ab)">
-     <use xlink:href="#mec2c7140d2" x="75.810937" y="312.426802" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mec2c7140d2" x="105.634056" y="321.996906" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mec2c7140d2" x="204.490635" y="335.63066" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mec2c7140d2" x="234.479899" y="358.497992" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mec2c7140d2" x="242.537956" y="346.252339" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mec2c7140d2" x="300.771958" y="332.122532" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mec2c7140d2" x="303.26414" y="346.533176" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mec2c7140d2" x="304.261013" y="350.518859" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mec2c7140d2" x="313.897453" y="352.354171" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mec2c7140d2" x="414.166268" y="359.340915" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mec2c7140d2" x="587.289889" y="378.013224" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mec2c7140d2" x="610.467187" y="363.415788" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p89333ce73e)">
+     <use xlink:href="#m419565db1a" x="75.810937" y="312.426802" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m419565db1a" x="105.634056" y="321.996906" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m419565db1a" x="204.490635" y="335.63066" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m419565db1a" x="234.479899" y="358.497992" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m419565db1a" x="242.537956" y="346.252339" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m419565db1a" x="300.771958" y="332.122532" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m419565db1a" x="303.26414" y="346.533176" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m419565db1a" x="304.261013" y="350.518859" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m419565db1a" x="313.897453" y="352.354171" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m419565db1a" x="414.166268" y="359.340915" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m419565db1a" x="587.289889" y="378.013224" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m419565db1a" x="610.467187" y="363.415788" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_73">
     <defs>
-     <path id="me687f5972a" d="M 0 -2.5 
+     <path id="m803880082b" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -1949,24 +1949,24 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p0db99e05ab)">
-     <use xlink:href="#me687f5972a" x="75.810937" y="273.921216" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#me687f5972a" x="105.634056" y="288.097179" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#me687f5972a" x="204.490635" y="320.580642" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#me687f5972a" x="234.479899" y="321.870427" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#me687f5972a" x="242.537956" y="327.716748" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#me687f5972a" x="300.771958" y="333.632059" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#me687f5972a" x="303.26414" y="338.271221" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#me687f5972a" x="304.261013" y="346.697055" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#me687f5972a" x="313.897453" y="336.75845" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#me687f5972a" x="414.166268" y="358.229758" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#me687f5972a" x="587.289889" y="367.501145" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#me687f5972a" x="610.467187" y="361.600921" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p89333ce73e)">
+     <use xlink:href="#m803880082b" x="75.810937" y="273.921216" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m803880082b" x="105.634056" y="288.097179" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m803880082b" x="204.490635" y="320.580642" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m803880082b" x="234.479899" y="321.870427" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m803880082b" x="242.537956" y="327.716748" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m803880082b" x="300.771958" y="333.632059" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m803880082b" x="303.26414" y="338.271221" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m803880082b" x="304.261013" y="346.697055" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m803880082b" x="313.897453" y="336.75845" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m803880082b" x="414.166268" y="358.229758" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m803880082b" x="587.289889" y="367.501145" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m803880082b" x="610.467187" y="361.600921" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_74">
     <defs>
-     <path id="m681eabb38b" d="M 0 -2.5 
+     <path id="mffeb0ab8b9" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -1975,19 +1975,19 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p0db99e05ab)">
-     <use xlink:href="#m681eabb38b" x="75.810937" y="347.776732" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m681eabb38b" x="105.634056" y="349.684654" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m681eabb38b" x="204.490635" y="366.019921" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m681eabb38b" x="234.479899" y="373.210832" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m681eabb38b" x="242.537956" y="378.663295" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m681eabb38b" x="300.771958" y="369.597094" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m681eabb38b" x="303.26414" y="374.003914" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m681eabb38b" x="304.261013" y="381.646168" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m681eabb38b" x="313.897453" y="386.383822" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m681eabb38b" x="414.166268" y="392.690652" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m681eabb38b" x="587.289889" y="396.192102" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m681eabb38b" x="610.467187" y="386.453116" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p89333ce73e)">
+     <use xlink:href="#mffeb0ab8b9" x="75.810937" y="347.776732" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mffeb0ab8b9" x="105.634056" y="349.684654" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mffeb0ab8b9" x="204.490635" y="366.019921" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mffeb0ab8b9" x="234.479899" y="373.210832" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mffeb0ab8b9" x="242.537956" y="378.663295" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mffeb0ab8b9" x="300.771958" y="369.597094" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mffeb0ab8b9" x="303.26414" y="374.003914" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mffeb0ab8b9" x="304.261013" y="381.646168" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mffeb0ab8b9" x="313.897453" y="386.383822" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mffeb0ab8b9" x="414.166268" y="392.690652" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mffeb0ab8b9" x="587.289889" y="396.192102" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mffeb0ab8b9" x="610.467187" y="386.453116" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="legend_1">
@@ -2006,7 +2006,7 @@ z
     </g>
     <g id="line2d_75">
      <defs>
-      <path id="md71d912ee8" d="M 0 3.5 
+      <path id="m918f06cbed" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -2019,7 +2019,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#md71d912ee8" x="434.04625" y="211.758125" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m918f06cbed" x="434.04625" y="211.758125" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_15">
@@ -2078,7 +2078,7 @@ z
     </g>
     <g id="line2d_76">
      <g>
-      <use xlink:href="#m584f3a17e6" x="434.04625" y="223.500625" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mce9b992f32" x="434.04625" y="223.500625" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_16">
@@ -2092,7 +2092,7 @@ z
     </g>
     <g id="line2d_77">
      <g>
-      <use xlink:href="#m8ea1332d51" x="434.04625" y="235.243125" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m304420e3e0" x="434.04625" y="235.243125" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -2137,7 +2137,7 @@ z
     </g>
     <g id="line2d_78">
      <g>
-      <use xlink:href="#md205d2f9e5" x="434.04625" y="247.208125" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m95a95bc721" x="434.04625" y="247.208125" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -2157,7 +2157,7 @@ z
     </g>
     <g id="line2d_79">
      <g>
-      <use xlink:href="#m7c100d36b7" x="537.72375" y="211.758125" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mb48fad6a09" x="537.72375" y="211.758125" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -2184,7 +2184,7 @@ z
     </g>
     <g id="line2d_80">
      <g>
-      <use xlink:href="#mec2c7140d2" x="537.72375" y="223.500625" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m419565db1a" x="537.72375" y="223.500625" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -2249,7 +2249,7 @@ z
     </g>
     <g id="line2d_81">
      <g>
-      <use xlink:href="#me687f5972a" x="537.72375" y="235.243125" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#m803880082b" x="537.72375" y="235.243125" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_21">
@@ -2287,7 +2287,7 @@ z
     </g>
     <g id="line2d_82">
      <g>
-      <use xlink:href="#m681eabb38b" x="537.72375" y="246.985625" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mffeb0ab8b9" x="537.72375" y="246.985625" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -2357,19 +2357,19 @@ z
     </g>
    </g>
    <g id="line2d_83">
-    <g clip-path="url(#p0db99e05ab)">
-     <use xlink:href="#md71d912ee8" x="75.810937" y="275.486618" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#md71d912ee8" x="105.634056" y="292.998775" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#md71d912ee8" x="204.490635" y="326.410296" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#md71d912ee8" x="234.479899" y="329.186544" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#md71d912ee8" x="242.537956" y="328.753877" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#md71d912ee8" x="300.771958" y="317.428597" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#md71d912ee8" x="303.26414" y="336.106915" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#md71d912ee8" x="304.261013" y="356.358937" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#md71d912ee8" x="313.897453" y="342.768285" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#md71d912ee8" x="414.166268" y="360.763565" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#md71d912ee8" x="587.289889" y="364.935308" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#md71d912ee8" x="610.467187" y="348.169444" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <g clip-path="url(#p89333ce73e)">
+     <use xlink:href="#m918f06cbed" x="75.810937" y="275.486618" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m918f06cbed" x="105.634056" y="292.998775" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m918f06cbed" x="204.490635" y="326.410296" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m918f06cbed" x="234.479899" y="329.186544" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m918f06cbed" x="242.537956" y="328.753877" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m918f06cbed" x="300.771958" y="317.428597" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m918f06cbed" x="303.26414" y="336.106915" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m918f06cbed" x="304.261013" y="356.358937" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m918f06cbed" x="313.897453" y="342.768285" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m918f06cbed" x="414.166268" y="360.763565" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m918f06cbed" x="587.289889" y="364.935308" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m918f06cbed" x="610.467187" y="348.169444" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
   </g>
@@ -3154,7 +3154,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p0db99e05ab">
+  <clipPath id="p89333ce73e">
    <rect x="49.078125" y="47.3475" width="588.121875" height="365.45625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_decode_ranking.svg
+++ b/bench/graphs/silesia_decode_ranking.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 291.674799 308.04375 
 L 291.674799 56.7075 
-" clip-path="url(#p85861be21e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p082d57e556)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="mc75cc90c6e" d="M 0 0 
+       <path id="m3d7267a495" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mc75cc90c6e" x="291.674799" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3d7267a495" x="291.674799" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -136,11 +136,11 @@ z
      <g id="line2d_3">
       <path d="M 449.853424 308.04375 
 L 449.853424 56.7075 
-" clip-path="url(#p85861be21e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p082d57e556)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mc75cc90c6e" x="449.853424" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3d7267a495" x="449.853424" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -177,16 +177,16 @@ z
      <g id="line2d_5">
       <path d="M 181.112686 308.04375 
 L 181.112686 56.7075 
-" clip-path="url(#p85861be21e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p082d57e556)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <defs>
-       <path id="mef381cfb8c" d="M 0 0 
+       <path id="m35eddc3981" d="M 0 0 
 L 0 2 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#mef381cfb8c" x="181.112686" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m35eddc3981" x="181.112686" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -194,11 +194,11 @@ L 0 2
      <g id="line2d_7">
       <path d="M 208.966559 308.04375 
 L 208.966559 56.7075 
-" clip-path="url(#p85861be21e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p082d57e556)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#mef381cfb8c" x="208.966559" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m35eddc3981" x="208.966559" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -206,11 +206,11 @@ L 208.966559 56.7075
      <g id="line2d_9">
       <path d="M 228.729196 308.04375 
 L 228.729196 56.7075 
-" clip-path="url(#p85861be21e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p082d57e556)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#mef381cfb8c" x="228.729196" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m35eddc3981" x="228.729196" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -218,11 +218,11 @@ L 228.729196 56.7075
      <g id="line2d_11">
       <path d="M 244.058289 308.04375 
 L 244.058289 56.7075 
-" clip-path="url(#p85861be21e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p082d57e556)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#mef381cfb8c" x="244.058289" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m35eddc3981" x="244.058289" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -230,11 +230,11 @@ L 244.058289 56.7075
      <g id="line2d_13">
       <path d="M 256.583069 308.04375 
 L 256.583069 56.7075 
-" clip-path="url(#p85861be21e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p082d57e556)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mef381cfb8c" x="256.583069" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m35eddc3981" x="256.583069" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -242,11 +242,11 @@ L 256.583069 56.7075
      <g id="line2d_15">
       <path d="M 267.172621 308.04375 
 L 267.172621 56.7075 
-" clip-path="url(#p85861be21e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p082d57e556)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <g>
-       <use xlink:href="#mef381cfb8c" x="267.172621" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m35eddc3981" x="267.172621" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -254,11 +254,11 @@ L 267.172621 56.7075
      <g id="line2d_17">
       <path d="M 276.345707 308.04375 
 L 276.345707 56.7075 
-" clip-path="url(#p85861be21e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p082d57e556)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mef381cfb8c" x="276.345707" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m35eddc3981" x="276.345707" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -266,11 +266,11 @@ L 276.345707 56.7075
      <g id="line2d_19">
       <path d="M 284.436943 308.04375 
 L 284.436943 56.7075 
-" clip-path="url(#p85861be21e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p082d57e556)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#mef381cfb8c" x="284.436943" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m35eddc3981" x="284.436943" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -278,11 +278,11 @@ L 284.436943 56.7075
      <g id="line2d_21">
       <path d="M 339.29131 308.04375 
 L 339.29131 56.7075 
-" clip-path="url(#p85861be21e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p082d57e556)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#mef381cfb8c" x="339.29131" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m35eddc3981" x="339.29131" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -290,11 +290,11 @@ L 339.29131 56.7075
      <g id="line2d_23">
       <path d="M 367.145183 308.04375 
 L 367.145183 56.7075 
-" clip-path="url(#p85861be21e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p082d57e556)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mef381cfb8c" x="367.145183" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m35eddc3981" x="367.145183" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -302,11 +302,11 @@ L 367.145183 56.7075
      <g id="line2d_25">
       <path d="M 386.907821 308.04375 
 L 386.907821 56.7075 
-" clip-path="url(#p85861be21e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p082d57e556)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mef381cfb8c" x="386.907821" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m35eddc3981" x="386.907821" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -314,11 +314,11 @@ L 386.907821 56.7075
      <g id="line2d_27">
       <path d="M 402.236913 308.04375 
 L 402.236913 56.7075 
-" clip-path="url(#p85861be21e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p082d57e556)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#mef381cfb8c" x="402.236913" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m35eddc3981" x="402.236913" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -326,11 +326,11 @@ L 402.236913 56.7075
      <g id="line2d_29">
       <path d="M 414.761694 308.04375 
 L 414.761694 56.7075 
-" clip-path="url(#p85861be21e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p082d57e556)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#mef381cfb8c" x="414.761694" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m35eddc3981" x="414.761694" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -338,11 +338,11 @@ L 414.761694 56.7075
      <g id="line2d_31">
       <path d="M 425.351245 308.04375 
 L 425.351245 56.7075 
-" clip-path="url(#p85861be21e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p082d57e556)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#mef381cfb8c" x="425.351245" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m35eddc3981" x="425.351245" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -350,11 +350,11 @@ L 425.351245 56.7075
      <g id="line2d_33">
       <path d="M 434.524331 308.04375 
 L 434.524331 56.7075 
-" clip-path="url(#p85861be21e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p082d57e556)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#mef381cfb8c" x="434.524331" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m35eddc3981" x="434.524331" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -362,11 +362,11 @@ L 434.524331 56.7075
      <g id="line2d_35">
       <path d="M 442.615567 308.04375 
 L 442.615567 56.7075 
-" clip-path="url(#p85861be21e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p082d57e556)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#mef381cfb8c" x="442.615567" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m35eddc3981" x="442.615567" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -374,11 +374,11 @@ L 442.615567 56.7075
      <g id="line2d_37">
       <path d="M 497.469935 308.04375 
 L 497.469935 56.7075 
-" clip-path="url(#p85861be21e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p082d57e556)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#mef381cfb8c" x="497.469935" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m35eddc3981" x="497.469935" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -386,11 +386,11 @@ L 497.469935 56.7075
      <g id="line2d_39">
       <path d="M 525.323808 308.04375 
 L 525.323808 56.7075 
-" clip-path="url(#p85861be21e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p082d57e556)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#mef381cfb8c" x="525.323808" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m35eddc3981" x="525.323808" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -398,11 +398,11 @@ L 525.323808 56.7075
      <g id="line2d_41">
       <path d="M 545.086445 308.04375 
 L 545.086445 56.7075 
-" clip-path="url(#p85861be21e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p082d57e556)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#mef381cfb8c" x="545.086445" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m35eddc3981" x="545.086445" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -410,11 +410,11 @@ L 545.086445 56.7075
      <g id="line2d_43">
       <path d="M 560.415538 308.04375 
 L 560.415538 56.7075 
-" clip-path="url(#p85861be21e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p082d57e556)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#mef381cfb8c" x="560.415538" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m35eddc3981" x="560.415538" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1016,12 +1016,12 @@ z
     <g id="ytick_1">
      <g id="line2d_45">
       <defs>
-       <path id="m7d38777626" d="M 0 0 
+       <path id="m5a6fd4a863" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m7d38777626" x="139.360469" y="296.619375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5a6fd4a863" x="139.360469" y="296.619375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -1093,7 +1093,7 @@ z
     <g id="ytick_2">
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m7d38777626" x="139.360469" y="263.978304" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5a6fd4a863" x="139.360469" y="263.978304" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -1160,7 +1160,7 @@ z
     <g id="ytick_3">
      <g id="line2d_47">
       <g>
-       <use xlink:href="#m7d38777626" x="139.360469" y="231.337232" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5a6fd4a863" x="139.360469" y="231.337232" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -1216,7 +1216,7 @@ z
     <g id="ytick_4">
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m7d38777626" x="139.360469" y="198.696161" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5a6fd4a863" x="139.360469" y="198.696161" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -1329,7 +1329,7 @@ z
     <g id="ytick_5">
      <g id="line2d_49">
       <g>
-       <use xlink:href="#m7d38777626" x="139.360469" y="166.055089" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5a6fd4a863" x="139.360469" y="166.055089" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -1376,7 +1376,7 @@ z
     <g id="ytick_6">
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m7d38777626" x="139.360469" y="133.414018" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5a6fd4a863" x="139.360469" y="133.414018" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -1392,7 +1392,7 @@ z
     <g id="ytick_7">
      <g id="line2d_51">
       <g>
-       <use xlink:href="#m7d38777626" x="139.360469" y="100.772946" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5a6fd4a863" x="139.360469" y="100.772946" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -1439,7 +1439,7 @@ z
     <g id="ytick_8">
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m7d38777626" x="139.360469" y="68.131875" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5a6fd4a863" x="139.360469" y="68.131875" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -1462,47 +1462,47 @@ z
    <g id="LineCollection_1">
     <path d="M 139.360469 296.619375 
 L 154.689561 296.619375 
-" clip-path="url(#p85861be21e)" style="fill: none; stroke: #17becf; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p082d57e556)" style="fill: none; stroke: #17becf; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_2">
     <path d="M 139.360469 263.978304 
 L 191.246836 263.978304 
-" clip-path="url(#p85861be21e)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p082d57e556)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_3">
     <path d="M 139.360469 231.337232 
 L 199.184828 231.337232 
-" clip-path="url(#p85861be21e)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p082d57e556)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_4">
     <path d="M 139.360469 198.696161 
 L 208.005334 198.696161 
-" clip-path="url(#p85861be21e)" style="fill: none; stroke: #d62728; stroke-opacity: 0.9; stroke-width: 2.4"/>
+" clip-path="url(#p082d57e556)" style="fill: none; stroke: #d62728; stroke-opacity: 0.9; stroke-width: 2.4"/>
    </g>
    <g id="LineCollection_5">
     <path d="M 139.360469 166.055089 
 L 208.240218 166.055089 
-" clip-path="url(#p85861be21e)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p082d57e556)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_6">
     <path d="M 139.360469 133.414018 
 L 240.877368 133.414018 
-" clip-path="url(#p85861be21e)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p082d57e556)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_7">
     <path d="M 139.360469 100.772946 
 L 248.29166 100.772946 
-" clip-path="url(#p85861be21e)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p082d57e556)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_8">
     <path d="M 139.360469 68.131875 
 L 287.6261 68.131875 
-" clip-path="url(#p85861be21e)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p082d57e556)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="line2d_53">
     <path d="M 542.085668 308.04375 
 L 542.085668 56.7075 
-" clip-path="url(#p85861be21e)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
+" clip-path="url(#p082d57e556)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
    </g>
    <g id="patch_3">
     <path d="M 139.360469 308.04375 
@@ -1922,7 +1922,7 @@ z
    </g>
    <g id="line2d_54">
     <defs>
-     <path id="m680cae0e41" d="M 0 3 
+     <path id="me77b412eb8" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1934,13 +1934,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #17becf"/>
     </defs>
-    <g clip-path="url(#p85861be21e)">
-     <use xlink:href="#m680cae0e41" x="154.689561" y="296.619375" style="fill: #17becf; stroke: #17becf"/>
+    <g clip-path="url(#p082d57e556)">
+     <use xlink:href="#me77b412eb8" x="154.689561" y="296.619375" style="fill: #17becf; stroke: #17becf"/>
     </g>
    </g>
    <g id="line2d_55">
     <defs>
-     <path id="m101ec68a1a" d="M 0 3 
+     <path id="mcbf854e707" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1952,13 +1952,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #e377c2"/>
     </defs>
-    <g clip-path="url(#p85861be21e)">
-     <use xlink:href="#m101ec68a1a" x="191.246836" y="263.978304" style="fill: #e377c2; stroke: #e377c2"/>
+    <g clip-path="url(#p082d57e556)">
+     <use xlink:href="#mcbf854e707" x="191.246836" y="263.978304" style="fill: #e377c2; stroke: #e377c2"/>
     </g>
    </g>
    <g id="line2d_56">
     <defs>
-     <path id="md3ca39a180" d="M 0 3 
+     <path id="maac372cb96" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1970,13 +1970,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #8c564b"/>
     </defs>
-    <g clip-path="url(#p85861be21e)">
-     <use xlink:href="#md3ca39a180" x="199.184828" y="231.337232" style="fill: #8c564b; stroke: #8c564b"/>
+    <g clip-path="url(#p082d57e556)">
+     <use xlink:href="#maac372cb96" x="199.184828" y="231.337232" style="fill: #8c564b; stroke: #8c564b"/>
     </g>
    </g>
    <g id="line2d_57">
     <defs>
-     <path id="m1f4c42242e" d="M 0 5 
+     <path id="m390a5c2730" d="M 0 5 
 C 1.326016 5 2.597899 4.473168 3.535534 3.535534 
 C 4.473168 2.597899 5 1.326016 5 0 
 C 5 -1.326016 4.473168 -2.597899 3.535534 -3.535534 
@@ -1988,13 +1988,13 @@ C -2.597899 4.473168 -1.326016 5 0 5
 z
 " style="stroke: #d62728"/>
     </defs>
-    <g clip-path="url(#p85861be21e)">
-     <use xlink:href="#m1f4c42242e" x="208.005334" y="198.696161" style="fill: #d62728; stroke: #d62728"/>
+    <g clip-path="url(#p082d57e556)">
+     <use xlink:href="#m390a5c2730" x="208.005334" y="198.696161" style="fill: #d62728; stroke: #d62728"/>
     </g>
    </g>
    <g id="line2d_58">
     <defs>
-     <path id="m0c6a8def35" d="M 0 3 
+     <path id="m41054d4c57" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -2006,13 +2006,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #bcbd22"/>
     </defs>
-    <g clip-path="url(#p85861be21e)">
-     <use xlink:href="#m0c6a8def35" x="208.240218" y="166.055089" style="fill: #bcbd22; stroke: #bcbd22"/>
+    <g clip-path="url(#p082d57e556)">
+     <use xlink:href="#m41054d4c57" x="208.240218" y="166.055089" style="fill: #bcbd22; stroke: #bcbd22"/>
     </g>
    </g>
    <g id="line2d_59">
     <defs>
-     <path id="mcd367103e1" d="M 0 3 
+     <path id="m4ba123a357" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -2024,13 +2024,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #1f77b4"/>
     </defs>
-    <g clip-path="url(#p85861be21e)">
-     <use xlink:href="#mcd367103e1" x="240.877368" y="133.414018" style="fill: #1f77b4; stroke: #1f77b4"/>
+    <g clip-path="url(#p082d57e556)">
+     <use xlink:href="#m4ba123a357" x="240.877368" y="133.414018" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_60">
     <defs>
-     <path id="m42a18f63fb" d="M 0 3 
+     <path id="m48fa89a504" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -2042,13 +2042,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #2ca02c"/>
     </defs>
-    <g clip-path="url(#p85861be21e)">
-     <use xlink:href="#m42a18f63fb" x="248.29166" y="100.772946" style="fill: #2ca02c; stroke: #2ca02c"/>
+    <g clip-path="url(#p082d57e556)">
+     <use xlink:href="#m48fa89a504" x="248.29166" y="100.772946" style="fill: #2ca02c; stroke: #2ca02c"/>
     </g>
    </g>
    <g id="line2d_61">
     <defs>
-     <path id="madff3f1fda" d="M 0 3 
+     <path id="m3b87754eba" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -2060,8 +2060,8 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #9467bd"/>
     </defs>
-    <g clip-path="url(#p85861be21e)">
-     <use xlink:href="#madff3f1fda" x="287.6261" y="68.131875" style="fill: #9467bd; stroke: #9467bd"/>
+    <g clip-path="url(#p082d57e556)">
+     <use xlink:href="#m3b87754eba" x="287.6261" y="68.131875" style="fill: #9467bd; stroke: #9467bd"/>
     </g>
    </g>
   </g>
@@ -2965,7 +2965,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p85861be21e">
+  <clipPath id="p082d57e556">
    <rect x="139.360469" y="56.7075" width="425.839531" height="251.33625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_ratio_heatmap.svg
+++ b/bench/graphs/silesia_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.34175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p0ae43f4c18)">
+   <g clip-path="url(#pbbc55f6494)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAosAAAGaCAYAAABniAm0AAAJ/klEQVR4nO3Yu45eVx2H4ZnM+IDHmbEtSCLCQcJRQAqBEoWCKhWCgmvgCmioqBB3QMUN0KGI0k1KpACBEAogSkIQB1lDjB1jGXs8Mx9X8BYoWvqjT89zBT9pb6397rV7fvsnm50tdPLTW9MTlrjw6svTE5bZfebT0xOW2Lz1u+kJS+x+5aXpCUtsHt6fnrDM8fdfm56wxDM/+tb0hCV2bzw7PWGNk4fTC5Y5/+V2nvdPTQ8AAOD/l1gEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACDt/vvktc30iBUO/nU8PWGJDw+vTE9Y5j+nD6YnLPHZj06mJyzx0aeem56wxPnmfHrCMtf3b0xPWOPOB9MLlrh/fTuf19N//tP0hGU2L35tesISbhYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEj7B3duT29Y48q16QVLbDYn0xOW+czrv56esMar35xesMTRh/+YnrDG+en0gnUOtvT8uHR1esESh//czu/z3c/fnJ6wzPW/vj09YQk3iwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEDafXJ2azM9YoW94/enJyxx++mL0xOWefDk3vSEJW7+5d70hCVOv/z16QlLPDy9Pz1hmaO9a9MTlti896vpCUs8+sLL0xOWuPz2G9MTlnn81VemJyzhZhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIuz9/73ub6REr3Lh8MD1hiXfu3ZmesMx3f/yb6QlL/PaH356esMTRpaPpCUv84BdvTk9Y5hvPX56esMR3br4yPWGJ1//2xvSEJa5e2M73cGdnZ+dn796dnrCEm0UAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAg7T45u7WZHrHC3cfH0xOWONg/nJ6wzDv3fj89YYkXrr00PWGJzeZ8esISV0+39x/67+fbeS4+f/DC9IQlHp09nJ6wxLaeHTs7Ozt7T+1PT1hie09FAAA+NrEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAApP293f3pDUt8cu/G9IQ19i5OL1jm6NLR9IQlDvYPpycscbY5nZ6wxPmF7f2Hfm5zZXoC/4Nt/T6fbB5NT1jm/uPj6QlLbO+pCADAxyYWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBI+4/OHk5vWOLy7v70hCU+ePDH6QnLnJ6fTE9Y4/jd6QVL3D86nJ6wxOHFG9MTljk5ezQ9YYlP3H5/esISj5/93PSEJQ7+8Nb0hGUef/FL0xOWcLMIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAApP8Cc6OciHDVLsgAAAAASUVORK5CYII=" id="imagedf1dbd9b22" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="468.72" height="295.2"/>
+iVBORw0KGgoAAAANSUhEUgAAAosAAAGaCAYAAABniAm0AAAJ/klEQVR4nO3Yu45eVx2H4ZnM+IDHmbEtSCLCQcJRQAqBEoWCKhWCgmvgCmioqBB3QMUN0KGI0k1KpACBEAogSkIQB1lDjB1jGXs8Mx9X8BYoWvqjT89zBT9pb6397rV7fvsnm50tdPLTW9MTlrjw6svTE5bZfebT0xOW2Lz1u+kJS+x+5aXpCUtsHt6fnrDM8fdfm56wxDM/+tb0hCV2bzw7PWGNk4fTC5Y5/+V2nvdPTQ8AAOD/l1gEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACDt/vvktc30iBUO/nU8PWGJDw+vTE9Y5j+nD6YnLPHZj06mJyzx0aeem56wxPnmfHrCMtf3b0xPWOPOB9MLlrh/fTuf19N//tP0hGU2L35tesISbhYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEj7B3duT29Y48q16QVLbDYn0xOW+czrv56esMar35xesMTRh/+YnrDG+en0gnUOtvT8uHR1esESh//czu/z3c/fnJ6wzPW/vj09YQk3iwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEDafXJ2azM9YoW94/enJyxx++mL0xOWefDk3vSEJW7+5d70hCVOv/z16QlLPDy9Pz1hmaO9a9MTlti896vpCUs8+sLL0xOWuPz2G9MTlnn81VemJyzhZhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIuz9/73ub6REr3Lh8MD1hiXfu3ZmesMx3f/yb6QlL/PaH356esMTRpaPpCUv84BdvTk9Y5hvPX56esMR3br4yPWGJ1//2xvSEJa5e2M73cGdnZ+dn796dnrCEm0UAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAg7T45u7WZHrHC3cfH0xOWONg/nJ6wzDv3fj89YYkXrr00PWGJzeZ8esISV0+39x/67+fbeS4+f/DC9IQlHp09nJ6wxLaeHTs7Ozt7T+1PT1hie09FAAA+NrEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAApP293f3pDUt8cu/G9IQ19i5OL1jm6NLR9IQlDvYPpycscbY5nZ6wxPmF7f2Hfm5zZXoC/4Nt/T6fbB5NT1jm/uPj6QlLbO+pCADAxyYWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBI+4/OHk5vWOLy7v70hCU+ePDH6QnLnJ6fTE9Y4/jd6QVL3D86nJ6wxOHFG9MTljk5ezQ9YYlP3H5/esISj5/93PSEJQ7+8Nb0hGUef/FL0xOWcLMIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAApP8Cc6OciHDVLsgAAAAASUVORK5CYII=" id="image06c67b48f9" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="468.72" height="295.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m7aeba4c713" d="M 0 0 
+       <path id="m0fb8f66542" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m7aeba4c713" x="115.182137" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0fb8f66542" x="115.182137" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m7aeba4c713" x="154.193912" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0fb8f66542" x="154.193912" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m7aeba4c713" x="193.205687" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0fb8f66542" x="193.205687" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m7aeba4c713" x="232.217462" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0fb8f66542" x="232.217462" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m7aeba4c713" x="271.229237" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0fb8f66542" x="271.229237" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m7aeba4c713" x="310.241012" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0fb8f66542" x="310.241012" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m7aeba4c713" x="349.252787" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0fb8f66542" x="349.252787" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m7aeba4c713" x="388.264562" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0fb8f66542" x="388.264562" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m7aeba4c713" x="427.276336" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0fb8f66542" x="427.276336" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m7aeba4c713" x="466.288111" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0fb8f66542" x="466.288111" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m7aeba4c713" x="505.299886" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0fb8f66542" x="505.299886" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m7aeba4c713" x="544.311661" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0fb8f66542" x="544.311661" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="m1d8715752e" d="M 0 0 
+       <path id="m01af5769d8" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m1d8715752e" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m01af5769d8" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m1d8715752e" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m01af5769d8" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m1d8715752e" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m01af5769d8" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m1d8715752e" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m01af5769d8" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -836,7 +836,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m1d8715752e" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m01af5769d8" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -899,7 +899,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m1d8715752e" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m01af5769d8" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -966,7 +966,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m1d8715752e" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m01af5769d8" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1047,7 +1047,7 @@ z
     <g id="ytick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m1d8715752e" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m01af5769d8" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -2060,18 +2060,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABEAAAFUCAYAAADCj9eRAAAB2ElEQVR4nO2aQY7EIAwEIeFP+6X9/33C3MPcKKSS1TygZRftNlLS2//fbJtn9KvvajAi17ZCM7Uzeg+TEyJhsh4TE8D25ZhYRMJkPSYmmZ0zIhfQEMPkJq74JpgQlUBMABkIrOV2KLMRItXMhrQjqcQUSszsbGuomFSbHULEAlblE0klor1zMaG0XwnDBDAsBVY0O4CIBizlE4ntEbCijK3mE8vKUPkEEIF8YslYje2RZFP5BJkdCxOonf1i6jEhRICOyjEBzFaPiWd2iChoYbKKhMkqgmSsh4kkHkU+6UyeACJEJaLZ6QQTzy7WtGPyicX2Kp/c+yKaATTliSWoTXsnPllEEtTLGX37f+7WRpuPQ4RhomlntCdMTohATIDbKceEaGfOD1BJZueIiImJZQBNTCxgw2Q91N7Zf7RBsxMmR0TqMdmvxPRmI0TmDJNVJExWkTBZRcJkFSnFZH6Q5aVhQrQzkYUOVEIxIXxSjAnRDjQ7mndsZud9VEwsPtFcsWjvaNZofHKoEpFPELCPJmORdqblMWxiYjEbw+QJk/dR+SQD+BbROFbEJAP4Q4RgQpiNCupKIhAT4gewakws7YTJIREoY4FPeNWYaNoJk18iQNqXY1LKJ1/07Ct/l+QCQgAAAABJRU5ErkJggg==" id="image5c6f95315c" transform="scale(1 -1) translate(0 -244.8)" x="573.84" y="-74.16" width="12.24" height="244.8"/>
+iVBORw0KGgoAAAANSUhEUgAAABEAAAFUCAYAAADCj9eRAAAB2ElEQVR4nO2aQY7EIAwEIeFP+6X9/33C3MPcKKSS1TygZRftNlLS2//fbJtn9KvvajAi17ZCM7Uzeg+TEyJhsh4TE8D25ZhYRMJkPSYmmZ0zIhfQEMPkJq74JpgQlUBMABkIrOV2KLMRItXMhrQjqcQUSszsbGuomFSbHULEAlblE0klor1zMaG0XwnDBDAsBVY0O4CIBizlE4ntEbCijK3mE8vKUPkEEIF8YslYje2RZFP5BJkdCxOonf1i6jEhRICOyjEBzFaPiWd2iChoYbKKhMkqgmSsh4kkHkU+6UyeACJEJaLZ6QQTzy7WtGPyicX2Kp/c+yKaATTliSWoTXsnPllEEtTLGX37f+7WRpuPQ4RhomlntCdMTohATIDbKceEaGfOD1BJZueIiImJZQBNTCxgw2Q91N7Zf7RBsxMmR0TqMdmvxPRmI0TmDJNVJExWkTBZRcJkFSnFZH6Q5aVhQrQzkYUOVEIxIXxSjAnRDjQ7mndsZud9VEwsPtFcsWjvaNZofHKoEpFPELCPJmORdqblMWxiYjEbw+QJk/dR+SQD+BbROFbEJAP4Q4RgQpiNCupKIhAT4gewakws7YTJIREoY4FPeNWYaNoJk18iQNqXY1LKJ1/07Ct/l+QCQgAAAABJRU5ErkJggg==" id="imagefd9c7c52de" transform="scale(1 -1) translate(0 -244.8)" x="573.84" y="-74.16" width="12.24" height="244.8"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_21">
       <defs>
-       <path id="m2325478433" d="M 0 0 
+       <path id="md1da1329d5" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m2325478433" x="585.876562" y="282.022672" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md1da1329d5" x="585.876562" y="282.022672" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_117">
@@ -2097,7 +2097,7 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m2325478433" x="585.876562" y="239.353777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md1da1329d5" x="585.876562" y="239.353777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_118">
@@ -2114,7 +2114,7 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m2325478433" x="585.876562" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md1da1329d5" x="585.876562" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_119">
@@ -2130,7 +2130,7 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m2325478433" x="585.876562" y="154.015985" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md1da1329d5" x="585.876562" y="154.015985" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_120">
@@ -2146,7 +2146,7 @@ z
     <g id="ytick_13">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m2325478433" x="585.876562" y="111.347089" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md1da1329d5" x="585.876562" y="111.347089" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_121">
@@ -2739,8 +2739,8 @@ z
    </g>
   </g>
   <g id="text_124">
-   <!-- 2026-07-08T06:11:08Z  ·  Linux chungus2 x86_64  ·  commit 28336125  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(43.380391 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-08T15:47:33Z  ·  Linux chungus2 x86_64  ·  commit f2026e66  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(44.448437 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -2870,14 +2870,14 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-38" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2917,109 +2917,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3262.744141 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3326.367188 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3389.990234 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3453.613281 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3517.236328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3580.859375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3612.646484 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3644.433594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3676.220703 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3708.007812 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3739.794922 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3767.578125 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3829.101562 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3890.380859 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3953.759766 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4017.236328 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4056.099609 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4117.28125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4176.460938 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4237.984375 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4279.097656 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4312.789062 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4340.572266 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4402.095703 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4463.375 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4526.753906 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4590.376953 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4624.068359 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4683.248047 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4746.871094 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4778.658203 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4842.28125 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4905.904297 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4937.691406 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(5001.314453 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5037.398438 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5076.261719 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5131.242188 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5194.865234 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5226.652344 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5258.439453 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5290.226562 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5322.013672 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5353.800781 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5393.009766 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5456.388672 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5495.251953 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5556.433594 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5619.8125 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5683.289062 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5746.667969 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5810.144531 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5873.523438 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5912.732422 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5944.519531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6028.308594 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6060.095703 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6157.507812 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6219.03125 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6282.507812 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6310.291016 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6371.570312 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6434.949219 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6466.736328 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6518.835938 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6582.214844 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6643.494141 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6706.970703 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6759.070312 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6822.449219 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6883.630859 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6922.839844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6956.53125 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6988.318359 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7029.431641 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7090.710938 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7129.919922 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7157.703125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7218.884766 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7250.671875 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7278.455078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7330.554688 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7362.341797 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7425.818359 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7487.341797 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7526.550781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7588.074219 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7627.4375 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7724.849609 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7752.632812 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7816.011719 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7843.794922 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7895.894531 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7935.103516 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7962.886719 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3107.080078 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3170.703125 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3234.326172 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3297.949219 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3361.572266 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3423.095703 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3486.71875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3550.341797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3582.128906 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3613.916016 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3645.703125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3677.490234 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3709.277344 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3737.060547 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3798.583984 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3859.863281 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3923.242188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3986.71875 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4025.582031 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4086.763672 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4145.943359 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4207.466797 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4248.580078 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4282.271484 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4310.054688 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4371.578125 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4432.857422 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4496.236328 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4559.859375 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4593.550781 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4652.730469 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4716.353516 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4748.140625 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4811.763672 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4875.386719 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4907.173828 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4970.796875 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5006.880859 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5045.744141 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5100.724609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5164.347656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5196.134766 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5227.921875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5259.708984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5291.496094 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5323.283203 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5362.492188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5425.871094 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5464.734375 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5525.916016 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5589.294922 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5652.771484 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5716.150391 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5779.626953 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5843.005859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5882.214844 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5914.001953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5997.791016 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6029.578125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6126.990234 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6188.513672 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6251.990234 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6279.773438 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6341.052734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6404.431641 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6436.21875 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6488.318359 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6551.697266 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6612.976562 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6676.453125 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6728.552734 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6791.931641 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6853.113281 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6892.322266 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6926.013672 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6957.800781 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6998.914062 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7060.193359 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7099.402344 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7127.185547 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7188.367188 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7220.154297 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7247.9375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7300.037109 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7331.824219 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7395.300781 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7456.824219 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7496.033203 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7557.556641 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7596.919922 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7694.332031 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7722.115234 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7785.494141 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7813.277344 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7865.376953 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7904.585938 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7932.369141 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p0ae43f4c18">
+  <clipPath id="pbbc55f6494">
    <rect x="95.67625" y="49.34175" width="468.141298" height="294.686261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_summary.svg
+++ b/bench/graphs/silesia_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="575.639219pt" height="386.202469pt" viewBox="0 0 575.639219 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="573.503125pt" height="386.202469pt" viewBox="0 0 573.503125 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,232 +22,232 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 386.202469 
-L 575.639219 386.202469 
-L 575.639219 0 
+L 573.503125 386.202469 
+L 573.503125 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 189.944609 104.1264 
-L 294.569609 104.1264 
-L 294.569609 74.7432 
-L 189.944609 74.7432 
+    <path d="M 188.876563 104.1264 
+L 293.501563 104.1264 
+L 293.501563 74.7432 
+L 188.876563 74.7432 
 z
-" clip-path="url(#p75ca475145)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p31c24e8678)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 294.569609 104.1264 
-L 399.194609 104.1264 
-L 399.194609 74.7432 
-L 294.569609 74.7432 
+    <path d="M 293.501563 104.1264 
+L 398.126563 104.1264 
+L 398.126563 74.7432 
+L 293.501563 74.7432 
 z
-" clip-path="url(#p75ca475145)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p31c24e8678)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 399.194609 104.1264 
-L 503.819609 104.1264 
-L 503.819609 74.7432 
-L 399.194609 74.7432 
+    <path d="M 398.126563 104.1264 
+L 502.751563 104.1264 
+L 502.751563 74.7432 
+L 398.126563 74.7432 
 z
-" clip-path="url(#p75ca475145)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p31c24e8678)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 189.944609 133.5096 
-L 294.569609 133.5096 
-L 294.569609 104.1264 
-L 189.944609 104.1264 
+    <path d="M 188.876563 133.5096 
+L 293.501563 133.5096 
+L 293.501563 104.1264 
+L 188.876563 104.1264 
 z
-" clip-path="url(#p75ca475145)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p31c24e8678)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 294.569609 133.5096 
-L 399.194609 133.5096 
-L 399.194609 104.1264 
-L 294.569609 104.1264 
+    <path d="M 293.501563 133.5096 
+L 398.126563 133.5096 
+L 398.126563 104.1264 
+L 293.501563 104.1264 
 z
-" clip-path="url(#p75ca475145)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p31c24e8678)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 399.194609 133.5096 
-L 503.819609 133.5096 
-L 503.819609 104.1264 
-L 399.194609 104.1264 
+    <path d="M 398.126563 133.5096 
+L 502.751563 133.5096 
+L 502.751563 104.1264 
+L 398.126563 104.1264 
 z
-" clip-path="url(#p75ca475145)" style="fill: #fece7c; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p31c24e8678)" style="fill: #fece7c; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 189.944609 162.8928 
-L 294.569609 162.8928 
-L 294.569609 133.5096 
-L 189.944609 133.5096 
+    <path d="M 188.876563 162.8928 
+L 293.501563 162.8928 
+L 293.501563 133.5096 
+L 188.876563 133.5096 
 z
-" clip-path="url(#p75ca475145)" style="fill: #fee08b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p31c24e8678)" style="fill: #fee08b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 294.569609 162.8928 
-L 399.194609 162.8928 
-L 399.194609 133.5096 
-L 294.569609 133.5096 
+    <path d="M 293.501563 162.8928 
+L 398.126563 162.8928 
+L 398.126563 133.5096 
+L 293.501563 133.5096 
 z
-" clip-path="url(#p75ca475145)" style="fill: #feefa3; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p31c24e8678)" style="fill: #feefa3; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 399.194609 162.8928 
-L 503.819609 162.8928 
-L 503.819609 133.5096 
-L 399.194609 133.5096 
+    <path d="M 398.126563 162.8928 
+L 502.751563 162.8928 
+L 502.751563 133.5096 
+L 398.126563 133.5096 
 z
-" clip-path="url(#p75ca475145)" style="fill: #fdbf6f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p31c24e8678)" style="fill: #fdbf6f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 189.944609 192.276 
-L 294.569609 192.276 
-L 294.569609 162.8928 
-L 189.944609 162.8928 
+    <path d="M 188.876563 192.276 
+L 293.501563 192.276 
+L 293.501563 162.8928 
+L 188.876563 162.8928 
 z
-" clip-path="url(#p75ca475145)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p31c24e8678)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 294.569609 192.276 
-L 399.194609 192.276 
-L 399.194609 162.8928 
-L 294.569609 162.8928 
+    <path d="M 293.501563 192.276 
+L 398.126563 192.276 
+L 398.126563 162.8928 
+L 293.501563 162.8928 
 z
-" clip-path="url(#p75ca475145)" style="fill: #fede89; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p31c24e8678)" style="fill: #fede89; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 399.194609 192.276 
-L 503.819609 192.276 
-L 503.819609 162.8928 
-L 399.194609 162.8928 
+    <path d="M 398.126563 192.276 
+L 502.751563 192.276 
+L 502.751563 162.8928 
+L 398.126563 162.8928 
 z
-" clip-path="url(#p75ca475145)" style="fill: #f7814c; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p31c24e8678)" style="fill: #f7814c; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 189.944609 221.6592 
-L 294.569609 221.6592 
-L 294.569609 192.276 
-L 189.944609 192.276 
+    <path d="M 188.876563 221.6592 
+L 293.501563 221.6592 
+L 293.501563 192.276 
+L 188.876563 192.276 
 z
-" clip-path="url(#p75ca475145)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p31c24e8678)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 294.569609 221.6592 
-L 399.194609 221.6592 
-L 399.194609 192.276 
-L 294.569609 192.276 
+    <path d="M 293.501563 221.6592 
+L 398.126563 221.6592 
+L 398.126563 192.276 
+L 293.501563 192.276 
 z
-" clip-path="url(#p75ca475145)" style="fill: #fed27f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p31c24e8678)" style="fill: #fed27f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 399.194609 221.6592 
-L 503.819609 221.6592 
-L 503.819609 192.276 
-L 399.194609 192.276 
+    <path d="M 398.126563 221.6592 
+L 502.751563 221.6592 
+L 502.751563 192.276 
+L 398.126563 192.276 
 z
-" clip-path="url(#p75ca475145)" style="fill: #fffcba; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p31c24e8678)" style="fill: #fffcba; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 189.944609 251.0424 
-L 294.569609 251.0424 
-L 294.569609 221.6592 
-L 189.944609 221.6592 
+    <path d="M 188.876563 251.0424 
+L 293.501563 251.0424 
+L 293.501563 221.6592 
+L 188.876563 221.6592 
 z
-" clip-path="url(#p75ca475145)" style="fill: #fff3ac; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p31c24e8678)" style="fill: #fff3ac; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 294.569609 251.0424 
-L 399.194609 251.0424 
-L 399.194609 221.6592 
-L 294.569609 221.6592 
+    <path d="M 293.501563 251.0424 
+L 398.126563 251.0424 
+L 398.126563 221.6592 
+L 293.501563 221.6592 
 z
-" clip-path="url(#p75ca475145)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p31c24e8678)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 399.194609 251.0424 
-L 503.819609 251.0424 
-L 503.819609 221.6592 
-L 399.194609 221.6592 
+    <path d="M 398.126563 251.0424 
+L 502.751563 251.0424 
+L 502.751563 221.6592 
+L 398.126563 221.6592 
 z
-" clip-path="url(#p75ca475145)" style="fill: #e8f59f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p31c24e8678)" style="fill: #e8f59f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 189.944609 280.4256 
-L 294.569609 280.4256 
-L 294.569609 251.0424 
-L 189.944609 251.0424 
+    <path d="M 188.876563 280.4256 
+L 293.501563 280.4256 
+L 293.501563 251.0424 
+L 188.876563 251.0424 
 z
-" clip-path="url(#p75ca475145)" style="fill: #feec9f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p31c24e8678)" style="fill: #feec9f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 294.569609 280.4256 
-L 399.194609 280.4256 
-L 399.194609 251.0424 
-L 294.569609 251.0424 
+    <path d="M 293.501563 280.4256 
+L 398.126563 280.4256 
+L 398.126563 251.0424 
+L 293.501563 251.0424 
 z
-" clip-path="url(#p75ca475145)" style="fill: #fdc171; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p31c24e8678)" style="fill: #fdc776; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 399.194609 280.4256 
-L 503.819609 280.4256 
-L 503.819609 251.0424 
-L 399.194609 251.0424 
+    <path d="M 398.126563 280.4256 
+L 502.751563 280.4256 
+L 502.751563 251.0424 
+L 398.126563 251.0424 
 z
-" clip-path="url(#p75ca475145)" style="fill: #f99153; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p31c24e8678)" style="fill: #fdc574; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 189.944609 309.8088 
-L 294.569609 309.8088 
-L 294.569609 280.4256 
-L 189.944609 280.4256 
+    <path d="M 188.876563 309.8088 
+L 293.501563 309.8088 
+L 293.501563 280.4256 
+L 188.876563 280.4256 
 z
-" clip-path="url(#p75ca475145)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p31c24e8678)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 294.569609 309.8088 
-L 399.194609 309.8088 
-L 399.194609 280.4256 
-L 294.569609 280.4256 
+    <path d="M 293.501563 309.8088 
+L 398.126563 309.8088 
+L 398.126563 280.4256 
+L 293.501563 280.4256 
 z
-" clip-path="url(#p75ca475145)" style="fill: #fa9b58; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p31c24e8678)" style="fill: #fa9b58; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 399.194609 309.8088 
-L 503.819609 309.8088 
-L 503.819609 280.4256 
-L 399.194609 280.4256 
+    <path d="M 398.126563 309.8088 
+L 502.751563 309.8088 
+L 502.751563 280.4256 
+L 398.126563 280.4256 
 z
-" clip-path="url(#p75ca475145)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p31c24e8678)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 189.944609 339.192 
-L 294.569609 339.192 
-L 294.569609 309.8088 
-L 189.944609 309.8088 
+    <path d="M 188.876563 339.192 
+L 293.501563 339.192 
+L 293.501563 309.8088 
+L 188.876563 309.8088 
 z
-" clip-path="url(#p75ca475145)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p31c24e8678)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 294.569609 339.192 
-L 399.194609 339.192 
-L 399.194609 309.8088 
-L 294.569609 309.8088 
+    <path d="M 293.501563 339.192 
+L 398.126563 339.192 
+L 398.126563 309.8088 
+L 293.501563 309.8088 
 z
-" clip-path="url(#p75ca475145)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p31c24e8678)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 399.194609 339.192 
-L 503.819609 339.192 
-L 503.819609 309.8088 
-L 399.194609 309.8088 
+    <path d="M 398.126563 339.192 
+L 502.751563 339.192 
+L 502.751563 309.8088 
+L 398.126563 309.8088 
 z
-" clip-path="url(#p75ca475145)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p31c24e8678)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(122.931875 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(121.863828 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(230.216094 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(229.148047 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(308.788203 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(307.720156 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(407.139922 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(406.071875 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(118.869609 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(117.801563 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.320 -->
-    <g transform="translate(230.805859 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(229.737813 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -918,7 +918,7 @@ z
    </g>
    <g id="text_7">
     <!-- 117 -->
-    <g transform="translate(339.247109 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(338.179063 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -952,7 +952,7 @@ z
    </g>
    <g id="text_8">
     <!-- 852 -->
-    <g transform="translate(443.872109 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(442.804063 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -1026,7 +1026,7 @@ z
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(113.507734 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(112.439688 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1125,7 +1125,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.324 -->
-    <g transform="translate(230.805859 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(229.737813 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1156,7 +1156,7 @@ z
    </g>
    <g id="text_11">
     <!-- 61 -->
-    <g transform="translate(341.792109 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(340.724063 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -1195,7 +1195,7 @@ z
    </g>
    <g id="text_12">
     <!-- 312 -->
-    <g transform="translate(443.872109 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(442.804063 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
@@ -1203,7 +1203,7 @@ z
    </g>
    <g id="text_13">
     <!-- Go compress/flate -->
-    <g transform="translate(101.200859 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(100.132813 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -1374,7 +1374,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.325 -->
-    <g transform="translate(230.805859 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(229.737813 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1384,14 +1384,14 @@ z
    </g>
    <g id="text_15">
     <!-- 50 -->
-    <g transform="translate(341.792109 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(340.724063 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
     <!-- 275 -->
-    <g transform="translate(443.872109 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(442.804063 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
@@ -1399,7 +1399,7 @@ z
    </g>
    <g id="text_17">
     <!-- JS fflate -->
-    <g transform="translate(122.233359 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(121.165313 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1459,7 +1459,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.329 -->
-    <g transform="translate(230.805859 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(229.737813 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-39" d="M 703 97 
 L 703 672 
@@ -1501,14 +1501,14 @@ z
    </g>
    <g id="text_19">
     <!-- 41 -->
-    <g transform="translate(341.792109 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(340.724063 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
     <!-- 160 -->
-    <g transform="translate(443.872109 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(442.804063 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -1516,7 +1516,7 @@ z
    </g>
    <g id="text_21">
     <!-- zlib -->
-    <g transform="translate(130.770859 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(129.702813 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1540,7 +1540,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.323 -->
-    <g transform="translate(230.805859 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(229.737813 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1550,14 +1550,14 @@ z
    </g>
    <g id="text_23">
     <!-- 38 -->
-    <g transform="translate(341.792109 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(340.724063 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_24">
     <!-- 448 -->
-    <g transform="translate(443.872109 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(442.804063 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(127.246094 0)"/>
@@ -1565,7 +1565,7 @@ z
    </g>
    <g id="text_25">
     <!-- miniz_oxide -->
-    <g transform="translate(114.077109 238.44705) scale(0.08 -0.08)">
+    <g transform="translate(113.009063 238.44705) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6e" d="M 3513 2113 
 L 3513 0 
@@ -1624,7 +1624,7 @@ z
    </g>
    <g id="text_26">
     <!-- 0.322 -->
-    <g transform="translate(230.805859 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(229.737813 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1634,14 +1634,14 @@ z
    </g>
    <g id="text_27">
     <!-- 36 -->
-    <g transform="translate(341.792109 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(340.724063 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_28">
     <!-- 527 -->
-    <g transform="translate(443.872109 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(442.804063 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
@@ -1649,7 +1649,7 @@ z
    </g>
    <g id="text_29">
     <!-- lean-zip (native) -->
-    <g transform="translate(100.578984 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(99.510938 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1758,7 +1758,7 @@ z
    </g>
    <g id="text_30">
     <!-- 0.323 -->
-    <g transform="translate(229.605234 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(228.537188 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1851,30 +1851,37 @@ z
     </g>
    </g>
    <g id="text_31">
-    <!-- 32 -->
-    <g transform="translate(341.315859 267.9415) scale(0.08 -0.08)">
+    <!-- 34 -->
+    <g transform="translate(340.247813 267.9415) scale(0.08 -0.08)">
+     <defs>
+      <path id="DejaVuSans-Bold-34" d="M 2356 3675 
+L 1038 1722 
+L 2356 1722 
+L 2356 3675 
+z
+M 2156 4666 
+L 3494 4666 
+L 3494 1722 
+L 4159 1722 
+L 4159 850 
+L 3494 850 
+L 3494 0 
+L 2356 0 
+L 2356 850 
+L 288 850 
+L 288 1881 
+L 2156 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-Bold-33"/>
-     <use xlink:href="#DejaVuSans-Bold-32" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-34" transform="translate(69.580078 0)"/>
     </g>
    </g>
    <g id="text_32">
-    <!-- 189 -->
-    <g transform="translate(443.157734 267.9415) scale(0.08 -0.08)">
+    <!-- 286 -->
+    <g transform="translate(442.089688 267.9415) scale(0.08 -0.08)">
      <defs>
-      <path id="DejaVuSans-Bold-31" d="M 750 831 
-L 1813 831 
-L 1813 3847 
-L 722 3622 
-L 722 4441 
-L 1806 4666 
-L 2950 4666 
-L 2950 831 
-L 4013 831 
-L 4013 0 
-L 750 0 
-L 750 831 
-z
-" transform="scale(0.015625)"/>
       <path id="DejaVuSans-Bold-38" d="M 2228 2088 
 Q 1891 2088 1709 1903 
 Q 1528 1719 1528 1375 
@@ -1914,45 +1921,45 @@ Q 1941 3994 1786 3844
 Q 1631 3694 1631 3419 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-39" d="M 641 103 
-L 641 966 
-Q 928 831 1190 764 
-Q 1453 697 1709 697 
-Q 2247 697 2547 995 
-Q 2847 1294 2900 1881 
-Q 2688 1725 2447 1647 
-Q 2206 1569 1925 1569 
-Q 1209 1569 770 1986 
-Q 331 2403 331 3084 
-Q 331 3838 820 4291 
-Q 1309 4744 2131 4744 
-Q 3044 4744 3544 4128 
-Q 4044 3513 4044 2388 
-Q 4044 1231 3459 570 
-Q 2875 -91 1856 -91 
-Q 1528 -91 1228 -42 
-Q 928 6 641 103 
+      <path id="DejaVuSans-Bold-36" d="M 2316 2303 
+Q 2000 2303 1842 2098 
+Q 1684 1894 1684 1484 
+Q 1684 1075 1842 870 
+Q 2000 666 2316 666 
+Q 2634 666 2792 870 
+Q 2950 1075 2950 1484 
+Q 2950 1894 2792 2098 
+Q 2634 2303 2316 2303 
 z
-M 2125 2350 
-Q 2441 2350 2600 2554 
-Q 2759 2759 2759 3169 
-Q 2759 3575 2600 3781 
-Q 2441 3988 2125 3988 
-Q 1809 3988 1650 3781 
-Q 1491 3575 1491 3169 
-Q 1491 2759 1650 2554 
-Q 1809 2350 2125 2350 
+M 3803 4544 
+L 3803 3681 
+Q 3506 3822 3243 3889 
+Q 2981 3956 2731 3956 
+Q 2194 3956 1894 3657 
+Q 1594 3359 1544 2772 
+Q 1750 2925 1990 3001 
+Q 2231 3078 2516 3078 
+Q 3231 3078 3670 2659 
+Q 4109 2241 4109 1563 
+Q 4109 813 3618 361 
+Q 3128 -91 2303 -91 
+Q 1394 -91 895 523 
+Q 397 1138 397 2266 
+Q 397 3422 980 4083 
+Q 1563 4744 2578 4744 
+Q 2900 4744 3203 4694 
+Q 3506 4644 3803 4544 
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-Bold-31"/>
+     <use xlink:href="#DejaVuSans-Bold-32"/>
      <use xlink:href="#DejaVuSans-Bold-38" transform="translate(69.580078 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-39" transform="translate(139.160156 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-36" transform="translate(139.160156 0)"/>
     </g>
    </g>
    <g id="text_33">
     <!-- OCaml decompress -->
-    <g transform="translate(98.693984 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(97.625938 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -2017,7 +2024,7 @@ z
    </g>
    <g id="text_34">
     <!-- 0.336 -->
-    <g transform="translate(230.805859 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(229.737813 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -2027,21 +2034,21 @@ z
    </g>
    <g id="text_35">
     <!-- 21 -->
-    <g transform="translate(341.792109 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(340.724063 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_36">
     <!-- 69 -->
-    <g transform="translate(446.417109 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(445.349063 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-36"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(126.915234 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(125.847188 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -2052,7 +2059,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.303 -->
-    <g transform="translate(230.805859 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(229.737813 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -2062,13 +2069,13 @@ z
    </g>
    <g id="text_39">
     <!-- 1 -->
-    <g transform="translate(344.337109 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(343.269063 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(447.507109 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(446.439063 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2084,7 +2091,7 @@ z
   </g>
   <g id="text_41">
    <!-- silesia — geomean over files, level 6 -->
-   <g transform="translate(154.421328 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(153.353281 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-2014" d="M 344 2156 
 L 6056 2156 
@@ -2157,36 +2164,6 @@ L 653 256
 L 653 1209 
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Bold-36" d="M 2316 2303 
-Q 2000 2303 1842 2098 
-Q 1684 1894 1684 1484 
-Q 1684 1075 1842 870 
-Q 2000 666 2316 666 
-Q 2634 666 2792 870 
-Q 2950 1075 2950 1484 
-Q 2950 1894 2792 2098 
-Q 2634 2303 2316 2303 
-z
-M 3803 4544 
-L 3803 3681 
-Q 3506 3822 3243 3889 
-Q 2981 3956 2731 3956 
-Q 2194 3956 1894 3657 
-Q 1594 3359 1544 2772 
-Q 1750 2925 1990 3001 
-Q 2231 3078 2516 3078 
-Q 3231 3078 3670 2659 
-Q 4109 2241 4109 1563 
-Q 4109 813 3618 361 
-Q 3128 -91 2303 -91 
-Q 1394 -91 895 523 
-Q 397 1138 397 2266 
-Q 397 3422 980 4083 
-Q 1563 4744 2578 4744 
-Q 2900 4744 3203 4694 
-Q 3506 4644 3803 4544 
-z
-" transform="scale(0.015625)"/>
     </defs>
     <use xlink:href="#DejaVuSans-Bold-73"/>
     <use xlink:href="#DejaVuSans-Bold-69" transform="translate(59.521484 0)"/>
@@ -2228,7 +2205,7 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-07-08T06:11:08Z  ·  Linux chungus2 x86_64  ·  commit 28336125  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-07-08T15:47:33Z  ·  Linux chungus2 x86_64  ·  commit f2026e66  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2369,14 +2346,14 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-38" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2416,110 +2393,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3262.744141 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3326.367188 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3389.990234 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3453.613281 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3517.236328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3580.859375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3612.646484 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3644.433594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3676.220703 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3708.007812 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3739.794922 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3767.578125 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3829.101562 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3890.380859 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3953.759766 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4017.236328 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4056.099609 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4117.28125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4176.460938 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4237.984375 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4279.097656 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4312.789062 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4340.572266 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4402.095703 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4463.375 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4526.753906 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4590.376953 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4624.068359 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4683.248047 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4746.871094 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4778.658203 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4842.28125 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4905.904297 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4937.691406 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(5001.314453 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5037.398438 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5076.261719 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5131.242188 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5194.865234 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5226.652344 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5258.439453 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5290.226562 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5322.013672 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5353.800781 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5393.009766 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5456.388672 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5495.251953 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5556.433594 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5619.8125 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5683.289062 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5746.667969 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5810.144531 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5873.523438 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5912.732422 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5944.519531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6028.308594 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6060.095703 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6157.507812 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6219.03125 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6282.507812 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6310.291016 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6371.570312 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6434.949219 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6466.736328 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6518.835938 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6582.214844 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6643.494141 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6706.970703 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6759.070312 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6822.449219 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6883.630859 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6922.839844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6956.53125 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6988.318359 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7029.431641 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7090.710938 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7129.919922 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7157.703125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7218.884766 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7250.671875 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7278.455078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7330.554688 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7362.341797 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7425.818359 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7487.341797 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7526.550781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7588.074219 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7627.4375 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7724.849609 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7752.632812 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7816.011719 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7843.794922 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7895.894531 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7935.103516 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7962.886719 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3107.080078 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3170.703125 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3234.326172 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3297.949219 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3361.572266 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3423.095703 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3486.71875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3550.341797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3582.128906 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3613.916016 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3645.703125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3677.490234 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3709.277344 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3737.060547 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3798.583984 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3859.863281 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3923.242188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3986.71875 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4025.582031 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4086.763672 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4145.943359 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4207.466797 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4248.580078 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4282.271484 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4310.054688 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4371.578125 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4432.857422 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4496.236328 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4559.859375 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4593.550781 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4652.730469 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4716.353516 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4748.140625 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4811.763672 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4875.386719 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4907.173828 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4970.796875 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5006.880859 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5045.744141 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5100.724609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5164.347656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5196.134766 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5227.921875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5259.708984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5291.496094 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5323.283203 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5362.492188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5425.871094 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5464.734375 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5525.916016 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5589.294922 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5652.771484 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5716.150391 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5779.626953 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5843.005859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5882.214844 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5914.001953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5997.791016 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6029.578125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6126.990234 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6188.513672 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6251.990234 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6279.773438 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6341.052734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6404.431641 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6436.21875 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6488.318359 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6551.697266 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6612.976562 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6676.453125 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6728.552734 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6791.931641 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6853.113281 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6892.322266 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6926.013672 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6957.800781 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6998.914062 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7060.193359 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7099.402344 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7127.185547 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7188.367188 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7220.154297 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7247.9375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7300.037109 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7331.824219 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7395.300781 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7456.824219 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7496.033203 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7557.556641 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7596.919922 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7694.332031 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7722.115234 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7785.494141 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7813.277344 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7865.376953 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7904.585938 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7932.369141 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p75ca475145">
-   <rect x="85.319609" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="p31c24e8678">
+   <rect x="84.251563" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/lakefile.lean
+++ b/bench/lakefile.lean
@@ -212,8 +212,18 @@ def linkFlags : IO (Array String) := do
                  "-Wl,--allow-shlib-undefined"]
   return args
 
+/-- LTO link flags mirroring the parent lakefile's `ltoLinkFlags` (issue
+    #2806, keep in sync with `../lakefile.lean`): on Linux the parent
+    library's objects are LLVM bitcode, so the bench executables' links run
+    the same LTO codegen at `-O3` — the bench binaries measure exactly what
+    the shipped library's consumers link. `LEAN_ZIP_LTO=0` opts out. -/
+def ltoLinkFlags : IO (Array String) := do
+  if Platform.isWindows || Platform.isOSX then return #[]
+  if (← IO.getEnv "LEAN_ZIP_LTO") == some "0" then return #[]
+  return #["-flto", "-fno-semantic-interposition", "-O3"]
+
 package «lean-zip-bench» where
-  moreLinkArgs := run_io linkFlags
+  moreLinkArgs := run_io do return (← linkFlags) ++ (← ltoLinkFlags)
 
 require «lean-zip» from ".."
 

--- a/bench/results/latest.json
+++ b/bench/results/latest.json
@@ -1,8 +1,8 @@
 {
  "meta": {
-  "date": "2026-07-08T06:11:08Z",
+  "date": "2026-07-08T15:47:33Z",
   "machine": "Linux chungus2 x86_64",
-  "git_commit": "28336125",
+  "git_commit": "f2026e66",
   "toolchain": "leanprover/lean4:v4.30.0-rc2",
   "note": "compress_mbps/decompress_mbps are a median-of-5 snapshot on the machine above; ratio is deterministic"
  },
@@ -14,8 +14,8 @@
    "level": 1,
    "out_size": 60455,
    "ratio": 0.3975,
-   "compress_mbps": 67.32,
-   "decompress_mbps": 114.55
+   "compress_mbps": 72.24,
+   "decompress_mbps": 205.62
   },
   {
    "compressor": "native",
@@ -24,8 +24,8 @@
    "level": 2,
    "out_size": 56316,
    "ratio": 0.3703,
-   "compress_mbps": 48.8,
-   "decompress_mbps": 126.88
+   "compress_mbps": 52.02,
+   "decompress_mbps": 235.72
   },
   {
    "compressor": "native",
@@ -34,8 +34,8 @@
    "level": 3,
    "out_size": 55646,
    "ratio": 0.3659,
-   "compress_mbps": 43.37,
-   "decompress_mbps": 138.35
+   "compress_mbps": 46.09,
+   "decompress_mbps": 257.11
   },
   {
    "compressor": "native",
@@ -44,8 +44,8 @@
    "level": 4,
    "out_size": 54357,
    "ratio": 0.3574,
-   "compress_mbps": 34.29,
-   "decompress_mbps": 143.1
+   "compress_mbps": 36.11,
+   "decompress_mbps": 260.56
   },
   {
    "compressor": "native",
@@ -54,8 +54,8 @@
    "level": 5,
    "out_size": 54078,
    "ratio": 0.3556,
-   "compress_mbps": 27.61,
-   "decompress_mbps": 150.05
+   "compress_mbps": 29.02,
+   "decompress_mbps": 261.0
   },
   {
    "compressor": "native",
@@ -64,8 +64,8 @@
    "level": 6,
    "out_size": 54013,
    "ratio": 0.3551,
-   "compress_mbps": 27.0,
-   "decompress_mbps": 154.54
+   "compress_mbps": 28.46,
+   "decompress_mbps": 267.84
   },
   {
    "compressor": "native",
@@ -74,8 +74,8 @@
    "level": 7,
    "out_size": 53772,
    "ratio": 0.3536,
-   "compress_mbps": 22.74,
-   "decompress_mbps": 155.01
+   "compress_mbps": 23.83,
+   "decompress_mbps": 267.95
   },
   {
    "compressor": "native",
@@ -84,8 +84,8 @@
    "level": 8,
    "out_size": 53753,
    "ratio": 0.3534,
-   "compress_mbps": 21.78,
-   "decompress_mbps": 155.32
+   "compress_mbps": 22.85,
+   "decompress_mbps": 268.69
   },
   {
    "compressor": "native",
@@ -94,8 +94,8 @@
    "level": 9,
    "out_size": 52732,
    "ratio": 0.3467,
-   "compress_mbps": 4.14,
-   "decompress_mbps": 155.16
+   "compress_mbps": 4.27,
+   "decompress_mbps": 268.76
   },
   {
    "compressor": "native",
@@ -104,7 +104,7 @@
    "level": 10,
    "out_size": 52078,
    "ratio": 0.3424,
-   "compress_mbps": 2.31,
+   "compress_mbps": 2.4,
    "decompress_mbps": null
   },
   {
@@ -114,8 +114,8 @@
    "level": 1,
    "out_size": 53135,
    "ratio": 0.4245,
-   "compress_mbps": 61.96,
-   "decompress_mbps": 107.7
+   "compress_mbps": 65.84,
+   "decompress_mbps": 199.39
   },
   {
    "compressor": "native",
@@ -124,8 +124,8 @@
    "level": 2,
    "out_size": 50187,
    "ratio": 0.4009,
-   "compress_mbps": 45.98,
-   "decompress_mbps": 115.48
+   "compress_mbps": 49.07,
+   "decompress_mbps": 215.45
   },
   {
    "compressor": "native",
@@ -134,8 +134,8 @@
    "level": 3,
    "out_size": 49810,
    "ratio": 0.3979,
-   "compress_mbps": 41.46,
-   "decompress_mbps": 125.6
+   "compress_mbps": 44.51,
+   "decompress_mbps": 236.5
   },
   {
    "compressor": "native",
@@ -144,8 +144,8 @@
    "level": 4,
    "out_size": 48687,
    "ratio": 0.3889,
-   "compress_mbps": 32.27,
-   "decompress_mbps": 130.76
+   "compress_mbps": 34.25,
+   "decompress_mbps": 240.73
   },
   {
    "compressor": "native",
@@ -154,8 +154,8 @@
    "level": 5,
    "out_size": 48586,
    "ratio": 0.3881,
-   "compress_mbps": 28.06,
-   "decompress_mbps": 136.26
+   "compress_mbps": 29.47,
+   "decompress_mbps": 239.52
   },
   {
    "compressor": "native",
@@ -164,8 +164,8 @@
    "level": 6,
    "out_size": 48373,
    "ratio": 0.3864,
-   "compress_mbps": 26.1,
-   "decompress_mbps": 139.54
+   "compress_mbps": 27.3,
+   "decompress_mbps": 244.11
   },
   {
    "compressor": "native",
@@ -174,8 +174,8 @@
    "level": 7,
    "out_size": 48288,
    "ratio": 0.3858,
-   "compress_mbps": 23.74,
-   "decompress_mbps": 140.32
+   "compress_mbps": 24.76,
+   "decompress_mbps": 245.11
   },
   {
    "compressor": "native",
@@ -184,8 +184,8 @@
    "level": 8,
    "out_size": 48284,
    "ratio": 0.3857,
-   "compress_mbps": 23.45,
-   "decompress_mbps": 140.34
+   "compress_mbps": 24.52,
+   "decompress_mbps": 245.63
   },
   {
    "compressor": "native",
@@ -194,8 +194,8 @@
    "level": 9,
    "out_size": 47430,
    "ratio": 0.3789,
-   "compress_mbps": 4.52,
-   "decompress_mbps": 140.87
+   "compress_mbps": 4.66,
+   "decompress_mbps": 246.53
   },
   {
    "compressor": "native",
@@ -204,7 +204,7 @@
    "level": 10,
    "out_size": 46865,
    "ratio": 0.3744,
-   "compress_mbps": 2.7,
+   "compress_mbps": 2.8,
    "decompress_mbps": null
   },
   {
@@ -214,8 +214,8 @@
    "level": 1,
    "out_size": 8476,
    "ratio": 0.3445,
-   "compress_mbps": 61.45,
-   "decompress_mbps": 132.55
+   "compress_mbps": 65.01,
+   "decompress_mbps": 262.66
   },
   {
    "compressor": "native",
@@ -224,8 +224,8 @@
    "level": 2,
    "out_size": 8271,
    "ratio": 0.3362,
-   "compress_mbps": 51.06,
-   "decompress_mbps": 137.54
+   "compress_mbps": 54.26,
+   "decompress_mbps": 269.19
   },
   {
    "compressor": "native",
@@ -234,8 +234,8 @@
    "level": 3,
    "out_size": 8158,
    "ratio": 0.3316,
-   "compress_mbps": 49.35,
-   "decompress_mbps": 140.85
+   "compress_mbps": 52.23,
+   "decompress_mbps": 274.29
   },
   {
    "compressor": "native",
@@ -244,8 +244,8 @@
    "level": 4,
    "out_size": 7948,
    "ratio": 0.3231,
-   "compress_mbps": 43.9,
-   "decompress_mbps": 147.71
+   "compress_mbps": 47.16,
+   "decompress_mbps": 280.7
   },
   {
    "compressor": "native",
@@ -254,8 +254,8 @@
    "level": 5,
    "out_size": 7899,
    "ratio": 0.3211,
-   "compress_mbps": 37.34,
-   "decompress_mbps": 152.71
+   "compress_mbps": 40.36,
+   "decompress_mbps": 288.27
   },
   {
    "compressor": "native",
@@ -264,8 +264,8 @@
    "level": 6,
    "out_size": 7912,
    "ratio": 0.3216,
-   "compress_mbps": 36.85,
-   "decompress_mbps": 154.06
+   "compress_mbps": 39.37,
+   "decompress_mbps": 287.29
   },
   {
    "compressor": "native",
@@ -274,8 +274,8 @@
    "level": 7,
    "out_size": 7897,
    "ratio": 0.321,
-   "compress_mbps": 33.55,
-   "decompress_mbps": 155.88
+   "compress_mbps": 35.86,
+   "decompress_mbps": 290.68
   },
   {
    "compressor": "native",
@@ -284,8 +284,8 @@
    "level": 8,
    "out_size": 7897,
    "ratio": 0.321,
-   "compress_mbps": 33.44,
-   "decompress_mbps": 156.05
+   "compress_mbps": 35.82,
+   "decompress_mbps": 291.0
   },
   {
    "compressor": "native",
@@ -294,8 +294,8 @@
    "level": 9,
    "out_size": 7803,
    "ratio": 0.3172,
-   "compress_mbps": 4.78,
-   "decompress_mbps": 155.63
+   "compress_mbps": 4.96,
+   "decompress_mbps": 291.69
   },
   {
    "compressor": "native",
@@ -304,7 +304,7 @@
    "level": 10,
    "out_size": 7737,
    "ratio": 0.3145,
-   "compress_mbps": 2.83,
+   "compress_mbps": 2.94,
    "decompress_mbps": null
   },
   {
@@ -314,8 +314,8 @@
    "level": 1,
    "out_size": 3509,
    "ratio": 0.3147,
-   "compress_mbps": 46.87,
-   "decompress_mbps": 109.64
+   "compress_mbps": 48.67,
+   "decompress_mbps": 181.04
   },
   {
    "compressor": "native",
@@ -324,8 +324,8 @@
    "level": 2,
    "out_size": 3269,
    "ratio": 0.2932,
-   "compress_mbps": 40.2,
-   "decompress_mbps": 115.21
+   "compress_mbps": 42.98,
+   "decompress_mbps": 183.14
   },
   {
    "compressor": "native",
@@ -334,8 +334,8 @@
    "level": 3,
    "out_size": 3208,
    "ratio": 0.2877,
-   "compress_mbps": 39.22,
-   "decompress_mbps": 119.1
+   "compress_mbps": 41.72,
+   "decompress_mbps": 186.75
   },
   {
    "compressor": "native",
@@ -344,8 +344,8 @@
    "level": 4,
    "out_size": 3128,
    "ratio": 0.2805,
-   "compress_mbps": 36.95,
-   "decompress_mbps": 122.45
+   "compress_mbps": 39.0,
+   "decompress_mbps": 190.97
   },
   {
    "compressor": "native",
@@ -354,8 +354,8 @@
    "level": 5,
    "out_size": 3111,
    "ratio": 0.279,
-   "compress_mbps": 32.86,
-   "decompress_mbps": 124.83
+   "compress_mbps": 35.26,
+   "decompress_mbps": 191.17
   },
   {
    "compressor": "native",
@@ -364,8 +364,8 @@
    "level": 6,
    "out_size": 3119,
    "ratio": 0.2797,
-   "compress_mbps": 33.09,
-   "decompress_mbps": 126.04
+   "compress_mbps": 35.57,
+   "decompress_mbps": 190.88
   },
   {
    "compressor": "native",
@@ -374,8 +374,8 @@
    "level": 7,
    "out_size": 3111,
    "ratio": 0.279,
-   "compress_mbps": 31.0,
-   "decompress_mbps": 126.35
+   "compress_mbps": 33.5,
+   "decompress_mbps": 192.77
   },
   {
    "compressor": "native",
@@ -384,8 +384,8 @@
    "level": 8,
    "out_size": 3111,
    "ratio": 0.279,
-   "compress_mbps": 30.85,
-   "decompress_mbps": 126.27
+   "compress_mbps": 33.33,
+   "decompress_mbps": 192.82
   },
   {
    "compressor": "native",
@@ -394,8 +394,8 @@
    "level": 9,
    "out_size": 3056,
    "ratio": 0.2741,
-   "compress_mbps": 5.28,
-   "decompress_mbps": 126.2
+   "compress_mbps": 5.45,
+   "decompress_mbps": 191.81
   },
   {
    "compressor": "native",
@@ -404,7 +404,7 @@
    "level": 10,
    "out_size": 3032,
    "ratio": 0.2719,
-   "compress_mbps": 2.97,
+   "compress_mbps": 3.06,
    "decompress_mbps": null
   },
   {
@@ -414,8 +414,8 @@
    "level": 1,
    "out_size": 1282,
    "ratio": 0.3445,
-   "compress_mbps": 24.79,
-   "decompress_mbps": 65.58
+   "compress_mbps": 25.2,
+   "decompress_mbps": 83.23
   },
   {
    "compressor": "native",
@@ -424,8 +424,8 @@
    "level": 2,
    "out_size": 1225,
    "ratio": 0.3292,
-   "compress_mbps": 23.27,
-   "decompress_mbps": 66.41
+   "compress_mbps": 23.91,
+   "decompress_mbps": 84.42
   },
   {
    "compressor": "native",
@@ -434,8 +434,8 @@
    "level": 3,
    "out_size": 1220,
    "ratio": 0.3279,
-   "compress_mbps": 23.04,
-   "decompress_mbps": 67.28
+   "compress_mbps": 23.66,
+   "decompress_mbps": 84.16
   },
   {
    "compressor": "native",
@@ -444,8 +444,8 @@
    "level": 4,
    "out_size": 1213,
    "ratio": 0.326,
-   "compress_mbps": 22.37,
-   "decompress_mbps": 68.54
+   "compress_mbps": 23.04,
+   "decompress_mbps": 84.73
   },
   {
    "compressor": "native",
@@ -454,8 +454,8 @@
    "level": 5,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 21.56,
-   "decompress_mbps": 68.97
+   "compress_mbps": 22.37,
+   "decompress_mbps": 84.49
   },
   {
    "compressor": "native",
@@ -464,8 +464,8 @@
    "level": 6,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 21.14,
-   "decompress_mbps": 68.95
+   "compress_mbps": 22.0,
+   "decompress_mbps": 85.11
   },
   {
    "compressor": "native",
@@ -474,8 +474,8 @@
    "level": 7,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 20.96,
-   "decompress_mbps": 69.41
+   "compress_mbps": 21.86,
+   "decompress_mbps": 84.79
   },
   {
    "compressor": "native",
@@ -484,8 +484,8 @@
    "level": 8,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 20.97,
-   "decompress_mbps": 69.46
+   "compress_mbps": 21.77,
+   "decompress_mbps": 84.82
   },
   {
    "compressor": "native",
@@ -494,8 +494,8 @@
    "level": 9,
    "out_size": 1205,
    "ratio": 0.3238,
-   "compress_mbps": 4.85,
-   "decompress_mbps": 69.41
+   "compress_mbps": 5.0,
+   "decompress_mbps": 85.59
   },
   {
    "compressor": "native",
@@ -504,7 +504,7 @@
    "level": 10,
    "out_size": 1191,
    "ratio": 0.3201,
-   "compress_mbps": 2.87,
+   "compress_mbps": 2.98,
    "decompress_mbps": null
   },
   {
@@ -514,8 +514,8 @@
    "level": 1,
    "out_size": 251793,
    "ratio": 0.2445,
-   "compress_mbps": 129.37,
-   "decompress_mbps": 215.96
+   "compress_mbps": 141.33,
+   "decompress_mbps": 383.26
   },
   {
    "compressor": "native",
@@ -524,8 +524,8 @@
    "level": 2,
    "out_size": 242565,
    "ratio": 0.2356,
-   "compress_mbps": 88.77,
-   "decompress_mbps": 229.69
+   "compress_mbps": 108.14,
+   "decompress_mbps": 409.03
   },
   {
    "compressor": "native",
@@ -534,8 +534,8 @@
    "level": 3,
    "out_size": 242532,
    "ratio": 0.2355,
-   "compress_mbps": 76.55,
-   "decompress_mbps": 239.65
+   "compress_mbps": 87.67,
+   "decompress_mbps": 435.08
   },
   {
    "compressor": "native",
@@ -544,8 +544,8 @@
    "level": 4,
    "out_size": 239953,
    "ratio": 0.233,
-   "compress_mbps": 73.51,
-   "decompress_mbps": 246.55
+   "compress_mbps": 85.73,
+   "decompress_mbps": 461.17
   },
   {
    "compressor": "native",
@@ -554,8 +554,8 @@
    "level": 5,
    "out_size": 218565,
    "ratio": 0.2123,
-   "compress_mbps": 49.65,
-   "decompress_mbps": 246.11
+   "compress_mbps": 56.22,
+   "decompress_mbps": 448.07
   },
   {
    "compressor": "native",
@@ -564,8 +564,8 @@
    "level": 6,
    "out_size": 202676,
    "ratio": 0.1968,
-   "compress_mbps": 38.21,
-   "decompress_mbps": 252.23
+   "compress_mbps": 41.84,
+   "decompress_mbps": 465.13
   },
   {
    "compressor": "native",
@@ -574,8 +574,8 @@
    "level": 7,
    "out_size": 201403,
    "ratio": 0.1956,
-   "compress_mbps": 28.21,
-   "decompress_mbps": 255.72
+   "compress_mbps": 30.27,
+   "decompress_mbps": 467.49
   },
   {
    "compressor": "native",
@@ -584,8 +584,8 @@
    "level": 8,
    "out_size": 200798,
    "ratio": 0.195,
-   "compress_mbps": 21.28,
-   "decompress_mbps": 258.27
+   "compress_mbps": 22.65,
+   "decompress_mbps": 477.64
   },
   {
    "compressor": "native",
@@ -594,8 +594,8 @@
    "level": 9,
    "out_size": 182508,
    "ratio": 0.1772,
-   "compress_mbps": 3.44,
-   "decompress_mbps": 259.64
+   "compress_mbps": 3.48,
+   "decompress_mbps": 476.59
   },
   {
    "compressor": "native",
@@ -604,7 +604,7 @@
    "level": 10,
    "out_size": 178067,
    "ratio": 0.1729,
-   "compress_mbps": 1.44,
+   "compress_mbps": 1.45,
    "decompress_mbps": null
   },
   {
@@ -614,8 +614,8 @@
    "level": 1,
    "out_size": 160674,
    "ratio": 0.3765,
-   "compress_mbps": 73.67,
-   "decompress_mbps": 122.3
+   "compress_mbps": 79.21,
+   "decompress_mbps": 213.5
   },
   {
    "compressor": "native",
@@ -624,8 +624,8 @@
    "level": 2,
    "out_size": 149787,
    "ratio": 0.351,
-   "compress_mbps": 52.19,
-   "decompress_mbps": 132.28
+   "compress_mbps": 56.61,
+   "decompress_mbps": 231.38
   },
   {
    "compressor": "native",
@@ -634,8 +634,8 @@
    "level": 3,
    "out_size": 148055,
    "ratio": 0.3469,
-   "compress_mbps": 45.82,
-   "decompress_mbps": 144.44
+   "compress_mbps": 49.8,
+   "decompress_mbps": 258.15
   },
   {
    "compressor": "native",
@@ -644,8 +644,8 @@
    "level": 4,
    "out_size": 144750,
    "ratio": 0.3392,
-   "compress_mbps": 34.21,
-   "decompress_mbps": 150.21
+   "compress_mbps": 39.05,
+   "decompress_mbps": 262.19
   },
   {
    "compressor": "native",
@@ -654,8 +654,8 @@
    "level": 5,
    "out_size": 144408,
    "ratio": 0.3384,
-   "compress_mbps": 29.38,
-   "decompress_mbps": 157.1
+   "compress_mbps": 31.43,
+   "decompress_mbps": 262.74
   },
   {
    "compressor": "native",
@@ -664,8 +664,8 @@
    "level": 6,
    "out_size": 144070,
    "ratio": 0.3376,
-   "compress_mbps": 28.08,
-   "decompress_mbps": 160.75
+   "compress_mbps": 30.49,
+   "decompress_mbps": 268.16
   },
   {
    "compressor": "native",
@@ -674,8 +674,8 @@
    "level": 7,
    "out_size": 143628,
    "ratio": 0.3366,
-   "compress_mbps": 24.17,
-   "decompress_mbps": 162.19
+   "compress_mbps": 25.79,
+   "decompress_mbps": 268.79
   },
   {
    "compressor": "native",
@@ -684,8 +684,8 @@
    "level": 8,
    "out_size": 143569,
    "ratio": 0.3364,
-   "compress_mbps": 23.56,
-   "decompress_mbps": 162.19
+   "compress_mbps": 24.87,
+   "decompress_mbps": 268.59
   },
   {
    "compressor": "native",
@@ -694,8 +694,8 @@
    "level": 9,
    "out_size": 140322,
    "ratio": 0.3288,
-   "compress_mbps": 4.1,
-   "decompress_mbps": 162.63
+   "compress_mbps": 4.26,
+   "decompress_mbps": 268.14
   },
   {
    "compressor": "native",
@@ -704,7 +704,7 @@
    "level": 10,
    "out_size": 138830,
    "ratio": 0.3253,
-   "compress_mbps": 2.4,
+   "compress_mbps": 2.5,
    "decompress_mbps": null
   },
   {
@@ -714,8 +714,8 @@
    "level": 1,
    "out_size": 212588,
    "ratio": 0.4412,
-   "compress_mbps": 62.35,
-   "decompress_mbps": 101.13
+   "compress_mbps": 66.93,
+   "decompress_mbps": 184.85
   },
   {
    "compressor": "native",
@@ -724,8 +724,8 @@
    "level": 2,
    "out_size": 199981,
    "ratio": 0.415,
-   "compress_mbps": 44.55,
-   "decompress_mbps": 109.48
+   "compress_mbps": 48.41,
+   "decompress_mbps": 206.31
   },
   {
    "compressor": "native",
@@ -734,8 +734,8 @@
    "level": 3,
    "out_size": 198551,
    "ratio": 0.4121,
-   "compress_mbps": 39.64,
-   "decompress_mbps": 120.51
+   "compress_mbps": 42.4,
+   "decompress_mbps": 227.54
   },
   {
    "compressor": "native",
@@ -744,8 +744,8 @@
    "level": 4,
    "out_size": 193783,
    "ratio": 0.4022,
-   "compress_mbps": 29.19,
-   "decompress_mbps": 125.91
+   "compress_mbps": 30.89,
+   "decompress_mbps": 230.7
   },
   {
    "compressor": "native",
@@ -754,8 +754,8 @@
    "level": 5,
    "out_size": 193223,
    "ratio": 0.401,
-   "compress_mbps": 24.53,
-   "decompress_mbps": 132.05
+   "compress_mbps": 25.83,
+   "decompress_mbps": 227.47
   },
   {
    "compressor": "native",
@@ -764,8 +764,8 @@
    "level": 6,
    "out_size": 193416,
    "ratio": 0.4014,
-   "compress_mbps": 24.59,
-   "decompress_mbps": 135.55
+   "compress_mbps": 26.17,
+   "decompress_mbps": 230.56
   },
   {
    "compressor": "native",
@@ -774,8 +774,8 @@
    "level": 7,
    "out_size": 192664,
    "ratio": 0.3998,
-   "compress_mbps": 20.74,
-   "decompress_mbps": 136.04
+   "compress_mbps": 21.81,
+   "decompress_mbps": 230.34
   },
   {
    "compressor": "native",
@@ -784,8 +784,8 @@
    "level": 8,
    "out_size": 192638,
    "ratio": 0.3998,
-   "compress_mbps": 20.18,
-   "decompress_mbps": 136.45
+   "compress_mbps": 21.19,
+   "decompress_mbps": 230.31
   },
   {
    "compressor": "native",
@@ -794,8 +794,8 @@
    "level": 9,
    "out_size": 189365,
    "ratio": 0.393,
-   "compress_mbps": 3.95,
-   "decompress_mbps": 135.72
+   "compress_mbps": 4.02,
+   "decompress_mbps": 230.18
   },
   {
    "compressor": "native",
@@ -804,7 +804,7 @@
    "level": 10,
    "out_size": 186147,
    "ratio": 0.3863,
-   "compress_mbps": 2.37,
+   "compress_mbps": 2.42,
    "decompress_mbps": null
   },
   {
@@ -814,8 +814,8 @@
    "level": 1,
    "out_size": 60161,
    "ratio": 0.1172,
-   "compress_mbps": 204.29,
-   "decompress_mbps": 389.32
+   "compress_mbps": 229.02,
+   "decompress_mbps": 567.71
   },
   {
    "compressor": "native",
@@ -824,8 +824,8 @@
    "level": 2,
    "out_size": 58873,
    "ratio": 0.1147,
-   "compress_mbps": 149.73,
-   "decompress_mbps": 404.44
+   "compress_mbps": 170.18,
+   "decompress_mbps": 593.38
   },
   {
    "compressor": "native",
@@ -834,8 +834,8 @@
    "level": 3,
    "out_size": 58327,
    "ratio": 0.1137,
-   "compress_mbps": 129.91,
-   "decompress_mbps": 420.1
+   "compress_mbps": 148.99,
+   "decompress_mbps": 623.53
   },
   {
    "compressor": "native",
@@ -844,8 +844,8 @@
    "level": 4,
    "out_size": 55588,
    "ratio": 0.1083,
-   "compress_mbps": 89.29,
-   "decompress_mbps": 453.56
+   "compress_mbps": 103.21,
+   "decompress_mbps": 639.25
   },
   {
    "compressor": "native",
@@ -854,8 +854,8 @@
    "level": 5,
    "out_size": 55097,
    "ratio": 0.1074,
-   "compress_mbps": 68.19,
-   "decompress_mbps": 471.67
+   "compress_mbps": 82.14,
+   "decompress_mbps": 663.16
   },
   {
    "compressor": "native",
@@ -864,8 +864,8 @@
    "level": 6,
    "out_size": 55195,
    "ratio": 0.1075,
-   "compress_mbps": 56.8,
-   "decompress_mbps": 485.92
+   "compress_mbps": 63.73,
+   "decompress_mbps": 685.64
   },
   {
    "compressor": "native",
@@ -874,8 +874,8 @@
    "level": 7,
    "out_size": 54316,
    "ratio": 0.1058,
-   "compress_mbps": 43.9,
-   "decompress_mbps": 496.52
+   "compress_mbps": 52.68,
+   "decompress_mbps": 698.6
   },
   {
    "compressor": "native",
@@ -884,8 +884,8 @@
    "level": 8,
    "out_size": 53091,
    "ratio": 0.1034,
-   "compress_mbps": 35.42,
-   "decompress_mbps": 514.83
+   "compress_mbps": 43.7,
+   "decompress_mbps": 725.17
   },
   {
    "compressor": "native",
@@ -894,8 +894,8 @@
    "level": 9,
    "out_size": 52605,
    "ratio": 0.1025,
-   "compress_mbps": 5.51,
-   "decompress_mbps": 528.72
+   "compress_mbps": 5.8,
+   "decompress_mbps": 733.9
   },
   {
    "compressor": "native",
@@ -904,7 +904,7 @@
    "level": 10,
    "out_size": 52234,
    "ratio": 0.1018,
-   "compress_mbps": 3.61,
+   "compress_mbps": 3.76,
    "decompress_mbps": null
   },
   {
@@ -914,8 +914,8 @@
    "level": 1,
    "out_size": 14249,
    "ratio": 0.3726,
-   "compress_mbps": 51.7,
-   "decompress_mbps": 123.97
+   "compress_mbps": 54.32,
+   "decompress_mbps": 234.7
   },
   {
    "compressor": "native",
@@ -924,8 +924,8 @@
    "level": 2,
    "out_size": 13825,
    "ratio": 0.3615,
-   "compress_mbps": 45.16,
-   "decompress_mbps": 126.49
+   "compress_mbps": 47.8,
+   "decompress_mbps": 242.52
   },
   {
    "compressor": "native",
@@ -934,8 +934,8 @@
    "level": 3,
    "out_size": 13751,
    "ratio": 0.3596,
-   "compress_mbps": 43.53,
-   "decompress_mbps": 126.94
+   "compress_mbps": 45.7,
+   "decompress_mbps": 243.24
   },
   {
    "compressor": "native",
@@ -944,8 +944,8 @@
    "level": 4,
    "out_size": 13287,
    "ratio": 0.3475,
-   "compress_mbps": 38.9,
-   "decompress_mbps": 133.67
+   "compress_mbps": 41.43,
+   "decompress_mbps": 249.46
   },
   {
    "compressor": "native",
@@ -954,8 +954,8 @@
    "level": 5,
    "out_size": 13240,
    "ratio": 0.3462,
-   "compress_mbps": 34.55,
-   "decompress_mbps": 140.37
+   "compress_mbps": 36.83,
+   "decompress_mbps": 257.91
   },
   {
    "compressor": "native",
@@ -964,8 +964,8 @@
    "level": 6,
    "out_size": 12944,
    "ratio": 0.3385,
-   "compress_mbps": 19.23,
-   "decompress_mbps": 142.5
+   "compress_mbps": 19.63,
+   "decompress_mbps": 259.87
   },
   {
    "compressor": "native",
@@ -974,8 +974,8 @@
    "level": 7,
    "out_size": 12929,
    "ratio": 0.3381,
-   "compress_mbps": 17.67,
-   "decompress_mbps": 142.77
+   "compress_mbps": 18.04,
+   "decompress_mbps": 264.26
   },
   {
    "compressor": "native",
@@ -984,8 +984,8 @@
    "level": 8,
    "out_size": 12921,
    "ratio": 0.3379,
-   "compress_mbps": 16.34,
-   "decompress_mbps": 144.85
+   "compress_mbps": 16.76,
+   "decompress_mbps": 263.81
   },
   {
    "compressor": "native",
@@ -994,8 +994,8 @@
    "level": 9,
    "out_size": 12427,
    "ratio": 0.325,
-   "compress_mbps": 5.24,
-   "decompress_mbps": 147.49
+   "compress_mbps": 5.42,
+   "decompress_mbps": 268.52
   },
   {
    "compressor": "native",
@@ -1004,7 +1004,7 @@
    "level": 10,
    "out_size": 12274,
    "ratio": 0.321,
-   "compress_mbps": 2.99,
+   "compress_mbps": 3.08,
    "decompress_mbps": null
   },
   {
@@ -1014,8 +1014,8 @@
    "level": 1,
    "out_size": 1800,
    "ratio": 0.4258,
-   "compress_mbps": 26.04,
-   "decompress_mbps": 66.48
+   "compress_mbps": 26.63,
+   "decompress_mbps": 90.4
   },
   {
    "compressor": "native",
@@ -1024,8 +1024,8 @@
    "level": 2,
    "out_size": 1750,
    "ratio": 0.414,
-   "compress_mbps": 24.39,
-   "decompress_mbps": 67.47
+   "compress_mbps": 25.27,
+   "decompress_mbps": 90.36
   },
   {
    "compressor": "native",
@@ -1034,8 +1034,8 @@
    "level": 3,
    "out_size": 1742,
    "ratio": 0.4121,
-   "compress_mbps": 24.3,
-   "decompress_mbps": 67.56
+   "compress_mbps": 25.14,
+   "decompress_mbps": 90.03
   },
   {
    "compressor": "native",
@@ -1044,8 +1044,8 @@
    "level": 4,
    "out_size": 1726,
    "ratio": 0.4083,
-   "compress_mbps": 23.93,
-   "decompress_mbps": 69.36
+   "compress_mbps": 24.76,
+   "decompress_mbps": 91.85
   },
   {
    "compressor": "native",
@@ -1054,8 +1054,8 @@
    "level": 5,
    "out_size": 1722,
    "ratio": 0.4074,
-   "compress_mbps": 23.41,
-   "decompress_mbps": 70.06
+   "compress_mbps": 24.36,
+   "decompress_mbps": 91.95
   },
   {
    "compressor": "native",
@@ -1064,8 +1064,8 @@
    "level": 6,
    "out_size": 1722,
    "ratio": 0.4074,
-   "compress_mbps": 22.39,
-   "decompress_mbps": 69.91
+   "compress_mbps": 23.37,
+   "decompress_mbps": 91.87
   },
   {
    "compressor": "native",
@@ -1074,8 +1074,8 @@
    "level": 7,
    "out_size": 1722,
    "ratio": 0.4074,
-   "compress_mbps": 22.43,
-   "decompress_mbps": 69.98
+   "compress_mbps": 23.36,
+   "decompress_mbps": 91.83
   },
   {
    "compressor": "native",
@@ -1084,8 +1084,8 @@
    "level": 8,
    "out_size": 1722,
    "ratio": 0.4074,
-   "compress_mbps": 22.42,
-   "decompress_mbps": 69.81
+   "compress_mbps": 23.39,
+   "decompress_mbps": 91.96
   },
   {
    "compressor": "native",
@@ -1094,8 +1094,8 @@
    "level": 9,
    "out_size": 1708,
    "ratio": 0.4041,
-   "compress_mbps": 5.33,
-   "decompress_mbps": 69.69
+   "compress_mbps": 5.48,
+   "decompress_mbps": 91.75
   },
   {
    "compressor": "native",
@@ -1104,7 +1104,7 @@
    "level": 10,
    "out_size": 1693,
    "ratio": 0.4005,
-   "compress_mbps": 3.17,
+   "compress_mbps": 3.31,
    "decompress_mbps": null
   },
   {
@@ -4414,8 +4414,8 @@
    "level": 1,
    "out_size": 4259644,
    "ratio": 0.4179,
-   "compress_mbps": 64.88,
-   "decompress_mbps": 106.96
+   "compress_mbps": 69.21,
+   "decompress_mbps": 187.78
   },
   {
    "compressor": "native",
@@ -4424,8 +4424,8 @@
    "level": 2,
    "out_size": 3977395,
    "ratio": 0.3902,
-   "compress_mbps": 45.43,
-   "decompress_mbps": 115.05
+   "compress_mbps": 49.6,
+   "decompress_mbps": 204.25
   },
   {
    "compressor": "native",
@@ -4434,8 +4434,8 @@
    "level": 3,
    "out_size": 3945296,
    "ratio": 0.3871,
-   "compress_mbps": 40.98,
-   "decompress_mbps": 126.92
+   "compress_mbps": 43.92,
+   "decompress_mbps": 226.52
   },
   {
    "compressor": "native",
@@ -4444,8 +4444,8 @@
    "level": 4,
    "out_size": 3851998,
    "ratio": 0.3779,
-   "compress_mbps": 31.26,
-   "decompress_mbps": 129.99
+   "compress_mbps": 33.09,
+   "decompress_mbps": 227.7
   },
   {
    "compressor": "native",
@@ -4454,8 +4454,8 @@
    "level": 5,
    "out_size": 3840481,
    "ratio": 0.3768,
-   "compress_mbps": 26.28,
-   "decompress_mbps": 136.32
+   "compress_mbps": 27.71,
+   "decompress_mbps": 225.33
   },
   {
    "compressor": "native",
@@ -4464,8 +4464,8 @@
    "level": 6,
    "out_size": 3847941,
    "ratio": 0.3775,
-   "compress_mbps": 26.48,
-   "decompress_mbps": 140.49
+   "compress_mbps": 28.1,
+   "decompress_mbps": 230.66
   },
   {
    "compressor": "native",
@@ -4474,8 +4474,8 @@
    "level": 7,
    "out_size": 3834802,
    "ratio": 0.3762,
-   "compress_mbps": 22.13,
-   "decompress_mbps": 141.3
+   "compress_mbps": 23.38,
+   "decompress_mbps": 233.02
   },
   {
    "compressor": "native",
@@ -4484,8 +4484,8 @@
    "level": 8,
    "out_size": 3833946,
    "ratio": 0.3762,
-   "compress_mbps": 21.43,
-   "decompress_mbps": 141.45
+   "compress_mbps": 22.41,
+   "decompress_mbps": 233.3
   },
   {
    "compressor": "native",
@@ -4494,8 +4494,8 @@
    "level": 9,
    "out_size": 3766584,
    "ratio": 0.3695,
-   "compress_mbps": 4.04,
-   "decompress_mbps": 143.94
+   "compress_mbps": 4.11,
+   "decompress_mbps": 241.39
   },
   {
    "compressor": "native",
@@ -4504,7 +4504,7 @@
    "level": 10,
    "out_size": 3711172,
    "ratio": 0.3641,
-   "compress_mbps": 2.37,
+   "compress_mbps": 2.43,
    "decompress_mbps": null
   },
   {
@@ -4514,8 +4514,8 @@
    "level": 1,
    "out_size": 21267086,
    "ratio": 0.4152,
-   "compress_mbps": 79.32,
-   "decompress_mbps": 141.42
+   "compress_mbps": 84.65,
+   "decompress_mbps": 208.26
   },
   {
    "compressor": "native",
@@ -4524,8 +4524,8 @@
    "level": 2,
    "out_size": 20802983,
    "ratio": 0.4061,
-   "compress_mbps": 61.61,
-   "decompress_mbps": 148.19
+   "compress_mbps": 68.14,
+   "decompress_mbps": 219.0
   },
   {
    "compressor": "native",
@@ -4534,8 +4534,8 @@
    "level": 3,
    "out_size": 20665485,
    "ratio": 0.4035,
-   "compress_mbps": 58.83,
-   "decompress_mbps": 148.49
+   "compress_mbps": 63.4,
+   "decompress_mbps": 226.68
   },
   {
    "compressor": "native",
@@ -4544,8 +4544,8 @@
    "level": 4,
    "out_size": 20356893,
    "ratio": 0.3974,
-   "compress_mbps": 47.52,
-   "decompress_mbps": 162.05
+   "compress_mbps": 51.51,
+   "decompress_mbps": 235.42
   },
   {
    "compressor": "native",
@@ -4554,8 +4554,8 @@
    "level": 5,
    "out_size": 20209289,
    "ratio": 0.3946,
-   "compress_mbps": 38.36,
-   "decompress_mbps": 170.92
+   "compress_mbps": 41.28,
+   "decompress_mbps": 236.68
   },
   {
    "compressor": "native",
@@ -4564,8 +4564,8 @@
    "level": 6,
    "out_size": 19174181,
    "ratio": 0.3743,
-   "compress_mbps": 26.28,
-   "decompress_mbps": 173.38
+   "compress_mbps": 27.59,
+   "decompress_mbps": 247.89
   },
   {
    "compressor": "native",
@@ -4574,8 +4574,8 @@
    "level": 7,
    "out_size": 19127630,
    "ratio": 0.3734,
-   "compress_mbps": 21.75,
-   "decompress_mbps": 173.78
+   "compress_mbps": 22.74,
+   "decompress_mbps": 248.93
   },
   {
    "compressor": "native",
@@ -4584,8 +4584,8 @@
    "level": 8,
    "out_size": 19117840,
    "ratio": 0.3732,
-   "compress_mbps": 18.83,
-   "decompress_mbps": 174.62
+   "compress_mbps": 19.73,
+   "decompress_mbps": 249.45
   },
   {
    "compressor": "native",
@@ -4594,8 +4594,8 @@
    "level": 9,
    "out_size": 18686872,
    "ratio": 0.3648,
-   "compress_mbps": 4.2,
-   "decompress_mbps": 170.7
+   "compress_mbps": 4.37,
+   "decompress_mbps": 238.36
   },
   {
    "compressor": "native",
@@ -4604,7 +4604,7 @@
    "level": 10,
    "out_size": 18539905,
    "ratio": 0.362,
-   "compress_mbps": 2.26,
+   "compress_mbps": 2.33,
    "decompress_mbps": null
   },
   {
@@ -4614,8 +4614,8 @@
    "level": 1,
    "out_size": 3864163,
    "ratio": 0.3876,
-   "compress_mbps": 79.6,
-   "decompress_mbps": 127.98
+   "compress_mbps": 86.55,
+   "decompress_mbps": 223.21
   },
   {
    "compressor": "native",
@@ -4624,8 +4624,8 @@
    "level": 2,
    "out_size": 3734957,
    "ratio": 0.3746,
-   "compress_mbps": 61.02,
-   "decompress_mbps": 135.25
+   "compress_mbps": 65.65,
+   "decompress_mbps": 240.6
   },
   {
    "compressor": "native",
@@ -4634,8 +4634,8 @@
    "level": 3,
    "out_size": 3708443,
    "ratio": 0.3719,
-   "compress_mbps": 52.21,
-   "decompress_mbps": 144.28
+   "compress_mbps": 55.68,
+   "decompress_mbps": 249.13
   },
   {
    "compressor": "native",
@@ -4644,8 +4644,8 @@
    "level": 4,
    "out_size": 3683603,
    "ratio": 0.3694,
-   "compress_mbps": 37.44,
-   "decompress_mbps": 141.34
+   "compress_mbps": 39.64,
+   "decompress_mbps": 238.83
   },
   {
    "compressor": "native",
@@ -4654,8 +4654,8 @@
    "level": 5,
    "out_size": 3677014,
    "ratio": 0.3688,
-   "compress_mbps": 30.27,
-   "decompress_mbps": 148.33
+   "compress_mbps": 32.13,
+   "decompress_mbps": 231.57
   },
   {
    "compressor": "native",
@@ -4664,8 +4664,8 @@
    "level": 6,
    "out_size": 3588221,
    "ratio": 0.3599,
-   "compress_mbps": 27.6,
-   "decompress_mbps": 154.76
+   "compress_mbps": 29.33,
+   "decompress_mbps": 237.88
   },
   {
    "compressor": "native",
@@ -4674,8 +4674,8 @@
    "level": 7,
    "out_size": 3581006,
    "ratio": 0.3592,
-   "compress_mbps": 22.28,
-   "decompress_mbps": 156.24
+   "compress_mbps": 24.13,
+   "decompress_mbps": 239.76
   },
   {
    "compressor": "native",
@@ -4684,8 +4684,8 @@
    "level": 8,
    "out_size": 3580944,
    "ratio": 0.3592,
-   "compress_mbps": 20.34,
-   "decompress_mbps": 159.65
+   "compress_mbps": 22.64,
+   "decompress_mbps": 246.53
   },
   {
    "compressor": "native",
@@ -4694,8 +4694,8 @@
    "level": 9,
    "out_size": 3581441,
    "ratio": 0.3592,
-   "compress_mbps": 4.55,
-   "decompress_mbps": 161.71
+   "compress_mbps": 4.73,
+   "decompress_mbps": 262.78
   },
   {
    "compressor": "native",
@@ -4704,7 +4704,7 @@
    "level": 10,
    "out_size": 3512886,
    "ratio": 0.3523,
-   "compress_mbps": 2.79,
+   "compress_mbps": 2.9,
    "decompress_mbps": null
   },
   {
@@ -4714,8 +4714,8 @@
    "level": 1,
    "out_size": 3785443,
    "ratio": 0.1128,
-   "compress_mbps": 233.71,
-   "decompress_mbps": 375.97
+   "compress_mbps": 263.2,
+   "decompress_mbps": 649.78
   },
   {
    "compressor": "native",
@@ -4724,8 +4724,8 @@
    "level": 2,
    "out_size": 3761560,
    "ratio": 0.1121,
-   "compress_mbps": 144.45,
-   "decompress_mbps": 420.46
+   "compress_mbps": 167.98,
+   "decompress_mbps": 722.0
   },
   {
    "compressor": "native",
@@ -4734,8 +4734,8 @@
    "level": 3,
    "out_size": 3606997,
    "ratio": 0.1075,
-   "compress_mbps": 121.48,
-   "decompress_mbps": 467.87
+   "compress_mbps": 143.99,
+   "decompress_mbps": 800.09
   },
   {
    "compressor": "native",
@@ -4744,8 +4744,8 @@
    "level": 4,
    "out_size": 3201209,
    "ratio": 0.0954,
-   "compress_mbps": 94.34,
-   "decompress_mbps": 490.91
+   "compress_mbps": 111.46,
+   "decompress_mbps": 815.07
   },
   {
    "compressor": "native",
@@ -4754,8 +4754,8 @@
    "level": 5,
    "out_size": 3091564,
    "ratio": 0.0921,
-   "compress_mbps": 72.89,
-   "decompress_mbps": 551.3
+   "compress_mbps": 85.02,
+   "decompress_mbps": 891.91
   },
   {
    "compressor": "native",
@@ -4764,8 +4764,8 @@
    "level": 6,
    "out_size": 3112756,
    "ratio": 0.0928,
-   "compress_mbps": 71.11,
-   "decompress_mbps": 588.6
+   "compress_mbps": 82.25,
+   "decompress_mbps": 940.14
   },
   {
    "compressor": "native",
@@ -4774,8 +4774,8 @@
    "level": 7,
    "out_size": 3062314,
    "ratio": 0.0913,
-   "compress_mbps": 55.0,
-   "decompress_mbps": 601.36
+   "compress_mbps": 63.53,
+   "decompress_mbps": 951.25
   },
   {
    "compressor": "native",
@@ -4784,8 +4784,8 @@
    "level": 8,
    "out_size": 3045348,
    "ratio": 0.0908,
-   "compress_mbps": 46.28,
-   "decompress_mbps": 621.13
+   "compress_mbps": 53.14,
+   "decompress_mbps": 957.69
   },
   {
    "compressor": "native",
@@ -4794,8 +4794,8 @@
    "level": 9,
    "out_size": 3031645,
    "ratio": 0.0904,
-   "compress_mbps": 3.24,
-   "decompress_mbps": 634.24
+   "compress_mbps": 3.54,
+   "decompress_mbps": 978.33
   },
   {
    "compressor": "native",
@@ -4804,7 +4804,7 @@
    "level": 10,
    "out_size": 2902186,
    "ratio": 0.0865,
-   "compress_mbps": 1.87,
+   "compress_mbps": 2.0,
    "decompress_mbps": null
   },
   {
@@ -4814,8 +4814,8 @@
    "level": 1,
    "out_size": 3357083,
    "ratio": 0.5457,
-   "compress_mbps": 55.9,
-   "decompress_mbps": 95.68
+   "compress_mbps": 59.84,
+   "decompress_mbps": 143.02
   },
   {
    "compressor": "native",
@@ -4824,8 +4824,8 @@
    "level": 2,
    "out_size": 3285077,
    "ratio": 0.534,
-   "compress_mbps": 46.59,
-   "decompress_mbps": 99.82
+   "compress_mbps": 49.45,
+   "decompress_mbps": 143.77
   },
   {
    "compressor": "native",
@@ -4834,8 +4834,8 @@
    "level": 3,
    "out_size": 3272746,
    "ratio": 0.532,
-   "compress_mbps": 44.15,
-   "decompress_mbps": 101.03
+   "compress_mbps": 47.12,
+   "decompress_mbps": 149.09
   },
   {
    "compressor": "native",
@@ -4844,8 +4844,8 @@
    "level": 4,
    "out_size": 3228052,
    "ratio": 0.5247,
-   "compress_mbps": 37.99,
-   "decompress_mbps": 112.81
+   "compress_mbps": 39.84,
+   "decompress_mbps": 159.01
   },
   {
    "compressor": "native",
@@ -4854,8 +4854,8 @@
    "level": 5,
    "out_size": 3223415,
    "ratio": 0.5239,
-   "compress_mbps": 34.3,
-   "decompress_mbps": 114.17
+   "compress_mbps": 35.65,
+   "decompress_mbps": 164.83
   },
   {
    "compressor": "native",
@@ -4864,8 +4864,8 @@
    "level": 6,
    "out_size": 3159522,
    "ratio": 0.5136,
-   "compress_mbps": 24.33,
-   "decompress_mbps": 116.64
+   "compress_mbps": 25.35,
+   "decompress_mbps": 167.8
   },
   {
    "compressor": "native",
@@ -4874,8 +4874,8 @@
    "level": 7,
    "out_size": 3156358,
    "ratio": 0.513,
-   "compress_mbps": 22.49,
-   "decompress_mbps": 117.12
+   "compress_mbps": 23.52,
+   "decompress_mbps": 167.15
   },
   {
    "compressor": "native",
@@ -4884,8 +4884,8 @@
    "level": 8,
    "out_size": 3155368,
    "ratio": 0.5129,
-   "compress_mbps": 21.57,
-   "decompress_mbps": 116.69
+   "compress_mbps": 22.55,
+   "decompress_mbps": 168.98
   },
   {
    "compressor": "native",
@@ -4894,8 +4894,8 @@
    "level": 9,
    "out_size": 3048772,
    "ratio": 0.4956,
-   "compress_mbps": 4.96,
-   "decompress_mbps": 118.6
+   "compress_mbps": 5.06,
+   "decompress_mbps": 174.05
   },
   {
    "compressor": "native",
@@ -4904,7 +4904,7 @@
    "level": 10,
    "out_size": 3021986,
    "ratio": 0.4912,
-   "compress_mbps": 3.08,
+   "compress_mbps": 3.16,
    "decompress_mbps": null
   },
   {
@@ -4914,8 +4914,8 @@
    "level": 1,
    "out_size": 3838828,
    "ratio": 0.3806,
-   "compress_mbps": 89.49,
-   "decompress_mbps": 167.47
+   "compress_mbps": 97.06,
+   "decompress_mbps": 253.1
   },
   {
    "compressor": "native",
@@ -4924,8 +4924,8 @@
    "level": 2,
    "out_size": 3792520,
    "ratio": 0.376,
-   "compress_mbps": 66.38,
-   "decompress_mbps": 171.09
+   "compress_mbps": 70.27,
+   "decompress_mbps": 260.81
   },
   {
    "compressor": "native",
@@ -4934,8 +4934,8 @@
    "level": 3,
    "out_size": 3783171,
    "ratio": 0.3751,
-   "compress_mbps": 64.42,
-   "decompress_mbps": 177.27
+   "compress_mbps": 69.87,
+   "decompress_mbps": 266.7
   },
   {
    "compressor": "native",
@@ -4944,8 +4944,8 @@
    "level": 4,
    "out_size": 3648458,
    "ratio": 0.3617,
-   "compress_mbps": 57.84,
-   "decompress_mbps": 189.06
+   "compress_mbps": 62.63,
+   "decompress_mbps": 281.28
   },
   {
    "compressor": "native",
@@ -4954,8 +4954,8 @@
    "level": 5,
    "out_size": 3648472,
    "ratio": 0.3617,
-   "compress_mbps": 53.81,
-   "decompress_mbps": 195.9
+   "compress_mbps": 58.75,
+   "decompress_mbps": 283.28
   },
   {
    "compressor": "native",
@@ -4964,8 +4964,8 @@
    "level": 6,
    "out_size": 3648595,
    "ratio": 0.3618,
-   "compress_mbps": 43.73,
-   "decompress_mbps": 206.99
+   "compress_mbps": 47.01,
+   "decompress_mbps": 272.34
   },
   {
    "compressor": "native",
@@ -4974,8 +4974,8 @@
    "level": 7,
    "out_size": 3648160,
    "ratio": 0.3617,
-   "compress_mbps": 43.54,
-   "decompress_mbps": 208.32
+   "compress_mbps": 46.38,
+   "decompress_mbps": 279.79
   },
   {
    "compressor": "native",
@@ -4984,8 +4984,8 @@
    "level": 8,
    "out_size": 3648156,
    "ratio": 0.3617,
-   "compress_mbps": 43.74,
-   "decompress_mbps": 210.01
+   "compress_mbps": 46.85,
+   "decompress_mbps": 277.61
   },
   {
    "compressor": "native",
@@ -4994,8 +4994,8 @@
    "level": 9,
    "out_size": 3648156,
    "ratio": 0.3617,
-   "compress_mbps": 5.73,
-   "decompress_mbps": 206.49
+   "compress_mbps": 5.96,
+   "decompress_mbps": 291.88
   },
   {
    "compressor": "native",
@@ -5004,7 +5004,7 @@
    "level": 10,
    "out_size": 3647321,
    "ratio": 0.3616,
-   "compress_mbps": 3.27,
+   "compress_mbps": 3.41,
    "decompress_mbps": null
   },
   {
@@ -5014,8 +5014,8 @@
    "level": 1,
    "out_size": 2254442,
    "ratio": 0.3402,
-   "compress_mbps": 82.78,
-   "decompress_mbps": 133.78
+   "compress_mbps": 90.47,
+   "decompress_mbps": 223.49
   },
   {
    "compressor": "native",
@@ -5024,8 +5024,8 @@
    "level": 2,
    "out_size": 2044843,
    "ratio": 0.3086,
-   "compress_mbps": 55.57,
-   "decompress_mbps": 145.12
+   "compress_mbps": 60.39,
+   "decompress_mbps": 261.13
   },
   {
    "compressor": "native",
@@ -5034,8 +5034,8 @@
    "level": 3,
    "out_size": 1992105,
    "ratio": 0.3006,
-   "compress_mbps": 45.57,
-   "decompress_mbps": 161.21
+   "compress_mbps": 48.9,
+   "decompress_mbps": 275.45
   },
   {
    "compressor": "native",
@@ -5044,8 +5044,8 @@
    "level": 4,
    "out_size": 1890729,
    "ratio": 0.2853,
-   "compress_mbps": 32.12,
-   "decompress_mbps": 164.48
+   "compress_mbps": 34.41,
+   "decompress_mbps": 297.1
   },
   {
    "compressor": "native",
@@ -5054,8 +5054,8 @@
    "level": 5,
    "out_size": 1858234,
    "ratio": 0.2804,
-   "compress_mbps": 21.18,
-   "decompress_mbps": 176.8
+   "compress_mbps": 22.19,
+   "decompress_mbps": 279.98
   },
   {
    "compressor": "native",
@@ -5064,8 +5064,8 @@
    "level": 6,
    "out_size": 1856235,
    "ratio": 0.2801,
-   "compress_mbps": 25.38,
-   "decompress_mbps": 191.54
+   "compress_mbps": 27.02,
+   "decompress_mbps": 307.63
   },
   {
    "compressor": "native",
@@ -5074,8 +5074,8 @@
    "level": 7,
    "out_size": 1823963,
    "ratio": 0.2752,
-   "compress_mbps": 16.36,
-   "decompress_mbps": 190.0
+   "compress_mbps": 17.15,
+   "decompress_mbps": 298.74
   },
   {
    "compressor": "native",
@@ -5084,8 +5084,8 @@
    "level": 8,
    "out_size": 1820112,
    "ratio": 0.2746,
-   "compress_mbps": 14.29,
-   "decompress_mbps": 198.7
+   "compress_mbps": 14.96,
+   "decompress_mbps": 312.43
   },
   {
    "compressor": "native",
@@ -5094,8 +5094,8 @@
    "level": 9,
    "out_size": 1773447,
    "ratio": 0.2676,
-   "compress_mbps": 2.85,
-   "decompress_mbps": 200.04
+   "compress_mbps": 2.95,
+   "decompress_mbps": 311.89
   },
   {
    "compressor": "native",
@@ -5104,7 +5104,7 @@
    "level": 10,
    "out_size": 1718500,
    "ratio": 0.2593,
-   "compress_mbps": 1.53,
+   "compress_mbps": 1.59,
    "decompress_mbps": null
   },
   {
@@ -5114,8 +5114,8 @@
    "level": 1,
    "out_size": 6406301,
    "ratio": 0.2965,
-   "compress_mbps": 109.71,
-   "decompress_mbps": 206.39
+   "compress_mbps": 119.03,
+   "decompress_mbps": 326.06
   },
   {
    "compressor": "native",
@@ -5124,8 +5124,8 @@
    "level": 2,
    "out_size": 6102377,
    "ratio": 0.2824,
-   "compress_mbps": 80.71,
-   "decompress_mbps": 218.84
+   "compress_mbps": 86.8,
+   "decompress_mbps": 345.97
   },
   {
    "compressor": "native",
@@ -5134,8 +5134,8 @@
    "level": 3,
    "out_size": 6022184,
    "ratio": 0.2787,
-   "compress_mbps": 73.08,
-   "decompress_mbps": 228.3
+   "compress_mbps": 78.85,
+   "decompress_mbps": 361.13
   },
   {
    "compressor": "native",
@@ -5144,8 +5144,8 @@
    "level": 4,
    "out_size": 5880892,
    "ratio": 0.2722,
-   "compress_mbps": 56.94,
-   "decompress_mbps": 242.67
+   "compress_mbps": 62.44,
+   "decompress_mbps": 374.15
   },
   {
    "compressor": "native",
@@ -5154,8 +5154,8 @@
    "level": 5,
    "out_size": 5834363,
    "ratio": 0.27,
-   "compress_mbps": 45.02,
-   "decompress_mbps": 250.78
+   "compress_mbps": 47.84,
+   "decompress_mbps": 374.61
   },
   {
    "compressor": "native",
@@ -5164,8 +5164,8 @@
    "level": 6,
    "out_size": 5409792,
    "ratio": 0.2504,
-   "compress_mbps": 38.23,
-   "decompress_mbps": 259.16
+   "compress_mbps": 40.02,
+   "decompress_mbps": 389.15
   },
   {
    "compressor": "native",
@@ -5174,8 +5174,8 @@
    "level": 7,
    "out_size": 5393735,
    "ratio": 0.2496,
-   "compress_mbps": 32.62,
-   "decompress_mbps": 260.71
+   "compress_mbps": 34.68,
+   "decompress_mbps": 388.18
   },
   {
    "compressor": "native",
@@ -5184,8 +5184,8 @@
    "level": 8,
    "out_size": 5389952,
    "ratio": 0.2495,
-   "compress_mbps": 30.57,
-   "decompress_mbps": 261.44
+   "compress_mbps": 32.86,
+   "decompress_mbps": 389.37
   },
   {
    "compressor": "native",
@@ -5194,8 +5194,8 @@
    "level": 9,
    "out_size": 5235865,
    "ratio": 0.2423,
-   "compress_mbps": 4.59,
-   "decompress_mbps": 261.82
+   "compress_mbps": 4.76,
+   "decompress_mbps": 393.26
   },
   {
    "compressor": "native",
@@ -5204,7 +5204,7 @@
    "level": 10,
    "out_size": 5177560,
    "ratio": 0.2396,
-   "compress_mbps": 2.52,
+   "compress_mbps": 2.59,
    "decompress_mbps": null
   },
   {
@@ -5214,8 +5214,8 @@
    "level": 1,
    "out_size": 5612204,
    "ratio": 0.7739,
-   "compress_mbps": 46.39,
-   "decompress_mbps": 97.82
+   "compress_mbps": 50.64,
+   "decompress_mbps": 139.65
   },
   {
    "compressor": "native",
@@ -5224,8 +5224,8 @@
    "level": 2,
    "out_size": 5533875,
    "ratio": 0.7631,
-   "compress_mbps": 39.57,
-   "decompress_mbps": 100.56
+   "compress_mbps": 41.71,
+   "decompress_mbps": 147.09
   },
   {
    "compressor": "native",
@@ -5234,8 +5234,8 @@
    "level": 3,
    "out_size": 5522436,
    "ratio": 0.7615,
-   "compress_mbps": 36.8,
-   "decompress_mbps": 104.32
+   "compress_mbps": 39.73,
+   "decompress_mbps": 151.61
   },
   {
    "compressor": "native",
@@ -5244,8 +5244,8 @@
    "level": 4,
    "out_size": 5494383,
    "ratio": 0.7576,
-   "compress_mbps": 32.14,
-   "decompress_mbps": 107.94
+   "compress_mbps": 33.61,
+   "decompress_mbps": 156.72
   },
   {
    "compressor": "native",
@@ -5254,8 +5254,8 @@
    "level": 5,
    "out_size": 5489807,
    "ratio": 0.757,
-   "compress_mbps": 30.35,
-   "decompress_mbps": 110.53
+   "compress_mbps": 31.61,
+   "decompress_mbps": 153.99
   },
   {
    "compressor": "native",
@@ -5264,8 +5264,8 @@
    "level": 6,
    "out_size": 5470520,
    "ratio": 0.7544,
-   "compress_mbps": 23.13,
-   "decompress_mbps": 112.78
+   "compress_mbps": 23.92,
+   "decompress_mbps": 155.87
   },
   {
    "compressor": "native",
@@ -5274,8 +5274,8 @@
    "level": 7,
    "out_size": 5463682,
    "ratio": 0.7534,
-   "compress_mbps": 22.15,
-   "decompress_mbps": 115.58
+   "compress_mbps": 22.64,
+   "decompress_mbps": 154.76
   },
   {
    "compressor": "native",
@@ -5284,8 +5284,8 @@
    "level": 8,
    "out_size": 5463761,
    "ratio": 0.7534,
-   "compress_mbps": 21.66,
-   "decompress_mbps": 113.33
+   "compress_mbps": 22.35,
+   "decompress_mbps": 156.0
   },
   {
    "compressor": "native",
@@ -5294,8 +5294,8 @@
    "level": 9,
    "out_size": 5284536,
    "ratio": 0.7287,
-   "compress_mbps": 4.97,
-   "decompress_mbps": 113.63
+   "compress_mbps": 5.06,
+   "decompress_mbps": 154.54
   },
   {
    "compressor": "native",
@@ -5304,7 +5304,7 @@
    "level": 10,
    "out_size": 5262319,
    "ratio": 0.7256,
-   "compress_mbps": 3.49,
+   "compress_mbps": 3.6,
    "decompress_mbps": null
   },
   {
@@ -5314,8 +5314,8 @@
    "level": 1,
    "out_size": 13727247,
    "ratio": 0.3311,
-   "compress_mbps": 82.64,
-   "decompress_mbps": 141.47
+   "compress_mbps": 88.62,
+   "decompress_mbps": 241.66
   },
   {
    "compressor": "native",
@@ -5324,8 +5324,8 @@
    "level": 2,
    "out_size": 12940398,
    "ratio": 0.3121,
-   "compress_mbps": 60.41,
-   "decompress_mbps": 149.19
+   "compress_mbps": 65.67,
+   "decompress_mbps": 263.82
   },
   {
    "compressor": "native",
@@ -5334,8 +5334,8 @@
    "level": 3,
    "out_size": 12703756,
    "ratio": 0.3064,
-   "compress_mbps": 55.92,
-   "decompress_mbps": 164.62
+   "compress_mbps": 60.41,
+   "decompress_mbps": 283.69
   },
   {
    "compressor": "native",
@@ -5344,8 +5344,8 @@
    "level": 4,
    "out_size": 12177338,
    "ratio": 0.2937,
-   "compress_mbps": 43.1,
-   "decompress_mbps": 172.1
+   "compress_mbps": 46.06,
+   "decompress_mbps": 286.12
   },
   {
    "compressor": "native",
@@ -5354,8 +5354,8 @@
    "level": 5,
    "out_size": 12051075,
    "ratio": 0.2907,
-   "compress_mbps": 33.66,
-   "decompress_mbps": 181.18
+   "compress_mbps": 35.55,
+   "decompress_mbps": 284.18
   },
   {
    "compressor": "native",
@@ -5364,8 +5364,8 @@
    "level": 6,
    "out_size": 12103573,
    "ratio": 0.2919,
-   "compress_mbps": 34.9,
-   "decompress_mbps": 186.07
+   "compress_mbps": 37.13,
+   "decompress_mbps": 298.1
   },
   {
    "compressor": "native",
@@ -5374,8 +5374,8 @@
    "level": 7,
    "out_size": 12027976,
    "ratio": 0.2901,
-   "compress_mbps": 27.91,
-   "decompress_mbps": 187.56
+   "compress_mbps": 29.65,
+   "decompress_mbps": 301.12
   },
   {
    "compressor": "native",
@@ -5384,8 +5384,8 @@
    "level": 8,
    "out_size": 12019953,
    "ratio": 0.2899,
-   "compress_mbps": 26.24,
-   "decompress_mbps": 188.42
+   "compress_mbps": 27.78,
+   "decompress_mbps": 290.9
   },
   {
    "compressor": "native",
@@ -5394,8 +5394,8 @@
    "level": 9,
    "out_size": 11806466,
    "ratio": 0.2848,
-   "compress_mbps": 3.75,
-   "decompress_mbps": 188.82
+   "compress_mbps": 3.89,
+   "decompress_mbps": 301.28
   },
   {
    "compressor": "native",
@@ -5404,7 +5404,7 @@
    "level": 10,
    "out_size": 11636727,
    "ratio": 0.2807,
-   "compress_mbps": 1.95,
+   "compress_mbps": 2.02,
    "decompress_mbps": null
   },
   {
@@ -5414,8 +5414,8 @@
    "level": 1,
    "out_size": 6438176,
    "ratio": 0.7597,
-   "compress_mbps": 42.85,
-   "decompress_mbps": 81.91
+   "compress_mbps": 45.47,
+   "decompress_mbps": 138.99
   },
   {
    "compressor": "native",
@@ -5424,8 +5424,8 @@
    "level": 2,
    "out_size": 6392101,
    "ratio": 0.7543,
-   "compress_mbps": 41.4,
-   "decompress_mbps": 83.75
+   "compress_mbps": 44.08,
+   "decompress_mbps": 140.38
   },
   {
    "compressor": "native",
@@ -5434,8 +5434,8 @@
    "level": 3,
    "out_size": 6392124,
    "ratio": 0.7543,
-   "compress_mbps": 41.09,
-   "decompress_mbps": 84.64
+   "compress_mbps": 43.81,
+   "decompress_mbps": 142.05
   },
   {
    "compressor": "native",
@@ -5444,8 +5444,8 @@
    "level": 4,
    "out_size": 6360604,
    "ratio": 0.7506,
-   "compress_mbps": 39.24,
-   "decompress_mbps": 84.24
+   "compress_mbps": 40.94,
+   "decompress_mbps": 128.74
   },
   {
    "compressor": "native",
@@ -5454,8 +5454,8 @@
    "level": 5,
    "out_size": 6360567,
    "ratio": 0.7506,
-   "compress_mbps": 39.5,
-   "decompress_mbps": 87.0
+   "compress_mbps": 40.99,
+   "decompress_mbps": 128.98
   },
   {
    "compressor": "native",
@@ -5464,8 +5464,8 @@
    "level": 6,
    "out_size": 6271453,
    "ratio": 0.7401,
-   "compress_mbps": 17.02,
-   "decompress_mbps": 88.27
+   "compress_mbps": 17.31,
+   "decompress_mbps": 130.61
   },
   {
    "compressor": "native",
@@ -5474,8 +5474,8 @@
    "level": 7,
    "out_size": 6271447,
    "ratio": 0.7401,
-   "compress_mbps": 17.1,
-   "decompress_mbps": 89.31
+   "compress_mbps": 17.35,
+   "decompress_mbps": 130.75
   },
   {
    "compressor": "native",
@@ -5484,8 +5484,8 @@
    "level": 8,
    "out_size": 6271447,
    "ratio": 0.7401,
-   "compress_mbps": 17.09,
-   "decompress_mbps": 88.0
+   "compress_mbps": 17.16,
+   "decompress_mbps": 131.67
   },
   {
    "compressor": "native",
@@ -5494,8 +5494,8 @@
    "level": 9,
    "out_size": 5952505,
    "ratio": 0.7024,
-   "compress_mbps": 5.9,
-   "decompress_mbps": 87.9
+   "compress_mbps": 5.91,
+   "decompress_mbps": 133.08
   },
   {
    "compressor": "native",
@@ -5504,7 +5504,7 @@
    "level": 10,
    "out_size": 5848663,
    "ratio": 0.6902,
-   "compress_mbps": 4.3,
+   "compress_mbps": 4.27,
    "decompress_mbps": null
   },
   {
@@ -5514,8 +5514,8 @@
    "level": 1,
    "out_size": 858525,
    "ratio": 0.1606,
-   "compress_mbps": 177.73,
-   "decompress_mbps": 267.24
+   "compress_mbps": 194.6,
+   "decompress_mbps": 415.53
   },
   {
    "compressor": "native",
@@ -5524,8 +5524,8 @@
    "level": 2,
    "out_size": 846807,
    "ratio": 0.1584,
-   "compress_mbps": 112.59,
-   "decompress_mbps": 311.5
+   "compress_mbps": 125.97,
+   "decompress_mbps": 500.76
   },
   {
    "compressor": "native",
@@ -5534,8 +5534,8 @@
    "level": 3,
    "out_size": 806798,
    "ratio": 0.1509,
-   "compress_mbps": 102.47,
-   "decompress_mbps": 366.78
+   "compress_mbps": 115.04,
+   "decompress_mbps": 609.02
   },
   {
    "compressor": "native",
@@ -5544,8 +5544,8 @@
    "level": 4,
    "out_size": 717301,
    "ratio": 0.1342,
-   "compress_mbps": 77.1,
-   "decompress_mbps": 348.53
+   "compress_mbps": 85.91,
+   "decompress_mbps": 603.65
   },
   {
    "compressor": "native",
@@ -5554,8 +5554,8 @@
    "level": 5,
    "out_size": 701552,
    "ratio": 0.1312,
-   "compress_mbps": 60.87,
-   "decompress_mbps": 383.36
+   "compress_mbps": 67.73,
+   "decompress_mbps": 653.81
   },
   {
    "compressor": "native",
@@ -5564,8 +5564,8 @@
    "level": 6,
    "out_size": 678544,
    "ratio": 0.1269,
-   "compress_mbps": 57.7,
-   "decompress_mbps": 409.91
+   "compress_mbps": 63.63,
+   "decompress_mbps": 695.8
   },
   {
    "compressor": "native",
@@ -5574,8 +5574,8 @@
    "level": 7,
    "out_size": 663716,
    "ratio": 0.1242,
-   "compress_mbps": 46.82,
-   "decompress_mbps": 418.22
+   "compress_mbps": 51.38,
+   "decompress_mbps": 706.68
   },
   {
    "compressor": "native",
@@ -5584,8 +5584,8 @@
    "level": 8,
    "out_size": 660481,
    "ratio": 0.1236,
-   "compress_mbps": 41.53,
-   "decompress_mbps": 430.45
+   "compress_mbps": 45.44,
+   "decompress_mbps": 718.37
   },
   {
    "compressor": "native",
@@ -5594,8 +5594,8 @@
    "level": 9,
    "out_size": 659417,
    "ratio": 0.1234,
-   "compress_mbps": 4.25,
-   "decompress_mbps": 425.09
+   "compress_mbps": 4.56,
+   "decompress_mbps": 627.97
   },
   {
    "compressor": "native",
@@ -5604,7 +5604,7 @@
    "level": 10,
    "out_size": 643093,
    "ratio": 0.1203,
-   "compress_mbps": 2.9,
+   "compress_mbps": 3.03,
    "decompress_mbps": null
   },
   {

--- a/c/copy_within_ffi.c
+++ b/c/copy_within_ffi.c
@@ -32,8 +32,8 @@
 
 /* No <string.h>: the toolchain clang compiles this file with -nostdinc
  * (freestanding headers only, so the object can join the library's LTO
- * bitcode; see lakefile `ltoFlags`). The __builtin_mem* forms lower to the
- * same libc calls the Lean runtime already links. */
+ * bitcode; see lakefile `ltoFlags`). The __builtin_mem* forms have the
+ * same C semantics and need no header prototype. */
 
 /* Internal Lean runtime helper: grow `a` to capacity `>= min_cap`, in place
  * when `a` is exclusive. Exported (non-static) from the runtime but not

--- a/c/copy_within_ffi.c
+++ b/c/copy_within_ffi.c
@@ -29,7 +29,11 @@
 
 #include <lean/lean.h>
 #include <stdint.h>
-#include <string.h>
+
+/* No <string.h>: the toolchain clang compiles this file with -nostdinc
+ * (freestanding headers only, so the object can join the library's LTO
+ * bitcode; see lakefile `ltoFlags`). The __builtin_mem* forms lower to the
+ * same libc calls the Lean runtime already links. */
 
 /* Internal Lean runtime helper: grow `a` to capacity `>= min_cap`, in place
  * when `a` is exclusive. Exported (non-static) from the runtime but not
@@ -55,13 +59,13 @@ LEAN_EXPORT lean_object *lean_zip_byte_array_copy_within(
         size_t cap = lean_sarray_capacity(r);
         if (cap < newsz) cap = newsz;
         lean_object *c = lean_alloc_sarray(1, oldsz, cap);
-        memcpy(lean_sarray_cptr(c), lean_sarray_cptr(r), oldsz);
+        __builtin_memcpy(lean_sarray_cptr(c), lean_sarray_cptr(r), oldsz);
         lean_dec(r);
         r = c;
     }
     lean_sarray_set_size(r, newsz);
 
     uint8_t *p = lean_sarray_cptr(r);
-    memcpy(p + oldsz, p + src_off, len);   /* src_off + len <= oldsz: disjoint */
+    __builtin_memcpy(p + oldsz, p + src_off, len);   /* src_off + len <= oldsz: disjoint */
     return r;
 }

--- a/c/extend_within_ffi.c
+++ b/c/extend_within_ffi.c
@@ -40,8 +40,8 @@
 
 /* No <string.h>: the toolchain clang compiles this file with -nostdinc
  * (freestanding headers only, so the object can join the library's LTO
- * bitcode; see lakefile `ltoFlags`). The __builtin_mem* forms lower to the
- * same libc calls the Lean runtime already links. */
+ * bitcode; see lakefile `ltoFlags`). The __builtin_mem* forms have the
+ * same C semantics and need no header prototype. */
 
 /* Internal Lean runtime helper: grow `a` to capacity `>= min_cap`, in place
  * when `a` is exclusive. Exported (non-static) from the runtime but not

--- a/c/extend_within_ffi.c
+++ b/c/extend_within_ffi.c
@@ -37,7 +37,11 @@
 
 #include <lean/lean.h>
 #include <stdint.h>
-#include <string.h>
+
+/* No <string.h>: the toolchain clang compiles this file with -nostdinc
+ * (freestanding headers only, so the object can join the library's LTO
+ * bitcode; see lakefile `ltoFlags`). The __builtin_mem* forms lower to the
+ * same libc calls the Lean runtime already links. */
 
 /* Internal Lean runtime helper: grow `a` to capacity `>= min_cap`, in place
  * when `a` is exclusive. Exported (non-static) from the runtime but not
@@ -73,7 +77,7 @@ LEAN_EXPORT lean_object *lean_zip_byte_array_extend_within(
         size_t cap = lean_sarray_capacity(r);
         if (cap < newsz) cap = newsz;
         lean_object *c = lean_alloc_sarray(1, oldsz, cap);
-        memcpy(lean_sarray_cptr(c), lean_sarray_cptr(r), oldsz);
+        __builtin_memcpy(lean_sarray_cptr(c), lean_sarray_cptr(r), oldsz);
         lean_dec(r);
         r = c;
     }
@@ -82,7 +86,7 @@ LEAN_EXPORT lean_object *lean_zip_byte_array_extend_within(
     uint8_t *p   = lean_sarray_cptr(r);
     uint8_t *dst = p + oldsz;
     if (period == 1) {                                  /* RLE broadcast */
-        memset(dst, p[src_off], len);
+        __builtin_memset(dst, p[src_off], len);
         return r;
     }
     /* Copy the window once (source [src_off, src_off+period) ends at or before
@@ -91,12 +95,12 @@ LEAN_EXPORT lean_object *lean_zip_byte_array_extend_within(
      * `fillDouble` returns the window and `.extract 0 len` keeps only `len`
      * bytes, so nothing past `dst[len)` is written. */
     size_t first = period < len ? period : len;
-    memcpy(dst, p + src_off, first);
+    __builtin_memcpy(dst, p + src_off, first);
     size_t filled = first;
     while (filled < len) {
         size_t chunk = filled;
         if (chunk > len - filled) chunk = len - filled;
-        memcpy(dst + filled, dst, chunk);   /* dest starts filled>=chunk past src */
+        __builtin_memcpy(dst + filled, dst, chunk);   /* dest starts filled>=chunk past src */
         filled += chunk;
     }
     return r;

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -55,6 +55,33 @@ def zlibLinkFlags : IO (Array String) := do
   -- pkg-config unavailable — try NIX_LDFLAGS for -L paths
   return libPaths ++ #["-lz"]
 
+/-- Link-time-optimization flags for the shipped library (issue #2806).
+
+    `-flto` lets the final link inline the project-local stopgap externs
+    (`c/bytearray_wide_ffi.c`, `c/extend_within_ffi.c`, `c/copy_within_ffi.c`)
+    into the hot matcher/decoder loops instead of leaving per-iteration
+    cross-object calls — a measured +2–5% end-to-end compress win with
+    byte-identical output (LTO is codegen-only). For the bitcode to merge,
+    every object must come from the same LLVM: the Lean-emitted C already
+    compiles with the toolchain clang, and the FFI targets below use
+    `buildLeanO` (same compiler) instead of the system `cc`.
+    `-fno-semantic-interposition` keeps `-fPIC` codegen from pessimizing
+    cross-object references. Linux-only: macOS links with the system ld64,
+    whose libLTO need not accept the toolchain clang's bitcode, and Windows
+    is untested. Set `LEAN_ZIP_LTO=0` to opt out (e.g. to link the static
+    libs with a non-LTO-aware toolchain). -/
+def ltoFlags : IO (Array String) := do
+  if Platform.isWindows || Platform.isOSX then return #[]
+  if (← IO.getEnv "LEAN_ZIP_LTO") == some "0" then return #[]
+  return #["-flto", "-fno-semantic-interposition"]
+
+/-- Link-side LTO flags: `-flto` marks the link as LTO, `-O3` runs the
+    link-time codegen pipeline at the same level as the per-module compiles
+    (lld's default is `--lto-O2`). Empty whenever `ltoFlags` is. -/
+def ltoLinkFlags : IO (Array String) := do
+  let flags ← ltoFlags
+  if flags.isEmpty then return #[] else return flags ++ #["-O3"]
+
 /-! The shipped package is the verified library plus its genuinely
     load-bearing FFI: zlib (`libzlib_ffi`) and the project-local primitives
     `libcopy_within_ffi` (lean#14158), `libextend_within_ffi` (overlapping-match
@@ -65,7 +92,8 @@ def zlibLinkFlags : IO (Array String) := do
     downstream `require lean-zip` never pulls in the Rust/libdeflate/zopfli
     comparators or triggers a cargo build on (re)configure. -/
 package «lean-zip» where
-  moreLinkArgs := run_io zlibLinkFlags
+  moreLeancArgs := run_io ltoFlags
+  moreLinkArgs := run_io do return (← zlibLinkFlags) ++ (← ltoLinkFlags)
   testDriver := "test"
 
 require zipCommon from git "https://github.com/kim-em/lean-zip-common" @ "89204d61227069f5c5d19dc69418ab57f96fe61c"
@@ -98,9 +126,13 @@ input_file copy_within_ffi.c where
 target copy_within_ffi.o pkg : FilePath := do
   let srcJob ← copy_within_ffi.c.fetch
   let oFile := pkg.buildDir / "c" / "copy_within_ffi.o"
-  let weakArgs := #["-I", (← getLeanIncludeDir).toString]
-  let hardArgs := if Platform.isWindows then #[] else #["-fPIC"]
-  buildO oFile srcJob weakArgs hardArgs "cc"
+  -- -O2/-DNDEBUG for the same reason as bytearray_wide_ffi (and because a
+  -- clang -O0 object carries `optnone`, which would block the LTO inlining).
+  -- `buildLeanO` compiles with the toolchain clang so the -flto bitcode
+  -- matches the Lean-emitted objects' LLVM version (see `ltoFlags`).
+  let hardArgs := #["-O2", "-DNDEBUG"] ++ (← ltoFlags) ++
+    if Platform.isWindows then #[] else #["-fPIC"]
+  buildLeanO oFile srcJob #[] hardArgs
 
 extern_lib libcopy_within_ffi pkg := do
   let ffiO ← copy_within_ffi.o.fetch
@@ -116,13 +148,13 @@ input_file extend_within_ffi.c where
 target extend_within_ffi.o pkg : FilePath := do
   let srcJob ← extend_within_ffi.c.fetch
   let oFile := pkg.buildDir / "c" / "extend_within_ffi.o"
-  let weakArgs := #["-I", (← getLeanIncludeDir).toString]
   -- -O2/-DNDEBUG for the same reason as bytearray_wide_ffi: this is a hot fill
   -- loop whose lean.h helpers only inline away under optimization, and its
   -- bounds are carried by the Lean-side reference body (+ conformance sweeps).
-  let hardArgs := #["-O2", "-DNDEBUG"] ++
+  -- `buildLeanO` + `ltoFlags`: see `copy_within_ffi.o`.
+  let hardArgs := #["-O2", "-DNDEBUG"] ++ (← ltoFlags) ++
     if Platform.isWindows then #[] else #["-fPIC"]
-  buildO oFile srcJob weakArgs hardArgs "cc"
+  buildLeanO oFile srcJob #[] hardArgs
 
 extern_lib libextend_within_ffi pkg := do
   let ffiO ← extend_within_ffi.o.fetch
@@ -138,7 +170,6 @@ input_file bytearray_wide_ffi.c where
 target bytearray_wide_ffi.o pkg : FilePath := do
   let srcJob ← bytearray_wide_ffi.c.fetch
   let oFile := pkg.buildDir / "c" / "bytearray_wide_ffi.o"
-  let weakArgs := #["-I", (← getLeanIncludeDir).toString]
   -- -O2 is essential here: these are single-load/store hot-loop primitives
   -- whose lean.h helpers (lean_sarray_cptr, lean_is_exclusive, ...) only
   -- disappear under optimization; without it each "wide" op is a pile of
@@ -146,9 +177,11 @@ target bytearray_wide_ffi.o pkg : FilePath := do
   -- -DNDEBUG matches how the release Lean runtime itself is built: the
   -- lean.h asserts are debug-only checks, and these externs' bounds are
   -- carried by Lean-side proofs (+ the ZipTest/Wide conformance sweeps).
-  let hardArgs := #["-O2", "-DNDEBUG"] ++
+  -- `buildLeanO` + `ltoFlags`: see `copy_within_ffi.o` — with LTO these
+  -- single-instruction externs inline into `countMatch`/`hash3` themselves.
+  let hardArgs := #["-O2", "-DNDEBUG"] ++ (← ltoFlags) ++
     if Platform.isWindows then #[] else #["-fPIC"]
-  buildO oFile srcJob weakArgs hardArgs "cc"
+  buildLeanO oFile srcJob #[] hardArgs
 
 extern_lib libbytearray_wide_ffi pkg := do
   let ffiO ← bytearray_wide_ffi.o.fetch

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -62,14 +62,24 @@ def zlibLinkFlags : IO (Array String) := do
     into the hot matcher/decoder loops instead of leaving per-iteration
     cross-object calls — a measured +2–5% end-to-end compress win with
     byte-identical output (LTO is codegen-only). For the bitcode to merge,
-    every object must come from the same LLVM: the Lean-emitted C already
-    compiles with the toolchain clang, and the FFI targets below use
-    `buildLeanO` (same compiler) instead of the system `cc`.
-    `-fno-semantic-interposition` keeps `-fPIC` codegen from pessimizing
-    cross-object references. Linux-only: macOS links with the system ld64,
-    whose libLTO need not accept the toolchain clang's bitcode, and Windows
-    is untested. Set `LEAN_ZIP_LTO=0` to opt out (e.g. to link the static
-    libs with a non-LTO-aware toolchain). -/
+    every object must come from the same compiler: the Lean-emitted C
+    already compiles with the toolchain's C compiler, and the FFI targets
+    below use `buildLeanO` (that same compiler — bundled clang, or
+    `LEAN_CC` if set, which must then itself support LTO) instead of the
+    system `cc`. `-fno-semantic-interposition` keeps `-fPIC` codegen from
+    pessimizing cross-object references. Linux-only: macOS links with the
+    system ld64, whose libLTO need not accept the toolchain clang's
+    bitcode, and Windows is untested.
+
+    Downstream `require lean-zip` consumers need no flags of their own:
+    Lake archives the bitcode with the toolchain `llvm-ar`, and the
+    toolchain lld consumes bitcode archive members natively (verified with
+    a flag-free downstream package — its executable gets the same
+    inlining). Set `LEAN_ZIP_LTO=0` to opt out (e.g. when linking the
+    static libs outside Lake with a non-LTO-aware linker, or with a custom
+    `LEAN_AR` that cannot index bitcode). Lake caches `run_io` config:
+    after toggling the env var, reconfigure with `lake -R build` (or
+    remove `.lake`). -/
 def ltoFlags : IO (Array String) := do
   if Platform.isWindows || Platform.isOSX then return #[]
   if (← IO.getEnv "LEAN_ZIP_LTO") == some "0" then return #[]

--- a/progress/2026-07-08T15-05Z_0490389c.md
+++ b/progress/2026-07-08T15-05Z_0490389c.md
@@ -1,0 +1,53 @@
+# 2026-07-08 — feature session (issue #2806): -flto for the wide-load externs
+
+Session 0490389c, branch `issue-2806`.
+
+## What was accomplished
+
+Enabled link-time optimization for the shipped library on Linux
+(lakefile `ltoFlags` / `ltoLinkFlags`, mirrored in `bench/lakefile.lean`),
+so the wide-load stopgap externs (`ugetUInt64LE`, `ugetUInt32LE`,
+`UInt64.ctz`) inline into `lz77Greedy.countMatch` / `hash3` instead of
+staying per-iteration cross-object calls. All measurements reproduced the
+issue's spike:
+
+- `countMatch` extern calls 3 → 0; **every** `lean_zip_*` call site in the
+  bench binary inlines away (including `extend_within`, `copy_within`,
+  `push_u64le` — the decode/emit paths get the same treatment for free).
+- Compressed sizes byte-identical across 7 corpus files × levels {1,6,9}.
+- Steady-state `deflateRaw` (EPYC 9455, pinned): lcet10 L6 +5.9%,
+  mozilla L6 +4.9%, x-ray L6/L8 +0.9%/+1.5%.
+- `lake exe test` and `lake -d bench exe bench-test` pass.
+- Clean-build wall time unchanged (~5m, elaboration-dominated); exe link
+  steps grow 0.2s → ~10s (test) / ~3s (bench).
+
+## Key decisions / discoveries
+
+- **One LLVM for all bitcode**: the FFI C targets switched from system `cc`
+  (clang 22 on this NixOS host — its bitcode is unreadable by the
+  toolchain's lld) to `buildLeanO` (bundled clang 19). This is the piece
+  the issue's "lakefile integration" bullet was missing.
+- `buildLeanO` compiles with `-nostdinc` (freestanding headers only): the
+  copy/extend FFI files' `#include <string.h>` fails there. Replaced the
+  six `memcpy`/`memset` call sites with `__builtin_mem*` and dropped the
+  include.
+- `copy_within_ffi.o` was compiled without `-O`; a clang `-O0` object
+  carries `optnone` which blocks LTO inlining, so it gained
+  `-O2 -DNDEBUG` like its siblings.
+- LTO is Linux-only (macOS ld64's libLTO need not accept toolchain
+  bitcode; Windows untested); `LEAN_ZIP_LTO=0` opts out.
+- Lake per-job timings (`Built test:exe (…)`) are the clean way to see the
+  LTO link cost; touching a C source does not force a rebuild (content-hash
+  traces).
+
+## Shelf life
+
+As the issue notes, once the toolchain bumps to a Lean with lean#14053
+(wide load/store primitives), the headline win folds into the primitive;
+LTO may still pay for the other cross-object calls (`extend_within`,
+`push_u64le`), which now also inline.
+
+## What remains
+
+Nothing on this issue. PR opened closing #2806; perf graphs posted per
+`perf-pr-graphs` once CI is green.


### PR DESCRIPTION
This PR enables link-time optimization for the shipped library on Linux so the wide-load stopgap externs (`ByteArray.ugetUInt64LE`, `ByteArray.ugetUInt32LE`, `UInt64.ctz`) inline into the hot matcher loops (`lz77Greedy.countMatch`, `hash3`) instead of remaining per-iteration cross-object calls, a measured +1–6% end-to-end compress win with byte-identical output.

Closes https://github.com/kim-em/lean-zip/issues/2806 ("perf: -flto to inline the wide-load stopgap externs out of countMatch/hash3").

The Lean-emitted C gains `-flto` via `moreLeancArgs`, links go through `-flto -O3`, and the three project-local FFI primitives (`bytearray_wide`, `extend_within`, `copy_within`) switch from the system `cc` to the toolchain's own C compiler (`buildLeanO`) so all bitcode comes from one LLVM — the system clang here is version 22, whose bitcode the toolchain's lld (LLVM 19) cannot read. Two consequences of `buildLeanO`'s `-nostdinc` header sandbox: the copy primitives use `__builtin_memcpy`/`__builtin_memset` instead of `<string.h>`, and `copy_within_ffi.o` gains `-O2 -DNDEBUG` like its siblings (a clang `-O0` object carries `optnone`, which blocks LTO inlining). LTO is Linux-only (macOS ld64's libLTO need not accept toolchain bitcode; Windows untested) with a `LEAN_ZIP_LTO=0` opt-out.

Verified on this branch (EPYC 9455, taskset-pinned, steady-state `deflateRaw` via `compress-pareto`): every `lean_zip_*` extern call site in the bench binary inlines away (`countMatch`: 3 → 0), compressed sizes are byte-identical across 7 corpus files × levels {1,6,9}, and the full test suite plus bench conformance pass.

| file | level | master | LTO | delta |
|------|-------|--------|-----|-------|
| lcet10 (text, 427 KB) | 6 | 30.51 MB/s | 32.31 MB/s | **+5.9%** |
| mozilla (binary, 51 MB) | 6 | 27.74 | 29.10 | **+4.9%** |
| x-ray (binary, 8.5 MB) | 6 | 17.92 | 18.08 | +0.9% |
| x-ray (binary, 8.5 MB) | 8 | 17.83 | 18.10 | +1.5% |

Clean-build wall time is unchanged (~5 min, elaboration-dominated); the executable link steps grow from ~0.2 s to ~10 s (`test`) / ~3 s (`bench`). A flag-free downstream package (`require lean-zip`, no LTO flags of its own) builds, runs, and gets the same inlining — the toolchain lld consumes bitcode archive members natively — so consumers need no changes. A Codex second opinion reviewed the design; its concerns (downstream link-arg propagation, `LEAN_CC`/`LEAN_AR` overrides, env-toggle staleness against Lake's cached `run_io` config) are addressed in the `ltoFlags` docstring and verified by the downstream-consumer test above.

As the issue notes, the headline win has a shelf life: once the toolchain bumps past lean#14053 (`uget*` as compiler primitives) that part folds into core, while the other now-inlined externs (`extend_within`, `push_u64le`, `copy_within`) keep benefiting.

🤖 Prepared with Claude Code
