### PR TITLE
doc(#2795): record the batched literal emission negative verdict

### DIFF
--- a/plans/track-d-state.md
+++ b/plans/track-d-state.md
@@ -176,6 +176,83 @@ Conclusion: chain-state *representation* tuning (element type, Wave-3a; packing,
 #2779) is now exhausted on this hardware — the matcher's remaining costs stay
 structural (instruction count, per-token allocation, RC traffic).
 
+**#2795 verdict (2026-07-08): batched literal emission via `pushUInt64LE` —
+measured negative; the per-literal push call is not on the decode critical
+path.** This was the deciding probe set up by #2795's framing after
+#2793/#2808 (−5% instructions moved wall-clock only 1–2%, so the decode is
+latency-bound on the loop-carried bitBuf→mask→table-load→shift recurrence):
+batch up to eight consecutive literals into a `UInt64` accumulator + `USize`
+count threaded through the production tree-free loop (`goTreeFreeUB`,
+replacing `goTreeFreeU`'s inline-literal `output.push`), flushing as **one**
+proven-reference `ByteArray.pushUInt64LE` call on batch-full and before any
+branch that observes `output` — removing the out-of-line
+`lean_byte_array_push` call (exclusivity + capacity + store + size bump) from
+the per-literal path. Same-worktree A/B per bench/README (`inflate-profile
+decode`, level-6 libdeflate payloads, `sizeHint` set, medians of 5 interleaved
+rounds — 8 for the shared baseline — AMD EPYC 9455; baseline = `41b1b857`, the
+merged #2808), in **two** variants: the landable exact-guard form (the
+output-limit guard reads the conceptual size `output.size + litCnt`) and a
+measurement-only **ceiling** form that keeps the baseline's cheap
+`output.size ≥ maxOut` guard (fires up to 7 bytes late; isolates the pure
+effect of removing the call from the guard arithmetic). Both regress on both
+axes (Δ vs baseline, exact / ceiling):
+
+| file | Δ instructions | Δ cycles |
+|---|---|---|
+| x-ray (8.5M gray image) | +6.2% / +3.9% | +4.6% / +2.2% |
+| ooffice (6.2M binary) | +5.5% / +3.1% | +5.4% / +3.4% |
+| sao (7.3M star catalog) | +6.6% / +1.0% | +5.1% / +2.4% |
+| alice29 (152K text) | +6.0% / +5.0% | +4.7% / +2.3% |
+| plrabn12 (482K text) | +6.2% / +5.3% | +4.4% / +2.2% |
+
+(Instruction counts are deterministic to ~0.01%; cycles are noisier, but the
+best-of-rounds cycle comparison is also positive on every file for both
+variants — exact +3.4–5.1%, ceiling +1.8–3.3% — so the regression is not a
+median artifact.) **Stated plainly, per the probe's decision rule: cycles do
+not drop more than instructions — median cycles do not drop at all, on any
+file, in either variant; both axes rise together.** Mechanism: `lean_byte_array_push`'s exclusive fast path is only
+~6–8 instructions *including* call overhead (1.96% whole-program self time on
+x-ray — the issue's "~4%" evidence predates #2804/#2805/#2808 shifting the
+mix), and its latency is fully hidden in the recurrence's shadow, so there was
+no serialization to reclaim. The batch bookkeeping — per-literal accumulator
+OR + two shifts, count increment + batch-full compare, one `pushUInt64LE` call
+per eight literals **plus one per slow-path entry even with an empty batch
+(i.e. per match)**, and in the exact form the boxed-Nat conceptual-size guard
+(`lean_usize_to_nat` + `lean_nat_add` + `lean_nat_dec_le` per literal) — costs
+more than the call it removes: the ceiling A/B on x-ray (+58.5M
+instructions/rep over ~8M literals) nets ~+7 instructions per literal.
+A leaner batcher was considered rather than measured — carry the shift (or a
+write pointer) instead of the count, skip empty flushes before matches,
+precompute the remaining output room per batch instead of per-literal Nat
+arithmetic — but those shavings target known spike overhead the ceiling
+variant already largely excludes, and the ceiling still regresses median
+cycles on every file: there is no evidence that simple literal batching is a
+lever here, and a substantially different output-write design should be
+measured as its own probe rather than as a third variant of this one.
+Consequence for the output-write story: per-literal *store-call*
+removal is not a lever — the batched-store motivation for the heavier
+structural rewrites (#2798/#2799) is dead, and any case for the
+fastloop/slowloop split or the write-once `uset` cursor must rest on what
+those *additionally* remove (the per-literal size-bump/guard bookkeeping, the
+bounds discipline) and needs its own probe before committing. Branch
+`perf/2795-batched-literal-spike` preserved unmerged: commit `604cc1a9` is the
+exact-guard spike (equivalence theorem `goTreeFreeUB_eq` stated and `sorry`'d,
+benchmark-first), commit `45b355c6` the ceiling probe; reproduce by building
+`inflate-profile` at each commit per bench/README § *Profiling the decoder*.
+Incidental discovery while attributing the loss (filed as #2811): the
+`copy_within_ffi.o` lakefile target is compiled without `-O2 -DNDEBUG` —
+unlike its `extend_within`/`bytearray_wide` siblings — so the match-copy
+primitive runs un-inlined `lean.h` helpers *with asserts enabled*; on x-ray
+decode that un-optimized TU (`lean_to_sarray` 9.1%, `lean_is_sarray` 6.4%,
+`lean_zip_byte_array_copy_within` 7.5%, plus helpers) is roughly a third of
+whole-program self time, inflating the denominator of every recent decode
+percentage. Fixing it is a likely across-the-board decode win and re-baselines
+future A/Bs. It does not change this verdict's sign — the added batching cost
+is absolute, per-literal, and inside the loop TU, which is compiled optimized —
+and #2795 needs no re-run after #2811 lands unless a post-#2811 profile shows
+`lean_byte_array_push` becoming a materially larger self-time share of the
+rebalanced decode.
+
 **W5.P1 comparative component profile (2026-06-12, perf, alice29, per-compressor
 windows, normalized to compressor-attributable samples; nix/Lean startup noise
 excluded; miniz attribution degraded — inline monolith):**

--- a/progress/batched-literal-emission-2795.md
+++ b/progress/batched-literal-emission-2795.md
@@ -1,0 +1,71 @@
+# Progress: batched literal emission via pushUInt64LE (#2795) — negative verdict
+
+**Date**: 2026-07-08 UTC
+**Session type**: Feature (benchmark-first probe; measured negative, recorded as verdict)
+**Issue**: #2795
+
+## What was done
+
+Followed the issue's framing comment exactly: spike first with the
+equivalence `sorry`'d, measure with `inflate-profile` same-worktree A/B,
+report both retired instructions and cycles, and treat the result as the
+deciding probe — not a guaranteed win.
+
+1. **Spike implemented** (`goTreeFreeUB` in `Zip/Native/InflateTreeFree.lean`):
+   up to 8 consecutive literals accumulate LSB-first in a `UInt64` + `USize`
+   count (both unboxed loop state), flushed as one `ByteArray.pushUInt64LE`
+   on batch-full and at every slow-path entry (match / end-of-block /
+   long-code literal); output-limit guard reads the conceptual size
+   `output.size + litCnt`. Equivalence theorem `goTreeFreeUB_eq` stated
+   against `goTreeFreeU` over `pushLEBytes`-flushed output, `sorry`'d
+   pending the measurement. Full test suite passes with the spike wired in
+   (behavioral witness).
+2. **Measured** (protocol: bench/README § *Profiling the decoder*; baseline
+   = 41b1b857 built in the same worktree; level-6 libdeflate payloads;
+   x-ray / ooffice / sao / alice29 / plrabn12; medians of 5 interleaved
+   rounds, 8 for the shared baseline; AMD EPYC 9455). Two variants: exact
+   guard, and a measurement-only "ceiling" with the baseline's cheap guard.
+   **Both regress: instructions +1.0–6.6%; median cycles +4.4–5.4% (exact)
+   / +2.2–3.4% (ceiling); best-of-rounds cycles also positive on every
+   file.** Full table in the `plans/track-d-state.md` verdict entry.
+3. **Verdict recorded** in `plans/track-d-state.md` (this PR), mirroring the
+   #2779/#2791 precedent. The equivalence proof was deliberately **not**
+   written (benchmark-first: the measurement says don't land the change).
+   A Codex second opinion concurred with the negative verdict; its asks
+   (soften the "cannot flip the sign" claim, name the leaner-batcher
+   shavings considered, more cycle rounds, a #2811 re-run caveat) are
+   incorporated in the ledger entry.
+4. **Spike preserved unmerged** on branch `perf/2795-batched-literal-spike`
+   (604cc1a9 exact-guard, 45b355c6 ceiling probe).
+5. **Incidental discovery filed as #2811**: `copy_within_ffi.o` is compiled
+   without `-O2 -DNDEBUG` (unlike its two sibling FFI targets), leaving
+   un-inlined lean.h helpers with asserts enabled on the match-copy path —
+   roughly a third of whole-program decode self time on x-ray. Likely
+   across-the-board decode win; re-baselines decode percentage claims.
+
+## Key findings
+
+- `lean_byte_array_push`'s exclusive fast path is ~6–8 instructions
+  including call overhead (1.96% self time on x-ray), fully hidden in the
+  bitBuf→table→len recurrence's latency shadow. The issue's "~4% / 10–15%"
+  evidence predates #2804/#2805/#2808 and is further inflated by #2811.
+- Batch bookkeeping nets ~+7 instructions per literal (ceiling A/B, x-ray),
+  i.e. the replacement costs more than the removed call. An empty-batch
+  flush call is also paid on every match.
+- Decision-rule consequence, stated per the framing comment: cycles did NOT
+  drop more than instructions — the store call was not on the critical
+  path, so the batched-store motivation for #2798/#2799 is dead; any case
+  for those rewrites must rest on what they additionally remove and needs
+  its own probe.
+
+## Quality metrics
+
+- sorry count on this branch (`grep -rc sorry Zip/`): unchanged from master
+  (the sorry'd spike lives only on the preserved spike branch).
+- `lake exe test`: passes (doc-only change on this branch).
+
+## What remains
+
+Nothing on #2795 (closed by this PR as measured-negative). Follow-ups live
+in #2811 (copy_within flags) and, if ever revisited, the preserved spike
+branch documents the exact re-measurement protocol.


### PR DESCRIPTION
This PR records the Track-D ledger verdict for issue #2795: batching up to eight consecutive literals into a `UInt64` accumulator + `USize` count in the production tree-free decode loop and flushing via the proven-reference extern `ByteArray.pushUInt64LE` — replacing the per-literal out-of-line `lean_byte_array_push` call — measured **slower on both axes on every corpus member** (same-worktree `inflate-profile` A/B vs 41b1b857, level-6 libdeflate payloads, medians of 5 interleaved rounds, AMD EPYC 9455). Exact-guard form: instructions +5.5–6.6%, cycles +4.4–5.4%; a measurement-only ceiling probe keeping the baseline's cheap output-limit guard still regresses +1.0–5.3% / +2.2–3.4%. Per the issue's decision rule, stated plainly: **cycles do not drop more than instructions — median cycles do not drop at all, in either variant.** The per-literal push call (~6–8 instructions on its exclusive fast path, 1.96% self time on x-ray) sits in the latency shadow of the decode's loop-carried recurrence, and the batch bookkeeping costs more than the call it removes (~+7 instructions/literal net in the ceiling A/B), so the batched-store motivation for the structural rewrites #2798/#2799 is dead; any case for those must rest on what they additionally remove and needs its own probe.

The spike (equivalence theorem stated and `sorry`'d, benchmark-first per the framing comment; full test suite passes with it wired in) is preserved unmerged on branch [`perf/2795-batched-literal-spike`](https://github.com/kim-em/lean-zip/tree/perf/2795-batched-literal-spike) — commit 604cc1a9 exact-guard, 45b355c6 ceiling probe. A Codex second opinion concurred with the verdict; its wording and methodology asks are incorporated.

Incidental discovery while attributing the loss, filed as [#2811 "perf(decode): compile copy_within_ffi.o with -O2 -DNDEBUG like its siblings"](https://github.com/kim-em/lean-zip/issues/2811): the match-copy FFI TU is compiled un-optimized with asserts enabled — roughly a third of whole-program decode self time on x-ray — which re-baselines future decode A/Bs (a caveat on when this verdict would warrant a re-run is in the ledger entry).

Closes #2795

🤖 Prepared with Claude Code
