### PR TITLE
perf(decode): build copy_within_ffi.o with -O2 -DNDEBUG like its siblings

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -99,7 +99,16 @@ target copy_within_ffi.o pkg : FilePath := do
   let srcJob ← copy_within_ffi.c.fetch
   let oFile := pkg.buildDir / "c" / "copy_within_ffi.o"
   let weakArgs := #["-I", (← getLeanIncludeDir).toString]
-  let hardArgs := if Platform.isWindows then #[] else #["-fPIC"]
+  -- -O2/-DNDEBUG for the same reason as bytearray_wide_ffi: this is a hot LZ77
+  -- match-copy primitive (the non-overlapping back-reference path in
+  -- Inflate.copyLoop). On some toolchains the lean.h static-inline helpers
+  -- (lean_sarray_cptr, lean_is_exclusive, ...) stay outlined at -O0; on others
+  -- (e.g. gcc 15.2) they inline anyway and only the debug-only lean.h asserts
+  -- remain. Either way -O2/-DNDEBUG matches the release runtime and this
+  -- primitive's two siblings. Its bounds are carried by copyWithin's Lean-side
+  -- reference body (+ the roundtrip conformance sweeps).
+  let hardArgs := #["-O2", "-DNDEBUG"] ++
+    if Platform.isWindows then #[] else #["-fPIC"]
   buildO oFile srcJob weakArgs hardArgs "cc"
 
 extern_lib libcopy_within_ffi pkg := do


### PR DESCRIPTION
This PR builds the `copy_within_ffi.o` target with `-O2 -DNDEBUG` (keeping the existing `-fPIC`), so it matches its sibling primitives `extend_within_ffi.o` and `bytearray_wide_ffi.o`, which already carry these flags for the same documented reason. `ByteArray.copyWithin` backs the non-overlapping LZ77 back-reference path in `Zip.Native.Inflate.copyLoop`, so it sits on the decode hot path; leaving it at the default optimization level was an oversight when the flags were added to its siblings.

The flags strip the debug-only `lean.h` asserts from the release object and let the runtime static-inline helpers fold: the optimized `lean_zip_byte_array_copy_within` body drops from 191 to 104 instructions, with all nine out-of-line assert calls gone.

The end-to-end decode impact is compiler-dependent, and I want to be precise rather than overclaim. On gcc 15.2, which already inlines the `lean.h` helpers even at `-O0`, a same-worktree A/B (two saved `inflate-profile` binaries, `taskset`-pinned, canterbury/`plrabn12`) measured about 0.6% fewer retired instructions with wall time and cycles within noise. On toolchains where `-O0` leaves those helpers outlined (the configuration behind the original profile in the issue, where `copy_within` plus `lean_to_sarray`/`lean_is_sarray`/`lean_sarray_cptr` accounted for roughly a third of decode self-time), the win is larger. So this is best read as consistency with the two siblings plus removing a compiler-dependent `-O0` codegen cliff, not a guaranteed large speedup on every compiler. It also means recent A/B percentage deltas that were measured against a denominator inflated by this overhead only re-baseline on toolchains where the overhead was actually present.

Correctness is unchanged: `copyWithin`'s bounds are carried by its Lean-side reference body (`a ++ a.extract srcOff (srcOff + len)`) and the roundtrip conformance sweeps, exactly the model already used by the two siblings that ship these flags. The full test suite passes.

Closes #2811

🤖 Prepared with Claude Code