### PR TITLE
perf(decode): proven-bounds uget for the literal fast-path read

### DIFF
--- a/Zip/Native/Inflate.lean
+++ b/Zip/Native/Inflate.lean
@@ -270,6 +270,51 @@ theorem DecodeTable.symAt_eq_unpackSym_entryAt (t : DecodeTable) (idx : Nat) :
   unfold DecodeTable.symAt DecodeTable.entryAt
   split <;> rfl
 
+/-- `entryAt` with the bounds proof supplied by the caller: an unchecked `uget` on
+    a `USize` index, so the hot loop pays **no** per-symbol bounds check and no
+    `USize→Nat` index round-trip. The `2^fastBits`-slot invariant on `packed`
+    (`buildTableCanonicalFastWithCount_size`) plus `bitBuf &&& 0x7FF < 2^fastBits`
+    discharge the proof once at the call site. Equal to `entryAt` in bounds
+    (`entryAtU_eq_entryAt`), so every decode proof still transfers. -/
+@[inline] def DecodeTable.entryAtU (t : DecodeTable) (i : USize)
+    (h : i.toNat < t.packed.size) : UInt32 :=
+  t.packed.uget i h
+
+theorem DecodeTable.entryAtU_eq_entryAt (t : DecodeTable) (i : USize)
+    (h : i.toNat < t.packed.size) : t.entryAtU i h = t.entryAt i.toNat := by
+  unfold DecodeTable.entryAtU DecodeTable.entryAt
+  rw [dif_pos h]; rfl
+
+/-- The `fastBits`-bit window index, taken as a `USize`, indexes the `2^fastBits`
+    packed slots. `bitBuf &&& 0x7FF ≤ 0x7FF = 2^fastBits − 1`, and the `USize`
+    round-trip can only shrink it (`mod`), so the bound survives. -/
+theorem and_0x7FF_toUSize_toNat_lt (bitBuf : UInt64) :
+    ((bitBuf &&& 0x7FF).toUSize).toNat < 2 ^ fastBits := by
+  have hlt : (bitBuf &&& 0x7FF).toNat < 2 ^ fastBits := by
+    simp only [fastBits]
+    rw [UInt64.toNat_and]
+    exact Nat.lt_of_le_of_lt Nat.and_le_right (by decide)
+  exact Nat.lt_of_le_of_lt (by rw [UInt64.toNat_toUSize]; exact Nat.mod_le _ _) hlt
+
+/-- The `USize` window index round-trips to its `Nat` value: `bitBuf &&& 0x7FF` is
+    far below `USize.size`. -/
+theorem and_0x7FF_toUSize_toNat_eq (bitBuf : UInt64) :
+    ((bitBuf &&& 0x7FF).toUSize).toNat = (bitBuf &&& 0x7FF).toNat := by
+  rw [UInt64.toNat_toUSize, ← USize.size_eq_two_pow]
+  refine Nat.mod_eq_of_lt ?_
+  have h1 : (bitBuf &&& 0x7FF).toNat ≤ 2047 := by
+    rw [UInt64.toNat_and]; exact Nat.le_trans Nat.and_le_right (by decide)
+  have h2 : (2047 : Nat) < USize.size := Nat.lt_of_lt_of_le (by decide) USize.le_size
+  omega
+
+/-- Reading the `fastBits`-bit window slot by `uget` on the `USize` index equals the
+    guarded `entryAt` read on the `Nat` index — the bridge that carries the tree-free
+    loop's `uget` optimization back to the boxed reference's `entryAt`/`lenAt`. -/
+@[simp] theorem DecodeTable.entryAtU_window_eq (t : DecodeTable) (bitBuf : UInt64)
+    (h : ((bitBuf &&& 0x7FF).toUSize).toNat < t.packed.size) :
+    t.entryAtU (bitBuf &&& 0x7FF).toUSize h = t.entryAt (bitBuf &&& 0x7FF).toNat := by
+  rw [entryAtU_eq_entryAt, and_0x7FF_toUSize_toNat_eq]
+
 /-- Build the `2^fastBits`-entry decode table for `tree`: slot `i` holds
     `packEntry sym codeLen` for the `(sym, codeLen)` reached by walking `tree` on
     the bits of `i`, stored in a single packed scalar array so each per-symbol read
@@ -278,6 +323,11 @@ theorem DecodeTable.symAt_eq_unpackSym_entryAt (t : DecodeTable) (idx : Nat) :
 def buildTable (tree : HuffTree) : DecodeTable where
   packed := Array.ofFn (n := 2 ^ fastBits) (fun i : Fin (2 ^ fastBits) =>
     packEntry (tableEntry tree i.val).1 (tableEntry tree i.val).2)
+
+/-- The tree-built decode table has exactly `2^fastBits` slots (`Array.ofFn`). -/
+@[simp] theorem buildTable_size (tree : HuffTree) :
+    (buildTable tree).packed.size = 2 ^ fastBits := by
+  simp only [buildTable, Array.size_ofFn]
 
 /-! ## Canonical O(n) table construction (libdeflate `build_decode_table`)
 
@@ -326,7 +376,7 @@ termination_by count
     `0 < count → base + (count-1)·stride < packed.size` states the last slot the
     fill touches is in range; it is preserved by the recursion because the last
     slot never moves as `base` advances by `stride` and `count` shrinks. Equal to
-    `fillSlots` (`HuffTree.fillSlotsU_eq` in `Zip.Spec.InflateCanonical`), so
+    `fillSlots` (`HuffTree.fillSlotsU_eq`, below), so
     `buildCanonicalLoop` can call it behind a single per-codeword bounds guard
     instead of paying a bounds check on every one of a codeword's `2^(fastBits-len)`
     slot writes. -/
@@ -373,6 +423,55 @@ def buildCanonicalLoop (lengths : Array UInt8) (nextCode : Array UInt32)
     else
       buildCanonicalLoop lengths nextCode (start + 1) packed
   else packed
+termination_by lengths.size - start
+
+/-- `fillSlots` preserves the array size. -/
+@[simp] theorem fillSlots_size (packed : Array UInt32) (base stride count : Nat)
+    (entry : UInt32) :
+    (fillSlots packed base stride count entry).size = packed.size := by
+  induction count generalizing packed base with
+  | zero => simp [fillSlots]
+  | succ n ih =>
+    rw [fillSlots]
+    simp only [Nat.succ_ne_zero, ↓reduceIte, Nat.add_sub_cancel]
+    rw [ih (packed.set! base entry) (base + stride)]
+    simp
+
+/-- A proof-carrying `Array.set` in bounds is the checked `set!`. -/
+private theorem set_eq_set! {α : Type _} {a : Array α} {i : Nat} {v : α} (h : i < a.size) :
+    a.set i v h = a.set! i v := by
+  rw [Array.set!_eq_setIfInBounds, Array.setIfInBounds_def, dif_pos h]
+
+/-- The unchecked fill `fillSlotsU` equals the checked `fillSlots`: each
+    proof-carrying `Array.set` in bounds is the corresponding `set!`. -/
+theorem fillSlotsU_eq (packed : Array UInt32) (base stride count : Nat) (entry : UInt32)
+    (hb : 0 < count → base + (count - 1) * stride < packed.size) :
+    fillSlotsU packed base stride count entry hb = fillSlots packed base stride count entry := by
+  rw [fillSlotsU, fillSlots]
+  by_cases hc : count = 0
+  · rw [dif_pos hc, if_pos hc]
+  · rw [dif_neg hc, if_neg hc]
+    simp only [set_eq_set!]
+    exact fillSlotsU_eq (packed.set! base entry) (base + stride) stride (count - 1) entry _
+termination_by count
+
+/-- `buildCanonicalLoop` preserves the array size: every fill (`fillSlots` /
+    `fillSlotsU`) is size-preserving and the recursion only threads `packed`. -/
+theorem buildCanonicalLoop_size (lengths : Array UInt8) (nextCode : Array UInt32)
+    (start : Nat) (packed : Array UInt32) :
+    (buildCanonicalLoop lengths nextCode start packed).size = packed.size := by
+  unfold buildCanonicalLoop
+  split
+  · dsimp only []
+    split
+    · split
+      · rw [buildCanonicalLoop_size]
+        split
+        · rw [fillSlotsU_eq, fillSlots_size]
+        · rw [fillSlots_size]
+      · rw [buildCanonicalLoop_size]
+    · rw [buildCanonicalLoop_size]
+  · rfl
 termination_by lengths.size - start
 
 /-- Build the `2^fastBits`-entry decode table directly from the code lengths,
@@ -486,6 +585,14 @@ def buildTableCanonicalFastWithCount (lengths : Array UInt8) (count : Array Nat)
   packed :=
     let nextCode := nextCodesFast count maxBits
     buildCanonicalLoop lengths nextCode 0 (Array.replicate (2 ^ fastBits) (packEntry 0 0))
+
+/-- The canonical fast table has exactly `2^fastBits` packed slots — the initial
+    `Array.replicate (2^fastBits)` that `buildCanonicalLoop` size-preserves. This is
+    the invariant the tree-free loop's `uget` indexing needs (`goTreeFreeU`'s `hlp`). -/
+@[simp] theorem buildTableCanonicalFastWithCount_size (lengths : Array UInt8)
+    (count : Array Nat) (maxBits : Nat) :
+    (buildTableCanonicalFastWithCount lengths count maxBits).packed.size = 2 ^ fastBits := by
+  simp only [buildTableCanonicalFastWithCount, buildCanonicalLoop_size, Array.size_replicate]
 
 /-- Bits remaining in the reader from its current `(pos, bitOff)`. -/
 def bitsAvail (br : BitReader) : Nat :=
@@ -928,6 +1035,21 @@ theorem litGuard_usize (table : HuffTree.DecodeTable) (bitBuf : UInt64) (cnt : U
   refine and_congr ?_ (and_congr ?_ Iff.rfl)
   · rw [Ne, Ne, ← UInt8.toNat_inj]; rfl
   · rw [USize.le_iff_toNat_le, UInt8.toNat_toUSize]
+
+/-- `litGuard_usize` for the `uget` read: the `entryAtU` slot on the `USize` window
+    index is the same word as `entryAt` on the `Nat` index (`entryAtU_window_eq`), so
+    the packed-`uget` guard matches the boxed reference's `lenAt`/`symAt` `Nat`
+    guard. -/
+theorem litGuardU_usize (table : HuffTree.DecodeTable) (bitBuf : UInt64) (cnt : USize)
+    (h : ((bitBuf &&& 0x7FF).toUSize).toNat < table.packed.size) :
+    (HuffTree.unpackLen (table.entryAtU (bitBuf &&& 0x7FF).toUSize h) ≠ 0
+        ∧ (HuffTree.unpackLen (table.entryAtU (bitBuf &&& 0x7FF).toUSize h)).toUSize ≤ cnt
+        ∧ HuffTree.unpackSym (table.entryAtU (bitBuf &&& 0x7FF).toUSize h) < 256)
+      ↔ ((table.lenAt (bitBuf &&& 0x7FF).toNat).toNat ≠ 0
+        ∧ (table.lenAt (bitBuf &&& 0x7FF).toNat).toNat ≤ cnt.toNat
+        ∧ table.symAt (bitBuf &&& 0x7FF).toNat < 256) := by
+  simp only [HuffTree.DecodeTable.entryAtU_window_eq]
+  exact litGuard_usize table bitBuf cnt
 
 /-- Load whole bytes into the high end of `bitBuf` until it holds > 56 bits or
     the input is exhausted. Preserves the consumed bit position `pos*8 - cnt`. -/

--- a/Zip/Native/InflateTreeFree.lean
+++ b/Zip/Native/InflateTreeFree.lean
@@ -217,7 +217,8 @@ set_option maxRecDepth 4096 in
 def goTreeFreeU (litTable distTable : DecodeTable) (litLD distLD : LongDecode)
     (maxBits : Nat) (data : ByteArray) (maxOut : Nat)
     (pos : USize) (bitBuf : UInt64) (cnt : USize)
-    (hsz : data.size < USize.size) (output : ByteArray) :
+    (hsz : data.size < USize.size)
+    (hlp : litTable.packed.size = 2 ^ HuffTree.fastBits) (output : ByteArray) :
     Except String (ByteArray × USize × UInt64 × USize) := do
   if hrc : cnt ≤ 56 ∧ pos < data.size.toUSize then
     goTreeFreeU litTable distTable litLD distLD maxBits data maxOut
@@ -225,9 +226,10 @@ def goTreeFreeU (litTable distTable : DecodeTable) (litLD distLD : LongDecode)
       (bitBuf ||| ((data.uget pos (by
           have h := USize.lt_iff_toNat_lt.mp hrc.2
           rwa [toUSize_toNat_of_lt hsz] at h)).toUInt64 <<< cnt.toUInt64))
-      (cnt + 8) hsz output
+      (cnt + 8) hsz hlp output
   else
-  let e := litTable.entryAt (bitBuf &&& 0x7FF).toNat
+  let e := litTable.entryAtU (bitBuf &&& 0x7FF).toUSize
+    (by rw [hlp]; exact HuffTree.and_0x7FF_toUSize_toNat_lt bitBuf)
   if hlit : HuffTree.unpackLen e ≠ 0
       ∧ (HuffTree.unpackLen e).toUSize ≤ cnt
       ∧ HuffTree.unpackSym e < 256 then
@@ -236,7 +238,7 @@ def goTreeFreeU (litTable distTable : DecodeTable) (litLD distLD : LongDecode)
       goTreeFreeU litTable distTable litLD distLD maxBits data maxOut pos
         (bitBuf >>> (HuffTree.unpackLen e).toUInt64)
         (cnt - (HuffTree.unpackLen e).toUSize)
-        hsz
+        hsz hlp
         (output.push (HuffTree.unpackSym e).toUInt8)
   else
   let cnt0 := cnt.toNat
@@ -248,7 +250,7 @@ def goTreeFreeU (litTable distTable : DecodeTable) (litLD distLD : LongDecode)
       else if hnp : cnt0 ≤ cnt' then throw "Inflate: no progress in Huffman decode"
       else
         goTreeFreeU litTable distTable litLD distLD maxBits data maxOut pos bitBuf
-          cnt'.toUSize hsz (output.push sym.toUInt8)
+          cnt'.toUSize hsz hlp (output.push sym.toUInt8)
     else if sym == 256 then .ok (output, pos, bitBuf, cnt'.toUSize)
     else
       let idx := sym.toNat - 257
@@ -277,7 +279,7 @@ def goTreeFreeU (litTable distTable : DecodeTable) (litLD distLD : LongDecode)
               let out := Inflate.copyLoop output (output.size - distance) distance 0 length
                 (by omega) (by omega)
               goTreeFreeU litTable distTable litLD distLD maxBits data maxOut pos bitBuf
-                cnt4.toUSize hsz out
+                cnt4.toUSize hsz hlp out
   termination_by (data.size - pos.toNat) * 9 + cnt.toNat
   decreasing_by
     · obtain ⟨hc, hp⟩ := hrc
@@ -321,7 +323,8 @@ def goTreeFreeU (litTable distTable : DecodeTable) (litLD distLD : LongDecode)
     `decodeHuffmanFastBufTreeFree` so the fixed-Huffman path can pass the
     compile-time-constant fixed tables instead of rebuilding them every block. -/
 def decodeHuffmanFastBufTables (br : BitReader) (output : ByteArray)
-    (litTable distTable : DecodeTable) (litLD distLD : LongDecode) (maxOut : Nat) :
+    (litTable distTable : DecodeTable) (litLD distLD : LongDecode) (maxOut : Nat)
+    (hlp : litTable.packed.size = 2 ^ HuffTree.fastBits) :
     Except String (ByteArray × BitReader) := do
   let (pos, bitBuf, cnt) := refill br.data br.pos 0 0
   let bitBuf := bitBuf >>> br.bitOff.toUInt64
@@ -330,7 +333,8 @@ def decodeHuffmanFastBufTables (br : BitReader) (output : ByteArray)
     if hsz : br.data.size.toUSize.toNat = br.data.size then
       Except.map (fun x => (x.1, x.2.1.toNat, x.2.2.1, x.2.2.2.toNat))
         (goTreeFreeU litTable distTable litLD distLD 15 br.data maxOut
-          pos.toUSize bitBuf cnt.toUSize (by rw [← hsz]; exact USize.toNat_lt_two_pow_numBits _) output)
+          pos.toUSize bitBuf cnt.toUSize (by rw [← hsz]; exact USize.toNat_lt_two_pow_numBits _)
+          hlp output)
     else
       goTreeFree litTable distTable litLD distLD 15 br.data maxOut pos bitBuf cnt output
   let _ := bitBuf'
@@ -350,6 +354,7 @@ def decodeHuffmanFastBufTreeFree (br : BitReader) (output : ByteArray)
   let litLD := HuffTree.buildLongDecodeWithCount litLengths litCount 15
   let distLD := HuffTree.buildLongDecodeWithCount distLengths distCount 15
   decodeHuffmanFastBufTables br output litTable distTable litLD distLD maxOut
+    (HuffTree.buildTableCanonicalFastWithCount_size litLengths litCount 15)
 
 end InflateBuf
 
@@ -396,6 +401,7 @@ def decodeHuffmanFastBufFixed (br : BitReader) (output : ByteArray) (maxOut : Na
     Except String (ByteArray × BitReader) :=
   InflateBuf.decodeHuffmanFastBufTables br output fixedLitTable fixedDistTable
     fixedLitLD fixedDistLD maxOut
+    (HuffTree.buildTableCanonicalFastWithCount_size fixedLitLengths fixedLitCount 15)
 
 /-- Like `decodeDynamicTrees`, but returns only the code-length vectors — it never
     builds the lit/dist Huffman trees (the whole point of the tree-free path). The

--- a/Zip/Spec/InflateCanonical.lean
+++ b/Zip/Spec/InflateCanonical.lean
@@ -25,8 +25,10 @@ The foundation lemmas here, bottom-up:
 1. `bitReverse` arithmetic — the bit-reversed codeword indexes the fast table.
 2. `cwOf`/`bitReverse` bridge (`cwOf_eq_iff_mod`) — slot `idx` lies on a
    codeword's path iff `idx % 2^len` is the bit-reversed code.
-3. `fillSlots` — what the slot-fill writes (`fillSlots_getElem_eq`) and
-   preserves (`fillSlots_getElem_ne`, `fillSlots_size`).
+3. `fillSlots` — what the slot-fill writes (`fillSlots_getElem_eq`) and which
+   slots it leaves unchanged (`fillSlots_getElem_ne`). Size preservation
+   (`fillSlots_size` / `buildCanonicalLoop_size`) lives in `Zip.Native.Inflate`,
+   where the tree-free decoder's `uget` bound needs it.
 -/
 
 namespace Zip.Native.HuffTree
@@ -152,37 +154,6 @@ theorem cwOf_eq_iff_mod (idx c len : Nat) :
     exact (cwOf_mod idx len).symm.trans hbr
 
 /-! ## `fillSlots` -/
-
-/-- `fillSlots` preserves the array size. -/
-@[simp] theorem fillSlots_size (packed : Array UInt32) (base stride count : Nat)
-    (entry : UInt32) :
-    (fillSlots packed base stride count entry).size = packed.size := by
-  induction count generalizing packed base with
-  | zero => simp [fillSlots]
-  | succ n ih =>
-    rw [fillSlots]
-    simp only [Nat.succ_ne_zero, ↓reduceIte, Nat.add_sub_cancel]
-    rw [ih (packed.set! base entry) (base + stride)]
-    simp
-
-/-- A proof-carrying `Array.set` in bounds is the checked `set!`. -/
-private theorem set_eq_set! {α : Type _} {a : Array α} {i : Nat} {v : α} (h : i < a.size) :
-    a.set i v h = a.set! i v := by
-  rw [Array.set!_eq_setIfInBounds, Array.setIfInBounds_def, dif_pos h]
-
-/-- The unchecked fill `fillSlotsU` (used on the decode path behind a single
-    per-codeword bounds guard) equals the checked `fillSlots`: each proof-carrying
-    `Array.set` in bounds is the corresponding `set!`. -/
-theorem fillSlotsU_eq (packed : Array UInt32) (base stride count : Nat) (entry : UInt32)
-    (hb : 0 < count → base + (count - 1) * stride < packed.size) :
-    fillSlotsU packed base stride count entry hb = fillSlots packed base stride count entry := by
-  rw [fillSlotsU, fillSlots]
-  by_cases hc : count = 0
-  · rw [dif_pos hc, if_pos hc]
-  · rw [dif_neg hc, if_neg hc]
-    simp only [set_eq_set!]
-    exact fillSlotsU_eq (packed.set! base entry) (base + stride) stride (count - 1) entry _
-termination_by count
 
 /-- A slot not on the fill's arithmetic progression `{base + j·stride : j < count}`
     keeps its old value. -/
@@ -446,27 +417,6 @@ theorem fillSlots_nomatch (packed : Array UInt32) (base len count idx : Nat) (en
   intro j _ heq
   apply hmod
   rw [heq, Nat.add_mul_mod_self_right, Nat.mod_eq_of_lt hbase]
-
-/-! ## `buildCanonicalLoop` preserves the table size -/
-
-/-- The canonical fill loop never changes the table length (every write is an
-    in-bounds `fillSlots`/`set!`). -/
-theorem buildCanonicalLoop_size (lengths : Array UInt8) (nextCode : Array UInt32)
-    (start : Nat) (packed : Array UInt32) :
-    (buildCanonicalLoop lengths nextCode start packed).size = packed.size := by
-  unfold buildCanonicalLoop
-  split
-  · dsimp only []
-    split
-    · split
-      · rw [buildCanonicalLoop_size]
-        split
-        · rw [fillSlotsU_eq, fillSlots_size]
-        · rw [fillSlots_size]
-      · rw [buildCanonicalLoop_size]
-    · rw [buildCanonicalLoop_size]
-  · rfl
-termination_by lengths.size - start
 
 /-! ## Tree-side slot characterization -/
 

--- a/Zip/Spec/InflateTreeFreeCorrect.lean
+++ b/Zip/Spec/InflateTreeFreeCorrect.lean
@@ -1525,16 +1525,17 @@ theorem goTreeFree_ok_iff_goFusedP (litTable distTable : HuffTree.DecodeTable)
     same `goFusedPU.induct`-style argument applies with `decodeSymCanon`. -/
 theorem goTreeFreeU_eq (litTable distTable : HuffTree.DecodeTable) (data : ByteArray)
     (litLD distLD : HuffTree.LongDecode) (maxBits : Nat) (maxOut : Nat)
-    (hsz : data.size < USize.size) :
+    (hsz : data.size < USize.size)
+    (hlp : litTable.packed.size = 2 ^ HuffTree.fastBits) :
     ∀ (pos : USize) (bitBuf : UInt64) (cnt : USize) (output : ByteArray),
     pos.toNat ≤ data.size →
     Except.map (fun x => (x.1, x.2.1.toNat, x.2.2.1, x.2.2.2.toNat))
-        (goTreeFreeU litTable distTable litLD distLD maxBits data maxOut pos bitBuf cnt hsz output)
+        (goTreeFreeU litTable distTable litLD distLD maxBits data maxOut pos bitBuf cnt hsz hlp output)
       = goTreeFree litTable distTable litLD distLD maxBits data maxOut pos.toNat bitBuf cnt.toNat output := by
   intro pos bitBuf cnt output
   induction pos, bitBuf, cnt, output using goTreeFreeU.induct
     (litTable := litTable) (litLD := litLD)
-    (maxBits := maxBits) (data := data) (maxOut := maxOut) (hsz := hsz) with
+    (maxBits := maxBits) (data := data) (maxOut := maxOut) (hsz := hsz) (hlp := hlp) with
   | case1 pos bitBuf cnt output hrc ih =>
       intro hpos
       have hgN := (refillGuard_usize data pos cnt hsz).mp hrc
@@ -1555,33 +1556,35 @@ theorem goTreeFreeU_eq (litTable distTable : HuffTree.DecodeTable) (data : ByteA
       intro hpos
       rw [goTreeFreeU, dif_neg hrc, dif_pos hlit, if_pos hmax,
           goTreeFree, dif_neg (fun h => hrc ((refillGuard_usize data pos cnt hsz).mpr h)),
-          dif_pos ((litGuard_usize litTable bitBuf cnt).mp hlit), if_pos hmax]
+          dif_pos ((litGuardU_usize litTable bitBuf cnt _).mp hlit), if_pos hmax]
       rfl
   | case3 pos bitBuf cnt output hrc ent hlit hmax ih =>
       intro hpos
       obtain ⟨hl0, hl1, hl2⟩ := hlit
-      have hle : litTable.lenAt (bitBuf &&& 0x7FF).toNat = HuffTree.unpackLen ent :=
-        litTable.lenAt_eq_unpackLen_entryAt _
-      have hse : litTable.symAt (bitBuf &&& 0x7FF).toNat = HuffTree.unpackSym ent :=
-        litTable.symAt_eq_unpackSym_entryAt _
+      have hle : litTable.lenAt (bitBuf &&& 0x7FF).toNat = HuffTree.unpackLen ent := by
+        rw [litTable.lenAt_eq_unpackLen_entryAt]; congr 1
+        exact (litTable.entryAtU_window_eq bitBuf _).symm
+      have hse : litTable.symAt (bitBuf &&& 0x7FF).toNat = HuffTree.unpackSym ent := by
+        rw [litTable.symAt_eq_unpackSym_entryAt]; congr 1
+        exact (litTable.entryAtU_window_eq bitBuf _).symm
       have hsub : (cnt - (HuffTree.unpackLen ent).toUSize).toNat
           = cnt.toNat - (HuffTree.unpackLen ent).toNat := by
         rw [USize.toNat_sub_of_le _ _ hl1, UInt8.toNat_toUSize]
       rw [goTreeFreeU, dif_neg hrc, dif_pos ⟨hl0, hl1, hl2⟩, if_neg hmax,
           goTreeFree, dif_neg (fun h => hrc ((refillGuard_usize data pos cnt hsz).mpr h)),
-          dif_pos ((litGuard_usize litTable bitBuf cnt).mp ⟨hl0, hl1, hl2⟩), if_neg hmax,
+          dif_pos ((litGuardU_usize litTable bitBuf cnt _).mp ⟨hl0, hl1, hl2⟩), if_neg hmax,
           ih hpos, hsub, hle, hse, uint8_toUInt64_toNat]
   | case4 pos bitBuf cnt output hrc ent hlit e hde =>
       intro hpos
       rw [goTreeFreeU, dif_neg hrc, dif_neg hlit,
           goTreeFree, dif_neg (fun h => hrc ((refillGuard_usize data pos cnt hsz).mpr h)),
-          dif_neg (fun h => hlit ((litGuard_usize litTable bitBuf cnt).mpr h))]
+          dif_neg (fun h => hlit ((litGuardU_usize litTable bitBuf cnt _).mpr h))]
       simp only [hde, Except.map]
   | case5 pos bitBuf cnt output hrc ent hlit sym bb c used hde hsym hmax =>
       intro hpos
       rw [goTreeFreeU, dif_neg hrc, dif_neg hlit,
           goTreeFree, dif_neg (fun h => hrc ((refillGuard_usize data pos cnt hsz).mpr h)),
-          dif_neg (fun h => hlit ((litGuard_usize litTable bitBuf cnt).mpr h))]
+          dif_neg (fun h => hlit ((litGuardU_usize litTable bitBuf cnt _).mpr h))]
       simp only [hde, if_pos hsym, if_pos hmax]
       rfl
   | case6 pos bitBuf cnt output hrc ent hlit cnt0 sym bb c used hde hsym hmax hnp =>
@@ -1589,7 +1592,7 @@ theorem goTreeFreeU_eq (litTable distTable : HuffTree.DecodeTable) (data : ByteA
       have hnp' : cnt.toNat ≤ c := hnp
       rw [goTreeFreeU, dif_neg hrc, dif_neg hlit,
           goTreeFree, dif_neg (fun h => hrc ((refillGuard_usize data pos cnt hsz).mpr h)),
-          dif_neg (fun h => hlit ((litGuard_usize litTable bitBuf cnt).mpr h))]
+          dif_neg (fun h => hlit ((litGuardU_usize litTable bitBuf cnt _).mpr h))]
       simp only [hde, if_pos hsym, if_neg hmax, dif_pos hnp']
       rfl
   | case7 pos bitBuf cnt output hrc ent hlit cnt0 sym bb c used hde hsym hmax hnp ih =>
@@ -1600,7 +1603,7 @@ theorem goTreeFreeU_eq (litTable distTable : HuffTree.DecodeTable) (data : ByteA
         toUSize_toNat_of_lt (Nat.lt_of_le_of_lt hcle cnt.toNat_lt_two_pow_numBits)
       rw [goTreeFreeU, dif_neg hrc, dif_neg hlit,
           goTreeFree, dif_neg (fun h => hrc ((refillGuard_usize data pos cnt hsz).mpr h)),
-          dif_neg (fun h => hlit ((litGuard_usize litTable bitBuf cnt).mpr h))]
+          dif_neg (fun h => hlit ((litGuardU_usize litTable bitBuf cnt _).mpr h))]
       simp only [hde, if_pos hsym, if_neg hmax, dif_neg hnp']
       rw [ih hpos, hcrt]
   | case8 pos bitBuf cnt output hrc ent hlit sym bb c used hde hsym heob =>
@@ -1610,14 +1613,14 @@ theorem goTreeFreeU_eq (litTable distTable : HuffTree.DecodeTable) (data : ByteA
         toUSize_toNat_of_lt (Nat.lt_of_le_of_lt hcle cnt.toNat_lt_two_pow_numBits)
       rw [goTreeFreeU, dif_neg hrc, dif_neg hlit,
           goTreeFree, dif_neg (fun h => hrc ((refillGuard_usize data pos cnt hsz).mpr h)),
-          dif_neg (fun h => hlit ((litGuard_usize litTable bitBuf cnt).mpr h))]
+          dif_neg (fun h => hlit ((litGuardU_usize litTable bitBuf cnt _).mpr h))]
       simp only [hde, if_neg hsym, if_pos heob, Except.map, hcrt]
   | case9 pos bitBuf cnt output hrc ent hlit sym bb c used hde hsym hneob idx hidx =>
       intro hpos
       have hidxc : sym.toNat - 257 ≥ Inflate.lengthBase.size := hidx
       rw [goTreeFreeU, dif_neg hrc, dif_neg hlit,
           goTreeFree, dif_neg (fun h => hrc ((refillGuard_usize data pos cnt hsz).mpr h)),
-          dif_neg (fun h => hlit ((litGuard_usize litTable bitBuf cnt).mpr h))]
+          dif_neg (fun h => hlit ((litGuardU_usize litTable bitBuf cnt _).mpr h))]
       simp only [hde, if_neg hsym, if_neg hneob, dif_pos hidxc]
       rfl
   | case10 pos bitBuf cnt output hrc ent hlit cnt0 sym bb c used hde hsym hneob idx hh base ih =>
@@ -1625,7 +1628,7 @@ theorem goTreeFreeU_eq (litTable distTable : HuffTree.DecodeTable) (data : ByteA
       have hhc : ¬ sym.toNat - 257 ≥ Inflate.lengthBase.size := hh
       rw [goTreeFreeU, dif_neg hrc, dif_neg hlit,
           goTreeFree, dif_neg (fun h => hrc ((refillGuard_usize data pos cnt hsz).mpr h)),
-          dif_neg (fun h => hlit ((litGuard_usize litTable bitBuf cnt).mpr h))]
+          dif_neg (fun h => hlit ((litGuardU_usize litTable bitBuf cnt _).mpr h))]
       simp only [hde, if_neg hsym, if_neg hneob, dif_neg hhc]
       cases hex : takeBits bb c
           (Inflate.lengthExtra[sym.toNat - 257]'(by
@@ -1702,8 +1705,8 @@ theorem decodeHuffmanFastBufTreeFree_ok_iff (br : BitReader) (output : ByteArray
   unfold decodeHuffmanFastBufTreeFree decodeHuffmanFastBufTables decodeHuffmanFastBuf
   rw [hrf]
   dsimp only []
-  rw [htlit, htdist,
-      goFusedPDispatch_eq (fromLengthsTree litLengths 15).buildTable
+  simp only [htlit, htdist]
+  rw [goFusedPDispatch_eq (fromLengthsTree litLengths 15).buildTable
         (fromLengthsTree distLengths 15).buildTable br.data (fromLengthsTree litLengths 15)
         (fromLengthsTree distLengths 15) maxOut pos0 (bitBuf0 >>> br.bitOff.toUInt64)
         (cnt0 - br.bitOff) output hbc2.posLe hbc2.cntLe]
@@ -1718,6 +1721,7 @@ theorem decodeHuffmanFastBufTreeFree_ok_iff (br : BitReader) (output : ByteArray
           (fromLengthsTree distLengths 15).buildTable br.data
           (buildLongDecodeWithCount litLengths (countLengthsFast litLengths 15) 15)
           (buildLongDecodeWithCount distLengths (countLengthsFast distLengths 15) 15) 15 maxOut hsz'
+          (HuffTree.buildTable_size _)
           pos0.toUSize (bitBuf0 >>> br.bitOff.toUInt64) (cnt0 - br.bitOff).toUSize output
           (by rw [toUSize_toNat_of_lt (Nat.lt_of_le_of_lt hbc2.posLe hsz')]; exact hbc2.posLe),
         toUSize_toNat_of_lt (Nat.lt_of_le_of_lt hbc2.posLe hsz'), toUSize_toNat_of_lt hcsz]


### PR DESCRIPTION
This PR replaces the guarded `entryAt` read in the production tree-free decode loop's literal fast path with a proven-bounds `uget`, following up #2808. A new `DecodeTable.entryAtU` reads the packed slot by `Array.uget` on the `USize` window index, so the compiled literal path drops both the per-literal bounds check (`lean_array_get_size` + `lean_nat_dec_lt`) and the `UInt64→Nat` index round-trip that `entryAt`'s `dite` kept — the generated C for `goTreeFreeU`'s literal read is now a single `lean_array_uget_borrowed` with a `size_t` index and no size/`nat_dec_lt` guard. The bound `idx.toUSize.toNat < packed.size` is discharged from a threaded invariant `litTable.packed.size = 2^fastBits`, established at the table builders (`buildTableCanonicalFastWithCount_size`, from `buildCanonicalLoop_size` + `Array.size_replicate`, which move into the Native layer so the decoder's caller can use them without importing the spec).

Equivalence to the boxed reference is preserved and reproven: `entryAtU_window_eq` shows the `uget` slot is the same word as the guarded `entryAt` read, `litGuardU_usize` restates the literal guard on it, and `goTreeFreeU_eq` is reproven threading the invariant — the only changed case is the literal fast path, which recovers the original `lenAt`/`symAt` guard.

Measured on the same payloads as #2808 (deterministic `perf stat`, branch vs #2808 as baseline): **~2-3% fewer retired instructions and ~1-3% fewer cycles** across `x-ray`, `ooffice`, `sao`, `alice29`, and `plrabn12` — on top of #2808's ~5% / ~1-2%. Full build green with no `sorry`; all tests pass. A Codex second opinion found no soundness concern in the bound proof, the `entryAtU`/`entryAt` bridge, the size-lemma move, or the reproven equivalence.

🤖 Prepared with Claude Code
