### PR TITLE
bench: refresh decode-density dashboard for the tree-free uget decoder

### DIFF
--- a/bench/graphs/silesia_decode_density.svg
+++ b/bench/graphs/silesia_decode_density.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 82.373685 412.80375 
 L 82.373685 47.3475 
-" clip-path="url(#p89333ce73e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc247673945)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m9aac86e160" d="M 0 0 
+       <path id="md813dfe720" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m9aac86e160" x="82.373685" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md813dfe720" x="82.373685" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -111,11 +111,11 @@ z
      <g id="line2d_3">
       <path d="M 165.44644 412.80375 
 L 165.44644 47.3475 
-" clip-path="url(#p89333ce73e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc247673945)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m9aac86e160" x="165.44644" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md813dfe720" x="165.44644" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -157,11 +157,11 @@ z
      <g id="line2d_5">
       <path d="M 248.519195 412.80375 
 L 248.519195 47.3475 
-" clip-path="url(#p89333ce73e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc247673945)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m9aac86e160" x="248.519195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md813dfe720" x="248.519195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -211,11 +211,11 @@ z
      <g id="line2d_7">
       <path d="M 331.59195 412.80375 
 L 331.59195 47.3475 
-" clip-path="url(#p89333ce73e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc247673945)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m9aac86e160" x="331.59195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md813dfe720" x="331.59195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -252,11 +252,11 @@ z
      <g id="line2d_9">
       <path d="M 414.664704 412.80375 
 L 414.664704 47.3475 
-" clip-path="url(#p89333ce73e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc247673945)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m9aac86e160" x="414.664704" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md813dfe720" x="414.664704" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -299,11 +299,11 @@ z
      <g id="line2d_11">
       <path d="M 497.737459 412.80375 
 L 497.737459 47.3475 
-" clip-path="url(#p89333ce73e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc247673945)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m9aac86e160" x="497.737459" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md813dfe720" x="497.737459" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -351,11 +351,11 @@ z
      <g id="line2d_13">
       <path d="M 580.810214 412.80375 
 L 580.810214 47.3475 
-" clip-path="url(#p89333ce73e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc247673945)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m9aac86e160" x="580.810214" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md813dfe720" x="580.810214" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -895,23 +895,23 @@ z
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
      <g id="line2d_15">
-      <path d="M 49.078125 392.557757 
-L 637.2 392.557757 
-" clip-path="url(#p89333ce73e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 391.33747 
+L 637.2 391.33747 
+" clip-path="url(#pc247673945)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="m5e681aa6cf" d="M 0 0 
+       <path id="m0ec2c8db9e" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m5e681aa6cf" x="49.078125" y="392.557757" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0ec2c8db9e" x="49.078125" y="391.33747" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- $\mathdefault{10^{2}}$ -->
-      <g transform="translate(24.478125 396.356976) scale(0.1 -0.1)">
+      <g transform="translate(24.478125 395.136689) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
        <use xlink:href="#DejaVuSans-32" transform="translate(128.203125 39.046875) scale(0.7)"/>
@@ -920,18 +920,18 @@ L -3.5 0
     </g>
     <g id="ytick_2">
      <g id="line2d_17">
-      <path d="M 49.078125 265.209319 
-L 637.2 265.209319 
-" clip-path="url(#p89333ce73e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 263.934445 
+L 637.2 263.934445 
+" clip-path="url(#pc247673945)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m5e681aa6cf" x="49.078125" y="265.209319" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0ec2c8db9e" x="49.078125" y="263.934445" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- $\mathdefault{10^{3}}$ -->
-      <g transform="translate(24.478125 269.008538) scale(0.1 -0.1)">
+      <g transform="translate(24.478125 267.733664) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
        <use xlink:href="#DejaVuSans-33" transform="translate(128.203125 39.046875) scale(0.7)"/>
@@ -940,18 +940,18 @@ L 637.2 265.209319
     </g>
     <g id="ytick_3">
      <g id="line2d_19">
-      <path d="M 49.078125 137.860881 
-L 637.2 137.860881 
-" clip-path="url(#p89333ce73e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 136.53142 
+L 637.2 136.53142 
+" clip-path="url(#pc247673945)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m5e681aa6cf" x="49.078125" y="137.860881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0ec2c8db9e" x="49.078125" y="136.53142" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- $\mathdefault{10^{4}}$ -->
-      <g transform="translate(24.478125 141.6601) scale(0.1 -0.1)">
+      <g transform="translate(24.478125 140.330639) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.684375)"/>
        <use xlink:href="#DejaVuSans-34" transform="translate(128.203125 38.965625) scale(0.7)"/>
@@ -960,282 +960,282 @@ L 637.2 137.860881
     </g>
     <g id="ytick_4">
      <g id="line2d_21">
-      <path d="M 49.078125 412.284279 
-L 637.2 412.284279 
-" clip-path="url(#p89333ce73e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 411.072449 
+L 637.2 411.072449 
+" clip-path="url(#pc247673945)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="m340ca10544" d="M 0 0 
+       <path id="m24e6e8a922" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m340ca10544" x="49.078125" y="412.284279" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m24e6e8a922" x="49.078125" y="411.072449" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_5">
      <g id="line2d_23">
-      <path d="M 49.078125 404.899096 
-L 637.2 404.899096 
-" clip-path="url(#p89333ce73e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 403.684099 
+L 637.2 403.684099 
+" clip-path="url(#pc247673945)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m340ca10544" x="49.078125" y="404.899096" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m24e6e8a922" x="49.078125" y="403.684099" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_6">
      <g id="line2d_25">
-      <path d="M 49.078125 398.384902 
-L 637.2 398.384902 
-" clip-path="url(#p89333ce73e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 397.167113 
+L 637.2 397.167113 
+" clip-path="url(#pc247673945)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m340ca10544" x="49.078125" y="398.384902" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m24e6e8a922" x="49.078125" y="397.167113" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_7">
      <g id="line2d_27">
-      <path d="M 49.078125 354.222057 
-L 637.2 354.222057 
-" clip-path="url(#p89333ce73e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 352.985338 
+L 637.2 352.985338 
+" clip-path="url(#pc247673945)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m340ca10544" x="49.078125" y="354.222057" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m24e6e8a922" x="49.078125" y="352.985338" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_8">
      <g id="line2d_29">
-      <path d="M 49.078125 331.79711 
-L 637.2 331.79711 
-" clip-path="url(#p89333ce73e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 330.550779 
+L 637.2 330.550779 
+" clip-path="url(#pc247673945)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m340ca10544" x="49.078125" y="331.79711" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m24e6e8a922" x="49.078125" y="330.550779" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_9">
      <g id="line2d_31">
-      <path d="M 49.078125 315.886357 
-L 637.2 315.886357 
-" clip-path="url(#p89333ce73e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 314.633206 
+L 637.2 314.633206 
+" clip-path="url(#pc247673945)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m340ca10544" x="49.078125" y="315.886357" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m24e6e8a922" x="49.078125" y="314.633206" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_10">
      <g id="line2d_33">
-      <path d="M 49.078125 303.545019 
-L 637.2 303.545019 
-" clip-path="url(#p89333ce73e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 302.286577 
+L 637.2 302.286577 
+" clip-path="url(#pc247673945)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m340ca10544" x="49.078125" y="303.545019" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m24e6e8a922" x="49.078125" y="302.286577" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_11">
      <g id="line2d_35">
-      <path d="M 49.078125 293.461411 
-L 637.2 293.461411 
-" clip-path="url(#p89333ce73e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 292.198647 
+L 637.2 292.198647 
+" clip-path="url(#pc247673945)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m340ca10544" x="49.078125" y="293.461411" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m24e6e8a922" x="49.078125" y="292.198647" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_12">
      <g id="line2d_37">
-      <path d="M 49.078125 284.935842 
-L 637.2 284.935842 
-" clip-path="url(#p89333ce73e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 283.669424 
+L 637.2 283.669424 
+" clip-path="url(#pc247673945)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m340ca10544" x="49.078125" y="284.935842" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m24e6e8a922" x="49.078125" y="283.669424" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_13">
      <g id="line2d_39">
-      <path d="M 49.078125 277.550658 
-L 637.2 277.550658 
-" clip-path="url(#p89333ce73e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 276.281074 
+L 637.2 276.281074 
+" clip-path="url(#pc247673945)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m340ca10544" x="49.078125" y="277.550658" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m24e6e8a922" x="49.078125" y="276.281074" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_14">
      <g id="line2d_41">
-      <path d="M 49.078125 271.036464 
-L 637.2 271.036464 
-" clip-path="url(#p89333ce73e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 269.764088 
+L 637.2 269.764088 
+" clip-path="url(#pc247673945)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m340ca10544" x="49.078125" y="271.036464" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m24e6e8a922" x="49.078125" y="269.764088" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_15">
      <g id="line2d_43">
-      <path d="M 49.078125 226.873619 
-L 637.2 226.873619 
-" clip-path="url(#p89333ce73e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 225.582313 
+L 637.2 225.582313 
+" clip-path="url(#pc247673945)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m340ca10544" x="49.078125" y="226.873619" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m24e6e8a922" x="49.078125" y="225.582313" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_16">
      <g id="line2d_45">
-      <path d="M 49.078125 204.448672 
-L 637.2 204.448672 
-" clip-path="url(#p89333ce73e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 203.147754 
+L 637.2 203.147754 
+" clip-path="url(#pc247673945)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m340ca10544" x="49.078125" y="204.448672" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m24e6e8a922" x="49.078125" y="203.147754" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_17">
      <g id="line2d_47">
-      <path d="M 49.078125 188.53792 
-L 637.2 188.53792 
-" clip-path="url(#p89333ce73e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 187.230181 
+L 637.2 187.230181 
+" clip-path="url(#pc247673945)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m340ca10544" x="49.078125" y="188.53792" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m24e6e8a922" x="49.078125" y="187.230181" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_18">
      <g id="line2d_49">
-      <path d="M 49.078125 176.196581 
-L 637.2 176.196581 
-" clip-path="url(#p89333ce73e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 174.883552 
+L 637.2 174.883552 
+" clip-path="url(#pc247673945)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m340ca10544" x="49.078125" y="176.196581" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m24e6e8a922" x="49.078125" y="174.883552" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_19">
      <g id="line2d_51">
-      <path d="M 49.078125 166.112973 
-L 637.2 166.112973 
-" clip-path="url(#p89333ce73e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 164.795622 
+L 637.2 164.795622 
+" clip-path="url(#pc247673945)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m340ca10544" x="49.078125" y="166.112973" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m24e6e8a922" x="49.078125" y="164.795622" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_20">
      <g id="line2d_53">
-      <path d="M 49.078125 157.587404 
-L 637.2 157.587404 
-" clip-path="url(#p89333ce73e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 156.266399 
+L 637.2 156.266399 
+" clip-path="url(#pc247673945)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#m340ca10544" x="49.078125" y="157.587404" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m24e6e8a922" x="49.078125" y="156.266399" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_21">
      <g id="line2d_55">
-      <path d="M 49.078125 150.20222 
-L 637.2 150.20222 
-" clip-path="url(#p89333ce73e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 148.878049 
+L 637.2 148.878049 
+" clip-path="url(#pc247673945)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#m340ca10544" x="49.078125" y="150.20222" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m24e6e8a922" x="49.078125" y="148.878049" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_22">
      <g id="line2d_57">
-      <path d="M 49.078125 143.688026 
-L 637.2 143.688026 
-" clip-path="url(#p89333ce73e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 142.361063 
+L 637.2 142.361063 
+" clip-path="url(#pc247673945)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#m340ca10544" x="49.078125" y="143.688026" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m24e6e8a922" x="49.078125" y="142.361063" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_23">
      <g id="line2d_59">
-      <path d="M 49.078125 99.525181 
-L 637.2 99.525181 
-" clip-path="url(#p89333ce73e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 98.179288 
+L 637.2 98.179288 
+" clip-path="url(#pc247673945)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#m340ca10544" x="49.078125" y="99.525181" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m24e6e8a922" x="49.078125" y="98.179288" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_24">
      <g id="line2d_61">
-      <path d="M 49.078125 77.100235 
-L 637.2 77.100235 
-" clip-path="url(#p89333ce73e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 75.744729 
+L 637.2 75.744729 
+" clip-path="url(#pc247673945)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#m340ca10544" x="49.078125" y="77.100235" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m24e6e8a922" x="49.078125" y="75.744729" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_25">
      <g id="line2d_63">
-      <path d="M 49.078125 61.189482 
-L 637.2 61.189482 
-" clip-path="url(#p89333ce73e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 59.827156 
+L 637.2 59.827156 
+" clip-path="url(#pc247673945)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#m340ca10544" x="49.078125" y="61.189482" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m24e6e8a922" x="49.078125" y="59.827156" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_26">
      <g id="line2d_65">
-      <path d="M 49.078125 48.848143 
-L 637.2 48.848143 
-" clip-path="url(#p89333ce73e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 47.480527 
+L 637.2 47.480527 
+" clip-path="url(#pc247673945)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#m340ca10544" x="49.078125" y="48.848143" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m24e6e8a922" x="49.078125" y="47.480527" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1398,7 +1398,7 @@ z
    <g id="line2d_67">
     <path d="M 49.078125 63.959148 
 L 637.2 63.959148 
-" clip-path="url(#p89333ce73e)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
+" clip-path="url(#pc247673945)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
    </g>
    <g id="patch_3">
     <path d="M 49.078125 412.80375 
@@ -1421,7 +1421,7 @@ L 637.2 47.3475
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_13">
-    <!--  memcpy ceiling ≈ 38 GB/s -->
+    <!--  memcpy ceiling ≈ 37 GB/s -->
     <g style="fill: #777777" transform="translate(525.255641 62.295398) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-79" d="M 2059 -325 
@@ -1482,45 +1482,6 @@ Q 3834 2663 4098 2780
 Q 4363 2897 4684 3163 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-38" d="M 2034 2216 
-Q 1584 2216 1326 1975 
-Q 1069 1734 1069 1313 
-Q 1069 891 1326 650 
-Q 1584 409 2034 409 
-Q 2484 409 2743 651 
-Q 3003 894 3003 1313 
-Q 3003 1734 2745 1975 
-Q 2488 2216 2034 2216 
-z
-M 1403 2484 
-Q 997 2584 770 2862 
-Q 544 3141 544 3541 
-Q 544 4100 942 4425 
-Q 1341 4750 2034 4750 
-Q 2731 4750 3128 4425 
-Q 3525 4100 3525 3541 
-Q 3525 3141 3298 2862 
-Q 3072 2584 2669 2484 
-Q 3125 2378 3379 2068 
-Q 3634 1759 3634 1313 
-Q 3634 634 3220 271 
-Q 2806 -91 2034 -91 
-Q 1263 -91 848 271 
-Q 434 634 434 1313 
-Q 434 1759 690 2068 
-Q 947 2378 1403 2484 
-z
-M 1172 3481 
-Q 1172 3119 1398 2916 
-Q 1625 2713 2034 2713 
-Q 2441 2713 2670 2916 
-Q 2900 3119 2900 3481 
-Q 2900 3844 2670 4047 
-Q 2441 4250 2034 4250 
-Q 1625 4250 1398 4047 
-Q 1172 3844 1172 3481 
-z
-" transform="scale(0.015625)"/>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
 L 2778 1919 
@@ -1566,7 +1527,7 @@ z
      <use xlink:href="#DejaVuSans-2248" transform="translate(856.054688 0)"/>
      <use xlink:href="#DejaVuSans-20" transform="translate(939.84375 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(971.630859 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(1035.253906 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(1035.253906 0)"/>
      <use xlink:href="#DejaVuSans-20" transform="translate(1098.876953 0)"/>
      <use xlink:href="#DejaVuSans-47" transform="translate(1130.664062 0)"/>
      <use xlink:href="#DejaVuSans-42" transform="translate(1208.154297 0)"/>
@@ -1801,78 +1762,78 @@ z
    </g>
    <g id="line2d_68">
     <defs>
-     <path id="mce9b992f32" d="M -2.5 2.5 
+     <path id="m13b3c49756" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p89333ce73e)">
-     <use xlink:href="#mce9b992f32" x="75.810937" y="262.071247" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mce9b992f32" x="105.634056" y="268.596154" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mce9b992f32" x="204.490635" y="300.845541" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mce9b992f32" x="234.479899" y="306.8179" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mce9b992f32" x="242.537956" y="314.611143" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mce9b992f32" x="300.771958" y="297.295948" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mce9b992f32" x="303.26414" y="309.008338" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mce9b992f32" x="304.261013" y="317.489766" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mce9b992f32" x="313.897453" y="317.717971" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mce9b992f32" x="414.166268" y="334.585481" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mce9b992f32" x="587.289889" y="328.108569" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mce9b992f32" x="610.467187" y="319.417439" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pc247673945)">
+     <use xlink:href="#m13b3c49756" x="75.810937" y="263.190298" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m13b3c49756" x="105.634056" y="267.887378" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m13b3c49756" x="204.490635" y="300.240046" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m13b3c49756" x="234.479899" y="306.367428" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m13b3c49756" x="242.537956" y="316.909198" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m13b3c49756" x="300.771958" y="297.352079" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m13b3c49756" x="303.26414" y="310.698625" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m13b3c49756" x="304.261013" y="317.548512" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m13b3c49756" x="313.897453" y="317.953886" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m13b3c49756" x="414.166268" y="334.149272" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m13b3c49756" x="587.289889" y="327.780982" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m13b3c49756" x="610.467187" y="318.981257" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_69">
     <defs>
-     <path id="m304420e3e0" d="M 0 -2.5 
+     <path id="m82612a4688" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p89333ce73e)">
-     <use xlink:href="#m304420e3e0" x="75.810937" y="260.356415" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m304420e3e0" x="105.634056" y="255.335352" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m304420e3e0" x="204.490635" y="300.329661" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m304420e3e0" x="234.479899" y="298.16824" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m304420e3e0" x="242.537956" y="305.868465" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m304420e3e0" x="300.771958" y="286.449653" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m304420e3e0" x="303.26414" y="299.806142" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m304420e3e0" x="304.261013" y="313.982391" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m304420e3e0" x="313.897453" y="307.348543" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m304420e3e0" x="414.166268" y="326.105079" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m304420e3e0" x="587.289889" y="328.229425" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m304420e3e0" x="610.467187" y="317.702252" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pc247673945)">
+     <use xlink:href="#m82612a4688" x="75.810937" y="260.629553" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m82612a4688" x="105.634056" y="253.888028" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m82612a4688" x="204.490635" y="301.454063" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m82612a4688" x="234.479899" y="296.198152" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m82612a4688" x="242.537956" y="306.497434" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m82612a4688" x="300.771958" y="285.157082" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m82612a4688" x="303.26414" y="299.127298" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m82612a4688" x="304.261013" y="312.289143" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m82612a4688" x="313.897453" y="305.55147" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m82612a4688" x="414.166268" y="323.799851" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m82612a4688" x="587.289889" y="327.192921" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m82612a4688" x="610.467187" y="316.49707" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_70">
     <defs>
-     <path id="m95a95bc721" d="M -0 3.535534 
+     <path id="m0c54aca1fd" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p89333ce73e)">
-     <use xlink:href="#m95a95bc721" x="75.810937" y="228.571334" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m95a95bc721" x="105.634056" y="231.338394" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m95a95bc721" x="204.490635" y="257.724879" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m95a95bc721" x="234.479899" y="258.806342" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m95a95bc721" x="242.537956" y="270.393131" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m95a95bc721" x="300.771958" y="258.431756" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m95a95bc721" x="303.26414" y="269.129678" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m95a95bc721" x="304.261013" y="279.340839" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m95a95bc721" x="313.897453" y="274.978134" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m95a95bc721" x="414.166268" y="294.726626" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m95a95bc721" x="587.289889" y="300.153563" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m95a95bc721" x="610.467187" y="298.472179" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pc247673945)">
+     <use xlink:href="#m0c54aca1fd" x="75.810937" y="229.675972" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0c54aca1fd" x="105.634056" y="230.807252" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0c54aca1fd" x="204.490635" y="262.817606" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0c54aca1fd" x="234.479899" y="260.308889" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0c54aca1fd" x="242.537956" y="274.651617" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0c54aca1fd" x="300.771958" y="258.820574" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0c54aca1fd" x="303.26414" y="270.569757" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0c54aca1fd" x="304.261013" y="279.042037" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0c54aca1fd" x="313.897453" y="275.908162" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0c54aca1fd" x="414.166268" y="294.938772" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0c54aca1fd" x="587.289889" y="301.872049" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0c54aca1fd" x="610.467187" y="298.545064" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_71">
     <defs>
-     <path id="mb48fad6a09" d="M -0.833333 2.5 
+     <path id="mfd9dc0e48d" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -1887,24 +1848,24 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p89333ce73e)">
-     <use xlink:href="#mb48fad6a09" x="75.810937" y="280.974255" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb48fad6a09" x="105.634056" y="299.415702" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb48fad6a09" x="204.490635" y="326.068499" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb48fad6a09" x="234.479899" y="340.121484" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb48fad6a09" x="242.537956" y="342.329412" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb48fad6a09" x="300.771958" y="338.660143" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb48fad6a09" x="303.26414" y="346.44421" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb48fad6a09" x="304.261013" y="346.535582" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb48fad6a09" x="313.897453" y="352.154021" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb48fad6a09" x="414.166268" y="366.002809" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb48fad6a09" x="587.289889" y="371.46125" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb48fad6a09" x="610.467187" y="359.767243" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pc247673945)">
+     <use xlink:href="#mfd9dc0e48d" x="75.810937" y="286.028664" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfd9dc0e48d" x="105.634056" y="293.887771" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfd9dc0e48d" x="204.490635" y="326.335201" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfd9dc0e48d" x="234.479899" y="337.903307" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfd9dc0e48d" x="242.537956" y="341.092058" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfd9dc0e48d" x="300.771958" y="336.485034" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfd9dc0e48d" x="303.26414" y="344.754119" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfd9dc0e48d" x="304.261013" y="344.606502" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfd9dc0e48d" x="313.897453" y="351.527394" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfd9dc0e48d" x="414.166268" y="363.295034" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfd9dc0e48d" x="587.289889" y="368.159128" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfd9dc0e48d" x="610.467187" y="356.976913" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_72">
     <defs>
-     <path id="m419565db1a" d="M -1.25 2.5 
+     <path id="m03541d0757" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -1919,24 +1880,24 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p89333ce73e)">
-     <use xlink:href="#m419565db1a" x="75.810937" y="312.426802" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m419565db1a" x="105.634056" y="321.996906" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m419565db1a" x="204.490635" y="335.63066" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m419565db1a" x="234.479899" y="358.497992" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m419565db1a" x="242.537956" y="346.252339" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m419565db1a" x="300.771958" y="332.122532" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m419565db1a" x="303.26414" y="346.533176" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m419565db1a" x="304.261013" y="350.518859" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m419565db1a" x="313.897453" y="352.354171" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m419565db1a" x="414.166268" y="359.340915" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m419565db1a" x="587.289889" y="378.013224" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m419565db1a" x="610.467187" y="363.415788" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pc247673945)">
+     <use xlink:href="#m03541d0757" x="75.810937" y="327.723121" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m03541d0757" x="105.634056" y="342.646685" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m03541d0757" x="204.490635" y="362.850184" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m03541d0757" x="234.479899" y="371.338643" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m03541d0757" x="242.537956" y="367.245927" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m03541d0757" x="300.771958" y="360.026985" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m03541d0757" x="303.26414" y="374.683393" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m03541d0757" x="304.261013" y="357.457726" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m03541d0757" x="313.897453" y="374.58929" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m03541d0757" x="414.166268" y="385.027438" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m03541d0757" x="587.289889" y="394.333029" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m03541d0757" x="610.467187" y="391.249012" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_73">
     <defs>
-     <path id="m803880082b" d="M 0 -2.5 
+     <path id="m26d72faad0" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -1949,24 +1910,24 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p89333ce73e)">
-     <use xlink:href="#m803880082b" x="75.810937" y="273.921216" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m803880082b" x="105.634056" y="288.097179" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m803880082b" x="204.490635" y="320.580642" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m803880082b" x="234.479899" y="321.870427" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m803880082b" x="242.537956" y="327.716748" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m803880082b" x="300.771958" y="333.632059" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m803880082b" x="303.26414" y="338.271221" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m803880082b" x="304.261013" y="346.697055" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m803880082b" x="313.897453" y="336.75845" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m803880082b" x="414.166268" y="358.229758" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m803880082b" x="587.289889" y="367.501145" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m803880082b" x="610.467187" y="361.600921" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#pc247673945)">
+     <use xlink:href="#m26d72faad0" x="75.810937" y="273.778134" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m26d72faad0" x="105.634056" y="286.227815" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m26d72faad0" x="204.490635" y="319.608779" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m26d72faad0" x="234.479899" y="321.188418" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m26d72faad0" x="242.537956" y="325.921453" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m26d72faad0" x="300.771958" y="333.05015" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m26d72faad0" x="303.26414" y="336.951003" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m26d72faad0" x="304.261013" y="345.759761" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m26d72faad0" x="313.897453" y="336.754653" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m26d72faad0" x="414.166268" y="357.454726" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m26d72faad0" x="587.289889" y="366.280671" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m26d72faad0" x="610.467187" y="360.878702" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_74">
     <defs>
-     <path id="mffeb0ab8b9" d="M 0 -2.5 
+     <path id="mf653614d22" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -1975,19 +1936,19 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p89333ce73e)">
-     <use xlink:href="#mffeb0ab8b9" x="75.810937" y="347.776732" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mffeb0ab8b9" x="105.634056" y="349.684654" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mffeb0ab8b9" x="204.490635" y="366.019921" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mffeb0ab8b9" x="234.479899" y="373.210832" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mffeb0ab8b9" x="242.537956" y="378.663295" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mffeb0ab8b9" x="300.771958" y="369.597094" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mffeb0ab8b9" x="303.26414" y="374.003914" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mffeb0ab8b9" x="304.261013" y="381.646168" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mffeb0ab8b9" x="313.897453" y="386.383822" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mffeb0ab8b9" x="414.166268" y="392.690652" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mffeb0ab8b9" x="587.289889" y="396.192102" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mffeb0ab8b9" x="610.467187" y="386.453116" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pc247673945)">
+     <use xlink:href="#mf653614d22" x="75.810937" y="347.176172" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf653614d22" x="105.634056" y="348.704001" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf653614d22" x="204.490635" y="367.31757" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf653614d22" x="234.479899" y="373.033423" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf653614d22" x="242.537956" y="380.00037" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf653614d22" x="300.771958" y="370.53122" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf653614d22" x="303.26414" y="375.375651" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf653614d22" x="304.261013" y="383.030012" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf653614d22" x="313.897453" y="385.215351" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf653614d22" x="414.166268" y="391.648192" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf653614d22" x="587.289889" y="396.192102" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf653614d22" x="610.467187" y="383.710333" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="legend_1">
@@ -2006,7 +1967,7 @@ z
     </g>
     <g id="line2d_75">
      <defs>
-      <path id="m918f06cbed" d="M 0 3.5 
+      <path id="m8d89c5c5f1" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -2019,7 +1980,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m918f06cbed" x="434.04625" y="211.758125" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m8d89c5c5f1" x="434.04625" y="211.758125" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_15">
@@ -2078,7 +2039,7 @@ z
     </g>
     <g id="line2d_76">
      <g>
-      <use xlink:href="#mce9b992f32" x="434.04625" y="223.500625" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m13b3c49756" x="434.04625" y="223.500625" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_16">
@@ -2092,7 +2053,7 @@ z
     </g>
     <g id="line2d_77">
      <g>
-      <use xlink:href="#m304420e3e0" x="434.04625" y="235.243125" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m82612a4688" x="434.04625" y="235.243125" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -2137,7 +2098,7 @@ z
     </g>
     <g id="line2d_78">
      <g>
-      <use xlink:href="#m95a95bc721" x="434.04625" y="247.208125" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m0c54aca1fd" x="434.04625" y="247.208125" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -2157,7 +2118,7 @@ z
     </g>
     <g id="line2d_79">
      <g>
-      <use xlink:href="#mb48fad6a09" x="537.72375" y="211.758125" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mfd9dc0e48d" x="537.72375" y="211.758125" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -2184,7 +2145,7 @@ z
     </g>
     <g id="line2d_80">
      <g>
-      <use xlink:href="#m419565db1a" x="537.72375" y="223.500625" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m03541d0757" x="537.72375" y="223.500625" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -2249,7 +2210,7 @@ z
     </g>
     <g id="line2d_81">
      <g>
-      <use xlink:href="#m803880082b" x="537.72375" y="235.243125" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#m26d72faad0" x="537.72375" y="235.243125" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_21">
@@ -2287,7 +2248,7 @@ z
     </g>
     <g id="line2d_82">
      <g>
-      <use xlink:href="#mffeb0ab8b9" x="537.72375" y="246.985625" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mf653614d22" x="537.72375" y="246.985625" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -2357,19 +2318,19 @@ z
     </g>
    </g>
    <g id="line2d_83">
-    <g clip-path="url(#p89333ce73e)">
-     <use xlink:href="#m918f06cbed" x="75.810937" y="275.486618" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m918f06cbed" x="105.634056" y="292.998775" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m918f06cbed" x="204.490635" y="326.410296" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m918f06cbed" x="234.479899" y="329.186544" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m918f06cbed" x="242.537956" y="328.753877" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m918f06cbed" x="300.771958" y="317.428597" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m918f06cbed" x="303.26414" y="336.106915" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m918f06cbed" x="304.261013" y="356.358937" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m918f06cbed" x="313.897453" y="342.768285" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m918f06cbed" x="414.166268" y="360.763565" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m918f06cbed" x="587.289889" y="364.935308" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m918f06cbed" x="610.467187" y="348.169444" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <g clip-path="url(#pc247673945)">
+     <use xlink:href="#m8d89c5c5f1" x="75.810937" y="272.143954" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m8d89c5c5f1" x="105.634056" y="288.399073" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m8d89c5c5f1" x="204.490635" y="322.103822" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m8d89c5c5f1" x="234.479899" y="324.29343" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m8d89c5c5f1" x="242.537956" y="324.418753" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m8d89c5c5f1" x="300.771958" y="312.453798" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m8d89c5c5f1" x="303.26414" y="333.249253" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m8d89c5c5f1" x="304.261013" y="351.748791" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m8d89c5c5f1" x="313.897453" y="337.048403" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m8d89c5c5f1" x="414.166268" y="356.441315" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m8d89c5c5f1" x="587.289889" y="359.296601" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m8d89c5c5f1" x="610.467187" y="343.193293" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
   </g>
@@ -2931,9 +2892,48 @@ z
    </g>
   </g>
   <g id="text_24">
-   <!-- 2026-07-08T15:12:34Z  ·  Linux chungus2 x86_64  ·  commit 7af11ed3  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(44.535391 465.66) scale(0.07 -0.07)">
+   <!-- 2026-07-08T17:40:34Z  ·  Linux chungus2 x86_64  ·  commit 28b506f0  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(44.380078 465.66) scale(0.07 -0.07)">
     <defs>
+     <path id="DejaVuSans-38" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
 L 3928 4134 
@@ -3006,10 +3006,10 @@ z
     <use xlink:href="#DejaVuSans-38" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
     <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
     <use xlink:href="#DejaVuSans-34" transform="translate(1027.734375 0)"/>
@@ -3052,109 +3052,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3196.777344 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3231.982422 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3295.605469 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3359.228516 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3420.751953 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3484.228516 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3547.851562 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3579.638672 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3611.425781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3643.212891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3675 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3706.787109 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3734.570312 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3796.09375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3857.373047 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3920.751953 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3984.228516 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4023.091797 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4084.273438 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4143.453125 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4204.976562 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4246.089844 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4279.78125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4307.564453 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4369.087891 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4430.367188 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4493.746094 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4557.369141 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4591.060547 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4650.240234 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4713.863281 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4745.650391 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4809.273438 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4872.896484 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4904.683594 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4968.306641 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5004.390625 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5043.253906 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5098.234375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5161.857422 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5193.644531 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5225.431641 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5257.21875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5289.005859 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5320.792969 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5360.001953 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5423.380859 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5462.244141 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5523.425781 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5586.804688 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5650.28125 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5713.660156 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5777.136719 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5840.515625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5879.724609 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5911.511719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5995.300781 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6027.087891 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6124.5 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6186.023438 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6249.5 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6277.283203 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6338.5625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6401.941406 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6433.728516 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6485.828125 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6549.207031 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6610.486328 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6673.962891 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6726.0625 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6789.441406 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6850.623047 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6889.832031 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6923.523438 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6955.310547 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6996.423828 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7057.703125 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7096.912109 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7124.695312 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7185.876953 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7217.664062 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7245.447266 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7297.546875 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7329.333984 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7392.810547 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7454.333984 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7493.542969 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7555.066406 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7594.429688 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7691.841797 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7719.625 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7783.003906 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7810.787109 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7862.886719 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7902.095703 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7929.878906 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3262.597656 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3326.220703 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3389.84375 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3453.466797 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3488.671875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3552.294922 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3584.082031 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3615.869141 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3647.65625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3679.443359 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3711.230469 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3739.013672 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3800.537109 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3861.816406 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3925.195312 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3988.671875 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4027.535156 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4088.716797 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4147.896484 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4209.419922 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4250.533203 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4284.224609 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4312.007812 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4373.53125 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4434.810547 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4498.189453 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4561.8125 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4595.503906 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4654.683594 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4718.306641 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4750.09375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4813.716797 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4877.339844 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4909.126953 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4972.75 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5008.833984 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5047.697266 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5102.677734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5166.300781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5198.087891 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5229.875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5261.662109 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5293.449219 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5325.236328 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5364.445312 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5427.824219 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5466.6875 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5527.869141 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5591.248047 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5654.724609 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5718.103516 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5781.580078 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5844.958984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5884.167969 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5915.955078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5999.744141 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6031.53125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6128.943359 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6190.466797 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6253.943359 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6281.726562 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6343.005859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6406.384766 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6438.171875 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6490.271484 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6553.650391 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6614.929688 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6678.40625 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6730.505859 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6793.884766 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6855.066406 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6894.275391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6927.966797 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6959.753906 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7000.867188 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7062.146484 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7101.355469 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7129.138672 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7190.320312 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7222.107422 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7249.890625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7301.990234 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7333.777344 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7397.253906 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7458.777344 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7497.986328 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7559.509766 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7598.873047 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7696.285156 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7724.068359 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7787.447266 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7815.230469 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7867.330078 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7906.539062 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7934.322266 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p89333ce73e">
+  <clipPath id="pc247673945">
    <rect x="49.078125" y="47.3475" width="588.121875" height="365.45625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_decode_ranking.svg
+++ b/bench/graphs/silesia_decode_ranking.svg
@@ -40,23 +40,23 @@ z
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
-      <path d="M 291.674799 308.04375 
-L 291.674799 56.7075 
-" clip-path="url(#p082d57e556)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 292.269187 308.04375 
+L 292.269187 56.7075 
+" clip-path="url(#pf794edbc1e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m3d7267a495" d="M 0 0 
+       <path id="m8b94943077" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m3d7267a495" x="291.674799" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8b94943077" x="292.269187" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
       <!-- $\mathdefault{10^{3}}$ -->
-      <g transform="translate(282.874799 322.642188) scale(0.1 -0.1)">
+      <g transform="translate(283.469187 322.642188) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -134,18 +134,18 @@ z
     </g>
     <g id="xtick_2">
      <g id="line2d_3">
-      <path d="M 449.853424 308.04375 
-L 449.853424 56.7075 
-" clip-path="url(#p082d57e556)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 449.991563 308.04375 
+L 449.991563 56.7075 
+" clip-path="url(#pf794edbc1e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m3d7267a495" x="449.853424" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8b94943077" x="449.991563" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
       <!-- $\mathdefault{10^{4}}$ -->
-      <g transform="translate(441.053424 322.642188) scale(0.1 -0.1)">
+      <g transform="translate(441.191563 322.642188) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -175,246 +175,246 @@ z
     </g>
     <g id="xtick_3">
      <g id="line2d_5">
-      <path d="M 181.112686 308.04375 
-L 181.112686 56.7075 
-" clip-path="url(#p082d57e556)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 182.025977 308.04375 
+L 182.025977 56.7075 
+" clip-path="url(#pf794edbc1e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <defs>
-       <path id="m35eddc3981" d="M 0 0 
+       <path id="m3dbbaa9b54" d="M 0 0 
 L 0 2 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m35eddc3981" x="181.112686" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3dbbaa9b54" x="182.025977" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_4">
      <g id="line2d_7">
-      <path d="M 208.966559 308.04375 
-L 208.966559 56.7075 
-" clip-path="url(#p082d57e556)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 209.799509 308.04375 
+L 209.799509 56.7075 
+" clip-path="url(#pf794edbc1e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m35eddc3981" x="208.966559" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3dbbaa9b54" x="209.799509" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_5">
      <g id="line2d_9">
-      <path d="M 228.729196 308.04375 
-L 228.729196 56.7075 
-" clip-path="url(#p082d57e556)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 229.505143 308.04375 
+L 229.505143 56.7075 
+" clip-path="url(#pf794edbc1e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m35eddc3981" x="228.729196" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3dbbaa9b54" x="229.505143" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_6">
      <g id="line2d_11">
-      <path d="M 244.058289 308.04375 
-L 244.058289 56.7075 
-" clip-path="url(#p082d57e556)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 244.790021 308.04375 
+L 244.790021 56.7075 
+" clip-path="url(#pf794edbc1e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m35eddc3981" x="244.058289" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3dbbaa9b54" x="244.790021" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_7">
      <g id="line2d_13">
-      <path d="M 256.583069 308.04375 
-L 256.583069 56.7075 
-" clip-path="url(#p082d57e556)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 257.278675 308.04375 
+L 257.278675 56.7075 
+" clip-path="url(#pf794edbc1e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m35eddc3981" x="256.583069" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3dbbaa9b54" x="257.278675" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_8">
      <g id="line2d_15">
-      <path d="M 267.172621 308.04375 
-L 267.172621 56.7075 
-" clip-path="url(#p082d57e556)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 267.837682 308.04375 
+L 267.837682 56.7075 
+" clip-path="url(#pf794edbc1e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m35eddc3981" x="267.172621" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3dbbaa9b54" x="267.837682" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_9">
      <g id="line2d_17">
-      <path d="M 276.345707 308.04375 
-L 276.345707 56.7075 
-" clip-path="url(#p082d57e556)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 276.984309 308.04375 
+L 276.984309 56.7075 
+" clip-path="url(#pf794edbc1e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m35eddc3981" x="276.345707" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3dbbaa9b54" x="276.984309" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_10">
      <g id="line2d_19">
-      <path d="M 284.436943 308.04375 
-L 284.436943 56.7075 
-" clip-path="url(#p082d57e556)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 285.052207 308.04375 
+L 285.052207 56.7075 
+" clip-path="url(#pf794edbc1e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m35eddc3981" x="284.436943" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3dbbaa9b54" x="285.052207" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_11">
      <g id="line2d_21">
-      <path d="M 339.29131 308.04375 
-L 339.29131 56.7075 
-" clip-path="url(#p082d57e556)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 339.748353 308.04375 
+L 339.748353 56.7075 
+" clip-path="url(#pf794edbc1e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m35eddc3981" x="339.29131" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3dbbaa9b54" x="339.748353" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_12">
      <g id="line2d_23">
-      <path d="M 367.145183 308.04375 
-L 367.145183 56.7075 
-" clip-path="url(#p082d57e556)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 367.521885 308.04375 
+L 367.521885 56.7075 
+" clip-path="url(#pf794edbc1e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m35eddc3981" x="367.145183" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3dbbaa9b54" x="367.521885" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_13">
      <g id="line2d_25">
-      <path d="M 386.907821 308.04375 
-L 386.907821 56.7075 
-" clip-path="url(#p082d57e556)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 387.227519 308.04375 
+L 387.227519 56.7075 
+" clip-path="url(#pf794edbc1e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m35eddc3981" x="386.907821" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3dbbaa9b54" x="387.227519" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_14">
      <g id="line2d_27">
-      <path d="M 402.236913 308.04375 
-L 402.236913 56.7075 
-" clip-path="url(#p082d57e556)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 402.512397 308.04375 
+L 402.512397 56.7075 
+" clip-path="url(#pf794edbc1e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m35eddc3981" x="402.236913" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3dbbaa9b54" x="402.512397" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_15">
      <g id="line2d_29">
-      <path d="M 414.761694 308.04375 
-L 414.761694 56.7075 
-" clip-path="url(#p082d57e556)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 415.001051 308.04375 
+L 415.001051 56.7075 
+" clip-path="url(#pf794edbc1e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m35eddc3981" x="414.761694" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3dbbaa9b54" x="415.001051" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_16">
      <g id="line2d_31">
-      <path d="M 425.351245 308.04375 
-L 425.351245 56.7075 
-" clip-path="url(#p082d57e556)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 425.560057 308.04375 
+L 425.560057 56.7075 
+" clip-path="url(#pf794edbc1e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m35eddc3981" x="425.351245" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3dbbaa9b54" x="425.560057" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_17">
      <g id="line2d_33">
-      <path d="M 434.524331 308.04375 
-L 434.524331 56.7075 
-" clip-path="url(#p082d57e556)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 434.706685 308.04375 
+L 434.706685 56.7075 
+" clip-path="url(#pf794edbc1e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m35eddc3981" x="434.524331" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3dbbaa9b54" x="434.706685" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_18">
      <g id="line2d_35">
-      <path d="M 442.615567 308.04375 
-L 442.615567 56.7075 
-" clip-path="url(#p082d57e556)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 442.774583 308.04375 
+L 442.774583 56.7075 
+" clip-path="url(#pf794edbc1e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m35eddc3981" x="442.615567" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3dbbaa9b54" x="442.774583" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_19">
      <g id="line2d_37">
-      <path d="M 497.469935 308.04375 
-L 497.469935 56.7075 
-" clip-path="url(#p082d57e556)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 497.470729 308.04375 
+L 497.470729 56.7075 
+" clip-path="url(#pf794edbc1e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m35eddc3981" x="497.469935" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3dbbaa9b54" x="497.470729" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_20">
      <g id="line2d_39">
-      <path d="M 525.323808 308.04375 
-L 525.323808 56.7075 
-" clip-path="url(#p082d57e556)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 525.24426 308.04375 
+L 525.24426 56.7075 
+" clip-path="url(#pf794edbc1e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m35eddc3981" x="525.323808" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3dbbaa9b54" x="525.24426" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_21">
      <g id="line2d_41">
-      <path d="M 545.086445 308.04375 
-L 545.086445 56.7075 
-" clip-path="url(#p082d57e556)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 544.949895 308.04375 
+L 544.949895 56.7075 
+" clip-path="url(#pf794edbc1e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m35eddc3981" x="545.086445" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3dbbaa9b54" x="544.949895" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_22">
      <g id="line2d_43">
-      <path d="M 560.415538 308.04375 
-L 560.415538 56.7075 
-" clip-path="url(#p082d57e556)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 560.234772 308.04375 
+L 560.234772 56.7075 
+" clip-path="url(#pf794edbc1e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m35eddc3981" x="560.415538" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3dbbaa9b54" x="560.234772" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1016,12 +1016,12 @@ z
     <g id="ytick_1">
      <g id="line2d_45">
       <defs>
-       <path id="m5a6fd4a863" d="M 0 0 
+       <path id="m0e2ebd563b" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m5a6fd4a863" x="139.360469" y="296.619375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0e2ebd563b" x="139.360469" y="296.619375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -1093,7 +1093,7 @@ z
     <g id="ytick_2">
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m5a6fd4a863" x="139.360469" y="263.978304" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0e2ebd563b" x="139.360469" y="263.978304" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -1160,7 +1160,7 @@ z
     <g id="ytick_3">
      <g id="line2d_47">
       <g>
-       <use xlink:href="#m5a6fd4a863" x="139.360469" y="231.337232" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0e2ebd563b" x="139.360469" y="231.337232" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -1216,12 +1216,59 @@ z
     <g id="ytick_4">
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m5a6fd4a863" x="139.360469" y="198.696161" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0e2ebd563b" x="139.360469" y="198.696161" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
+      <!-- Zig std.flate -->
+      <g transform="translate(78.080625 202.115458) scale(0.09 -0.09)">
+       <defs>
+        <path id="DejaVuSans-5a" d="M 359 4666 
+L 4025 4666 
+L 4025 4184 
+L 1075 531 
+L 4097 531 
+L 4097 0 
+L 288 0 
+L 288 481 
+L 3238 4134 
+L 359 4134 
+L 359 4666 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-2e" d="M 684 794 
+L 1344 794 
+L 1344 0 
+L 684 0 
+L 684 794 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-5a"/>
+       <use xlink:href="#DejaVuSans-69" transform="translate(68.505859 0)"/>
+       <use xlink:href="#DejaVuSans-67" transform="translate(96.289062 0)"/>
+       <use xlink:href="#DejaVuSans-20" transform="translate(159.765625 0)"/>
+       <use xlink:href="#DejaVuSans-73" transform="translate(191.552734 0)"/>
+       <use xlink:href="#DejaVuSans-74" transform="translate(243.652344 0)"/>
+       <use xlink:href="#DejaVuSans-64" transform="translate(282.861328 0)"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(346.337891 0)"/>
+       <use xlink:href="#DejaVuSans-66" transform="translate(378.125 0)"/>
+       <use xlink:href="#DejaVuSans-6c" transform="translate(413.330078 0)"/>
+       <use xlink:href="#DejaVuSans-61" transform="translate(441.113281 0)"/>
+       <use xlink:href="#DejaVuSans-74" transform="translate(502.392578 0)"/>
+       <use xlink:href="#DejaVuSans-65" transform="translate(541.601562 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_49">
+      <g>
+       <use xlink:href="#m0e2ebd563b" x="139.360469" y="166.055089" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
       <!-- lean-zip (native)  ◄ subject -->
-      <g transform="translate(10.8 202.115458) scale(0.09 -0.09)">
+      <g transform="translate(10.8 169.474386) scale(0.09 -0.09)">
        <defs>
         <path id="DejaVuSans-2d" d="M 313 2009 
 L 1997 2009 
@@ -1326,57 +1373,10 @@ z
       </g>
      </g>
     </g>
-    <g id="ytick_5">
-     <g id="line2d_49">
-      <g>
-       <use xlink:href="#m5a6fd4a863" x="139.360469" y="166.055089" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_8">
-      <!-- Zig std.flate -->
-      <g transform="translate(78.080625 169.474386) scale(0.09 -0.09)">
-       <defs>
-        <path id="DejaVuSans-5a" d="M 359 4666 
-L 4025 4666 
-L 4025 4184 
-L 1075 531 
-L 4097 531 
-L 4097 0 
-L 288 0 
-L 288 481 
-L 3238 4134 
-L 359 4134 
-L 359 4666 
-z
-" transform="scale(0.015625)"/>
-        <path id="DejaVuSans-2e" d="M 684 794 
-L 1344 794 
-L 1344 0 
-L 684 0 
-L 684 794 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#DejaVuSans-5a"/>
-       <use xlink:href="#DejaVuSans-69" transform="translate(68.505859 0)"/>
-       <use xlink:href="#DejaVuSans-67" transform="translate(96.289062 0)"/>
-       <use xlink:href="#DejaVuSans-20" transform="translate(159.765625 0)"/>
-       <use xlink:href="#DejaVuSans-73" transform="translate(191.552734 0)"/>
-       <use xlink:href="#DejaVuSans-74" transform="translate(243.652344 0)"/>
-       <use xlink:href="#DejaVuSans-64" transform="translate(282.861328 0)"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(346.337891 0)"/>
-       <use xlink:href="#DejaVuSans-66" transform="translate(378.125 0)"/>
-       <use xlink:href="#DejaVuSans-6c" transform="translate(413.330078 0)"/>
-       <use xlink:href="#DejaVuSans-61" transform="translate(441.113281 0)"/>
-       <use xlink:href="#DejaVuSans-74" transform="translate(502.392578 0)"/>
-       <use xlink:href="#DejaVuSans-65" transform="translate(541.601562 0)"/>
-      </g>
-     </g>
-    </g>
     <g id="ytick_6">
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m5a6fd4a863" x="139.360469" y="133.414018" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0e2ebd563b" x="139.360469" y="133.414018" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -1392,7 +1392,7 @@ z
     <g id="ytick_7">
      <g id="line2d_51">
       <g>
-       <use xlink:href="#m5a6fd4a863" x="139.360469" y="100.772946" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0e2ebd563b" x="139.360469" y="100.772946" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -1439,7 +1439,7 @@ z
     <g id="ytick_8">
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m5a6fd4a863" x="139.360469" y="68.131875" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0e2ebd563b" x="139.360469" y="68.131875" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -1461,48 +1461,48 @@ z
    </g>
    <g id="LineCollection_1">
     <path d="M 139.360469 296.619375 
-L 154.689561 296.619375 
-" clip-path="url(#p082d57e556)" style="fill: none; stroke: #17becf; stroke-opacity: 0.9; stroke-width: 1.3"/>
+L 154.645346 296.619375 
+" clip-path="url(#pf794edbc1e)" style="fill: none; stroke: #17becf; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_2">
     <path d="M 139.360469 263.978304 
-L 191.246836 263.978304 
-" clip-path="url(#p082d57e556)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.9; stroke-width: 1.3"/>
+L 161.142927 263.978304 
+" clip-path="url(#pf794edbc1e)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_3">
     <path d="M 139.360469 231.337232 
-L 199.184828 231.337232 
-" clip-path="url(#p082d57e556)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.9; stroke-width: 1.3"/>
+L 200.65327 231.337232 
+" clip-path="url(#pf794edbc1e)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_4">
     <path d="M 139.360469 198.696161 
-L 208.005334 198.696161 
-" clip-path="url(#p082d57e556)" style="fill: none; stroke: #d62728; stroke-opacity: 0.9; stroke-width: 2.4"/>
+L 208.426981 198.696161 
+" clip-path="url(#pf794edbc1e)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_5">
     <path d="M 139.360469 166.055089 
-L 208.240218 166.055089 
-" clip-path="url(#p082d57e556)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.9; stroke-width: 1.3"/>
+L 212.673671 166.055089 
+" clip-path="url(#pf794edbc1e)" style="fill: none; stroke: #d62728; stroke-opacity: 0.9; stroke-width: 2.4"/>
    </g>
    <g id="LineCollection_6">
     <path d="M 139.360469 133.414018 
-L 240.877368 133.414018 
-" clip-path="url(#p082d57e556)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.9; stroke-width: 1.3"/>
+L 239.878265 133.414018 
+" clip-path="url(#pf794edbc1e)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_7">
     <path d="M 139.360469 100.772946 
-L 248.29166 100.772946 
-" clip-path="url(#p082d57e556)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.9; stroke-width: 1.3"/>
+L 248.943982 100.772946 
+" clip-path="url(#pf794edbc1e)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_8">
     <path d="M 139.360469 68.131875 
-L 287.6261 68.131875 
-" clip-path="url(#p082d57e556)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.9; stroke-width: 1.3"/>
+L 284.774562 68.131875 
+" clip-path="url(#pf794edbc1e)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="line2d_53">
-    <path d="M 542.085668 308.04375 
-L 542.085668 56.7075 
-" clip-path="url(#p082d57e556)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
+    <path d="M 542.152339 308.04375 
+L 542.152339 56.7075 
+" clip-path="url(#pf794edbc1e)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
    </g>
    <g id="patch_3">
     <path d="M 139.360469 308.04375 
@@ -1525,9 +1525,61 @@ L 565.2 56.7075
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_12">
-    <!-- 136 -->
-    <g style="fill: #17becf" transform="translate(158.041255 298.964844) scale(0.085 -0.085)">
+    <!-- 134 -->
+    <g style="fill: #17becf" transform="translate(157.987373 298.964844) scale(0.085 -0.085)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(127.246094 0)"/>
+    </g>
+   </g>
+   <g id="text_13">
+    <!-- 147 -->
+    <g style="fill: #e377c2" transform="translate(164.484954 266.323772) scale(0.085 -0.085)">
      <defs>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
+    </g>
+   </g>
+   <g id="text_14">
+    <!-- 263 -->
+    <g style="fill: #8c564b" transform="translate(203.995296 233.682701) scale(0.085 -0.085)">
+     <defs>
+      <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
 Q 1191 2003 1191 1497 
@@ -1559,148 +1611,14 @@ Q 3103 4656 3366 4563
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(127.246094 0)"/>
-    </g>
-   </g>
-   <g id="text_13">
-    <!-- 232 -->
-    <g style="fill: #e377c2" transform="translate(194.59853 266.323772) scale(0.085 -0.085)">
-     <defs>
-      <path id="DejaVuSans-32" d="M 1228 531 
-L 3431 531 
-L 3431 0 
-L 469 0 
-L 469 531 
-Q 828 903 1448 1529 
-Q 2069 2156 2228 2338 
-Q 2531 2678 2651 2914 
-Q 2772 3150 2772 3378 
-Q 2772 3750 2511 3984 
-Q 2250 4219 1831 4219 
-Q 1534 4219 1204 4116 
-Q 875 4013 500 3803 
-L 500 4441 
-Q 881 4594 1212 4672 
-Q 1544 4750 1819 4750 
-Q 2544 4750 2975 4387 
-Q 3406 4025 3406 3419 
-Q 3406 3131 3298 2873 
-Q 3191 2616 2906 2266 
-Q 2828 2175 2409 1742 
-Q 1991 1309 1228 531 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
-    </g>
-   </g>
-   <g id="text_14">
-    <!-- 260 -->
-    <g style="fill: #8c564b" transform="translate(202.536522 233.682701) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_15">
-    <!-- 296 -->
-    <g style="fill: #d62728" transform="translate(211.357028 201.041629) scale(0.085 -0.085)">
-     <defs>
-      <path id="DejaVuSans-Bold-32" d="M 1844 884 
-L 3897 884 
-L 3897 0 
-L 506 0 
-L 506 884 
-L 2209 2388 
-Q 2438 2594 2547 2791 
-Q 2656 2988 2656 3200 
-Q 2656 3528 2436 3728 
-Q 2216 3928 1850 3928 
-Q 1569 3928 1234 3808 
-Q 900 3688 519 3450 
-L 519 4475 
-Q 925 4609 1322 4679 
-Q 1719 4750 2100 4750 
-Q 2938 4750 3402 4381 
-Q 3866 4013 3866 3353 
-Q 3866 2972 3669 2642 
-Q 3472 2313 2841 1759 
-L 1844 884 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-39" d="M 641 103 
-L 641 966 
-Q 928 831 1190 764 
-Q 1453 697 1709 697 
-Q 2247 697 2547 995 
-Q 2847 1294 2900 1881 
-Q 2688 1725 2447 1647 
-Q 2206 1569 1925 1569 
-Q 1209 1569 770 1986 
-Q 331 2403 331 3084 
-Q 331 3838 820 4291 
-Q 1309 4744 2131 4744 
-Q 3044 4744 3544 4128 
-Q 4044 3513 4044 2388 
-Q 4044 1231 3459 570 
-Q 2875 -91 1856 -91 
-Q 1528 -91 1228 -42 
-Q 928 6 641 103 
-z
-M 2125 2350 
-Q 2441 2350 2600 2554 
-Q 2759 2759 2759 3169 
-Q 2759 3575 2600 3781 
-Q 2441 3988 2125 3988 
-Q 1809 3988 1650 3781 
-Q 1491 3575 1491 3169 
-Q 1491 2759 1650 2554 
-Q 1809 2350 2125 2350 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-36" d="M 2316 2303 
-Q 2000 2303 1842 2098 
-Q 1684 1894 1684 1484 
-Q 1684 1075 1842 870 
-Q 2000 666 2316 666 
-Q 2634 666 2792 870 
-Q 2950 1075 2950 1484 
-Q 2950 1894 2792 2098 
-Q 2634 2303 2316 2303 
-z
-M 3803 4544 
-L 3803 3681 
-Q 3506 3822 3243 3889 
-Q 2981 3956 2731 3956 
-Q 2194 3956 1894 3657 
-Q 1594 3359 1544 2772 
-Q 1750 2925 1990 3001 
-Q 2231 3078 2516 3078 
-Q 3231 3078 3670 2659 
-Q 4109 2241 4109 1563 
-Q 4109 813 3618 361 
-Q 3128 -91 2303 -91 
-Q 1394 -91 895 523 
-Q 397 1138 397 2266 
-Q 397 3422 980 4083 
-Q 1563 4744 2578 4744 
-Q 2900 4744 3203 4694 
-Q 3506 4644 3803 4544 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-Bold-32"/>
-     <use xlink:href="#DejaVuSans-Bold-39" transform="translate(69.580078 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-36" transform="translate(139.160156 0)"/>
-    </g>
-   </g>
-   <g id="text_16">
-    <!-- 297 -->
-    <g style="fill: #bcbd22" transform="translate(211.591912 168.400558) scale(0.085 -0.085)">
+    <!-- 294 -->
+    <g style="fill: #bcbd22" transform="translate(211.769007 201.041629) scale(0.085 -0.085)">
      <defs>
       <path id="DejaVuSans-39" d="M 703 97 
 L 703 672 
@@ -1732,33 +1650,71 @@ Q 1038 2656 1286 2365
 Q 1534 2075 1959 2075 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
-z
-" transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(127.246094 0)"/>
+    </g>
+   </g>
+   <g id="text_16">
+    <!-- 313 -->
+    <g style="fill: #d62728" transform="translate(216.015698 168.400558) scale(0.085 -0.085)">
+     <defs>
+      <path id="DejaVuSans-Bold-33" d="M 2981 2516 
+Q 3453 2394 3698 2092 
+Q 3944 1791 3944 1325 
+Q 3944 631 3412 270 
+Q 2881 -91 1863 -91 
+Q 1503 -91 1142 -33 
+Q 781 25 428 141 
+L 428 1069 
+Q 766 900 1098 814 
+Q 1431 728 1753 728 
+Q 2231 728 2486 893 
+Q 2741 1059 2741 1369 
+Q 2741 1688 2480 1852 
+Q 2219 2016 1709 2016 
+L 1228 2016 
+L 1228 2791 
+L 1734 2791 
+Q 2188 2791 2409 2933 
+Q 2631 3075 2631 3366 
+Q 2631 3634 2415 3781 
+Q 2200 3928 1806 3928 
+Q 1516 3928 1219 3862 
+Q 922 3797 628 3669 
+L 628 4550 
+Q 984 4650 1334 4700 
+Q 1684 4750 2022 4750 
+Q 2931 4750 3382 4451 
+Q 3834 4153 3834 3553 
+Q 3834 3144 3618 2883 
+Q 3403 2622 2981 2516 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-31" d="M 750 831 
+L 1813 831 
+L 1813 3847 
+L 722 3622 
+L 722 4441 
+L 1806 4666 
+L 2950 4666 
+L 2950 831 
+L 4013 831 
+L 4013 0 
+L 750 0 
+L 750 831 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-Bold-33"/>
+     <use xlink:href="#DejaVuSans-Bold-31" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-33" transform="translate(139.160156 0)"/>
     </g>
    </g>
    <g id="text_17">
-    <!-- 477 -->
-    <g style="fill: #1f77b4" transform="translate(244.229062 135.759487) scale(0.085 -0.085)">
-     <use xlink:href="#DejaVuSans-34"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
-    </g>
-   </g>
-   <g id="text_18">
-    <!-- 532 -->
-    <g style="fill: #2ca02c" transform="translate(251.643354 103.118415) scale(0.085 -0.085)">
+    <!-- 465 -->
+    <g style="fill: #1f77b4" transform="translate(243.220291 135.759487) scale(0.085 -0.085)">
      <defs>
       <path id="DejaVuSans-35" d="M 691 4666 
 L 3169 4666 
@@ -1786,22 +1742,71 @@ L 691 4666
 z
 " transform="scale(0.015625)"/>
      </defs>
+     <use xlink:href="#DejaVuSans-34"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
+    </g>
+   </g>
+   <g id="text_18">
+    <!-- 531 -->
+    <g style="fill: #2ca02c" transform="translate(252.286008 103.118415) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_19">
-    <!-- 943 -->
-    <g style="fill: #9467bd" transform="translate(290.977794 70.477344) scale(0.085 -0.085)">
-     <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(127.246094 0)"/>
+    <!-- 896 -->
+    <g style="fill: #9467bd" transform="translate(288.116589 70.477344) scale(0.085 -0.085)">
+     <defs>
+      <path id="DejaVuSans-38" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-38"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_20">
     <!-- memcpy ≈ 38 GB/s  -->
-    <g style="fill: #777777" transform="translate(540.421918 128.870982) rotate(-90) scale(0.08 -0.08)">
+    <g style="fill: #777777" transform="translate(540.488589 128.870982) rotate(-90) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-79" d="M 2059 -325 
 Q 1816 -950 1584 -1140 
@@ -1861,45 +1866,6 @@ Q 3834 2663 4098 2780
 Q 4363 2897 4684 3163 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-38" d="M 2034 2216 
-Q 1584 2216 1326 1975 
-Q 1069 1734 1069 1313 
-Q 1069 891 1326 650 
-Q 1584 409 2034 409 
-Q 2484 409 2743 651 
-Q 3003 894 3003 1313 
-Q 3003 1734 2745 1975 
-Q 2488 2216 2034 2216 
-z
-M 1403 2484 
-Q 997 2584 770 2862 
-Q 544 3141 544 3541 
-Q 544 4100 942 4425 
-Q 1341 4750 2034 4750 
-Q 2731 4750 3128 4425 
-Q 3525 4100 3525 3541 
-Q 3525 3141 3298 2862 
-Q 3072 2584 2669 2484 
-Q 3125 2378 3379 2068 
-Q 3634 1759 3634 1313 
-Q 3634 634 3220 271 
-Q 2806 -91 2034 -91 
-Q 1263 -91 848 271 
-Q 434 634 434 1313 
-Q 434 1759 690 2068 
-Q 947 2378 1403 2484 
-z
-M 1172 3481 
-Q 1172 3119 1398 2916 
-Q 1625 2713 2034 2713 
-Q 2441 2713 2670 2916 
-Q 2900 3119 2900 3481 
-Q 2900 3844 2670 4047 
-Q 2441 4250 2034 4250 
-Q 1625 4250 1398 4047 
-Q 1172 3844 1172 3481 
-z
-" transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-6d"/>
      <use xlink:href="#DejaVuSans-65" transform="translate(97.412109 0)"/>
@@ -1922,7 +1888,7 @@ z
    </g>
    <g id="line2d_54">
     <defs>
-     <path id="me77b412eb8" d="M 0 3 
+     <path id="ma95fb566a0" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1934,13 +1900,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #17becf"/>
     </defs>
-    <g clip-path="url(#p082d57e556)">
-     <use xlink:href="#me77b412eb8" x="154.689561" y="296.619375" style="fill: #17becf; stroke: #17becf"/>
+    <g clip-path="url(#pf794edbc1e)">
+     <use xlink:href="#ma95fb566a0" x="154.645346" y="296.619375" style="fill: #17becf; stroke: #17becf"/>
     </g>
    </g>
    <g id="line2d_55">
     <defs>
-     <path id="mcbf854e707" d="M 0 3 
+     <path id="mb636c73521" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1952,13 +1918,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #e377c2"/>
     </defs>
-    <g clip-path="url(#p082d57e556)">
-     <use xlink:href="#mcbf854e707" x="191.246836" y="263.978304" style="fill: #e377c2; stroke: #e377c2"/>
+    <g clip-path="url(#pf794edbc1e)">
+     <use xlink:href="#mb636c73521" x="161.142927" y="263.978304" style="fill: #e377c2; stroke: #e377c2"/>
     </g>
    </g>
    <g id="line2d_56">
     <defs>
-     <path id="maac372cb96" d="M 0 3 
+     <path id="m36e487e295" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1970,31 +1936,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #8c564b"/>
     </defs>
-    <g clip-path="url(#p082d57e556)">
-     <use xlink:href="#maac372cb96" x="199.184828" y="231.337232" style="fill: #8c564b; stroke: #8c564b"/>
+    <g clip-path="url(#pf794edbc1e)">
+     <use xlink:href="#m36e487e295" x="200.65327" y="231.337232" style="fill: #8c564b; stroke: #8c564b"/>
     </g>
    </g>
    <g id="line2d_57">
     <defs>
-     <path id="m390a5c2730" d="M 0 5 
-C 1.326016 5 2.597899 4.473168 3.535534 3.535534 
-C 4.473168 2.597899 5 1.326016 5 0 
-C 5 -1.326016 4.473168 -2.597899 3.535534 -3.535534 
-C 2.597899 -4.473168 1.326016 -5 0 -5 
-C -1.326016 -5 -2.597899 -4.473168 -3.535534 -3.535534 
-C -4.473168 -2.597899 -5 -1.326016 -5 0 
-C -5 1.326016 -4.473168 2.597899 -3.535534 3.535534 
-C -2.597899 4.473168 -1.326016 5 0 5 
-z
-" style="stroke: #d62728"/>
-    </defs>
-    <g clip-path="url(#p082d57e556)">
-     <use xlink:href="#m390a5c2730" x="208.005334" y="198.696161" style="fill: #d62728; stroke: #d62728"/>
-    </g>
-   </g>
-   <g id="line2d_58">
-    <defs>
-     <path id="m41054d4c57" d="M 0 3 
+     <path id="m354b75e604" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -2006,13 +1954,31 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #bcbd22"/>
     </defs>
-    <g clip-path="url(#p082d57e556)">
-     <use xlink:href="#m41054d4c57" x="208.240218" y="166.055089" style="fill: #bcbd22; stroke: #bcbd22"/>
+    <g clip-path="url(#pf794edbc1e)">
+     <use xlink:href="#m354b75e604" x="208.426981" y="198.696161" style="fill: #bcbd22; stroke: #bcbd22"/>
+    </g>
+   </g>
+   <g id="line2d_58">
+    <defs>
+     <path id="m417978cbe7" d="M 0 5 
+C 1.326016 5 2.597899 4.473168 3.535534 3.535534 
+C 4.473168 2.597899 5 1.326016 5 0 
+C 5 -1.326016 4.473168 -2.597899 3.535534 -3.535534 
+C 2.597899 -4.473168 1.326016 -5 0 -5 
+C -1.326016 -5 -2.597899 -4.473168 -3.535534 -3.535534 
+C -4.473168 -2.597899 -5 -1.326016 -5 0 
+C -5 1.326016 -4.473168 2.597899 -3.535534 3.535534 
+C -2.597899 4.473168 -1.326016 5 0 5 
+z
+" style="stroke: #d62728"/>
+    </defs>
+    <g clip-path="url(#pf794edbc1e)">
+     <use xlink:href="#m417978cbe7" x="212.673671" y="166.055089" style="fill: #d62728; stroke: #d62728"/>
     </g>
    </g>
    <g id="line2d_59">
     <defs>
-     <path id="m4ba123a357" d="M 0 3 
+     <path id="m856784679e" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -2024,13 +1990,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #1f77b4"/>
     </defs>
-    <g clip-path="url(#p082d57e556)">
-     <use xlink:href="#m4ba123a357" x="240.877368" y="133.414018" style="fill: #1f77b4; stroke: #1f77b4"/>
+    <g clip-path="url(#pf794edbc1e)">
+     <use xlink:href="#m856784679e" x="239.878265" y="133.414018" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_60">
     <defs>
-     <path id="m48fa89a504" d="M 0 3 
+     <path id="mb3fe1fe665" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -2042,13 +2008,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #2ca02c"/>
     </defs>
-    <g clip-path="url(#p082d57e556)">
-     <use xlink:href="#m48fa89a504" x="248.29166" y="100.772946" style="fill: #2ca02c; stroke: #2ca02c"/>
+    <g clip-path="url(#pf794edbc1e)">
+     <use xlink:href="#mb3fe1fe665" x="248.943982" y="100.772946" style="fill: #2ca02c; stroke: #2ca02c"/>
     </g>
    </g>
    <g id="line2d_61">
     <defs>
-     <path id="m3b87754eba" d="M 0 3 
+     <path id="m3a03e0623e" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -2060,8 +2026,8 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #9467bd"/>
     </defs>
-    <g clip-path="url(#p082d57e556)">
-     <use xlink:href="#m3b87754eba" x="287.6261" y="68.131875" style="fill: #9467bd; stroke: #9467bd"/>
+    <g clip-path="url(#pf794edbc1e)">
+     <use xlink:href="#m3a03e0623e" x="284.774562" y="68.131875" style="fill: #9467bd; stroke: #9467bd"/>
     </g>
    </g>
   </g>
@@ -2525,20 +2491,6 @@ L 588 0
 L 588 4666 
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Bold-31" d="M 750 831 
-L 1813 831 
-L 1813 3847 
-L 722 3622 
-L 722 4441 
-L 1806 4666 
-L 2950 4666 
-L 2950 831 
-L 4013 831 
-L 4013 0 
-L 750 0 
-L 750 831 
-z
-" transform="scale(0.015625)"/>
      <path id="DejaVuSans-Bold-2f" d="M 1644 4666 
 L 2338 4666 
 L 691 -594 
@@ -2546,36 +2498,86 @@ L 0 -594
 L 1644 4666 
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Bold-33" d="M 2981 2516 
-Q 3453 2394 3698 2092 
-Q 3944 1791 3944 1325 
-Q 3944 631 3412 270 
-Q 2881 -91 1863 -91 
-Q 1503 -91 1142 -33 
-Q 781 25 428 141 
-L 428 1069 
-Q 766 900 1098 814 
-Q 1431 728 1753 728 
-Q 2231 728 2486 893 
-Q 2741 1059 2741 1369 
-Q 2741 1688 2480 1852 
-Q 2219 2016 1709 2016 
-L 1228 2016 
-L 1228 2791 
-L 1734 2791 
-Q 2188 2791 2409 2933 
-Q 2631 3075 2631 3366 
-Q 2631 3634 2415 3781 
-Q 2200 3928 1806 3928 
-Q 1516 3928 1219 3862 
-Q 922 3797 628 3669 
-L 628 4550 
-Q 984 4650 1334 4700 
-Q 1684 4750 2022 4750 
-Q 2931 4750 3382 4451 
-Q 3834 4153 3834 3553 
-Q 3834 3144 3618 2883 
-Q 3403 2622 2981 2516 
+     <path id="DejaVuSans-Bold-36" d="M 2316 2303 
+Q 2000 2303 1842 2098 
+Q 1684 1894 1684 1484 
+Q 1684 1075 1842 870 
+Q 2000 666 2316 666 
+Q 2634 666 2792 870 
+Q 2950 1075 2950 1484 
+Q 2950 1894 2792 2098 
+Q 2634 2303 2316 2303 
+z
+M 3803 4544 
+L 3803 3681 
+Q 3506 3822 3243 3889 
+Q 2981 3956 2731 3956 
+Q 2194 3956 1894 3657 
+Q 1594 3359 1544 2772 
+Q 1750 2925 1990 3001 
+Q 2231 3078 2516 3078 
+Q 3231 3078 3670 2659 
+Q 4109 2241 4109 1563 
+Q 4109 813 3618 361 
+Q 3128 -91 2303 -91 
+Q 1394 -91 895 523 
+Q 397 1138 397 2266 
+Q 397 3422 980 4083 
+Q 1563 4744 2578 4744 
+Q 2900 4744 3203 4694 
+Q 3506 4644 3803 4544 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-39" d="M 641 103 
+L 641 966 
+Q 928 831 1190 764 
+Q 1453 697 1709 697 
+Q 2247 697 2547 995 
+Q 2847 1294 2900 1881 
+Q 2688 1725 2447 1647 
+Q 2206 1569 1925 1569 
+Q 1209 1569 770 1986 
+Q 331 2403 331 3084 
+Q 331 3838 820 4291 
+Q 1309 4744 2131 4744 
+Q 3044 4744 3544 4128 
+Q 4044 3513 4044 2388 
+Q 4044 1231 3459 570 
+Q 2875 -91 1856 -91 
+Q 1528 -91 1228 -42 
+Q 928 6 641 103 
+z
+M 2125 2350 
+Q 2441 2350 2600 2554 
+Q 2759 2759 2759 3169 
+Q 2759 3575 2600 3781 
+Q 2441 3988 2125 3988 
+Q 1809 3988 1650 3781 
+Q 1491 3575 1491 3169 
+Q 1491 2759 1650 2554 
+Q 1809 2350 2125 2350 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-32" d="M 1844 884 
+L 3897 884 
+L 3897 0 
+L 506 0 
+L 506 884 
+L 2209 2388 
+Q 2438 2594 2547 2791 
+Q 2656 2988 2656 3200 
+Q 2656 3528 2436 3728 
+Q 2216 3928 1850 3928 
+Q 1569 3928 1234 3808 
+Q 900 3688 519 3450 
+L 519 4475 
+Q 925 4609 1322 4679 
+Q 1719 4750 2100 4750 
+Q 2938 4750 3402 4381 
+Q 3866 4013 3866 3353 
+Q 3866 2972 3669 2642 
+Q 3472 2313 2841 1759 
+L 1844 884 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-Bold-2b" d="M 3053 4013 
@@ -2733,8 +2735,8 @@ z
    </g>
   </g>
   <g id="text_22">
-   <!-- 2026-07-08T15:12:34Z  ·  Linux chungus2 x86_64  ·  commit 7af11ed3  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(8.535391 358.2) scale(0.07 -0.07)">
+   <!-- 2026-07-08T17:40:34Z  ·  Linux chungus2 x86_64  ·  commit 28b506f0  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(8.380078 358.2) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2817,10 +2819,10 @@ z
     <use xlink:href="#DejaVuSans-38" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
     <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
     <use xlink:href="#DejaVuSans-34" transform="translate(1027.734375 0)"/>
@@ -2863,109 +2865,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3196.777344 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3231.982422 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3295.605469 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3359.228516 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3420.751953 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3484.228516 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3547.851562 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3579.638672 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3611.425781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3643.212891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3675 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3706.787109 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3734.570312 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3796.09375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3857.373047 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3920.751953 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3984.228516 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4023.091797 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4084.273438 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4143.453125 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4204.976562 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4246.089844 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4279.78125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4307.564453 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4369.087891 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4430.367188 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4493.746094 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4557.369141 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4591.060547 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4650.240234 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4713.863281 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4745.650391 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4809.273438 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4872.896484 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4904.683594 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4968.306641 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5004.390625 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5043.253906 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5098.234375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5161.857422 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5193.644531 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5225.431641 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5257.21875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5289.005859 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5320.792969 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5360.001953 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5423.380859 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5462.244141 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5523.425781 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5586.804688 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5650.28125 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5713.660156 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5777.136719 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5840.515625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5879.724609 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5911.511719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5995.300781 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6027.087891 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6124.5 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6186.023438 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6249.5 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6277.283203 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6338.5625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6401.941406 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6433.728516 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6485.828125 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6549.207031 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6610.486328 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6673.962891 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6726.0625 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6789.441406 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6850.623047 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6889.832031 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6923.523438 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6955.310547 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6996.423828 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7057.703125 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7096.912109 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7124.695312 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7185.876953 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7217.664062 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7245.447266 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7297.546875 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7329.333984 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7392.810547 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7454.333984 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7493.542969 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7555.066406 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7594.429688 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7691.841797 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7719.625 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7783.003906 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7810.787109 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7862.886719 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7902.095703 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7929.878906 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3262.597656 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3326.220703 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3389.84375 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3453.466797 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3488.671875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3552.294922 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3584.082031 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3615.869141 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3647.65625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3679.443359 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3711.230469 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3739.013672 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3800.537109 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3861.816406 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3925.195312 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3988.671875 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4027.535156 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4088.716797 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4147.896484 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4209.419922 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4250.533203 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4284.224609 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4312.007812 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4373.53125 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4434.810547 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4498.189453 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4561.8125 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4595.503906 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4654.683594 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4718.306641 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4750.09375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4813.716797 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4877.339844 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4909.126953 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4972.75 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5008.833984 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5047.697266 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5102.677734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5166.300781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5198.087891 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5229.875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5261.662109 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5293.449219 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5325.236328 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5364.445312 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5427.824219 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5466.6875 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5527.869141 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5591.248047 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5654.724609 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5718.103516 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5781.580078 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5844.958984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5884.167969 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5915.955078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5999.744141 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6031.53125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6128.943359 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6190.466797 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6253.943359 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6281.726562 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6343.005859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6406.384766 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6438.171875 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6490.271484 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6553.650391 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6614.929688 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6678.40625 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6730.505859 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6793.884766 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6855.066406 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6894.275391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6927.966797 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6959.753906 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7000.867188 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7062.146484 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7101.355469 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7129.138672 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7190.320312 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7222.107422 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7249.890625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7301.990234 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7333.777344 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7397.253906 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7458.777344 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7497.986328 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7559.509766 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7598.873047 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7696.285156 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7724.068359 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7787.447266 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7815.230469 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7867.330078 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7906.539062 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7934.322266 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p082d57e556">
+  <clipPath id="pf794edbc1e">
    <rect x="139.360469" y="56.7075" width="425.839531" height="251.33625"/>
   </clipPath>
  </defs>

--- a/bench/results/decode_density.json
+++ b/bench/results/decode_density.json
@@ -1,8 +1,8 @@
 {
 "meta": {
-"date": "2026-07-08T15:12:34Z",
+"date": "2026-07-08T17:40:34Z",
 "machine": "Linux chungus2 x86_64",
-"git_commit": "7af11ed3",
+"git_commit": "28b506f0",
 "toolchain": "leanprover/lean4:v4.30.0-rc2",
 "experiment": "decode-density: fixed encoder (libdeflate levels + zopfli, level 0 = zopfli), ratio = encoder compression ratio, decompress_mbps = each decoder on identical streams; compressor field holds the decoder name"
 },
@@ -15,7 +15,7 @@
 "out_size": 4217525,
 "ratio": 0.4138,
 "compress_mbps": null,
-"decompress_mbps": 212.7
+"decompress_mbps": 229.43
 },
 {
 "compressor": "zlib",
@@ -24,2570 +24,2570 @@
 "level": 1,
 "out_size": 4217525,
 "ratio": 0.4138,
-"compress_mbps": null,
-"decompress_mbps": 387.43
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 1,
-"out_size": 4217525,
-"ratio": 0.4138,
-"compress_mbps": null,
-"decompress_mbps": 452.76
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 1,
-"out_size": 4217525,
-"ratio": 0.4138,
-"compress_mbps": null,
-"decompress_mbps": 770.65
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 1,
-"out_size": 4217525,
-"ratio": 0.4138,
-"compress_mbps": null,
-"decompress_mbps": 35810.95
-},
-{
-"compressor": "native",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 3,
-"out_size": 3989875,
-"ratio": 0.3915,
-"compress_mbps": null,
-"decompress_mbps": 250.42
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 3,
-"out_size": 3989875,
-"ratio": 0.3915,
-"compress_mbps": null,
-"decompress_mbps": 394.29
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 3,
-"out_size": 3989875,
-"ratio": 0.3915,
-"compress_mbps": null,
-"decompress_mbps": 492.07
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 3,
-"out_size": 3989875,
-"ratio": 0.3915,
-"compress_mbps": null,
-"decompress_mbps": 881.76
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 3,
-"out_size": 3989875,
-"ratio": 0.3915,
-"compress_mbps": null,
-"decompress_mbps": 36987.34
-},
-{
-"compressor": "native",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 6,
-"out_size": 3859436,
-"ratio": 0.3787,
-"compress_mbps": null,
-"decompress_mbps": 246.02
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 6,
-"out_size": 3859436,
-"ratio": 0.3787,
-"compress_mbps": null,
-"decompress_mbps": 386.97
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 6,
-"out_size": 3859436,
-"ratio": 0.3787,
-"compress_mbps": null,
-"decompress_mbps": 466.77
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 6,
-"out_size": 3859436,
-"ratio": 0.3787,
-"compress_mbps": null,
-"decompress_mbps": 838.09
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 6,
-"out_size": 3859436,
-"ratio": 0.3787,
-"compress_mbps": null,
-"decompress_mbps": 59286.95
-},
-{
-"compressor": "native",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 9,
-"out_size": 3810354,
-"ratio": 0.3738,
-"compress_mbps": null,
-"decompress_mbps": 242.6
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 9,
-"out_size": 3810354,
-"ratio": 0.3738,
-"compress_mbps": null,
-"decompress_mbps": 381.39
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 9,
-"out_size": 3810354,
-"ratio": 0.3738,
-"compress_mbps": null,
-"decompress_mbps": 443.58
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 9,
-"out_size": 3810354,
-"ratio": 0.3738,
-"compress_mbps": null,
-"decompress_mbps": 779.04
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 9,
-"out_size": 3810354,
-"ratio": 0.3738,
-"compress_mbps": null,
-"decompress_mbps": 59471.95
-},
-{
-"compressor": "native",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 12,
-"out_size": 3679105,
-"ratio": 0.361,
-"compress_mbps": null,
-"decompress_mbps": 265.85
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 12,
-"out_size": 3679105,
-"ratio": 0.361,
-"compress_mbps": null,
-"decompress_mbps": 433.48
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 12,
-"out_size": 3679105,
-"ratio": 0.361,
-"compress_mbps": null,
-"decompress_mbps": 506.8
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 12,
-"out_size": 3679105,
-"ratio": 0.361,
-"compress_mbps": null,
-"decompress_mbps": 939.75
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 12,
-"out_size": 3679105,
-"ratio": 0.361,
-"compress_mbps": null,
-"decompress_mbps": 44207.98
-},
-{
-"compressor": "native",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 0,
-"out_size": 3673380,
-"ratio": 0.3604,
-"compress_mbps": null,
-"decompress_mbps": 259.39
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 0,
-"out_size": 3673380,
-"ratio": 0.3604,
-"compress_mbps": null,
-"decompress_mbps": 420.23
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 0,
-"out_size": 3673380,
-"ratio": 0.3604,
-"compress_mbps": null,
-"decompress_mbps": 471.36
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 0,
-"out_size": 3673380,
-"ratio": 0.3604,
-"compress_mbps": null,
-"decompress_mbps": 886.58
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 0,
-"out_size": 3673380,
-"ratio": 0.3604,
-"compress_mbps": null,
-"decompress_mbps": 57862.56
-},
-{
-"compressor": "native",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 1,
-"out_size": 20192961,
-"ratio": 0.3942,
-"compress_mbps": null,
-"decompress_mbps": 239.16
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 1,
-"out_size": 20192961,
-"ratio": 0.3942,
-"compress_mbps": null,
-"decompress_mbps": 381.33
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 1,
-"out_size": 20192961,
-"ratio": 0.3942,
-"compress_mbps": null,
-"decompress_mbps": 421.59
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 1,
-"out_size": 20192961,
-"ratio": 0.3942,
-"compress_mbps": null,
-"decompress_mbps": 742.02
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 1,
-"out_size": 20192961,
-"ratio": 0.3942,
-"compress_mbps": null,
-"decompress_mbps": 19673.54
-},
-{
-"compressor": "native",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 3,
-"out_size": 19234937,
-"ratio": 0.3755,
-"compress_mbps": null,
-"decompress_mbps": 184.79
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 3,
-"out_size": 19234937,
-"ratio": 0.3755,
-"compress_mbps": null,
-"decompress_mbps": 379.7
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 3,
-"out_size": 19234937,
-"ratio": 0.3755,
-"compress_mbps": null,
-"decompress_mbps": 395.01
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 3,
-"out_size": 19234937,
-"ratio": 0.3755,
-"compress_mbps": null,
-"decompress_mbps": 745.95
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 3,
-"out_size": 19234937,
-"ratio": 0.3755,
-"compress_mbps": null,
-"decompress_mbps": 20162.89
-},
-{
-"compressor": "native",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 6,
-"out_size": 18805391,
-"ratio": 0.3671,
-"compress_mbps": null,
-"decompress_mbps": 192.42
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 6,
-"out_size": 18805391,
-"ratio": 0.3671,
-"compress_mbps": null,
-"decompress_mbps": 388.57
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 6,
-"out_size": 18805391,
-"ratio": 0.3671,
-"compress_mbps": null,
-"decompress_mbps": 414.01
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 6,
-"out_size": 18805391,
-"ratio": 0.3671,
-"compress_mbps": null,
-"decompress_mbps": 774.52
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 6,
-"out_size": 18805391,
-"ratio": 0.3671,
-"compress_mbps": null,
-"decompress_mbps": 19853.73
-},
-{
-"compressor": "native",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 9,
-"out_size": 18713659,
-"ratio": 0.3654,
-"compress_mbps": null,
-"decompress_mbps": 199.22
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 9,
-"out_size": 18713659,
-"ratio": 0.3654,
-"compress_mbps": null,
-"decompress_mbps": 391.62
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 9,
-"out_size": 18713659,
-"ratio": 0.3654,
-"compress_mbps": null,
-"decompress_mbps": 419.28
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 9,
-"out_size": 18713659,
-"ratio": 0.3654,
-"compress_mbps": null,
-"decompress_mbps": 790.47
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 9,
-"out_size": 18713659,
-"ratio": 0.3654,
-"compress_mbps": null,
-"decompress_mbps": 19333.78
-},
-{
-"compressor": "native",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 12,
-"out_size": 18241312,
-"ratio": 0.3561,
-"compress_mbps": null,
-"decompress_mbps": 180.13
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 12,
-"out_size": 18241312,
-"ratio": 0.3561,
-"compress_mbps": null,
-"decompress_mbps": 391.54
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 12,
-"out_size": 18241312,
-"ratio": 0.3561,
-"compress_mbps": null,
-"decompress_mbps": 405.68
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 12,
-"out_size": 18241312,
-"ratio": 0.3561,
-"compress_mbps": null,
-"decompress_mbps": 775.77
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 12,
-"out_size": 18241312,
-"ratio": 0.3561,
-"compress_mbps": null,
-"decompress_mbps": 19765.79
-},
-{
-"compressor": "native",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 0,
-"out_size": 18317341,
-"ratio": 0.3576,
-"compress_mbps": null,
-"decompress_mbps": 244.32
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 0,
-"out_size": 18317341,
-"ratio": 0.3576,
-"compress_mbps": null,
-"decompress_mbps": 390.37
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 0,
-"out_size": 18317341,
-"ratio": 0.3576,
-"compress_mbps": null,
-"decompress_mbps": 417.51
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 0,
-"out_size": 18317341,
-"ratio": 0.3576,
-"compress_mbps": null,
-"decompress_mbps": 778.84
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 0,
-"out_size": 18317341,
-"ratio": 0.3576,
-"compress_mbps": null,
-"decompress_mbps": 19989.2
-},
-{
-"compressor": "native",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 1,
-"out_size": 3740775,
-"ratio": 0.3752,
-"compress_mbps": null,
-"decompress_mbps": 247.39
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 1,
-"out_size": 3740775,
-"ratio": 0.3752,
-"compress_mbps": null,
-"decompress_mbps": 448.76
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 1,
-"out_size": 3740775,
-"ratio": 0.3752,
-"compress_mbps": null,
-"decompress_mbps": 537.03
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 1,
-"out_size": 3740775,
-"ratio": 0.3752,
-"compress_mbps": null,
-"decompress_mbps": 863.95
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 1,
-"out_size": 3740775,
-"ratio": 0.3752,
-"compress_mbps": null,
-"decompress_mbps": 43354.25
-},
-{
-"compressor": "native",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 3,
-"out_size": 3672389,
-"ratio": 0.3683,
-"compress_mbps": null,
-"decompress_mbps": 265.3
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 3,
-"out_size": 3672389,
-"ratio": 0.3683,
-"compress_mbps": null,
-"decompress_mbps": 459.47
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 3,
-"out_size": 3672389,
-"ratio": 0.3683,
-"compress_mbps": null,
-"decompress_mbps": 543.58
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 3,
-"out_size": 3672389,
-"ratio": 0.3683,
-"compress_mbps": null,
-"decompress_mbps": 905.98
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 3,
-"out_size": 3672389,
-"ratio": 0.3683,
-"compress_mbps": null,
-"decompress_mbps": 45049.2
-},
-{
-"compressor": "native",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 6,
-"out_size": 3648644,
-"ratio": 0.3659,
-"compress_mbps": null,
-"decompress_mbps": 277.51
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 6,
-"out_size": 3648644,
-"ratio": 0.3659,
-"compress_mbps": null,
-"decompress_mbps": 452.97
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 6,
-"out_size": 3648644,
-"ratio": 0.3659,
-"compress_mbps": null,
-"decompress_mbps": 534.97
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 6,
-"out_size": 3648644,
-"ratio": 0.3659,
-"compress_mbps": null,
-"decompress_mbps": 931.57
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 6,
-"out_size": 3648644,
-"ratio": 0.3659,
-"compress_mbps": null,
-"decompress_mbps": 57577.71
-},
-{
-"compressor": "native",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 9,
-"out_size": 3625176,
-"ratio": 0.3636,
-"compress_mbps": null,
-"decompress_mbps": 270.74
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 9,
-"out_size": 3625176,
-"ratio": 0.3636,
-"compress_mbps": null,
-"decompress_mbps": 457.11
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 9,
-"out_size": 3625176,
-"ratio": 0.3636,
-"compress_mbps": null,
-"decompress_mbps": 528.48
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 9,
-"out_size": 3625176,
-"ratio": 0.3636,
-"compress_mbps": null,
-"decompress_mbps": 924.56
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 9,
-"out_size": 3625176,
-"ratio": 0.3636,
-"compress_mbps": null,
-"decompress_mbps": 44951.24
-},
-{
-"compressor": "native",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 12,
-"out_size": 3447985,
-"ratio": 0.3458,
-"compress_mbps": null,
-"decompress_mbps": 263.22
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 12,
-"out_size": 3447985,
-"ratio": 0.3458,
-"compress_mbps": null,
-"decompress_mbps": 495.88
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 12,
-"out_size": 3447985,
-"ratio": 0.3458,
-"compress_mbps": null,
-"decompress_mbps": 523.45
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 12,
-"out_size": 3447985,
-"ratio": 0.3458,
-"compress_mbps": null,
-"decompress_mbps": 940.67
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 12,
-"out_size": 3447985,
-"ratio": 0.3458,
-"compress_mbps": null,
-"decompress_mbps": 57504.59
-},
-{
-"compressor": "native",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 0,
-"out_size": 3450225,
-"ratio": 0.346,
-"compress_mbps": null,
-"decompress_mbps": 251.93
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 0,
-"out_size": 3450225,
-"ratio": 0.346,
-"compress_mbps": null,
-"decompress_mbps": 428.8
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 0,
-"out_size": 3450225,
-"ratio": 0.346,
-"compress_mbps": null,
-"decompress_mbps": 506.75
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 0,
-"out_size": 3450225,
-"ratio": 0.346,
-"compress_mbps": null,
-"decompress_mbps": 838.91
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 0,
-"out_size": 3450225,
-"ratio": 0.346,
-"compress_mbps": null,
-"decompress_mbps": 41105.6
-},
-{
-"compressor": "native",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 1,
-"out_size": 3837577,
-"ratio": 0.1144,
-"compress_mbps": null,
-"decompress_mbps": 593.71
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 1,
-"out_size": 3837577,
-"ratio": 0.1144,
-"compress_mbps": null,
-"decompress_mbps": 879.69
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 1,
-"out_size": 3837577,
-"ratio": 0.1144,
-"compress_mbps": null,
-"decompress_mbps": 873.02
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 1,
-"out_size": 3837577,
-"ratio": 0.1144,
-"compress_mbps": null,
-"decompress_mbps": 1792.68
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 1,
-"out_size": 3837577,
-"ratio": 0.1144,
-"compress_mbps": null,
-"decompress_mbps": 20759.27
-},
-{
-"compressor": "native",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 3,
-"out_size": 3599455,
-"ratio": 0.1073,
-"compress_mbps": null,
-"decompress_mbps": 688.85
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 3,
-"out_size": 3599455,
-"ratio": 0.1073,
-"compress_mbps": null,
-"decompress_mbps": 928.83
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 3,
-"out_size": 3599455,
-"ratio": 0.1073,
-"compress_mbps": null,
-"decompress_mbps": 938.83
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 3,
-"out_size": 3599455,
-"ratio": 0.1073,
-"compress_mbps": null,
-"decompress_mbps": 1872.32
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 3,
-"out_size": 3599455,
-"ratio": 0.1073,
-"compress_mbps": null,
-"decompress_mbps": 19277.11
-},
-{
-"compressor": "native",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 6,
-"out_size": 3091741,
-"ratio": 0.0921,
-"compress_mbps": null,
-"decompress_mbps": 830.42
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 6,
-"out_size": 3091741,
-"ratio": 0.0921,
-"compress_mbps": null,
-"decompress_mbps": 1058.38
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 6,
-"out_size": 3091741,
-"ratio": 0.0921,
-"compress_mbps": null,
-"decompress_mbps": 1091.71
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 6,
-"out_size": 3091741,
-"ratio": 0.0921,
-"compress_mbps": null,
-"decompress_mbps": 1939.54
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 6,
-"out_size": 3091741,
-"ratio": 0.0921,
-"compress_mbps": null,
-"decompress_mbps": 19135.69
-},
-{
-"compressor": "native",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 9,
-"out_size": 2925243,
-"ratio": 0.0872,
-"compress_mbps": null,
-"decompress_mbps": 925.7
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 9,
-"out_size": 2925243,
-"ratio": 0.0872,
-"compress_mbps": null,
-"decompress_mbps": 1125.23
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 9,
-"out_size": 2925243,
-"ratio": 0.0872,
-"compress_mbps": null,
-"decompress_mbps": 1159.45
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 9,
-"out_size": 2925243,
-"ratio": 0.0872,
-"compress_mbps": null,
-"decompress_mbps": 2006.79
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 9,
-"out_size": 2925243,
-"ratio": 0.0872,
-"compress_mbps": null,
-"decompress_mbps": 20293.19
-},
-{
-"compressor": "native",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 12,
-"out_size": 2748273,
-"ratio": 0.0819,
-"compress_mbps": null,
-"decompress_mbps": 831.06
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 12,
-"out_size": 2748273,
-"ratio": 0.0819,
-"compress_mbps": null,
-"decompress_mbps": 1135.64
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 12,
-"out_size": 2748273,
-"ratio": 0.0819,
-"compress_mbps": null,
-"decompress_mbps": 1141.14
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 12,
-"out_size": 2748273,
-"ratio": 0.0819,
-"compress_mbps": null,
-"decompress_mbps": 1993.69
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 12,
-"out_size": 2748273,
-"ratio": 0.0819,
-"compress_mbps": null,
-"decompress_mbps": 20961.92
-},
-{
-"compressor": "native",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 0,
-"out_size": 2740598,
-"ratio": 0.0817,
-"compress_mbps": null,
-"decompress_mbps": 1008.75
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 0,
-"out_size": 2740598,
-"ratio": 0.0817,
-"compress_mbps": null,
-"decompress_mbps": 1148.95
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 0,
-"out_size": 2740598,
-"ratio": 0.0817,
-"compress_mbps": null,
-"decompress_mbps": 1170.85
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 0,
-"out_size": 2740598,
-"ratio": 0.0817,
-"compress_mbps": null,
-"decompress_mbps": 2035.91
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 0,
-"out_size": 2740598,
-"ratio": 0.0817,
-"compress_mbps": null,
-"decompress_mbps": 20892.28
-},
-{
-"compressor": "native",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 1,
-"out_size": 3275124,
-"ratio": 0.5324,
-"compress_mbps": null,
-"decompress_mbps": 189.22
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 1,
-"out_size": 3275124,
-"ratio": 0.5324,
-"compress_mbps": null,
-"decompress_mbps": 288.74
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 1,
-"out_size": 3275124,
-"ratio": 0.5324,
-"compress_mbps": null,
-"decompress_mbps": 362.71
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 1,
-"out_size": 3275124,
-"ratio": 0.5324,
-"compress_mbps": null,
-"decompress_mbps": 595.26
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 1,
-"out_size": 3275124,
-"ratio": 0.5324,
-"compress_mbps": null,
-"decompress_mbps": 54240.43
-},
-{
-"compressor": "native",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 3,
-"out_size": 3137061,
-"ratio": 0.5099,
-"compress_mbps": null,
-"decompress_mbps": 166.83
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 3,
-"out_size": 3137061,
-"ratio": 0.5099,
-"compress_mbps": null,
-"decompress_mbps": 281.41
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 3,
-"out_size": 3137061,
-"ratio": 0.5099,
-"compress_mbps": null,
-"decompress_mbps": 320.89
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 3,
-"out_size": 3137061,
-"ratio": 0.5099,
-"compress_mbps": null,
-"decompress_mbps": 568.43
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 3,
-"out_size": 3137061,
-"ratio": 0.5099,
-"compress_mbps": null,
-"decompress_mbps": 61805.41
-},
-{
-"compressor": "native",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 6,
-"out_size": 3072378,
-"ratio": 0.4994,
-"compress_mbps": null,
-"decompress_mbps": 177.69
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 6,
-"out_size": 3072378,
-"ratio": 0.4994,
-"compress_mbps": null,
-"decompress_mbps": 285.25
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 6,
-"out_size": 3072378,
-"ratio": 0.4994,
-"compress_mbps": null,
-"decompress_mbps": 332.52
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 6,
-"out_size": 3072378,
-"ratio": 0.4994,
-"compress_mbps": null,
-"decompress_mbps": 586.43
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 6,
-"out_size": 3072378,
-"ratio": 0.4994,
-"compress_mbps": null,
-"decompress_mbps": 56277.28
-},
-{
-"compressor": "native",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 9,
-"out_size": 3066968,
-"ratio": 0.4985,
-"compress_mbps": null,
-"decompress_mbps": 182.24
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 9,
-"out_size": 3066968,
-"ratio": 0.4985,
-"compress_mbps": null,
-"decompress_mbps": 287.08
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 9,
-"out_size": 3066968,
-"ratio": 0.4985,
-"compress_mbps": null,
-"decompress_mbps": 339.03
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 9,
-"out_size": 3066968,
-"ratio": 0.4985,
-"compress_mbps": null,
-"decompress_mbps": 598.47
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 9,
-"out_size": 3066968,
-"ratio": 0.4985,
-"compress_mbps": null,
-"decompress_mbps": 62001.35
-},
-{
-"compressor": "native",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 12,
-"out_size": 2994086,
-"ratio": 0.4867,
-"compress_mbps": null,
-"decompress_mbps": 168.02
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 12,
-"out_size": 2994086,
-"ratio": 0.4867,
-"compress_mbps": null,
-"decompress_mbps": 283.71
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 12,
-"out_size": 2994086,
-"ratio": 0.4867,
-"compress_mbps": null,
-"decompress_mbps": 315.89
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 12,
-"out_size": 2994086,
-"ratio": 0.4867,
-"compress_mbps": null,
-"decompress_mbps": 570.95
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 12,
-"out_size": 2994086,
-"ratio": 0.4867,
-"compress_mbps": null,
-"decompress_mbps": 60421.69
-},
-{
-"compressor": "native",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 0,
-"out_size": 2992113,
-"ratio": 0.4863,
-"compress_mbps": null,
-"decompress_mbps": 172.65
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 0,
-"out_size": 2992113,
-"ratio": 0.4863,
-"compress_mbps": null,
-"decompress_mbps": 284.16
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 0,
-"out_size": 2992113,
-"ratio": 0.4863,
-"compress_mbps": null,
-"decompress_mbps": 316.59
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 0,
-"out_size": 2992113,
-"ratio": 0.4863,
-"compress_mbps": null,
-"decompress_mbps": 568.45
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 0,
-"out_size": 2992113,
-"ratio": 0.4863,
-"compress_mbps": null,
-"decompress_mbps": 63014.86
-},
-{
-"compressor": "native",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 1,
-"out_size": 3868663,
-"ratio": 0.3836,
-"compress_mbps": null,
-"decompress_mbps": 290.72
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 1,
-"out_size": 3868663,
-"ratio": 0.3836,
-"compress_mbps": null,
-"decompress_mbps": 528.35
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 1,
-"out_size": 3868663,
-"ratio": 0.3836,
-"compress_mbps": null,
-"decompress_mbps": 627.56
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 1,
-"out_size": 3868663,
-"ratio": 0.3836,
-"compress_mbps": null,
-"decompress_mbps": 1052.76
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 1,
-"out_size": 3868663,
-"ratio": 0.3836,
-"compress_mbps": null,
-"decompress_mbps": 56069.92
-},
-{
-"compressor": "native",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 3,
-"out_size": 3818964,
-"ratio": 0.3787,
-"compress_mbps": null,
-"decompress_mbps": 370.48
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 3,
-"out_size": 3818964,
-"ratio": 0.3787,
-"compress_mbps": null,
-"decompress_mbps": 552.62
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 3,
-"out_size": 3818964,
-"ratio": 0.3787,
-"compress_mbps": null,
-"decompress_mbps": 632.37
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 3,
-"out_size": 3818964,
-"ratio": 0.3787,
-"compress_mbps": null,
-"decompress_mbps": 1120.8
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 3,
-"out_size": 3818964,
-"ratio": 0.3787,
-"compress_mbps": null,
-"decompress_mbps": 43110.83
-},
-{
-"compressor": "native",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 6,
-"out_size": 3660266,
-"ratio": 0.3629,
-"compress_mbps": null,
-"decompress_mbps": 389.0
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 6,
-"out_size": 3660266,
-"ratio": 0.3629,
-"compress_mbps": null,
-"decompress_mbps": 559.81
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 6,
-"out_size": 3660266,
-"ratio": 0.3629,
-"compress_mbps": null,
-"decompress_mbps": 681.1
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 6,
-"out_size": 3660266,
-"ratio": 0.3629,
-"compress_mbps": null,
-"decompress_mbps": 1130.37
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 6,
-"out_size": 3660266,
-"ratio": 0.3629,
-"compress_mbps": null,
-"decompress_mbps": 44913.11
-},
-{
-"compressor": "native",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 9,
-"out_size": 3654860,
-"ratio": 0.3624,
-"compress_mbps": null,
-"decompress_mbps": 393.38
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 9,
-"out_size": 3654860,
-"ratio": 0.3624,
-"compress_mbps": null,
-"decompress_mbps": 560.44
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 9,
-"out_size": 3654860,
-"ratio": 0.3624,
-"compress_mbps": null,
-"decompress_mbps": 678.76
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 9,
-"out_size": 3654860,
-"ratio": 0.3624,
-"compress_mbps": null,
-"decompress_mbps": 1147.06
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 9,
-"out_size": 3654860,
-"ratio": 0.3624,
-"compress_mbps": null,
-"decompress_mbps": 55799.29
-},
-{
-"compressor": "native",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 12,
-"out_size": 3608138,
-"ratio": 0.3577,
-"compress_mbps": null,
-"decompress_mbps": 387.72
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 12,
-"out_size": 3608138,
-"ratio": 0.3577,
-"compress_mbps": null,
-"decompress_mbps": 564.45
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 12,
-"out_size": 3608138,
-"ratio": 0.3577,
-"compress_mbps": null,
-"decompress_mbps": 674.18
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 12,
-"out_size": 3608138,
-"ratio": 0.3577,
-"compress_mbps": null,
-"decompress_mbps": 1129.54
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 12,
-"out_size": 3608138,
-"ratio": 0.3577,
-"compress_mbps": null,
-"decompress_mbps": 43586.14
-},
-{
-"compressor": "native",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 0,
-"out_size": 3607217,
-"ratio": 0.3577,
-"compress_mbps": null,
-"decompress_mbps": 430.4
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 0,
-"out_size": 3607217,
-"ratio": 0.3577,
-"compress_mbps": null,
-"decompress_mbps": 583.93
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 0,
-"out_size": 3607217,
-"ratio": 0.3577,
-"compress_mbps": null,
-"decompress_mbps": 713.94
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 0,
-"out_size": 3607217,
-"ratio": 0.3577,
-"compress_mbps": null,
-"decompress_mbps": 1186.91
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 0,
-"out_size": 3607217,
-"ratio": 0.3577,
-"compress_mbps": null,
-"decompress_mbps": 57256.47
-},
-{
-"compressor": "native",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 1,
-"out_size": 2197055,
-"ratio": 0.3315,
-"compress_mbps": null,
-"decompress_mbps": 251.07
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 1,
-"out_size": 2197055,
-"ratio": 0.3315,
-"compress_mbps": null,
-"decompress_mbps": 441.44
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 1,
-"out_size": 2197055,
-"ratio": 0.3315,
-"compress_mbps": null,
-"decompress_mbps": 543.54
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 1,
-"out_size": 2197055,
-"ratio": 0.3315,
-"compress_mbps": null,
-"decompress_mbps": 1039.44
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 1,
-"out_size": 2197055,
-"ratio": 0.3315,
-"compress_mbps": null,
-"decompress_mbps": 63739.25
-},
-{
-"compressor": "native",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 3,
-"out_size": 2021047,
-"ratio": 0.305,
-"compress_mbps": null,
-"decompress_mbps": 308.35
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 3,
-"out_size": 2021047,
-"ratio": 0.305,
-"compress_mbps": null,
-"decompress_mbps": 474.83
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 3,
-"out_size": 2021047,
-"ratio": 0.305,
-"compress_mbps": null,
-"decompress_mbps": 585.17
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 3,
-"out_size": 2021047,
-"ratio": 0.305,
-"compress_mbps": null,
-"decompress_mbps": 1203.33
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 3,
-"out_size": 2021047,
-"ratio": 0.305,
-"compress_mbps": null,
-"decompress_mbps": 60506.36
-},
-{
-"compressor": "native",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 6,
-"out_size": 1876257,
-"ratio": 0.2831,
-"compress_mbps": null,
-"decompress_mbps": 314.5
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 6,
-"out_size": 1876257,
-"ratio": 0.2831,
-"compress_mbps": null,
-"decompress_mbps": 471.27
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 6,
-"out_size": 1876257,
-"ratio": 0.2831,
-"compress_mbps": null,
-"decompress_mbps": 551.05
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 6,
-"out_size": 1876257,
-"ratio": 0.2831,
-"compress_mbps": null,
-"decompress_mbps": 1122.74
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 6,
-"out_size": 1876257,
-"ratio": 0.2831,
-"compress_mbps": null,
-"decompress_mbps": 58024.94
-},
-{
-"compressor": "native",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 9,
-"out_size": 1806374,
-"ratio": 0.2726,
-"compress_mbps": null,
-"decompress_mbps": 322.32
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 9,
-"out_size": 1806374,
-"ratio": 0.2726,
-"compress_mbps": null,
-"decompress_mbps": 461.34
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 9,
-"out_size": 1806374,
-"ratio": 0.2726,
-"compress_mbps": null,
-"decompress_mbps": 528.49
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 9,
-"out_size": 1806374,
-"ratio": 0.2726,
-"compress_mbps": null,
-"decompress_mbps": 1040.33
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 9,
-"out_size": 1806374,
-"ratio": 0.2726,
-"compress_mbps": null,
-"decompress_mbps": 63713.54
-},
-{
-"compressor": "native",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 12,
-"out_size": 1696488,
-"ratio": 0.256,
-"compress_mbps": null,
-"decompress_mbps": 329.41
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 12,
-"out_size": 1696488,
-"ratio": 0.256,
-"compress_mbps": null,
-"decompress_mbps": 542.44
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 12,
-"out_size": 1696488,
-"ratio": 0.256,
-"compress_mbps": null,
-"decompress_mbps": 588.58
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 12,
-"out_size": 1696488,
-"ratio": 0.256,
-"compress_mbps": null,
-"decompress_mbps": 1202.13
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 12,
-"out_size": 1696488,
-"ratio": 0.256,
-"compress_mbps": null,
-"decompress_mbps": 61925.64
-},
-{
-"compressor": "native",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 0,
-"out_size": 1691994,
-"ratio": 0.2553,
-"compress_mbps": null,
-"decompress_mbps": 342.5
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 0,
-"out_size": 1691994,
-"ratio": 0.2553,
-"compress_mbps": null,
-"decompress_mbps": 550.91
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 0,
-"out_size": 1691994,
-"ratio": 0.2553,
-"compress_mbps": null,
-"decompress_mbps": 591.09
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 0,
-"out_size": 1691994,
-"ratio": 0.2553,
-"compress_mbps": null,
-"decompress_mbps": 1217.67
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 0,
-"out_size": 1691994,
-"ratio": 0.2553,
-"compress_mbps": null,
-"decompress_mbps": 63888.08
-},
-{
-"compressor": "native",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 1,
-"out_size": 5866517,
-"ratio": 0.2715,
-"compress_mbps": null,
-"decompress_mbps": 345.08
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 1,
-"out_size": 5866517,
-"ratio": 0.2715,
-"compress_mbps": null,
-"decompress_mbps": 569.12
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 1,
-"out_size": 5866517,
-"ratio": 0.2715,
-"compress_mbps": null,
-"decompress_mbps": 589.62
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 1,
-"out_size": 5866517,
-"ratio": 0.2715,
-"compress_mbps": null,
-"decompress_mbps": 1108.73
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 1,
-"out_size": 5866517,
-"ratio": 0.2715,
-"compress_mbps": null,
-"decompress_mbps": 18302.49
-},
-{
-"compressor": "native",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 3,
-"out_size": 5605878,
-"ratio": 0.2595,
-"compress_mbps": null,
-"decompress_mbps": 309.18
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 3,
-"out_size": 5605878,
-"ratio": 0.2595,
-"compress_mbps": null,
-"decompress_mbps": 580.87
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 3,
-"out_size": 5605878,
-"ratio": 0.2595,
-"compress_mbps": null,
-"decompress_mbps": 599.49
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 3,
-"out_size": 5605878,
-"ratio": 0.2595,
-"compress_mbps": null,
-"decompress_mbps": 1149.86
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 3,
-"out_size": 5605878,
-"ratio": 0.2595,
-"compress_mbps": null,
-"decompress_mbps": 18742.3
-},
-{
-"compressor": "native",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 6,
-"out_size": 5337149,
-"ratio": 0.247,
-"compress_mbps": null,
-"decompress_mbps": 330.69
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 6,
-"out_size": 5337149,
-"ratio": 0.247,
-"compress_mbps": null,
-"decompress_mbps": 525.01
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 6,
-"out_size": 5337149,
-"ratio": 0.247,
-"compress_mbps": null,
-"decompress_mbps": 529.93
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 6,
-"out_size": 5337149,
-"ratio": 0.247,
-"compress_mbps": null,
-"decompress_mbps": 1144.91
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 6,
-"out_size": 5337149,
-"ratio": 0.247,
-"compress_mbps": null,
-"decompress_mbps": 23571.57
-},
-{
-"compressor": "native",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 9,
-"out_size": 5270405,
-"ratio": 0.2439,
-"compress_mbps": null,
-"decompress_mbps": 341.57
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 9,
-"out_size": 5270405,
-"ratio": 0.2439,
-"compress_mbps": null,
-"decompress_mbps": 541.38
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 9,
-"out_size": 5270405,
-"ratio": 0.2439,
-"compress_mbps": null,
-"decompress_mbps": 546.71
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 9,
-"out_size": 5270405,
-"ratio": 0.2439,
-"compress_mbps": null,
-"decompress_mbps": 1114.48
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 9,
-"out_size": 5270405,
-"ratio": 0.2439,
-"compress_mbps": null,
-"decompress_mbps": 18431.51
-},
-{
-"compressor": "native",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 12,
-"out_size": 5118130,
-"ratio": 0.2369,
-"compress_mbps": null,
-"decompress_mbps": 284.7
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 12,
-"out_size": 5118130,
-"ratio": 0.2369,
-"compress_mbps": null,
-"decompress_mbps": 552.22
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 12,
-"out_size": 5118130,
-"ratio": 0.2369,
-"compress_mbps": null,
-"decompress_mbps": 541.51
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 12,
-"out_size": 5118130,
-"ratio": 0.2369,
-"compress_mbps": null,
-"decompress_mbps": 1136.41
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 12,
-"out_size": 5118130,
-"ratio": 0.2369,
-"compress_mbps": null,
-"decompress_mbps": 18844.78
-},
-{
-"compressor": "native",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 0,
-"out_size": 5107588,
-"ratio": 0.2364,
-"compress_mbps": null,
-"decompress_mbps": 390.88
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 0,
-"out_size": 5107588,
-"ratio": 0.2364,
-"compress_mbps": null,
-"decompress_mbps": 566.62
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 0,
-"out_size": 5107588,
-"ratio": 0.2364,
-"compress_mbps": null,
-"decompress_mbps": 564.78
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 0,
-"out_size": 5107588,
-"ratio": 0.2364,
-"compress_mbps": null,
-"decompress_mbps": 1188.56
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 0,
-"out_size": 5107588,
-"ratio": 0.2364,
-"compress_mbps": null,
-"decompress_mbps": 17894.82
-},
-{
-"compressor": "native",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 1,
-"out_size": 5575128,
-"ratio": 0.7688,
-"compress_mbps": null,
-"decompress_mbps": 193.34
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 1,
-"out_size": 5575128,
-"ratio": 0.7688,
-"compress_mbps": null,
-"decompress_mbps": 372.44
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 1,
-"out_size": 5575128,
-"ratio": 0.7688,
-"compress_mbps": null,
-"decompress_mbps": 396.87
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 1,
-"out_size": 5575128,
-"ratio": 0.7688,
-"compress_mbps": null,
-"decompress_mbps": 586.19
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 1,
-"out_size": 5575128,
-"ratio": 0.7688,
-"compress_mbps": null,
-"decompress_mbps": 61291.89
-},
-{
-"compressor": "native",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 3,
-"out_size": 5397999,
-"ratio": 0.7444,
-"compress_mbps": null,
-"decompress_mbps": 223.99
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 3,
-"out_size": 5397999,
-"ratio": 0.7444,
-"compress_mbps": null,
-"decompress_mbps": 373.92
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 3,
-"out_size": 5397999,
-"ratio": 0.7444,
-"compress_mbps": null,
-"decompress_mbps": 392.28
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 3,
-"out_size": 5397999,
-"ratio": 0.7444,
-"compress_mbps": null,
-"decompress_mbps": 587.58
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 3,
-"out_size": 5397999,
-"ratio": 0.7444,
-"compress_mbps": null,
-"decompress_mbps": 60086.3
-},
-{
-"compressor": "native",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 6,
-"out_size": 5335405,
-"ratio": 0.7357,
-"compress_mbps": null,
-"decompress_mbps": 223.13
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 6,
-"out_size": 5335405,
-"ratio": 0.7357,
-"compress_mbps": null,
-"decompress_mbps": 375.26
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 6,
-"out_size": 5335405,
-"ratio": 0.7357,
-"compress_mbps": null,
-"decompress_mbps": 387.08
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 6,
-"out_size": 5335405,
-"ratio": 0.7357,
-"compress_mbps": null,
-"decompress_mbps": 548.03
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 6,
-"out_size": 5335405,
-"ratio": 0.7357,
-"compress_mbps": null,
-"decompress_mbps": 33122.57
-},
-{
-"compressor": "native",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 9,
-"out_size": 5323197,
-"ratio": 0.734,
-"compress_mbps": null,
-"decompress_mbps": 225.16
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 9,
-"out_size": 5323197,
-"ratio": 0.734,
-"compress_mbps": null,
-"decompress_mbps": 378.59
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 9,
-"out_size": 5323197,
-"ratio": 0.734,
 "compress_mbps": null,
 "decompress_mbps": 384.34
 },
 {
+"compressor": "miniz_oxide",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 1,
+"out_size": 4217525,
+"ratio": 0.4138,
+"compress_mbps": null,
+"decompress_mbps": 452.69
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 1,
+"out_size": 4217525,
+"ratio": 0.4138,
+"compress_mbps": null,
+"decompress_mbps": 771.99
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 1,
+"out_size": 4217525,
+"ratio": 0.4138,
+"compress_mbps": null,
+"decompress_mbps": 45236.04
+},
+{
+"compressor": "native",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 3,
+"out_size": 3989875,
+"ratio": 0.3915,
+"compress_mbps": null,
+"decompress_mbps": 275.58
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 3,
+"out_size": 3989875,
+"ratio": 0.3915,
+"compress_mbps": null,
+"decompress_mbps": 389.74
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 3,
+"out_size": 3989875,
+"ratio": 0.3915,
+"compress_mbps": null,
+"decompress_mbps": 493.94
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 3,
+"out_size": 3989875,
+"ratio": 0.3915,
+"compress_mbps": null,
+"decompress_mbps": 867.29
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 3,
+"out_size": 3989875,
+"ratio": 0.3915,
+"compress_mbps": null,
+"decompress_mbps": 51506.33
+},
+{
+"compressor": "native",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 6,
+"out_size": 3859436,
+"ratio": 0.3787,
+"compress_mbps": null,
+"decompress_mbps": 266.76
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 6,
+"out_size": 3859436,
+"ratio": 0.3787,
+"compress_mbps": null,
+"decompress_mbps": 376.7
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 6,
+"out_size": 3859436,
+"ratio": 0.3787,
+"compress_mbps": null,
+"decompress_mbps": 471.35
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 6,
+"out_size": 3859436,
+"ratio": 0.3787,
+"compress_mbps": null,
+"decompress_mbps": 805.41
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 6,
+"out_size": 3859436,
+"ratio": 0.3787,
+"compress_mbps": null,
+"decompress_mbps": 45679.05
+},
+{
+"compressor": "native",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 9,
+"out_size": 3810354,
+"ratio": 0.3738,
+"compress_mbps": null,
+"decompress_mbps": 259.63
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 9,
+"out_size": 3810354,
+"ratio": 0.3738,
+"compress_mbps": null,
+"decompress_mbps": 372.24
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 9,
+"out_size": 3810354,
+"ratio": 0.3738,
+"compress_mbps": null,
+"decompress_mbps": 445.59
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 9,
+"out_size": 3810354,
+"ratio": 0.3738,
+"compress_mbps": null,
+"decompress_mbps": 738.11
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 9,
+"out_size": 3810354,
+"ratio": 0.3738,
+"compress_mbps": null,
+"decompress_mbps": 59005.88
+},
+{
+"compressor": "native",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 12,
+"out_size": 3679105,
+"ratio": 0.361,
+"compress_mbps": null,
+"decompress_mbps": 289.4
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 12,
+"out_size": 3679105,
+"ratio": 0.361,
+"compress_mbps": null,
+"decompress_mbps": 421.13
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 12,
+"out_size": 3679105,
+"ratio": 0.361,
+"compress_mbps": null,
+"decompress_mbps": 506.1
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 12,
+"out_size": 3679105,
+"ratio": 0.361,
+"compress_mbps": null,
+"decompress_mbps": 884.13
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 12,
+"out_size": 3679105,
+"ratio": 0.361,
+"compress_mbps": null,
+"decompress_mbps": 57824.7
+},
+{
+"compressor": "native",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 0,
+"out_size": 3673380,
+"ratio": 0.3604,
+"compress_mbps": null,
+"decompress_mbps": 269.33
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 0,
+"out_size": 3673380,
+"ratio": 0.3604,
+"compress_mbps": null,
+"decompress_mbps": 409.4
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 0,
+"out_size": 3673380,
+"ratio": 0.3604,
+"compress_mbps": null,
+"decompress_mbps": 474.29
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 0,
+"out_size": 3673380,
+"ratio": 0.3604,
+"compress_mbps": null,
+"decompress_mbps": 824.75
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 0,
+"out_size": 3673380,
+"ratio": 0.3604,
+"compress_mbps": null,
+"decompress_mbps": 48425.34
+},
+{
+"compressor": "native",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 1,
+"out_size": 20192961,
+"ratio": 0.3942,
+"compress_mbps": null,
+"decompress_mbps": 258.96
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 1,
+"out_size": 20192961,
+"ratio": 0.3942,
+"compress_mbps": null,
+"decompress_mbps": 375.75
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 1,
+"out_size": 20192961,
+"ratio": 0.3942,
+"compress_mbps": null,
+"decompress_mbps": 431.7
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 1,
+"out_size": 20192961,
+"ratio": 0.3942,
+"compress_mbps": null,
+"decompress_mbps": 747.62
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 1,
+"out_size": 20192961,
+"ratio": 0.3942,
+"compress_mbps": null,
+"decompress_mbps": 20782.48
+},
+{
+"compressor": "native",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 3,
+"out_size": 19234937,
+"ratio": 0.3755,
+"compress_mbps": null,
+"decompress_mbps": 193.78
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 3,
+"out_size": 19234937,
+"ratio": 0.3755,
+"compress_mbps": null,
+"decompress_mbps": 372.11
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 3,
+"out_size": 19234937,
+"ratio": 0.3755,
+"compress_mbps": null,
+"decompress_mbps": 399.24
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 3,
+"out_size": 19234937,
+"ratio": 0.3755,
+"compress_mbps": null,
+"decompress_mbps": 731.96
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 3,
+"out_size": 19234937,
+"ratio": 0.3755,
+"compress_mbps": null,
+"decompress_mbps": 20270.98
+},
+{
+"compressor": "native",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 6,
+"out_size": 18805391,
+"ratio": 0.3671,
+"compress_mbps": null,
+"decompress_mbps": 204.52
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 6,
+"out_size": 18805391,
+"ratio": 0.3671,
+"compress_mbps": null,
+"decompress_mbps": 379.47
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 6,
+"out_size": 18805391,
+"ratio": 0.3671,
+"compress_mbps": null,
+"decompress_mbps": 417.31
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 6,
+"out_size": 18805391,
+"ratio": 0.3671,
+"compress_mbps": null,
+"decompress_mbps": 761.06
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 6,
+"out_size": 18805391,
+"ratio": 0.3671,
+"compress_mbps": null,
+"decompress_mbps": 20489.57
+},
+{
+"compressor": "native",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 9,
+"out_size": 18713659,
+"ratio": 0.3654,
+"compress_mbps": null,
+"decompress_mbps": 205.76
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 9,
+"out_size": 18713659,
+"ratio": 0.3654,
+"compress_mbps": null,
+"decompress_mbps": 382.95
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 9,
+"out_size": 18713659,
+"ratio": 0.3654,
+"compress_mbps": null,
+"decompress_mbps": 422.91
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 9,
+"out_size": 18713659,
+"ratio": 0.3654,
+"compress_mbps": null,
+"decompress_mbps": 771.88
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 9,
+"out_size": 18713659,
+"ratio": 0.3654,
+"compress_mbps": null,
+"decompress_mbps": 20210.25
+},
+{
+"compressor": "native",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 12,
+"out_size": 18241312,
+"ratio": 0.3561,
+"compress_mbps": null,
+"decompress_mbps": 186.18
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 12,
+"out_size": 18241312,
+"ratio": 0.3561,
+"compress_mbps": null,
+"decompress_mbps": 381.47
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 12,
+"out_size": 18241312,
+"ratio": 0.3561,
+"compress_mbps": null,
+"decompress_mbps": 409.19
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 12,
+"out_size": 18241312,
+"ratio": 0.3561,
+"compress_mbps": null,
+"decompress_mbps": 756.68
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 12,
+"out_size": 18241312,
+"ratio": 0.3561,
+"compress_mbps": null,
+"decompress_mbps": 19852.99
+},
+{
+"compressor": "native",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 0,
+"out_size": 18317341,
+"ratio": 0.3576,
+"compress_mbps": null,
+"decompress_mbps": 257.73
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 0,
+"out_size": 18317341,
+"ratio": 0.3576,
+"compress_mbps": null,
+"decompress_mbps": 378.13
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 0,
+"out_size": 18317341,
+"ratio": 0.3576,
+"compress_mbps": null,
+"decompress_mbps": 407.94
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 0,
+"out_size": 18317341,
+"ratio": 0.3576,
+"compress_mbps": null,
+"decompress_mbps": 751.72
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 0,
+"out_size": 18317341,
+"ratio": 0.3576,
+"compress_mbps": null,
+"decompress_mbps": 20006.99
+},
+{
+"compressor": "native",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 1,
+"out_size": 3740775,
+"ratio": 0.3752,
+"compress_mbps": null,
+"decompress_mbps": 260.44
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 1,
+"out_size": 3740775,
+"ratio": 0.3752,
+"compress_mbps": null,
+"decompress_mbps": 428.28
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 1,
+"out_size": 3740775,
+"ratio": 0.3752,
+"compress_mbps": null,
+"decompress_mbps": 520.57
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 1,
+"out_size": 3740775,
+"ratio": 0.3752,
+"compress_mbps": null,
+"decompress_mbps": 805.07
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 1,
+"out_size": 3740775,
+"ratio": 0.3752,
+"compress_mbps": null,
+"decompress_mbps": 29833.65
+},
+{
+"compressor": "native",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 3,
+"out_size": 3672389,
+"ratio": 0.3683,
+"compress_mbps": null,
+"decompress_mbps": 276.83
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 3,
+"out_size": 3672389,
+"ratio": 0.3683,
+"compress_mbps": null,
+"decompress_mbps": 441.24
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 3,
+"out_size": 3672389,
+"ratio": 0.3683,
+"compress_mbps": null,
+"decompress_mbps": 530.08
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 3,
+"out_size": 3672389,
+"ratio": 0.3683,
+"compress_mbps": null,
+"decompress_mbps": 844.98
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 3,
+"out_size": 3672389,
+"ratio": 0.3683,
+"compress_mbps": null,
+"decompress_mbps": 32380.42
+},
+{
+"compressor": "native",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 6,
+"out_size": 3648644,
+"ratio": 0.3659,
+"compress_mbps": null,
+"decompress_mbps": 285.72
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 6,
+"out_size": 3648644,
+"ratio": 0.3659,
+"compress_mbps": null,
+"decompress_mbps": 429.48
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 6,
+"out_size": 3648644,
+"ratio": 0.3659,
+"compress_mbps": null,
+"decompress_mbps": 529.38
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 6,
+"out_size": 3648644,
+"ratio": 0.3659,
+"compress_mbps": null,
+"decompress_mbps": 886.99
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 6,
+"out_size": 3648644,
+"ratio": 0.3659,
+"compress_mbps": null,
+"decompress_mbps": 33095.97
+},
+{
+"compressor": "native",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 9,
+"out_size": 3625176,
+"ratio": 0.3636,
+"compress_mbps": null,
+"decompress_mbps": 288.49
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 9,
+"out_size": 3625176,
+"ratio": 0.3636,
+"compress_mbps": null,
+"decompress_mbps": 440.1
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 9,
+"out_size": 3625176,
+"ratio": 0.3636,
+"compress_mbps": null,
+"decompress_mbps": 513.6
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 9,
+"out_size": 3625176,
+"ratio": 0.3636,
+"compress_mbps": null,
+"decompress_mbps": 873.81
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 9,
+"out_size": 3625176,
+"ratio": 0.3636,
+"compress_mbps": null,
+"decompress_mbps": 37966.19
+},
+{
+"compressor": "native",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 12,
+"out_size": 3447985,
+"ratio": 0.3458,
+"compress_mbps": null,
+"decompress_mbps": 277.32
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 12,
+"out_size": 3447985,
+"ratio": 0.3458,
+"compress_mbps": null,
+"decompress_mbps": 479.4
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 12,
+"out_size": 3447985,
+"ratio": 0.3458,
+"compress_mbps": null,
+"decompress_mbps": 516.53
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 12,
+"out_size": 3447985,
+"ratio": 0.3458,
+"compress_mbps": null,
+"decompress_mbps": 871.36
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 12,
+"out_size": 3447985,
+"ratio": 0.3458,
+"compress_mbps": null,
+"decompress_mbps": 41555.43
+},
+{
+"compressor": "native",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 0,
+"out_size": 3450225,
+"ratio": 0.346,
+"compress_mbps": null,
+"decompress_mbps": 261.9
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 0,
+"out_size": 3450225,
+"ratio": 0.346,
+"compress_mbps": null,
+"decompress_mbps": 418.19
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 0,
+"out_size": 3450225,
+"ratio": 0.346,
+"compress_mbps": null,
+"decompress_mbps": 515.14
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 0,
+"out_size": 3450225,
+"ratio": 0.346,
+"compress_mbps": null,
+"decompress_mbps": 797.9
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 0,
+"out_size": 3450225,
+"ratio": 0.346,
+"compress_mbps": null,
+"decompress_mbps": 42070.97
+},
+{
+"compressor": "native",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 1,
+"out_size": 3837577,
+"ratio": 0.1144,
+"compress_mbps": null,
+"decompress_mbps": 619.7
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 1,
+"out_size": 3837577,
+"ratio": 0.1144,
+"compress_mbps": null,
+"decompress_mbps": 880.31
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 1,
+"out_size": 3837577,
+"ratio": 0.1144,
+"compress_mbps": null,
+"decompress_mbps": 871.41
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 1,
+"out_size": 3837577,
+"ratio": 0.1144,
+"compress_mbps": null,
+"decompress_mbps": 1797.33
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 1,
+"out_size": 3837577,
+"ratio": 0.1144,
+"compress_mbps": null,
+"decompress_mbps": 23936.65
+},
+{
+"compressor": "native",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 3,
+"out_size": 3599455,
+"ratio": 0.1073,
+"compress_mbps": null,
+"decompress_mbps": 718.96
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 3,
+"out_size": 3599455,
+"ratio": 0.1073,
+"compress_mbps": null,
+"decompress_mbps": 924.28
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 3,
+"out_size": 3599455,
+"ratio": 0.1073,
+"compress_mbps": null,
+"decompress_mbps": 909.55
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 3,
+"out_size": 3599455,
+"ratio": 0.1073,
+"compress_mbps": null,
+"decompress_mbps": 1779.21
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 3,
+"out_size": 3599455,
+"ratio": 0.1073,
+"compress_mbps": null,
+"decompress_mbps": 24509.74
+},
+{
+"compressor": "native",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 6,
+"out_size": 3091741,
+"ratio": 0.0921,
+"compress_mbps": null,
+"decompress_mbps": 862.11
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 6,
+"out_size": 3091741,
+"ratio": 0.0921,
+"compress_mbps": null,
+"decompress_mbps": 1013.54
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 6,
+"out_size": 3091741,
+"ratio": 0.0921,
+"compress_mbps": null,
+"decompress_mbps": 1061.55
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 6,
+"out_size": 3091741,
+"ratio": 0.0921,
+"compress_mbps": null,
+"decompress_mbps": 1857.37
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 6,
+"out_size": 3091741,
+"ratio": 0.0921,
+"compress_mbps": null,
+"decompress_mbps": 19291.31
+},
+{
+"compressor": "native",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 9,
+"out_size": 2925243,
+"ratio": 0.0872,
+"compress_mbps": null,
+"decompress_mbps": 964.84
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 9,
+"out_size": 2925243,
+"ratio": 0.0872,
+"compress_mbps": null,
+"decompress_mbps": 1070.49
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 9,
+"out_size": 2925243,
+"ratio": 0.0872,
+"compress_mbps": null,
+"decompress_mbps": 1105.9
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 9,
+"out_size": 2925243,
+"ratio": 0.0872,
+"compress_mbps": null,
+"decompress_mbps": 1914.11
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 9,
+"out_size": 2925243,
+"ratio": 0.0872,
+"compress_mbps": null,
+"decompress_mbps": 19045.79
+},
+{
+"compressor": "native",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 12,
+"out_size": 2748273,
+"ratio": 0.0819,
+"compress_mbps": null,
+"decompress_mbps": 856.67
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 12,
+"out_size": 2748273,
+"ratio": 0.0819,
+"compress_mbps": null,
+"decompress_mbps": 1096.42
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 12,
+"out_size": 2748273,
+"ratio": 0.0819,
+"compress_mbps": null,
+"decompress_mbps": 1121.74
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 12,
+"out_size": 2748273,
+"ratio": 0.0819,
+"compress_mbps": null,
+"decompress_mbps": 1957.22
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 12,
+"out_size": 2748273,
+"ratio": 0.0819,
+"compress_mbps": null,
+"decompress_mbps": 19529.84
+},
+{
+"compressor": "native",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 0,
+"out_size": 2740598,
+"ratio": 0.0817,
+"compress_mbps": null,
+"decompress_mbps": 1050.78
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 0,
+"out_size": 2740598,
+"ratio": 0.0817,
+"compress_mbps": null,
+"decompress_mbps": 1102.02
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 0,
+"out_size": 2740598,
+"ratio": 0.0817,
+"compress_mbps": null,
+"decompress_mbps": 1112.89
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 0,
+"out_size": 2740598,
+"ratio": 0.0817,
+"compress_mbps": null,
+"decompress_mbps": 1966.16
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 0,
+"out_size": 2740598,
+"ratio": 0.0817,
+"compress_mbps": null,
+"decompress_mbps": 19335.2
+},
+{
+"compressor": "native",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 1,
+"out_size": 3275124,
+"ratio": 0.5324,
+"compress_mbps": null,
+"decompress_mbps": 200.45
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 1,
+"out_size": 3275124,
+"ratio": 0.5324,
+"compress_mbps": null,
+"decompress_mbps": 283.72
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 1,
+"out_size": 3275124,
+"ratio": 0.5324,
+"compress_mbps": null,
+"decompress_mbps": 365.8
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 1,
+"out_size": 3275124,
+"ratio": 0.5324,
+"compress_mbps": null,
+"decompress_mbps": 574.34
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 1,
+"out_size": 3275124,
+"ratio": 0.5324,
+"compress_mbps": null,
+"decompress_mbps": 61942.44
+},
+{
+"compressor": "native",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 3,
+"out_size": 3137061,
+"ratio": 0.5099,
+"compress_mbps": null,
+"decompress_mbps": 176.34
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 3,
+"out_size": 3137061,
+"ratio": 0.5099,
+"compress_mbps": null,
+"decompress_mbps": 276.4
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 3,
+"out_size": 3137061,
+"ratio": 0.5099,
+"compress_mbps": null,
+"decompress_mbps": 329.07
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 3,
+"out_size": 3137061,
+"ratio": 0.5099,
+"compress_mbps": null,
+"decompress_mbps": 549.0
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 3,
+"out_size": 3137061,
+"ratio": 0.5099,
+"compress_mbps": null,
+"decompress_mbps": 62873.05
+},
+{
+"compressor": "native",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 6,
+"out_size": 3072378,
+"ratio": 0.4994,
+"compress_mbps": null,
+"decompress_mbps": 187.89
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 6,
+"out_size": 3072378,
+"ratio": 0.4994,
+"compress_mbps": null,
+"decompress_mbps": 281.11
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 6,
+"out_size": 3072378,
+"ratio": 0.4994,
+"compress_mbps": null,
+"decompress_mbps": 338.93
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 6,
+"out_size": 3072378,
+"ratio": 0.4994,
+"compress_mbps": null,
+"decompress_mbps": 571.01
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 6,
+"out_size": 3072378,
+"ratio": 0.4994,
+"compress_mbps": null,
+"decompress_mbps": 61513.17
+},
+{
+"compressor": "native",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 9,
+"out_size": 3066968,
+"ratio": 0.4985,
+"compress_mbps": null,
+"decompress_mbps": 192.01
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 9,
+"out_size": 3066968,
+"ratio": 0.4985,
+"compress_mbps": null,
+"decompress_mbps": 285.39
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 9,
+"out_size": 3066968,
+"ratio": 0.4985,
+"compress_mbps": null,
+"decompress_mbps": 345.6
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 9,
+"out_size": 3066968,
+"ratio": 0.4985,
+"compress_mbps": null,
+"decompress_mbps": 580.14
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 9,
+"out_size": 3066968,
+"ratio": 0.4985,
+"compress_mbps": null,
+"decompress_mbps": 63116.54
+},
+{
+"compressor": "native",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 12,
+"out_size": 2994086,
+"ratio": 0.4867,
+"compress_mbps": null,
+"decompress_mbps": 177.04
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 12,
+"out_size": 2994086,
+"ratio": 0.4867,
+"compress_mbps": null,
+"decompress_mbps": 277.42
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 12,
+"out_size": 2994086,
+"ratio": 0.4867,
+"compress_mbps": null,
+"decompress_mbps": 321.62
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 12,
+"out_size": 2994086,
+"ratio": 0.4867,
+"compress_mbps": null,
+"decompress_mbps": 554.92
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 12,
+"out_size": 2994086,
+"ratio": 0.4867,
+"compress_mbps": null,
+"decompress_mbps": 61994.14
+},
+{
+"compressor": "native",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 0,
+"out_size": 2992113,
+"ratio": 0.4863,
+"compress_mbps": null,
+"decompress_mbps": 181.06
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 0,
+"out_size": 2992113,
+"ratio": 0.4863,
+"compress_mbps": null,
+"decompress_mbps": 274.08
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 0,
+"out_size": 2992113,
+"ratio": 0.4863,
+"compress_mbps": null,
+"decompress_mbps": 322.14
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 0,
+"out_size": 2992113,
+"ratio": 0.4863,
+"compress_mbps": null,
+"decompress_mbps": 555.4
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 0,
+"out_size": 2992113,
+"ratio": 0.4863,
+"compress_mbps": null,
+"decompress_mbps": 50046.81
+},
+{
+"compressor": "native",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 1,
+"out_size": 3868663,
+"ratio": 0.3836,
+"compress_mbps": null,
+"decompress_mbps": 296.88
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 1,
+"out_size": 3868663,
+"ratio": 0.3836,
+"compress_mbps": null,
+"decompress_mbps": 516.65
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 1,
+"out_size": 3868663,
+"ratio": 0.3836,
+"compress_mbps": null,
+"decompress_mbps": 622.73
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 1,
+"out_size": 3868663,
+"ratio": 0.3836,
+"compress_mbps": null,
+"decompress_mbps": 1035.19
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 1,
+"out_size": 3868663,
+"ratio": 0.3836,
+"compress_mbps": null,
+"decompress_mbps": 44931.79
+},
+{
+"compressor": "native",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 3,
+"out_size": 3818964,
+"ratio": 0.3787,
+"compress_mbps": null,
+"decompress_mbps": 398.33
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 3,
+"out_size": 3818964,
+"ratio": 0.3787,
+"compress_mbps": null,
+"decompress_mbps": 537.68
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 3,
+"out_size": 3818964,
+"ratio": 0.3787,
+"compress_mbps": null,
+"decompress_mbps": 632.36
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 3,
+"out_size": 3818964,
+"ratio": 0.3787,
+"compress_mbps": null,
+"decompress_mbps": 1071.66
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 3,
+"out_size": 3818964,
+"ratio": 0.3787,
+"compress_mbps": null,
+"decompress_mbps": 47418.71
+},
+{
+"compressor": "native",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 6,
+"out_size": 3660266,
+"ratio": 0.3629,
+"compress_mbps": null,
+"decompress_mbps": 416.07
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 6,
+"out_size": 3660266,
+"ratio": 0.3629,
+"compress_mbps": null,
+"decompress_mbps": 546.64
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 6,
+"out_size": 3660266,
+"ratio": 0.3629,
+"compress_mbps": null,
+"decompress_mbps": 681.43
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 6,
+"out_size": 3660266,
+"ratio": 0.3629,
+"compress_mbps": null,
+"decompress_mbps": 1096.83
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 6,
+"out_size": 3660266,
+"ratio": 0.3629,
+"compress_mbps": null,
+"decompress_mbps": 58705.33
+},
+{
+"compressor": "native",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 9,
+"out_size": 3654860,
+"ratio": 0.3624,
+"compress_mbps": null,
+"decompress_mbps": 414.34
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 9,
+"out_size": 3654860,
+"ratio": 0.3624,
+"compress_mbps": null,
+"decompress_mbps": 547.62
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 9,
+"out_size": 3654860,
+"ratio": 0.3624,
+"compress_mbps": null,
+"decompress_mbps": 680.14
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 9,
+"out_size": 3654860,
+"ratio": 0.3624,
+"compress_mbps": null,
+"decompress_mbps": 1073.51
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 9,
+"out_size": 3654860,
+"ratio": 0.3624,
+"compress_mbps": null,
+"decompress_mbps": 43904.86
+},
+{
+"compressor": "native",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 12,
+"out_size": 3608138,
+"ratio": 0.3577,
+"compress_mbps": null,
+"decompress_mbps": 408.16
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 12,
+"out_size": 3608138,
+"ratio": 0.3577,
+"compress_mbps": null,
+"decompress_mbps": 552.67
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 12,
+"out_size": 3608138,
+"ratio": 0.3577,
+"compress_mbps": null,
+"decompress_mbps": 671.79
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 12,
+"out_size": 3608138,
+"ratio": 0.3577,
+"compress_mbps": null,
+"decompress_mbps": 1032.6
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 12,
+"out_size": 3608138,
+"ratio": 0.3577,
+"compress_mbps": null,
+"decompress_mbps": 44001.47
+},
+{
+"compressor": "native",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 0,
+"out_size": 3607217,
+"ratio": 0.3577,
+"compress_mbps": null,
+"decompress_mbps": 454.26
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 0,
+"out_size": 3607217,
+"ratio": 0.3577,
+"compress_mbps": null,
+"decompress_mbps": 564.5
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 0,
+"out_size": 3607217,
+"ratio": 0.3577,
+"compress_mbps": null,
+"decompress_mbps": 706.25
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 0,
+"out_size": 3607217,
+"ratio": 0.3577,
+"compress_mbps": null,
+"decompress_mbps": 1135.05
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 0,
+"out_size": 3607217,
+"ratio": 0.3577,
+"compress_mbps": null,
+"decompress_mbps": 57276.93
+},
+{
+"compressor": "native",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 1,
+"out_size": 2197055,
+"ratio": 0.3315,
+"compress_mbps": null,
+"decompress_mbps": 270.46
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 1,
+"out_size": 2197055,
+"ratio": 0.3315,
+"compress_mbps": null,
+"decompress_mbps": 426.89
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 1,
+"out_size": 2197055,
+"ratio": 0.3315,
+"compress_mbps": null,
+"decompress_mbps": 536.98
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 1,
+"out_size": 2197055,
+"ratio": 0.3315,
+"compress_mbps": null,
+"decompress_mbps": 1000.87
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 1,
+"out_size": 2197055,
+"ratio": 0.3315,
+"compress_mbps": null,
+"decompress_mbps": 62875.6
+},
+{
+"compressor": "native",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 3,
+"out_size": 2021047,
+"ratio": 0.305,
+"compress_mbps": null,
+"decompress_mbps": 335.49
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 3,
+"out_size": 2021047,
+"ratio": 0.305,
+"compress_mbps": null,
+"decompress_mbps": 465.55
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 3,
+"out_size": 2021047,
+"ratio": 0.305,
+"compress_mbps": null,
+"decompress_mbps": 588.55
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 3,
+"out_size": 2021047,
+"ratio": 0.305,
+"compress_mbps": null,
+"decompress_mbps": 1165.76
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 3,
+"out_size": 2021047,
+"ratio": 0.305,
+"compress_mbps": null,
+"decompress_mbps": 62576.16
+},
+{
+"compressor": "native",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 6,
+"out_size": 1876257,
+"ratio": 0.2831,
+"compress_mbps": null,
+"decompress_mbps": 335.92
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 6,
+"out_size": 1876257,
+"ratio": 0.2831,
+"compress_mbps": null,
+"decompress_mbps": 464.45
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 6,
+"out_size": 1876257,
+"ratio": 0.2831,
+"compress_mbps": null,
+"decompress_mbps": 558.16
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 6,
+"out_size": 1876257,
+"ratio": 0.2831,
+"compress_mbps": null,
+"decompress_mbps": 1067.72
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 6,
+"out_size": 1876257,
+"ratio": 0.2831,
+"compress_mbps": null,
+"decompress_mbps": 63057.52
+},
+{
+"compressor": "native",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 9,
+"out_size": 1806374,
+"ratio": 0.2726,
+"compress_mbps": null,
+"decompress_mbps": 340.88
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 9,
+"out_size": 1806374,
+"ratio": 0.2726,
+"compress_mbps": null,
+"decompress_mbps": 453.49
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 9,
+"out_size": 1806374,
+"ratio": 0.2726,
+"compress_mbps": null,
+"decompress_mbps": 527.59
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 9,
+"out_size": 1806374,
+"ratio": 0.2726,
+"compress_mbps": null,
+"decompress_mbps": 987.97
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 9,
+"out_size": 1806374,
+"ratio": 0.2726,
+"compress_mbps": null,
+"decompress_mbps": 59840.67
+},
+{
+"compressor": "native",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 12,
+"out_size": 1696488,
+"ratio": 0.256,
+"compress_mbps": null,
+"decompress_mbps": 352.76
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 12,
+"out_size": 1696488,
+"ratio": 0.256,
+"compress_mbps": null,
+"decompress_mbps": 532.13
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 12,
+"out_size": 1696488,
+"ratio": 0.256,
+"compress_mbps": null,
+"decompress_mbps": 593.99
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 12,
+"out_size": 1696488,
+"ratio": 0.256,
+"compress_mbps": null,
+"decompress_mbps": 1146.66
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 12,
+"out_size": 1696488,
+"ratio": 0.256,
+"compress_mbps": null,
+"decompress_mbps": 62495.72
+},
+{
+"compressor": "native",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 0,
+"out_size": 1691994,
+"ratio": 0.2553,
+"compress_mbps": null,
+"decompress_mbps": 367.62
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 0,
+"out_size": 1691994,
+"ratio": 0.2553,
+"compress_mbps": null,
+"decompress_mbps": 536.37
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 0,
+"out_size": 1691994,
+"ratio": 0.2553,
+"compress_mbps": null,
+"decompress_mbps": 594.2
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 0,
+"out_size": 1691994,
+"ratio": 0.2553,
+"compress_mbps": null,
+"decompress_mbps": 1171.68
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 0,
+"out_size": 1691994,
+"ratio": 0.2553,
+"compress_mbps": null,
+"decompress_mbps": 59552.54
+},
+{
+"compressor": "native",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 1,
+"out_size": 5866517,
+"ratio": 0.2715,
+"compress_mbps": null,
+"decompress_mbps": 367.84
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 1,
+"out_size": 5866517,
+"ratio": 0.2715,
+"compress_mbps": null,
+"decompress_mbps": 554.28
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 1,
+"out_size": 5866517,
+"ratio": 0.2715,
+"compress_mbps": null,
+"decompress_mbps": 672.14
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 1,
+"out_size": 5866517,
+"ratio": 0.2715,
+"compress_mbps": null,
+"decompress_mbps": 1076.1
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 1,
+"out_size": 5866517,
+"ratio": 0.2715,
+"compress_mbps": null,
+"decompress_mbps": 20019.19
+},
+{
+"compressor": "native",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 3,
+"out_size": 5605878,
+"ratio": 0.2595,
+"compress_mbps": null,
+"decompress_mbps": 325.1
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 3,
+"out_size": 5605878,
+"ratio": 0.2595,
+"compress_mbps": null,
+"decompress_mbps": 568.49
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 3,
+"out_size": 5605878,
+"ratio": 0.2595,
+"compress_mbps": null,
+"decompress_mbps": 674.87
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 3,
+"out_size": 5605878,
+"ratio": 0.2595,
+"compress_mbps": null,
+"decompress_mbps": 1117.25
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 3,
+"out_size": 5605878,
+"ratio": 0.2595,
+"compress_mbps": null,
+"decompress_mbps": 19701.17
+},
+{
+"compressor": "native",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 6,
+"out_size": 5337149,
+"ratio": 0.247,
+"compress_mbps": null,
+"decompress_mbps": 349.48
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 6,
+"out_size": 5337149,
+"ratio": 0.247,
+"compress_mbps": null,
+"decompress_mbps": 518.84
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 6,
+"out_size": 5337149,
+"ratio": 0.247,
+"compress_mbps": null,
+"decompress_mbps": 507.58
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 6,
+"out_size": 5337149,
+"ratio": 0.247,
+"compress_mbps": null,
+"decompress_mbps": 1020.39
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 6,
+"out_size": 5337149,
+"ratio": 0.247,
+"compress_mbps": null,
+"decompress_mbps": 17972.65
+},
+{
+"compressor": "native",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 9,
+"out_size": 5270405,
+"ratio": 0.2439,
+"compress_mbps": null,
+"decompress_mbps": 345.44
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 9,
+"out_size": 5270405,
+"ratio": 0.2439,
+"compress_mbps": null,
+"decompress_mbps": 499.83
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 9,
+"out_size": 5270405,
+"ratio": 0.2439,
+"compress_mbps": null,
+"decompress_mbps": 508.68
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 9,
+"out_size": 5270405,
+"ratio": 0.2439,
+"compress_mbps": null,
+"decompress_mbps": 1027.54
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 9,
+"out_size": 5270405,
+"ratio": 0.2439,
+"compress_mbps": null,
+"decompress_mbps": 17766.7
+},
+{
+"compressor": "native",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 12,
+"out_size": 5118130,
+"ratio": 0.2369,
+"compress_mbps": null,
+"decompress_mbps": 296.63
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 12,
+"out_size": 5118130,
+"ratio": 0.2369,
+"compress_mbps": null,
+"decompress_mbps": 600.53
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 12,
+"out_size": 5118130,
+"ratio": 0.2369,
+"compress_mbps": null,
+"decompress_mbps": 653.51
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 12,
+"out_size": 5118130,
+"ratio": 0.2369,
+"compress_mbps": null,
+"decompress_mbps": 1078.57
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 12,
+"out_size": 5118130,
+"ratio": 0.2369,
+"compress_mbps": null,
+"decompress_mbps": 18380.64
+},
+{
+"compressor": "native",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 0,
+"out_size": 5107588,
+"ratio": 0.2364,
+"compress_mbps": null,
+"decompress_mbps": 410.16
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 0,
+"out_size": 5107588,
+"ratio": 0.2364,
+"compress_mbps": null,
+"decompress_mbps": 548.7
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 0,
+"out_size": 5107588,
+"ratio": 0.2364,
+"compress_mbps": null,
+"decompress_mbps": 562.89
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 0,
+"out_size": 5107588,
+"ratio": 0.2364,
+"compress_mbps": null,
+"decompress_mbps": 1082.31
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 0,
+"out_size": 5107588,
+"ratio": 0.2364,
+"compress_mbps": null,
+"decompress_mbps": 18860.15
+},
+{
+"compressor": "native",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 1,
+"out_size": 5575128,
+"ratio": 0.7688,
+"compress_mbps": null,
+"decompress_mbps": 200.37
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 1,
+"out_size": 5575128,
+"ratio": 0.7688,
+"compress_mbps": null,
+"decompress_mbps": 371.14
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 1,
+"out_size": 5575128,
+"ratio": 0.7688,
+"compress_mbps": null,
+"decompress_mbps": 392.6
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 1,
+"out_size": 5575128,
+"ratio": 0.7688,
+"compress_mbps": null,
+"decompress_mbps": 548.11
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 1,
+"out_size": 5575128,
+"ratio": 0.7688,
+"compress_mbps": null,
+"decompress_mbps": 60270.09
+},
+{
+"compressor": "native",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 3,
+"out_size": 5397999,
+"ratio": 0.7444,
+"compress_mbps": null,
+"decompress_mbps": 232.61
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 3,
+"out_size": 5397999,
+"ratio": 0.7444,
+"compress_mbps": null,
+"decompress_mbps": 370.2
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 3,
+"out_size": 5397999,
+"ratio": 0.7444,
+"compress_mbps": null,
+"decompress_mbps": 386.76
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 3,
+"out_size": 5397999,
+"ratio": 0.7444,
+"compress_mbps": null,
+"decompress_mbps": 549.59
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 3,
+"out_size": 5397999,
+"ratio": 0.7444,
+"compress_mbps": null,
+"decompress_mbps": 61515.41
+},
+{
+"compressor": "native",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 6,
+"out_size": 5335405,
+"ratio": 0.7357,
+"compress_mbps": null,
+"decompress_mbps": 238.72
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 6,
+"out_size": 5335405,
+"ratio": 0.7357,
+"compress_mbps": null,
+"decompress_mbps": 369.77
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 6,
+"out_size": 5335405,
+"ratio": 0.7357,
+"compress_mbps": null,
+"decompress_mbps": 386.75
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 6,
+"out_size": 5335405,
+"ratio": 0.7357,
+"compress_mbps": null,
+"decompress_mbps": 534.98
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 6,
+"out_size": 5335405,
+"ratio": 0.7357,
+"compress_mbps": null,
+"decompress_mbps": 36664.53
+},
+{
+"compressor": "native",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 9,
+"out_size": 5323197,
+"ratio": 0.734,
+"compress_mbps": null,
+"decompress_mbps": 238.94
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 9,
+"out_size": 5323197,
+"ratio": 0.734,
+"compress_mbps": null,
+"decompress_mbps": 369.1
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 9,
+"out_size": 5323197,
+"ratio": 0.734,
+"compress_mbps": null,
+"decompress_mbps": 381.4
+},
+{
 "compressor": "libdeflate",
 "pattern": "silesia/sao",
 "size": 7251944,
@@ -2595,7 +2595,7 @@
 "out_size": 5323197,
 "ratio": 0.734,
 "compress_mbps": null,
-"decompress_mbps": 573.88
+"decompress_mbps": 517.97
 },
 {
 "compressor": "memcpy",
@@ -2605,7 +2605,7 @@
 "out_size": 5323197,
 "ratio": 0.734,
 "compress_mbps": null,
-"decompress_mbps": 62523.67
+"decompress_mbps": 59241.18
 },
 {
 "compressor": "native",
@@ -2615,7 +2615,7 @@
 "out_size": 5250745,
 "ratio": 0.724,
 "compress_mbps": null,
-"decompress_mbps": 223.99
+"decompress_mbps": 240.85
 },
 {
 "compressor": "zlib",
@@ -2625,7 +2625,7 @@
 "out_size": 5250745,
 "ratio": 0.724,
 "compress_mbps": null,
-"decompress_mbps": 379.64
+"decompress_mbps": 375.45
 },
 {
 "compressor": "miniz_oxide",
@@ -2635,7 +2635,7 @@
 "out_size": 5250745,
 "ratio": 0.724,
 "compress_mbps": null,
-"decompress_mbps": 395.24
+"decompress_mbps": 394.48
 },
 {
 "compressor": "libdeflate",
@@ -2645,7 +2645,7 @@
 "out_size": 5250745,
 "ratio": 0.724,
 "compress_mbps": null,
-"decompress_mbps": 594.28
+"decompress_mbps": 572.56
 },
 {
 "compressor": "memcpy",
@@ -2655,7 +2655,7 @@
 "out_size": 5250745,
 "ratio": 0.724,
 "compress_mbps": null,
-"decompress_mbps": 58927.72
+"decompress_mbps": 59170.22
 },
 {
 "compressor": "native",
@@ -2665,7 +2665,7 @@
 "out_size": 5242394,
 "ratio": 0.7229,
 "compress_mbps": null,
-"decompress_mbps": 194.04
+"decompress_mbps": 203.06
 },
 {
 "compressor": "zlib",
@@ -2675,7 +2675,7 @@
 "out_size": 5242394,
 "ratio": 0.7229,
 "compress_mbps": null,
-"decompress_mbps": 375.76
+"decompress_mbps": 370.08
 },
 {
 "compressor": "miniz_oxide",
@@ -2685,7 +2685,7 @@
 "out_size": 5242394,
 "ratio": 0.7229,
 "compress_mbps": null,
-"decompress_mbps": 386.13
+"decompress_mbps": 386.9
 },
 {
 "compressor": "libdeflate",
@@ -2695,7 +2695,7 @@
 "out_size": 5242394,
 "ratio": 0.7229,
 "compress_mbps": null,
-"decompress_mbps": 583.79
+"decompress_mbps": 553.85
 },
 {
 "compressor": "memcpy",
@@ -2705,7 +2705,7 @@
 "out_size": 5242394,
 "ratio": 0.7229,
 "compress_mbps": null,
-"decompress_mbps": 60747.07
+"decompress_mbps": 61630.53
 },
 {
 "compressor": "native",
@@ -2715,7 +2715,7 @@
 "out_size": 13550569,
 "ratio": 0.3268,
 "compress_mbps": null,
-"decompress_mbps": 258.08
+"decompress_mbps": 273.32
 },
 {
 "compressor": "zlib",
@@ -2725,7 +2725,7 @@
 "out_size": 13550569,
 "ratio": 0.3268,
 "compress_mbps": null,
-"decompress_mbps": 396.55
+"decompress_mbps": 378.95
 },
 {
 "compressor": "miniz_oxide",
@@ -2735,7 +2735,7 @@
 "out_size": 13550569,
 "ratio": 0.3268,
 "compress_mbps": null,
-"decompress_mbps": 436.66
+"decompress_mbps": 430.31
 },
 {
 "compressor": "libdeflate",
@@ -2745,7 +2745,7 @@
 "out_size": 13550569,
 "ratio": 0.3268,
 "compress_mbps": null,
-"decompress_mbps": 876.73
+"decompress_mbps": 827.95
 },
 {
 "compressor": "memcpy",
@@ -2755,7 +2755,7 @@
 "out_size": 13550569,
 "ratio": 0.3268,
 "compress_mbps": null,
-"decompress_mbps": 19741.63
+"decompress_mbps": 22564.73
 },
 {
 "compressor": "native",
@@ -2765,7 +2765,7 @@
 "out_size": 12839361,
 "ratio": 0.3097,
 "compress_mbps": null,
-"decompress_mbps": 308.27
+"decompress_mbps": 329.33
 },
 {
 "compressor": "zlib",
@@ -2775,7 +2775,7 @@
 "out_size": 12839361,
 "ratio": 0.3097,
 "compress_mbps": null,
-"decompress_mbps": 408.68
+"decompress_mbps": 388.38
 },
 {
 "compressor": "miniz_oxide",
@@ -2785,7 +2785,7 @@
 "out_size": 12839361,
 "ratio": 0.3097,
 "compress_mbps": null,
-"decompress_mbps": 470.96
+"decompress_mbps": 445.09
 },
 {
 "compressor": "libdeflate",
@@ -2795,7 +2795,7 @@
 "out_size": 12839361,
 "ratio": 0.3097,
 "compress_mbps": null,
-"decompress_mbps": 951.99
+"decompress_mbps": 868.93
 },
 {
 "compressor": "memcpy",
@@ -2805,7 +2805,7 @@
 "out_size": 12839361,
 "ratio": 0.3097,
 "compress_mbps": null,
-"decompress_mbps": 19760.1
+"decompress_mbps": 21910.52
 },
 {
 "compressor": "native",
@@ -2815,7 +2815,7 @@
 "out_size": 12140474,
 "ratio": 0.2928,
 "compress_mbps": null,
-"decompress_mbps": 316.97
+"decompress_mbps": 335.16
 },
 {
 "compressor": "zlib",
@@ -2825,7 +2825,7 @@
 "out_size": 12140474,
 "ratio": 0.2928,
 "compress_mbps": null,
-"decompress_mbps": 409.33
+"decompress_mbps": 383.88
 },
 {
 "compressor": "miniz_oxide",
@@ -2835,7 +2835,7 @@
 "out_size": 12140474,
 "ratio": 0.2928,
 "compress_mbps": null,
-"decompress_mbps": 479.43
+"decompress_mbps": 463.36
 },
 {
 "compressor": "libdeflate",
@@ -2845,7 +2845,7 @@
 "out_size": 12140474,
 "ratio": 0.2928,
 "compress_mbps": null,
-"decompress_mbps": 910.53
+"decompress_mbps": 823.91
 },
 {
 "compressor": "memcpy",
@@ -2855,7 +2855,7 @@
 "out_size": 12140474,
 "ratio": 0.2928,
 "compress_mbps": null,
-"decompress_mbps": 19839.84
+"decompress_mbps": 19893.71
 },
 {
 "compressor": "native",
@@ -2865,7 +2865,7 @@
 "out_size": 11882496,
 "ratio": 0.2866,
 "compress_mbps": null,
-"decompress_mbps": 320.08
+"decompress_mbps": 336.19
 },
 {
 "compressor": "zlib",
@@ -2875,7 +2875,7 @@
 "out_size": 11882496,
 "ratio": 0.2866,
 "compress_mbps": null,
-"decompress_mbps": 412.85
+"decompress_mbps": 385.11
 },
 {
 "compressor": "miniz_oxide",
@@ -2885,7 +2885,7 @@
 "out_size": 11882496,
 "ratio": 0.2866,
 "compress_mbps": null,
-"decompress_mbps": 470.99
+"decompress_mbps": 469.7
 },
 {
 "compressor": "libdeflate",
@@ -2895,7 +2895,7 @@
 "out_size": 11882496,
 "ratio": 0.2866,
 "compress_mbps": null,
-"decompress_mbps": 874.55
+"decompress_mbps": 710.18
 },
 {
 "compressor": "memcpy",
@@ -2905,7 +2905,7 @@
 "out_size": 11882496,
 "ratio": 0.2866,
 "compress_mbps": null,
-"decompress_mbps": 19671.38
+"decompress_mbps": 19681.49
 },
 {
 "compressor": "native",
@@ -2915,7 +2915,7 @@
 "out_size": 11520871,
 "ratio": 0.2779,
 "compress_mbps": null,
-"decompress_mbps": 320.97
+"decompress_mbps": 344.02
 },
 {
 "compressor": "zlib",
@@ -2925,7 +2925,7 @@
 "out_size": 11520871,
 "ratio": 0.2779,
 "compress_mbps": null,
-"decompress_mbps": 431.43
+"decompress_mbps": 386.52
 },
 {
 "compressor": "miniz_oxide",
@@ -2935,7 +2935,7 @@
 "out_size": 11520871,
 "ratio": 0.2779,
 "compress_mbps": null,
-"decompress_mbps": 487.96
+"decompress_mbps": 463.33
 },
 {
 "compressor": "libdeflate",
@@ -2945,7 +2945,7 @@
 "out_size": 11520871,
 "ratio": 0.2779,
 "compress_mbps": null,
-"decompress_mbps": 922.51
+"decompress_mbps": 788.83
 },
 {
 "compressor": "memcpy",
@@ -2955,7 +2955,7 @@
 "out_size": 11520871,
 "ratio": 0.2779,
 "compress_mbps": null,
-"decompress_mbps": 19881.89
+"decompress_mbps": 20010.17
 },
 {
 "compressor": "native",
@@ -2965,7 +2965,7 @@
 "out_size": 11518290,
 "ratio": 0.2778,
 "compress_mbps": null,
-"decompress_mbps": 331.81
+"decompress_mbps": 356.9
 },
 {
 "compressor": "zlib",
@@ -2975,7 +2975,7 @@
 "out_size": 11518290,
 "ratio": 0.2778,
 "compress_mbps": null,
-"decompress_mbps": 435.19
+"decompress_mbps": 409.57
 },
 {
 "compressor": "miniz_oxide",
@@ -2985,7 +2985,7 @@
 "out_size": 11518290,
 "ratio": 0.2778,
 "compress_mbps": null,
-"decompress_mbps": 492.86
+"decompress_mbps": 473.72
 },
 {
 "compressor": "libdeflate",
@@ -2995,7 +2995,7 @@
 "out_size": 11518290,
 "ratio": 0.2778,
 "compress_mbps": null,
-"decompress_mbps": 922.14
+"decompress_mbps": 829.58
 },
 {
 "compressor": "memcpy",
@@ -3005,7 +3005,7 @@
 "out_size": 11518290,
 "ratio": 0.2778,
 "compress_mbps": null,
-"decompress_mbps": 19838.44
+"decompress_mbps": 19889.91
 },
 {
 "compressor": "native",
@@ -3015,7 +3015,7 @@
 "out_size": 6293390,
 "ratio": 0.7426,
 "compress_mbps": null,
-"decompress_mbps": 191.39
+"decompress_mbps": 199.12
 },
 {
 "compressor": "zlib",
@@ -3025,7 +3025,7 @@
 "out_size": 6293390,
 "ratio": 0.7426,
 "compress_mbps": null,
-"decompress_mbps": 331.92
+"decompress_mbps": 326.36
 },
 {
 "compressor": "miniz_oxide",
@@ -3035,7 +3035,7 @@
 "out_size": 6293390,
 "ratio": 0.7426,
 "compress_mbps": null,
-"decompress_mbps": 355.1
+"decompress_mbps": 353.39
 },
 {
 "compressor": "libdeflate",
@@ -3045,7 +3045,7 @@
 "out_size": 6293390,
 "ratio": 0.7426,
 "compress_mbps": null,
-"decompress_mbps": 508.67
+"decompress_mbps": 497.24
 },
 {
 "compressor": "memcpy",
@@ -3055,7 +3055,7 @@
 "out_size": 6293390,
 "ratio": 0.7426,
 "compress_mbps": null,
-"decompress_mbps": 33420.31
+"decompress_mbps": 61170.98
 },
 {
 "compressor": "native",
@@ -3065,7 +3065,7 @@
 "out_size": 6058381,
 "ratio": 0.7149,
 "compress_mbps": null,
-"decompress_mbps": 154.69
+"decompress_mbps": 164.31
 },
 {
 "compressor": "zlib",
@@ -3075,7 +3075,7 @@
 "out_size": 6058381,
 "ratio": 0.7149,
 "compress_mbps": null,
-"decompress_mbps": 278.45
+"decompress_mbps": 273.78
 },
 {
 "compressor": "miniz_oxide",
@@ -3085,7 +3085,7 @@
 "out_size": 6058381,
 "ratio": 0.7149,
 "compress_mbps": null,
-"decompress_mbps": 297.68
+"decompress_mbps": 298.1
 },
 {
 "compressor": "libdeflate",
@@ -3095,7 +3095,7 @@
 "out_size": 6058381,
 "ratio": 0.7149,
 "compress_mbps": null,
-"decompress_mbps": 473.4
+"decompress_mbps": 434.26
 },
 {
 "compressor": "memcpy",
@@ -3105,7 +3105,7 @@
 "out_size": 6058381,
 "ratio": 0.7149,
 "compress_mbps": null,
-"decompress_mbps": 46919.59
+"decompress_mbps": 57702.27
 },
 {
 "compressor": "native",
@@ -3115,7 +3115,7 @@
 "out_size": 5998438,
 "ratio": 0.7078,
 "compress_mbps": null,
-"decompress_mbps": 164.78
+"decompress_mbps": 178.44
 },
 {
 "compressor": "zlib",
@@ -3125,7 +3125,7 @@
 "out_size": 5998438,
 "ratio": 0.7078,
 "compress_mbps": null,
-"decompress_mbps": 320.69
+"decompress_mbps": 315.4
 },
 {
 "compressor": "miniz_oxide",
@@ -3135,7 +3135,7 @@
 "out_size": 5998438,
 "ratio": 0.7078,
 "compress_mbps": null,
-"decompress_mbps": 319.99
+"decompress_mbps": 318.77
 },
 {
 "compressor": "libdeflate",
@@ -3145,7 +3145,7 @@
 "out_size": 5998438,
 "ratio": 0.7078,
 "compress_mbps": null,
-"decompress_mbps": 531.62
+"decompress_mbps": 503.76
 },
 {
 "compressor": "memcpy",
@@ -3155,7 +3155,7 @@
 "out_size": 5998438,
 "ratio": 0.7078,
 "compress_mbps": null,
-"decompress_mbps": 49058.58
+"decompress_mbps": 61161.72
 },
 {
 "compressor": "native",
@@ -3165,7 +3165,7 @@
 "out_size": 5986859,
 "ratio": 0.7065,
 "compress_mbps": null,
-"decompress_mbps": 163.67
+"decompress_mbps": 177.66
 },
 {
 "compressor": "zlib",
@@ -3175,7 +3175,7 @@
 "out_size": 5986859,
 "ratio": 0.7065,
 "compress_mbps": null,
-"decompress_mbps": 313.9
+"decompress_mbps": 308.52
 },
 {
 "compressor": "miniz_oxide",
@@ -3185,7 +3185,7 @@
 "out_size": 5986859,
 "ratio": 0.7065,
 "compress_mbps": null,
-"decompress_mbps": 311.49
+"decompress_mbps": 311.7
 },
 {
 "compressor": "libdeflate",
@@ -3195,7 +3195,7 @@
 "out_size": 5986859,
 "ratio": 0.7065,
 "compress_mbps": null,
-"decompress_mbps": 517.43
+"decompress_mbps": 484.06
 },
 {
 "compressor": "memcpy",
@@ -3205,7 +3205,7 @@
 "out_size": 5986859,
 "ratio": 0.7065,
 "compress_mbps": null,
-"decompress_mbps": 55256.6
+"decompress_mbps": 58437.45
 },
 {
 "compressor": "native",
@@ -3215,7 +3215,7 @@
 "out_size": 5747146,
 "ratio": 0.6782,
 "compress_mbps": null,
-"decompress_mbps": 165.33
+"decompress_mbps": 179.69
 },
 {
 "compressor": "zlib",
@@ -3225,7 +3225,7 @@
 "out_size": 5747146,
 "ratio": 0.6782,
 "compress_mbps": null,
-"decompress_mbps": 299.81
+"decompress_mbps": 295.16
 },
 {
 "compressor": "miniz_oxide",
@@ -3235,7 +3235,7 @@
 "out_size": 5747146,
 "ratio": 0.6782,
 "compress_mbps": null,
-"decompress_mbps": 326.81
+"decompress_mbps": 329.87
 },
 {
 "compressor": "libdeflate",
@@ -3245,7 +3245,7 @@
 "out_size": 5747146,
 "ratio": 0.6782,
 "compress_mbps": null,
-"decompress_mbps": 570.62
+"decompress_mbps": 535.78
 },
 {
 "compressor": "memcpy",
@@ -3255,7 +3255,7 @@
 "out_size": 5747146,
 "ratio": 0.6782,
 "compress_mbps": null,
-"decompress_mbps": 59766.35
+"decompress_mbps": 34730.72
 },
 {
 "compressor": "native",
@@ -3265,7 +3265,7 @@
 "out_size": 5744697,
 "ratio": 0.6779,
 "compress_mbps": null,
-"decompress_mbps": 162.12
+"decompress_mbps": 171.78
 },
 {
 "compressor": "zlib",
@@ -3275,7 +3275,7 @@
 "out_size": 5744697,
 "ratio": 0.6779,
 "compress_mbps": null,
-"decompress_mbps": 290.28
+"decompress_mbps": 286.29
 },
 {
 "compressor": "miniz_oxide",
@@ -3285,7 +3285,7 @@
 "out_size": 5744697,
 "ratio": 0.6779,
 "compress_mbps": null,
-"decompress_mbps": 324.3
+"decompress_mbps": 326.24
 },
 {
 "compressor": "libdeflate",
@@ -3295,7 +3295,7 @@
 "out_size": 5744697,
 "ratio": 0.6779,
 "compress_mbps": null,
-"decompress_mbps": 567.36
+"decompress_mbps": 545.7
 },
 {
 "compressor": "memcpy",
@@ -3305,7 +3305,7 @@
 "out_size": 5744697,
 "ratio": 0.6779,
 "compress_mbps": null,
-"decompress_mbps": 44615.82
+"decompress_mbps": 60820.65
 },
 {
 "compressor": "native",
@@ -3315,7 +3315,7 @@
 "out_size": 887708,
 "ratio": 0.1661,
 "compress_mbps": null,
-"decompress_mbps": 417.54
+"decompress_mbps": 442.39
 },
 {
 "compressor": "zlib",
@@ -3325,7 +3325,7 @@
 "out_size": 887708,
 "ratio": 0.1661,
 "compress_mbps": null,
-"decompress_mbps": 755.96
+"decompress_mbps": 761.43
 },
 {
 "compressor": "miniz_oxide",
@@ -3335,7 +3335,7 @@
 "out_size": 887708,
 "ratio": 0.1661,
 "compress_mbps": null,
-"decompress_mbps": 903.91
+"decompress_mbps": 909.27
 },
 {
 "compressor": "libdeflate",
@@ -3345,7 +3345,7 @@
 "out_size": 887708,
 "ratio": 0.1661,
 "compress_mbps": null,
-"decompress_mbps": 1695.42
+"decompress_mbps": 1630.65
 },
 {
 "compressor": "memcpy",
@@ -3355,7 +3355,7 @@
 "out_size": 887708,
 "ratio": 0.1661,
 "compress_mbps": null,
-"decompress_mbps": 50426.91
+"decompress_mbps": 61556.98
 },
 {
 "compressor": "native",
@@ -3365,7 +3365,7 @@
 "out_size": 793388,
 "ratio": 0.1484,
 "compress_mbps": null,
-"decompress_mbps": 542.64
+"decompress_mbps": 580.76
 },
 {
 "compressor": "zlib",
@@ -3375,7 +3375,7 @@
 "out_size": 793388,
 "ratio": 0.1484,
 "compress_mbps": null,
-"decompress_mbps": 851.48
+"decompress_mbps": 850.79
 },
 {
 "compressor": "miniz_oxide",
@@ -3385,7 +3385,7 @@
 "out_size": 793388,
 "ratio": 0.1484,
 "compress_mbps": null,
-"decompress_mbps": 1074.15
+"decompress_mbps": 1076.59
 },
 {
 "compressor": "libdeflate",
@@ -3395,7 +3395,7 @@
 "out_size": 793388,
 "ratio": 0.1484,
 "compress_mbps": null,
-"decompress_mbps": 1852.41
+"decompress_mbps": 1807.72
 },
 {
 "compressor": "memcpy",
@@ -3405,7 +3405,7 @@
 "out_size": 793388,
 "ratio": 0.1484,
 "compress_mbps": null,
-"decompress_mbps": 57508.36
+"decompress_mbps": 59975.25
 },
 {
 "compressor": "native",
@@ -3415,7 +3415,7 @@
 "out_size": 684405,
 "ratio": 0.128,
 "compress_mbps": null,
-"decompress_mbps": 605.04
+"decompress_mbps": 642.65
 },
 {
 "compressor": "zlib",
@@ -3425,7 +3425,7 @@
 "out_size": 684405,
 "ratio": 0.128,
 "compress_mbps": null,
-"decompress_mbps": 940.6
+"decompress_mbps": 931.05
 },
 {
 "compressor": "miniz_oxide",
@@ -3435,7 +3435,7 @@
 "out_size": 684405,
 "ratio": 0.128,
 "compress_mbps": null,
-"decompress_mbps": 1195.46
+"decompress_mbps": 1199.1
 },
 {
 "compressor": "libdeflate",
@@ -3445,7 +3445,7 @@
 "out_size": 684405,
 "ratio": 0.128,
 "compress_mbps": null,
-"decompress_mbps": 1844.89
+"decompress_mbps": 1819.78
 },
 {
 "compressor": "memcpy",
@@ -3455,7 +3455,7 @@
 "out_size": 684405,
 "ratio": 0.128,
 "compress_mbps": null,
-"decompress_mbps": 63642.74
+"decompress_mbps": 62763.56
 },
 {
 "compressor": "native",
@@ -3465,7 +3465,7 @@
 "out_size": 649494,
 "ratio": 0.1215,
 "compress_mbps": null,
-"decompress_mbps": 632.74
+"decompress_mbps": 661.8
 },
 {
 "compressor": "zlib",
@@ -3475,7 +3475,7 @@
 "out_size": 649494,
 "ratio": 0.1215,
 "compress_mbps": null,
-"decompress_mbps": 985.74
+"decompress_mbps": 957.38
 },
 {
 "compressor": "miniz_oxide",
@@ -3485,7 +3485,7 @@
 "out_size": 649494,
 "ratio": 0.1215,
 "compress_mbps": null,
-"decompress_mbps": 1215.16
+"decompress_mbps": 1180.8
 },
 {
 "compressor": "libdeflate",
@@ -3495,7 +3495,7 @@
 "out_size": 649494,
 "ratio": 0.1215,
 "compress_mbps": null,
-"decompress_mbps": 1849.63
+"decompress_mbps": 1777.65
 },
 {
 "compressor": "memcpy",
@@ -3505,7 +3505,7 @@
 "out_size": 649494,
 "ratio": 0.1215,
 "compress_mbps": null,
-"decompress_mbps": 61083.43
+"decompress_mbps": 64187.67
 },
 {
 "compressor": "native",
@@ -3515,7 +3515,7 @@
 "out_size": 629349,
 "ratio": 0.1177,
 "compress_mbps": null,
-"decompress_mbps": 592.92
+"decompress_mbps": 627.7
 },
 {
 "compressor": "zlib",
@@ -3525,7 +3525,7 @@
 "out_size": 629349,
 "ratio": 0.1177,
 "compress_mbps": null,
-"decompress_mbps": 1017.57
+"decompress_mbps": 989.32
 },
 {
 "compressor": "miniz_oxide",
@@ -3535,7 +3535,7 @@
 "out_size": 629349,
 "ratio": 0.1177,
 "compress_mbps": null,
-"decompress_mbps": 1217.07
+"decompress_mbps": 1183.87
 },
 {
 "compressor": "libdeflate",
@@ -3545,7 +3545,7 @@
 "out_size": 629349,
 "ratio": 0.1177,
 "compress_mbps": null,
-"decompress_mbps": 1913.95
+"decompress_mbps": 1852.66
 },
 {
 "compressor": "memcpy",
@@ -3555,7 +3555,7 @@
 "out_size": 629349,
 "ratio": 0.1177,
 "compress_mbps": null,
-"decompress_mbps": 64334.29
+"decompress_mbps": 62028.87
 },
 {
 "compressor": "native",
@@ -3565,7 +3565,7 @@
 "out_size": 627169,
 "ratio": 0.1173,
 "compress_mbps": null,
-"decompress_mbps": 673.93
+"decompress_mbps": 713.77
 },
 {
 "compressor": "zlib",
@@ -3575,7 +3575,7 @@
 "out_size": 627169,
 "ratio": 0.1173,
 "compress_mbps": null,
-"decompress_mbps": 1023.37
+"decompress_mbps": 994.4
 },
 {
 "compressor": "miniz_oxide",
@@ -3585,7 +3585,7 @@
 "out_size": 627169,
 "ratio": 0.1173,
 "compress_mbps": null,
-"decompress_mbps": 1235.19
+"decompress_mbps": 1214.13
 },
 {
 "compressor": "libdeflate",
@@ -3595,7 +3595,7 @@
 "out_size": 627169,
 "ratio": 0.1173,
 "compress_mbps": null,
-"decompress_mbps": 1937.02
+"decompress_mbps": 1872.5
 },
 {
 "compressor": "memcpy",
@@ -3605,7 +3605,7 @@
 "out_size": 627169,
 "ratio": 0.1173,
 "compress_mbps": null,
-"decompress_mbps": 63873.2
+"decompress_mbps": 64252.39
 },
 {
 "compressor": "go",
@@ -3615,7 +3615,7 @@
 "out_size": 4217525,
 "ratio": 0.4138,
 "compress_mbps": null,
-"decompress_mbps": 190.42
+"decompress_mbps": 192.06
 },
 {
 "compressor": "go",
@@ -3625,7 +3625,7 @@
 "out_size": 3679105,
 "ratio": 0.361,
 "compress_mbps": null,
-"decompress_mbps": 224.21
+"decompress_mbps": 221.08
 },
 {
 "compressor": "go",
@@ -3635,7 +3635,7 @@
 "out_size": 3989875,
 "ratio": 0.3915,
 "compress_mbps": null,
-"decompress_mbps": 207.21
+"decompress_mbps": 202.07
 },
 {
 "compressor": "go",
@@ -3645,7 +3645,7 @@
 "out_size": 3859436,
 "ratio": 0.3787,
 "compress_mbps": null,
-"decompress_mbps": 207.62
+"decompress_mbps": 205.34
 },
 {
 "compressor": "go",
@@ -3655,7 +3655,7 @@
 "out_size": 3810354,
 "ratio": 0.3738,
 "compress_mbps": null,
-"decompress_mbps": 204.57
+"decompress_mbps": 203.21
 },
 {
 "compressor": "go",
@@ -3665,7 +3665,7 @@
 "out_size": 3673380,
 "ratio": 0.3604,
 "compress_mbps": null,
-"decompress_mbps": 211.92
+"decompress_mbps": 214.43
 },
 {
 "compressor": "go",
@@ -3675,7 +3675,7 @@
 "out_size": 20192961,
 "ratio": 0.3942,
 "compress_mbps": null,
-"decompress_mbps": 233.54
+"decompress_mbps": 231.18
 },
 {
 "compressor": "go",
@@ -3685,7 +3685,7 @@
 "out_size": 18241312,
 "ratio": 0.3561,
 "compress_mbps": null,
-"decompress_mbps": 231.44
+"decompress_mbps": 231.96
 },
 {
 "compressor": "go",
@@ -3695,7 +3695,7 @@
 "out_size": 19234937,
 "ratio": 0.3755,
 "compress_mbps": null,
-"decompress_mbps": 226.32
+"decompress_mbps": 224.51
 },
 {
 "compressor": "go",
@@ -3705,7 +3705,7 @@
 "out_size": 18805391,
 "ratio": 0.3671,
 "compress_mbps": null,
-"decompress_mbps": 229.82
+"decompress_mbps": 232.7
 },
 {
 "compressor": "go",
@@ -3715,7 +3715,7 @@
 "out_size": 18713659,
 "ratio": 0.3654,
 "compress_mbps": null,
-"decompress_mbps": 238.72
+"decompress_mbps": 234.15
 },
 {
 "compressor": "go",
@@ -3725,7 +3725,7 @@
 "out_size": 18317341,
 "ratio": 0.3576,
 "compress_mbps": null,
-"decompress_mbps": 235.54
+"decompress_mbps": 238.76
 },
 {
 "compressor": "go",
@@ -3734,258 +3734,258 @@
 "level": 1,
 "out_size": 3740775,
 "ratio": 0.3752,
+"compress_mbps": null,
+"decompress_mbps": 230.41
+},
+{
+"compressor": "go",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 12,
+"out_size": 3447985,
+"ratio": 0.3458,
+"compress_mbps": null,
+"decompress_mbps": 235.41
+},
+{
+"compressor": "go",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 3,
+"out_size": 3672389,
+"ratio": 0.3683,
+"compress_mbps": null,
+"decompress_mbps": 225.26
+},
+{
+"compressor": "go",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 6,
+"out_size": 3648644,
+"ratio": 0.3659,
+"compress_mbps": null,
+"decompress_mbps": 232.08
+},
+{
+"compressor": "go",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 9,
+"out_size": 3625176,
+"ratio": 0.3636,
+"compress_mbps": null,
+"decompress_mbps": 233
+},
+{
+"compressor": "go",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 0,
+"out_size": 3450225,
+"ratio": 0.346,
+"compress_mbps": null,
+"decompress_mbps": 233.65
+},
+{
+"compressor": "go",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 1,
+"out_size": 3837577,
+"ratio": 0.1144,
+"compress_mbps": null,
+"decompress_mbps": 580.78
+},
+{
+"compressor": "go",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 12,
+"out_size": 2748273,
+"ratio": 0.0819,
+"compress_mbps": null,
+"decompress_mbps": 784.5
+},
+{
+"compressor": "go",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 3,
+"out_size": 3599455,
+"ratio": 0.1073,
+"compress_mbps": null,
+"decompress_mbps": 599.89
+},
+{
+"compressor": "go",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 6,
+"out_size": 3091741,
+"ratio": 0.0921,
+"compress_mbps": null,
+"decompress_mbps": 670.78
+},
+{
+"compressor": "go",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 9,
+"out_size": 2925243,
+"ratio": 0.0872,
+"compress_mbps": null,
+"decompress_mbps": 741.92
+},
+{
+"compressor": "go",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 0,
+"out_size": 2740598,
+"ratio": 0.0817,
+"compress_mbps": null,
+"decompress_mbps": 749.65
+},
+{
+"compressor": "go",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 1,
+"out_size": 3275124,
+"ratio": 0.5324,
+"compress_mbps": null,
+"decompress_mbps": 168.31
+},
+{
+"compressor": "go",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 12,
+"out_size": 2994086,
+"ratio": 0.4867,
+"compress_mbps": null,
+"decompress_mbps": 160.64
+},
+{
+"compressor": "go",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 3,
+"out_size": 3137061,
+"ratio": 0.5099,
+"compress_mbps": null,
+"decompress_mbps": 155.39
+},
+{
+"compressor": "go",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 6,
+"out_size": 3072378,
+"ratio": 0.4994,
+"compress_mbps": null,
+"decompress_mbps": 166
+},
+{
+"compressor": "go",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 9,
+"out_size": 3066968,
+"ratio": 0.4985,
+"compress_mbps": null,
+"decompress_mbps": 169.75
+},
+{
+"compressor": "go",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 0,
+"out_size": 2992113,
+"ratio": 0.4863,
+"compress_mbps": null,
+"decompress_mbps": 160.99
+},
+{
+"compressor": "go",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 1,
+"out_size": 3868663,
+"ratio": 0.3836,
+"compress_mbps": null,
+"decompress_mbps": 253.4
+},
+{
+"compressor": "go",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 12,
+"out_size": 3608138,
+"ratio": 0.3577,
+"compress_mbps": null,
+"decompress_mbps": 269.43
+},
+{
+"compressor": "go",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 3,
+"out_size": 3818964,
+"ratio": 0.3787,
+"compress_mbps": null,
+"decompress_mbps": 262.57
+},
+{
+"compressor": "go",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 6,
+"out_size": 3660266,
+"ratio": 0.3629,
+"compress_mbps": null,
+"decompress_mbps": 269.49
+},
+{
+"compressor": "go",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 9,
+"out_size": 3654860,
+"ratio": 0.3624,
+"compress_mbps": null,
+"decompress_mbps": 270.57
+},
+{
+"compressor": "go",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 0,
+"out_size": 3607217,
+"ratio": 0.3577,
+"compress_mbps": null,
+"decompress_mbps": 285.93
+},
+{
+"compressor": "go",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 1,
+"out_size": 2197055,
+"ratio": 0.3315,
 "compress_mbps": null,
 "decompress_mbps": 227.09
 },
 {
 "compressor": "go",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 12,
-"out_size": 3447985,
-"ratio": 0.3458,
-"compress_mbps": null,
-"decompress_mbps": 236.46
-},
-{
-"compressor": "go",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 3,
-"out_size": 3672389,
-"ratio": 0.3683,
-"compress_mbps": null,
-"decompress_mbps": 230.1
-},
-{
-"compressor": "go",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 6,
-"out_size": 3648644,
-"ratio": 0.3659,
-"compress_mbps": null,
-"decompress_mbps": 230.2
-},
-{
-"compressor": "go",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 9,
-"out_size": 3625176,
-"ratio": 0.3636,
-"compress_mbps": null,
-"decompress_mbps": 225.82
-},
-{
-"compressor": "go",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 0,
-"out_size": 3450225,
-"ratio": 0.346,
-"compress_mbps": null,
-"decompress_mbps": 238.29
-},
-{
-"compressor": "go",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 1,
-"out_size": 3837577,
-"ratio": 0.1144,
-"compress_mbps": null,
-"decompress_mbps": 593.14
-},
-{
-"compressor": "go",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 12,
-"out_size": 2748273,
-"ratio": 0.0819,
-"compress_mbps": null,
-"decompress_mbps": 783.24
-},
-{
-"compressor": "go",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 3,
-"out_size": 3599455,
-"ratio": 0.1073,
-"compress_mbps": null,
-"decompress_mbps": 615.56
-},
-{
-"compressor": "go",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 6,
-"out_size": 3091741,
-"ratio": 0.0921,
-"compress_mbps": null,
-"decompress_mbps": 751.98
-},
-{
-"compressor": "go",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 9,
-"out_size": 2925243,
-"ratio": 0.0872,
-"compress_mbps": null,
-"decompress_mbps": 686.45
-},
-{
-"compressor": "go",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 0,
-"out_size": 2740598,
-"ratio": 0.0817,
-"compress_mbps": null,
-"decompress_mbps": 830.21
-},
-{
-"compressor": "go",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 1,
-"out_size": 3275124,
-"ratio": 0.5324,
-"compress_mbps": null,
-"decompress_mbps": 165.63
-},
-{
-"compressor": "go",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 12,
-"out_size": 2994086,
-"ratio": 0.4867,
-"compress_mbps": null,
-"decompress_mbps": 156.63
-},
-{
-"compressor": "go",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 3,
-"out_size": 3137061,
-"ratio": 0.5099,
-"compress_mbps": null,
-"decompress_mbps": 153.13
-},
-{
-"compressor": "go",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 6,
-"out_size": 3072378,
-"ratio": 0.4994,
-"compress_mbps": null,
-"decompress_mbps": 161.63
-},
-{
-"compressor": "go",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 9,
-"out_size": 3066968,
-"ratio": 0.4985,
-"compress_mbps": null,
-"decompress_mbps": 166.03
-},
-{
-"compressor": "go",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 0,
-"out_size": 2992113,
-"ratio": 0.4863,
-"compress_mbps": null,
-"decompress_mbps": 158.06
-},
-{
-"compressor": "go",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 1,
-"out_size": 3868663,
-"ratio": 0.3836,
-"compress_mbps": null,
-"decompress_mbps": 261.44
-},
-{
-"compressor": "go",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 12,
-"out_size": 3608138,
-"ratio": 0.3577,
-"compress_mbps": null,
-"decompress_mbps": 277.89
-},
-{
-"compressor": "go",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 3,
-"out_size": 3818964,
-"ratio": 0.3787,
-"compress_mbps": null,
-"decompress_mbps": 272.34
-},
-{
-"compressor": "go",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 6,
-"out_size": 3660266,
-"ratio": 0.3629,
-"compress_mbps": null,
-"decompress_mbps": 264.99
-},
-{
-"compressor": "go",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 9,
-"out_size": 3654860,
-"ratio": 0.3624,
-"compress_mbps": null,
-"decompress_mbps": 276.02
-},
-{
-"compressor": "go",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 0,
-"out_size": 3607217,
-"ratio": 0.3577,
-"compress_mbps": null,
-"decompress_mbps": 290.55
-},
-{
-"compressor": "go",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 1,
-"out_size": 2197055,
-"ratio": 0.3315,
-"compress_mbps": null,
-"decompress_mbps": 225.87
-},
-{
-"compressor": "go",
 "pattern": "silesia/reymont",
 "size": 6627202,
 "level": 12,
 "out_size": 1696488,
 "ratio": 0.256,
 "compress_mbps": null,
-"decompress_mbps": 278.8
+"decompress_mbps": 283.58
 },
 {
 "compressor": "go",
@@ -3995,7 +3995,7 @@
 "out_size": 2021047,
 "ratio": 0.305,
 "compress_mbps": null,
-"decompress_mbps": 253.21
+"decompress_mbps": 256.09
 },
 {
 "compressor": "go",
@@ -4005,7 +4005,7 @@
 "out_size": 1876257,
 "ratio": 0.2831,
 "compress_mbps": null,
-"decompress_mbps": 258.08
+"decompress_mbps": 262.67
 },
 {
 "compressor": "go",
@@ -4015,7 +4015,7 @@
 "out_size": 1806374,
 "ratio": 0.2726,
 "compress_mbps": null,
-"decompress_mbps": 259.71
+"decompress_mbps": 260.9
 },
 {
 "compressor": "go",
@@ -4025,7 +4025,7 @@
 "out_size": 1691994,
 "ratio": 0.2553,
 "compress_mbps": null,
-"decompress_mbps": 296.5
+"decompress_mbps": 285.32
 },
 {
 "compressor": "go",
@@ -4035,7 +4035,7 @@
 "out_size": 5866517,
 "ratio": 0.2715,
 "compress_mbps": null,
-"decompress_mbps": 308.49
+"decompress_mbps": 306.97
 },
 {
 "compressor": "go",
@@ -4045,7 +4045,7 @@
 "out_size": 5118130,
 "ratio": 0.2369,
 "compress_mbps": null,
-"decompress_mbps": 337.39
+"decompress_mbps": 324.28
 },
 {
 "compressor": "go",
@@ -4055,7 +4055,7 @@
 "out_size": 5605878,
 "ratio": 0.2595,
 "compress_mbps": null,
-"decompress_mbps": 327.43
+"decompress_mbps": 316.81
 },
 {
 "compressor": "go",
@@ -4065,7 +4065,7 @@
 "out_size": 5337149,
 "ratio": 0.247,
 "compress_mbps": null,
-"decompress_mbps": 332.74
+"decompress_mbps": 323.75
 },
 {
 "compressor": "go",
@@ -4075,7 +4075,7 @@
 "out_size": 5270405,
 "ratio": 0.2439,
 "compress_mbps": null,
-"decompress_mbps": 326.46
+"decompress_mbps": 328.64
 },
 {
 "compressor": "go",
@@ -4085,7 +4085,7 @@
 "out_size": 5107588,
 "ratio": 0.2364,
 "compress_mbps": null,
-"decompress_mbps": 353.27
+"decompress_mbps": 344.93
 },
 {
 "compressor": "go",
@@ -4095,7 +4095,7 @@
 "out_size": 5575128,
 "ratio": 0.7688,
 "compress_mbps": null,
-"decompress_mbps": 176.7
+"decompress_mbps": 182.22
 },
 {
 "compressor": "go",
@@ -4105,7 +4105,7 @@
 "out_size": 5250745,
 "ratio": 0.724,
 "compress_mbps": null,
-"decompress_mbps": 179.11
+"decompress_mbps": 188.68
 },
 {
 "compressor": "go",
@@ -4115,7 +4115,7 @@
 "out_size": 5397999,
 "ratio": 0.7444,
 "compress_mbps": null,
-"decompress_mbps": 178.4
+"decompress_mbps": 187.28
 },
 {
 "compressor": "go",
@@ -4125,7 +4125,7 @@
 "out_size": 5335405,
 "ratio": 0.7357,
 "compress_mbps": null,
-"decompress_mbps": 180.92
+"decompress_mbps": 186.08
 },
 {
 "compressor": "go",
@@ -4135,7 +4135,7 @@
 "out_size": 5323197,
 "ratio": 0.734,
 "compress_mbps": null,
-"decompress_mbps": 182.69
+"decompress_mbps": 188.75
 },
 {
 "compressor": "go",
@@ -4145,7 +4145,7 @@
 "out_size": 5242394,
 "ratio": 0.7229,
 "compress_mbps": null,
-"decompress_mbps": 177.28
+"decompress_mbps": 186.36
 },
 {
 "compressor": "go",
@@ -4155,7 +4155,7 @@
 "out_size": 13550569,
 "ratio": 0.3268,
 "compress_mbps": null,
-"decompress_mbps": 224.97
+"decompress_mbps": 225.06
 },
 {
 "compressor": "go",
@@ -4165,7 +4165,7 @@
 "out_size": 11520871,
 "ratio": 0.2779,
 "compress_mbps": null,
-"decompress_mbps": 254.33
+"decompress_mbps": 256.66
 },
 {
 "compressor": "go",
@@ -4175,7 +4175,7 @@
 "out_size": 12839361,
 "ratio": 0.3097,
 "compress_mbps": null,
-"decompress_mbps": 237.53
+"decompress_mbps": 242.54
 },
 {
 "compressor": "go",
@@ -4185,7 +4185,7 @@
 "out_size": 12140474,
 "ratio": 0.2928,
 "compress_mbps": null,
-"decompress_mbps": 247.98
+"decompress_mbps": 247.96
 },
 {
 "compressor": "go",
@@ -4195,7 +4195,7 @@
 "out_size": 11882496,
 "ratio": 0.2866,
 "compress_mbps": null,
-"decompress_mbps": 247.8
+"decompress_mbps": 250.83
 },
 {
 "compressor": "go",
@@ -4205,7 +4205,7 @@
 "out_size": 11518290,
 "ratio": 0.2778,
 "compress_mbps": null,
-"decompress_mbps": 260.8
+"decompress_mbps": 256.89
 },
 {
 "compressor": "go",
@@ -4215,7 +4215,7 @@
 "out_size": 6293390,
 "ratio": 0.7426,
 "compress_mbps": null,
-"decompress_mbps": 168.1
+"decompress_mbps": 166.3
 },
 {
 "compressor": "go",
@@ -4225,7 +4225,7 @@
 "out_size": 5747146,
 "ratio": 0.6782,
 "compress_mbps": null,
-"decompress_mbps": 137.18
+"decompress_mbps": 140.99
 },
 {
 "compressor": "go",
@@ -4235,7 +4235,7 @@
 "out_size": 6058381,
 "ratio": 0.7149,
 "compress_mbps": null,
-"decompress_mbps": 137.55
+"decompress_mbps": 144.96
 },
 {
 "compressor": "go",
@@ -4245,7 +4245,7 @@
 "out_size": 5998438,
 "ratio": 0.7078,
 "compress_mbps": null,
-"decompress_mbps": 146.44
+"decompress_mbps": 152.03
 },
 {
 "compressor": "go",
@@ -4255,7 +4255,7 @@
 "out_size": 5986859,
 "ratio": 0.7065,
 "compress_mbps": null,
-"decompress_mbps": 144.97
+"decompress_mbps": 149.13
 },
 {
 "compressor": "go",
@@ -4265,7 +4265,7 @@
 "out_size": 5744697,
 "ratio": 0.6779,
 "compress_mbps": null,
-"decompress_mbps": 134.43
+"decompress_mbps": 136.8
 },
 {
 "compressor": "go",
@@ -4275,7 +4275,7 @@
 "out_size": 887708,
 "ratio": 0.1661,
 "compress_mbps": null,
-"decompress_mbps": 412.29
+"decompress_mbps": 440.5
 },
 {
 "compressor": "go",
@@ -4285,7 +4285,7 @@
 "out_size": 629349,
 "ratio": 0.1177,
 "compress_mbps": null,
-"decompress_mbps": 558.24
+"decompress_mbps": 615.59
 },
 {
 "compressor": "go",
@@ -4295,7 +4295,7 @@
 "out_size": 793388,
 "ratio": 0.1484,
 "compress_mbps": null,
-"decompress_mbps": 475.78
+"decompress_mbps": 507.61
 },
 {
 "compressor": "go",
@@ -4305,7 +4305,7 @@
 "out_size": 684405,
 "ratio": 0.128,
 "compress_mbps": null,
-"decompress_mbps": 538.76
+"decompress_mbps": 581.96
 },
 {
 "compressor": "go",
@@ -4315,7 +4315,7 @@
 "out_size": 649494,
 "ratio": 0.1215,
 "compress_mbps": null,
-"decompress_mbps": 547.37
+"decompress_mbps": 607.22
 },
 {
 "compressor": "go",
@@ -4325,7 +4325,7 @@
 "out_size": 627169,
 "ratio": 0.1173,
 "compress_mbps": null,
-"decompress_mbps": 544.31
+"decompress_mbps": 618.22
 },
 {
 "compressor": "js",
@@ -4335,7 +4335,7 @@
 "out_size": 4217525,
 "ratio": 0.4138,
 "compress_mbps": null,
-"decompress_mbps": 173.89
+"decompress_mbps": 110.32
 },
 {
 "compressor": "js",
@@ -4345,7 +4345,7 @@
 "out_size": 3679105,
 "ratio": 0.361,
 "compress_mbps": null,
-"decompress_mbps": 199.26
+"decompress_mbps": 121.35
 },
 {
 "compressor": "js",
@@ -4355,7 +4355,7 @@
 "out_size": 3989875,
 "ratio": 0.3915,
 "compress_mbps": null,
-"decompress_mbps": 207.53
+"decompress_mbps": 135.89
 },
 {
 "compressor": "js",
@@ -4365,7 +4365,7 @@
 "out_size": 3859436,
 "ratio": 0.3787,
 "compress_mbps": null,
-"decompress_mbps": 206.87
+"decompress_mbps": 135.35
 },
 {
 "compressor": "js",
@@ -4375,7 +4375,7 @@
 "out_size": 3810354,
 "ratio": 0.3738,
 "compress_mbps": null,
-"decompress_mbps": 166.4
+"decompress_mbps": 122.04
 },
 {
 "compressor": "js",
@@ -4385,7 +4385,7 @@
 "out_size": 3673380,
 "ratio": 0.3604,
 "compress_mbps": null,
-"decompress_mbps": 207.68
+"decompress_mbps": 129.36
 },
 {
 "compressor": "js",
@@ -4395,7 +4395,7 @@
 "out_size": 20192961,
 "ratio": 0.3942,
 "compress_mbps": null,
-"decompress_mbps": 212.32
+"decompress_mbps": 157.13
 },
 {
 "compressor": "js",
@@ -4405,7 +4405,7 @@
 "out_size": 18241312,
 "ratio": 0.3561,
 "compress_mbps": null,
-"decompress_mbps": 209.52
+"decompress_mbps": 151.8
 },
 {
 "compressor": "js",
@@ -4415,7 +4415,7 @@
 "out_size": 19234937,
 "ratio": 0.3755,
 "compress_mbps": null,
-"decompress_mbps": 204.74
+"decompress_mbps": 155.7
 },
 {
 "compressor": "js",
@@ -4425,7 +4425,7 @@
 "out_size": 18805391,
 "ratio": 0.3671,
 "compress_mbps": null,
-"decompress_mbps": 213.85
+"decompress_mbps": 184.47
 },
 {
 "compressor": "js",
@@ -4435,7 +4435,7 @@
 "out_size": 18713659,
 "ratio": 0.3654,
 "compress_mbps": null,
-"decompress_mbps": 215.23
+"decompress_mbps": 161.51
 },
 {
 "compressor": "js",
@@ -4445,7 +4445,7 @@
 "out_size": 18317341,
 "ratio": 0.3576,
 "compress_mbps": null,
-"decompress_mbps": 226.92
+"decompress_mbps": 179.47
 },
 {
 "compressor": "js",
@@ -4455,7 +4455,7 @@
 "out_size": 3740775,
 "ratio": 0.3752,
 "compress_mbps": null,
-"decompress_mbps": 242.87
+"decompress_mbps": 139.97
 },
 {
 "compressor": "js",
@@ -4465,7 +4465,7 @@
 "out_size": 3447985,
 "ratio": 0.3458,
 "compress_mbps": null,
-"decompress_mbps": 231.85
+"decompress_mbps": 140.17
 },
 {
 "compressor": "js",
@@ -4475,7 +4475,7 @@
 "out_size": 3672389,
 "ratio": 0.3683,
 "compress_mbps": null,
-"decompress_mbps": 252.96
+"decompress_mbps": 142.22
 },
 {
 "compressor": "js",
@@ -4485,7 +4485,7 @@
 "out_size": 3648644,
 "ratio": 0.3659,
 "compress_mbps": null,
-"decompress_mbps": 229.83
+"decompress_mbps": 135.12
 },
 {
 "compressor": "js",
@@ -4495,7 +4495,7 @@
 "out_size": 3625176,
 "ratio": 0.3636,
 "compress_mbps": null,
-"decompress_mbps": 228.15
+"decompress_mbps": 134.98
 },
 {
 "compressor": "js",
@@ -4505,7 +4505,7 @@
 "out_size": 3450225,
 "ratio": 0.346,
 "compress_mbps": null,
-"decompress_mbps": 216.16
+"decompress_mbps": 135.73
 },
 {
 "compressor": "js",
@@ -4515,7 +4515,7 @@
 "out_size": 3837577,
 "ratio": 0.1144,
 "compress_mbps": null,
-"decompress_mbps": 382.33
+"decompress_mbps": 247.01
 },
 {
 "compressor": "js",
@@ -4525,7 +4525,7 @@
 "out_size": 2748273,
 "ratio": 0.0819,
 "compress_mbps": null,
-"decompress_mbps": 448.83
+"decompress_mbps": 288.55
 },
 {
 "compressor": "js",
@@ -4535,7 +4535,7 @@
 "out_size": 3599455,
 "ratio": 0.1073,
 "compress_mbps": null,
-"decompress_mbps": 399.2
+"decompress_mbps": 285.59
 },
 {
 "compressor": "js",
@@ -4545,7 +4545,7 @@
 "out_size": 3091741,
 "ratio": 0.0921,
 "compress_mbps": null,
-"decompress_mbps": 425.82
+"decompress_mbps": 315.73
 },
 {
 "compressor": "js",
@@ -4555,7 +4555,7 @@
 "out_size": 2925243,
 "ratio": 0.0872,
 "compress_mbps": null,
-"decompress_mbps": 438.54
+"decompress_mbps": 325.56
 },
 {
 "compressor": "js",
@@ -4565,7 +4565,7 @@
 "out_size": 2740598,
 "ratio": 0.0817,
 "compress_mbps": null,
-"decompress_mbps": 433.87
+"decompress_mbps": 282.97
 },
 {
 "compressor": "js",
@@ -4575,7 +4575,7 @@
 "out_size": 3275124,
 "ratio": 0.5324,
 "compress_mbps": null,
-"decompress_mbps": 166.97
+"decompress_mbps": 103.44
 },
 {
 "compressor": "js",
@@ -4585,7 +4585,7 @@
 "out_size": 2994086,
 "ratio": 0.4867,
 "compress_mbps": null,
-"decompress_mbps": 162.63
+"decompress_mbps": 100.24
 },
 {
 "compressor": "js",
@@ -4595,7 +4595,7 @@
 "out_size": 3137061,
 "ratio": 0.5099,
 "compress_mbps": null,
-"decompress_mbps": 176.92
+"decompress_mbps": 111.59
 },
 {
 "compressor": "js",
@@ -4605,7 +4605,7 @@
 "out_size": 3072378,
 "ratio": 0.4994,
 "compress_mbps": null,
-"decompress_mbps": 182.32
+"decompress_mbps": 112.08
 },
 {
 "compressor": "js",
@@ -4615,7 +4615,7 @@
 "out_size": 3066968,
 "ratio": 0.4985,
 "compress_mbps": null,
-"decompress_mbps": 169.8
+"decompress_mbps": 100.54
 },
 {
 "compressor": "js",
@@ -4625,7 +4625,7 @@
 "out_size": 2992113,
 "ratio": 0.4863,
 "compress_mbps": null,
-"decompress_mbps": 142.45
+"decompress_mbps": 86.65
 },
 {
 "compressor": "js",
@@ -4635,7 +4635,7 @@
 "out_size": 3868663,
 "ratio": 0.3836,
 "compress_mbps": null,
-"decompress_mbps": 254.12
+"decompress_mbps": 147.38
 },
 {
 "compressor": "js",
@@ -4645,7 +4645,7 @@
 "out_size": 3608138,
 "ratio": 0.3577,
 "compress_mbps": null,
-"decompress_mbps": 298.29
+"decompress_mbps": 179.06
 },
 {
 "compressor": "js",
@@ -4655,7 +4655,7 @@
 "out_size": 3818964,
 "ratio": 0.3787,
 "compress_mbps": null,
-"decompress_mbps": 300.28
+"decompress_mbps": 162.32
 },
 {
 "compressor": "js",
@@ -4665,7 +4665,7 @@
 "out_size": 3660266,
 "ratio": 0.3629,
 "compress_mbps": null,
-"decompress_mbps": 298.24
+"decompress_mbps": 176.1
 },
 {
 "compressor": "js",
@@ -4675,7 +4675,7 @@
 "out_size": 3654860,
 "ratio": 0.3624,
 "compress_mbps": null,
-"decompress_mbps": 269.06
+"decompress_mbps": 161.28
 },
 {
 "compressor": "js",
@@ -4685,7 +4685,7 @@
 "out_size": 3607217,
 "ratio": 0.3577,
 "compress_mbps": null,
-"decompress_mbps": 310.69
+"decompress_mbps": 178.95
 },
 {
 "compressor": "js",
@@ -4695,7 +4695,7 @@
 "out_size": 2197055,
 "ratio": 0.3315,
 "compress_mbps": null,
-"decompress_mbps": 192.42
+"decompress_mbps": 116.87
 },
 {
 "compressor": "js",
@@ -4705,7 +4705,7 @@
 "out_size": 1696488,
 "ratio": 0.256,
 "compress_mbps": null,
-"decompress_mbps": 239.5
+"decompress_mbps": 143.07
 },
 {
 "compressor": "js",
@@ -4715,7 +4715,7 @@
 "out_size": 2021047,
 "ratio": 0.305,
 "compress_mbps": null,
-"decompress_mbps": 241.22
+"decompress_mbps": 147.34
 },
 {
 "compressor": "js",
@@ -4725,7 +4725,7 @@
 "out_size": 1876257,
 "ratio": 0.2831,
 "compress_mbps": null,
-"decompress_mbps": 185.12
+"decompress_mbps": 143.54
 },
 {
 "compressor": "js",
@@ -4735,7 +4735,7 @@
 "out_size": 1806374,
 "ratio": 0.2726,
 "compress_mbps": null,
-"decompress_mbps": 229.26
+"decompress_mbps": 144.39
 },
 {
 "compressor": "js",
@@ -4745,7 +4745,7 @@
 "out_size": 1691994,
 "ratio": 0.2553,
 "compress_mbps": null,
-"decompress_mbps": 192.23
+"decompress_mbps": 107.62
 },
 {
 "compressor": "js",
@@ -4755,7 +4755,7 @@
 "out_size": 5866517,
 "ratio": 0.2715,
 "compress_mbps": null,
-"decompress_mbps": 263.85
+"decompress_mbps": 171.56
 },
 {
 "compressor": "js",
@@ -4765,7 +4765,7 @@
 "out_size": 5118130,
 "ratio": 0.2369,
 "compress_mbps": null,
-"decompress_mbps": 258.26
+"decompress_mbps": 169.28
 },
 {
 "compressor": "js",
@@ -4775,7 +4775,7 @@
 "out_size": 5605878,
 "ratio": 0.2595,
 "compress_mbps": null,
-"decompress_mbps": 265.67
+"decompress_mbps": 157
 },
 {
 "compressor": "js",
@@ -4785,7 +4785,7 @@
 "out_size": 5337149,
 "ratio": 0.247,
 "compress_mbps": null,
-"decompress_mbps": 279.91
+"decompress_mbps": 167.34
 },
 {
 "compressor": "js",
@@ -4795,7 +4795,7 @@
 "out_size": 5270405,
 "ratio": 0.2439,
 "compress_mbps": null,
-"decompress_mbps": 290.57
+"decompress_mbps": 175.15
 },
 {
 "compressor": "js",
@@ -4805,7 +4805,7 @@
 "out_size": 5107588,
 "ratio": 0.2364,
 "compress_mbps": null,
-"decompress_mbps": 257.4
+"decompress_mbps": 190.12
 },
 {
 "compressor": "js",
@@ -4815,7 +4815,7 @@
 "out_size": 5575128,
 "ratio": 0.7688,
 "compress_mbps": null,
-"decompress_mbps": 164.29
+"decompress_mbps": 99.87
 },
 {
 "compressor": "js",
@@ -4825,7 +4825,7 @@
 "out_size": 5250745,
 "ratio": 0.724,
 "compress_mbps": null,
-"decompress_mbps": 169.98
+"decompress_mbps": 98.34
 },
 {
 "compressor": "js",
@@ -4835,7 +4835,7 @@
 "out_size": 5397999,
 "ratio": 0.7444,
 "compress_mbps": null,
-"decompress_mbps": 196.22
+"decompress_mbps": 104.89
 },
 {
 "compressor": "js",
@@ -4845,7 +4845,7 @@
 "out_size": 5335405,
 "ratio": 0.7357,
 "compress_mbps": null,
-"decompress_mbps": 169.37
+"decompress_mbps": 100.16
 },
 {
 "compressor": "js",
@@ -4855,7 +4855,7 @@
 "out_size": 5323197,
 "ratio": 0.734,
 "compress_mbps": null,
-"decompress_mbps": 199.79
+"decompress_mbps": 107.95
 },
 {
 "compressor": "js",
@@ -4865,7 +4865,7 @@
 "out_size": 5242394,
 "ratio": 0.7229,
 "compress_mbps": null,
-"decompress_mbps": 191.84
+"decompress_mbps": 112.69
 },
 {
 "compressor": "js",
@@ -4875,7 +4875,7 @@
 "out_size": 13550569,
 "ratio": 0.3268,
 "compress_mbps": null,
-"decompress_mbps": 204.01
+"decompress_mbps": 141.66
 },
 {
 "compressor": "js",
@@ -4885,7 +4885,7 @@
 "out_size": 11520871,
 "ratio": 0.2779,
 "compress_mbps": null,
-"decompress_mbps": 234.97
+"decompress_mbps": 158.68
 },
 {
 "compressor": "js",
@@ -4895,7 +4895,7 @@
 "out_size": 12839361,
 "ratio": 0.3097,
 "compress_mbps": null,
-"decompress_mbps": 219.45
+"decompress_mbps": 148.82
 },
 {
 "compressor": "js",
@@ -4905,7 +4905,7 @@
 "out_size": 12140474,
 "ratio": 0.2928,
 "compress_mbps": null,
-"decompress_mbps": 231
+"decompress_mbps": 154.56
 },
 {
 "compressor": "js",
@@ -4915,7 +4915,7 @@
 "out_size": 11882496,
 "ratio": 0.2866,
 "compress_mbps": null,
-"decompress_mbps": 231.45
+"decompress_mbps": 162.66
 },
 {
 "compressor": "js",
@@ -4925,7 +4925,7 @@
 "out_size": 11518290,
 "ratio": 0.2778,
 "compress_mbps": null,
-"decompress_mbps": 226.29
+"decompress_mbps": 145.3
 },
 {
 "compressor": "js",
@@ -4935,7 +4935,7 @@
 "out_size": 6293390,
 "ratio": 0.7426,
 "compress_mbps": null,
-"decompress_mbps": 150.6
+"decompress_mbps": 100.14
 },
 {
 "compressor": "js",
@@ -4945,7 +4945,7 @@
 "out_size": 5747146,
 "ratio": 0.6782,
 "compress_mbps": null,
-"decompress_mbps": 185.48
+"decompress_mbps": 107.98
 },
 {
 "compressor": "js",
@@ -4955,7 +4955,7 @@
 "out_size": 6058381,
 "ratio": 0.7149,
 "compress_mbps": null,
-"decompress_mbps": 166.63
+"decompress_mbps": 102.33
 },
 {
 "compressor": "js",
@@ -4965,7 +4965,7 @@
 "out_size": 5998438,
 "ratio": 0.7078,
 "compress_mbps": null,
-"decompress_mbps": 130.08
+"decompress_mbps": 94.73
 },
 {
 "compressor": "js",
@@ -4975,7 +4975,7 @@
 "out_size": 5986859,
 "ratio": 0.7065,
 "compress_mbps": null,
-"decompress_mbps": 177.1
+"decompress_mbps": 105.01
 },
 {
 "compressor": "js",
@@ -4985,7 +4985,7 @@
 "out_size": 5744697,
 "ratio": 0.6779,
 "compress_mbps": null,
-"decompress_mbps": 152.54
+"decompress_mbps": 96.26
 },
 {
 "compressor": "js",
@@ -4995,7 +4995,7 @@
 "out_size": 887708,
 "ratio": 0.1661,
 "compress_mbps": null,
-"decompress_mbps": 322.07
+"decompress_mbps": 183.84
 },
 {
 "compressor": "js",
@@ -5005,7 +5005,7 @@
 "out_size": 629349,
 "ratio": 0.1177,
 "compress_mbps": null,
-"decompress_mbps": 391.53
+"decompress_mbps": 269.82
 },
 {
 "compressor": "js",
@@ -5015,7 +5015,7 @@
 "out_size": 793388,
 "ratio": 0.1484,
 "compress_mbps": null,
-"decompress_mbps": 337.54
+"decompress_mbps": 181.01
 },
 {
 "compressor": "js",
@@ -5025,7 +5025,7 @@
 "out_size": 684405,
 "ratio": 0.128,
 "compress_mbps": null,
-"decompress_mbps": 358.16
+"decompress_mbps": 241.09
 },
 {
 "compressor": "js",
@@ -5035,7 +5035,7 @@
 "out_size": 649494,
 "ratio": 0.1215,
 "compress_mbps": null,
-"decompress_mbps": 278.12
+"decompress_mbps": 241.61
 },
 {
 "compressor": "js",
@@ -5045,7 +5045,7 @@
 "out_size": 627169,
 "ratio": 0.1173,
 "compress_mbps": null,
-"decompress_mbps": 340.64
+"decompress_mbps": 150.18
 },
 {
 "compressor": "zig",
@@ -5055,7 +5055,7 @@
 "out_size": 4217525,
 "ratio": 0.4138,
 "compress_mbps": null,
-"decompress_mbps": 233.42
+"decompress_mbps": 221.52
 },
 {
 "compressor": "zig",
@@ -5065,7 +5065,7 @@
 "out_size": 3679105,
 "ratio": 0.361,
 "compress_mbps": null,
-"decompress_mbps": 293.7
+"decompress_mbps": 279.11
 },
 {
 "compressor": "zig",
@@ -5075,7 +5075,7 @@
 "out_size": 3989875,
 "ratio": 0.3915,
 "compress_mbps": null,
-"decompress_mbps": 275.52
+"decompress_mbps": 271.68
 },
 {
 "compressor": "zig",
@@ -5085,7 +5085,7 @@
 "out_size": 3859436,
 "ratio": 0.3787,
 "compress_mbps": null,
-"decompress_mbps": 274.26
+"decompress_mbps": 268.18
 },
 {
 "compressor": "zig",
@@ -5095,7 +5095,7 @@
 "out_size": 3810354,
 "ratio": 0.3738,
 "compress_mbps": null,
-"decompress_mbps": 264.85
+"decompress_mbps": 261.3
 },
 {
 "compressor": "zig",
@@ -5105,7 +5105,7 @@
 "out_size": 3673380,
 "ratio": 0.3604,
 "compress_mbps": null,
-"decompress_mbps": 284.58
+"decompress_mbps": 280.48
 },
 {
 "compressor": "zig",
@@ -5115,7 +5115,7 @@
 "out_size": 20192961,
 "ratio": 0.3942,
 "compress_mbps": null,
-"decompress_mbps": 237.68
+"decompress_mbps": 235.66
 },
 {
 "compressor": "zig",
@@ -5125,7 +5125,7 @@
 "out_size": 18241312,
 "ratio": 0.3561,
 "compress_mbps": null,
-"decompress_mbps": 219.5
+"decompress_mbps": 217.47
 },
 {
 "compressor": "zig",
@@ -5135,7 +5135,7 @@
 "out_size": 19234937,
 "ratio": 0.3755,
 "compress_mbps": null,
-"decompress_mbps": 220.59
+"decompress_mbps": 217.25
 },
 {
 "compressor": "zig",
@@ -5145,7 +5145,7 @@
 "out_size": 18805391,
 "ratio": 0.3671,
 "compress_mbps": null,
-"decompress_mbps": 229.15
+"decompress_mbps": 227.9
 },
 {
 "compressor": "zig",
@@ -5155,7 +5155,7 @@
 "out_size": 18713659,
 "ratio": 0.3654,
 "compress_mbps": null,
-"decompress_mbps": 232.11
+"decompress_mbps": 231.3
 },
 {
 "compressor": "zig",
@@ -5165,7 +5165,7 @@
 "out_size": 18317341,
 "ratio": 0.3576,
 "compress_mbps": null,
-"decompress_mbps": 252.05
+"decompress_mbps": 252.69
 },
 {
 "compressor": "zig",
@@ -5175,7 +5175,7 @@
 "out_size": 3740775,
 "ratio": 0.3752,
 "compress_mbps": null,
-"decompress_mbps": 234.29
+"decompress_mbps": 231.68
 },
 {
 "compressor": "zig",
@@ -5185,7 +5185,7 @@
 "out_size": 3447985,
 "ratio": 0.3458,
 "compress_mbps": null,
-"decompress_mbps": 268.41
+"decompress_mbps": 267.47
 },
 {
 "compressor": "zig",
@@ -5195,7 +5195,7 @@
 "out_size": 3672389,
 "ratio": 0.3683,
 "compress_mbps": null,
-"decompress_mbps": 258.38
+"decompress_mbps": 260.13
 },
 {
 "compressor": "zig",
@@ -5205,7 +5205,7 @@
 "out_size": 3648644,
 "ratio": 0.3659,
 "compress_mbps": null,
-"decompress_mbps": 266.86
+"decompress_mbps": 267.23
 },
 {
 "compressor": "zig",
@@ -5215,7 +5215,7 @@
 "out_size": 3625176,
 "ratio": 0.3636,
 "compress_mbps": null,
-"decompress_mbps": 270.07
+"decompress_mbps": 269.92
 },
 {
 "compressor": "zig",
@@ -5225,7 +5225,7 @@
 "out_size": 3450225,
 "ratio": 0.346,
 "compress_mbps": null,
-"decompress_mbps": 251.51
+"decompress_mbps": 250.54
 },
 {
 "compressor": "zig",
@@ -5235,7 +5235,7 @@
 "out_size": 3837577,
 "ratio": 0.1144,
 "compress_mbps": null,
-"decompress_mbps": 685.81
+"decompress_mbps": 681.98
 },
 {
 "compressor": "zig",
@@ -5245,7 +5245,7 @@
 "out_size": 2748273,
 "ratio": 0.0819,
 "compress_mbps": null,
-"decompress_mbps": 859.84
+"decompress_mbps": 850.06
 },
 {
 "compressor": "zig",
@@ -5255,7 +5255,7 @@
 "out_size": 3599455,
 "ratio": 0.1073,
 "compress_mbps": null,
-"decompress_mbps": 751.45
+"decompress_mbps": 740.59
 },
 {
 "compressor": "zig",
@@ -5265,7 +5265,7 @@
 "out_size": 3091741,
 "ratio": 0.0921,
 "compress_mbps": null,
-"decompress_mbps": 854.26
+"decompress_mbps": 837.02
 },
 {
 "compressor": "zig",
@@ -5275,7 +5275,7 @@
 "out_size": 2925243,
 "ratio": 0.0872,
 "compress_mbps": null,
-"decompress_mbps": 908.97
+"decompress_mbps": 898.09
 },
 {
 "compressor": "zig",
@@ -5285,7 +5285,7 @@
 "out_size": 2740598,
 "ratio": 0.0817,
 "compress_mbps": null,
-"decompress_mbps": 954.25
+"decompress_mbps": 929.1
 },
 {
 "compressor": "zig",
@@ -5295,7 +5295,7 @@
 "out_size": 3275124,
 "ratio": 0.5324,
 "compress_mbps": null,
-"decompress_mbps": 178.42
+"decompress_mbps": 175.52
 },
 {
 "compressor": "zig",
@@ -5305,7 +5305,7 @@
 "out_size": 2994086,
 "ratio": 0.4867,
 "compress_mbps": null,
-"decompress_mbps": 182.9
+"decompress_mbps": 180.02
 },
 {
 "compressor": "zig",
@@ -5315,7 +5315,7 @@
 "out_size": 3137061,
 "ratio": 0.5099,
 "compress_mbps": null,
-"decompress_mbps": 177.93
+"decompress_mbps": 176.42
 },
 {
 "compressor": "zig",
@@ -5325,7 +5325,7 @@
 "out_size": 3072378,
 "ratio": 0.4994,
 "compress_mbps": null,
-"decompress_mbps": 186.02
+"decompress_mbps": 184.48
 },
 {
 "compressor": "zig",
@@ -5335,7 +5335,7 @@
 "out_size": 3066968,
 "ratio": 0.4985,
 "compress_mbps": null,
-"decompress_mbps": 188.58
+"decompress_mbps": 187.36
 },
 {
 "compressor": "zig",
@@ -5345,7 +5345,7 @@
 "out_size": 2992113,
 "ratio": 0.4863,
 "compress_mbps": null,
-"decompress_mbps": 183.55
+"decompress_mbps": 181.46
 },
 {
 "compressor": "zig",
@@ -5355,7 +5355,7 @@
 "out_size": 3868663,
 "ratio": 0.3836,
 "compress_mbps": null,
-"decompress_mbps": 255.63
+"decompress_mbps": 253.03
 },
 {
 "compressor": "zig",
@@ -5365,7 +5365,7 @@
 "out_size": 3608138,
 "ratio": 0.3577,
 "compress_mbps": null,
-"decompress_mbps": 292.87
+"decompress_mbps": 290.53
 },
 {
 "compressor": "zig",
@@ -5375,7 +5375,7 @@
 "out_size": 3818964,
 "ratio": 0.3787,
 "compress_mbps": null,
-"decompress_mbps": 285.99
+"decompress_mbps": 282.62
 },
 {
 "compressor": "zig",
@@ -5385,7 +5385,7 @@
 "out_size": 3660266,
 "ratio": 0.3629,
 "compress_mbps": null,
-"decompress_mbps": 290.21
+"decompress_mbps": 286.75
 },
 {
 "compressor": "zig",
@@ -5395,7 +5395,7 @@
 "out_size": 3654860,
 "ratio": 0.3624,
 "compress_mbps": null,
-"decompress_mbps": 289.61
+"decompress_mbps": 287.31
 },
 {
 "compressor": "zig",
@@ -5405,7 +5405,7 @@
 "out_size": 3607217,
 "ratio": 0.3577,
 "compress_mbps": null,
-"decompress_mbps": 291.68
+"decompress_mbps": 289.16
 },
 {
 "compressor": "zig",
@@ -5415,7 +5415,7 @@
 "out_size": 2197055,
 "ratio": 0.3315,
 "compress_mbps": null,
-"decompress_mbps": 288.21
+"decompress_mbps": 286.4
 },
 {
 "compressor": "zig",
@@ -5425,7 +5425,7 @@
 "out_size": 1696488,
 "ratio": 0.256,
 "compress_mbps": null,
-"decompress_mbps": 377.45
+"decompress_mbps": 374.93
 },
 {
 "compressor": "zig",
@@ -5435,7 +5435,7 @@
 "out_size": 2021047,
 "ratio": 0.305,
 "compress_mbps": null,
-"decompress_mbps": 357.44
+"decompress_mbps": 352.79
 },
 {
 "compressor": "zig",
@@ -5445,7 +5445,7 @@
 "out_size": 1876257,
 "ratio": 0.2831,
 "compress_mbps": null,
-"decompress_mbps": 358.98
+"decompress_mbps": 355.31
 },
 {
 "compressor": "zig",
@@ -5455,7 +5455,7 @@
 "out_size": 1806374,
 "ratio": 0.2726,
 "compress_mbps": null,
-"decompress_mbps": 350.84
+"decompress_mbps": 347.95
 },
 {
 "compressor": "zig",
@@ -5465,7 +5465,7 @@
 "out_size": 1691994,
 "ratio": 0.2553,
 "compress_mbps": null,
-"decompress_mbps": 383.24
+"decompress_mbps": 380.13
 },
 {
 "compressor": "zig",
@@ -5475,7 +5475,7 @@
 "out_size": 5866517,
 "ratio": 0.2715,
 "compress_mbps": null,
-"decompress_mbps": 356.8
+"decompress_mbps": 349.73
 },
 {
 "compressor": "zig",
@@ -5485,7 +5485,7 @@
 "out_size": 5118130,
 "ratio": 0.2369,
 "compress_mbps": null,
-"decompress_mbps": 336.27
+"decompress_mbps": 329.93
 },
 {
 "compressor": "zig",
@@ -5495,7 +5495,7 @@
 "out_size": 5605878,
 "ratio": 0.2595,
 "compress_mbps": null,
-"decompress_mbps": 345.5
+"decompress_mbps": 342.11
 },
 {
 "compressor": "zig",
@@ -5505,7 +5505,7 @@
 "out_size": 5337149,
 "ratio": 0.247,
 "compress_mbps": null,
-"decompress_mbps": 367.45
+"decompress_mbps": 365.6
 },
 {
 "compressor": "zig",
@@ -5515,7 +5515,7 @@
 "out_size": 5270405,
 "ratio": 0.2439,
 "compress_mbps": null,
-"decompress_mbps": 368.0
+"decompress_mbps": 369.05
 },
 {
 "compressor": "zig",
@@ -5525,7 +5525,7 @@
 "out_size": 5107588,
 "ratio": 0.2364,
 "compress_mbps": null,
-"decompress_mbps": 406.03
+"decompress_mbps": 398.36
 },
 {
 "compressor": "zig",
@@ -5535,7 +5535,7 @@
 "out_size": 5575128,
 "ratio": 0.7688,
 "compress_mbps": null,
-"decompress_mbps": 160.69
+"decompress_mbps": 159.66
 },
 {
 "compressor": "zig",
@@ -5545,7 +5545,7 @@
 "out_size": 5250745,
 "ratio": 0.724,
 "compress_mbps": null,
-"decompress_mbps": 177.4
+"decompress_mbps": 174.01
 },
 {
 "compressor": "zig",
@@ -5555,7 +5555,7 @@
 "out_size": 5397999,
 "ratio": 0.7444,
 "compress_mbps": null,
-"decompress_mbps": 172.39
+"decompress_mbps": 172.0
 },
 {
 "compressor": "zig",
@@ -5565,7 +5565,7 @@
 "out_size": 5335405,
 "ratio": 0.7357,
 "compress_mbps": null,
-"decompress_mbps": 175.02
+"decompress_mbps": 173.41
 },
 {
 "compressor": "zig",
@@ -5575,7 +5575,7 @@
 "out_size": 5323197,
 "ratio": 0.734,
 "compress_mbps": null,
-"decompress_mbps": 174.81
+"decompress_mbps": 175.23
 },
 {
 "compressor": "zig",
@@ -5585,7 +5585,7 @@
 "out_size": 5242394,
 "ratio": 0.7229,
 "compress_mbps": null,
-"decompress_mbps": 167.64
+"decompress_mbps": 165.88
 },
 {
 "compressor": "zig",
@@ -5595,7 +5595,7 @@
 "out_size": 13550569,
 "ratio": 0.3268,
 "compress_mbps": null,
-"decompress_mbps": 275.61
+"decompress_mbps": 275.01
 },
 {
 "compressor": "zig",
@@ -5605,7 +5605,7 @@
 "out_size": 11520871,
 "ratio": 0.2779,
 "compress_mbps": null,
-"decompress_mbps": 335.52
+"decompress_mbps": 330.5
 },
 {
 "compressor": "zig",
@@ -5615,7 +5615,7 @@
 "out_size": 12839361,
 "ratio": 0.3097,
 "compress_mbps": null,
-"decompress_mbps": 320.21
+"decompress_mbps": 316.23
 },
 {
 "compressor": "zig",
@@ -5625,7 +5625,7 @@
 "out_size": 12140474,
 "ratio": 0.2928,
 "compress_mbps": null,
-"decompress_mbps": 322.97
+"decompress_mbps": 326.18
 },
 {
 "compressor": "zig",
@@ -5635,7 +5635,7 @@
 "out_size": 11882496,
 "ratio": 0.2866,
 "compress_mbps": null,
-"decompress_mbps": 326.37
+"decompress_mbps": 328.09
 },
 {
 "compressor": "zig",
@@ -5645,7 +5645,7 @@
 "out_size": 11518290,
 "ratio": 0.2778,
 "compress_mbps": null,
-"decompress_mbps": 335.0
+"decompress_mbps": 338.32
 },
 {
 "compressor": "zig",
@@ -5655,7 +5655,7 @@
 "out_size": 6293390,
 "ratio": 0.7426,
 "compress_mbps": null,
-"decompress_mbps": 152.41
+"decompress_mbps": 150.88
 },
 {
 "compressor": "zig",
@@ -5665,7 +5665,7 @@
 "out_size": 5747146,
 "ratio": 0.6782,
 "compress_mbps": null,
-"decompress_mbps": 149.25
+"decompress_mbps": 149.76
 },
 {
 "compressor": "zig",
@@ -5675,7 +5675,7 @@
 "out_size": 6058381,
 "ratio": 0.7149,
 "compress_mbps": null,
-"decompress_mbps": 144.56
+"decompress_mbps": 143.82
 },
 {
 "compressor": "zig",
@@ -5685,7 +5685,7 @@
 "out_size": 5998438,
 "ratio": 0.7078,
 "compress_mbps": null,
-"decompress_mbps": 157.31
+"decompress_mbps": 157.28
 },
 {
 "compressor": "zig",
@@ -5695,7 +5695,7 @@
 "out_size": 5986859,
 "ratio": 0.7065,
 "compress_mbps": null,
-"decompress_mbps": 156.47
+"decompress_mbps": 154.91
 },
 {
 "compressor": "zig",
@@ -5705,7 +5705,7 @@
 "out_size": 5744697,
 "ratio": 0.6779,
 "compress_mbps": null,
-"decompress_mbps": 145.45
+"decompress_mbps": 145.13
 },
 {
 "compressor": "zig",
@@ -5715,7 +5715,7 @@
 "out_size": 887708,
 "ratio": 0.1661,
 "compress_mbps": null,
-"decompress_mbps": 513.66
+"decompress_mbps": 507.13
 },
 {
 "compressor": "zig",
@@ -5725,7 +5725,7 @@
 "out_size": 629349,
 "ratio": 0.1177,
 "compress_mbps": null,
-"decompress_mbps": 676.91
+"decompress_mbps": 667.01
 },
 {
 "compressor": "zig",
@@ -5735,7 +5735,7 @@
 "out_size": 793388,
 "ratio": 0.1484,
 "compress_mbps": null,
-"decompress_mbps": 611.81
+"decompress_mbps": 600.84
 },
 {
 "compressor": "zig",
@@ -5745,7 +5745,7 @@
 "out_size": 684405,
 "ratio": 0.128,
 "compress_mbps": null,
-"decompress_mbps": 661.11
+"decompress_mbps": 668.37
 },
 {
 "compressor": "zig",
@@ -5755,7 +5755,7 @@
 "out_size": 649494,
 "ratio": 0.1215,
 "compress_mbps": null,
-"decompress_mbps": 687.45
+"decompress_mbps": 685.14
 },
 {
 "compressor": "zig",
@@ -5765,7 +5765,7 @@
 "out_size": 627169,
 "ratio": 0.1173,
 "compress_mbps": null,
-"decompress_mbps": 718.37
+"decompress_mbps": 710.32
 },
 {
 "compressor": "ocaml",
@@ -5775,7 +5775,7 @@
 "out_size": 4217525,
 "ratio": 0.4138,
 "compress_mbps": null,
-"decompress_mbps": 106.77
+"decompress_mbps": 105.29
 },
 {
 "compressor": "ocaml",
@@ -5785,7 +5785,7 @@
 "out_size": 3679105,
 "ratio": 0.361,
 "compress_mbps": null,
-"decompress_mbps": 117.21
+"decompress_mbps": 115.26
 },
 {
 "compressor": "ocaml",
@@ -5795,7 +5795,7 @@
 "out_size": 3989875,
 "ratio": 0.3915,
 "compress_mbps": null,
-"decompress_mbps": 111.12
+"decompress_mbps": 110.2
 },
 {
 "compressor": "ocaml",
@@ -5805,7 +5805,7 @@
 "out_size": 3859436,
 "ratio": 0.3787,
 "compress_mbps": null,
-"decompress_mbps": 111.81
+"decompress_mbps": 111.7
 },
 {
 "compressor": "ocaml",
@@ -5815,7 +5815,7 @@
 "out_size": 3810354,
 "ratio": 0.3738,
 "compress_mbps": null,
-"decompress_mbps": 110.98
+"decompress_mbps": 112.72
 },
 {
 "compressor": "ocaml",
@@ -5825,7 +5825,7 @@
 "out_size": 3673380,
 "ratio": 0.3604,
 "compress_mbps": null,
-"decompress_mbps": 113.62
+"decompress_mbps": 110.97
 },
 {
 "compressor": "ocaml",
@@ -5835,7 +5835,7 @@
 "out_size": 20192961,
 "ratio": 0.3942,
 "compress_mbps": null,
-"decompress_mbps": 124.58
+"decompress_mbps": 122.7
 },
 {
 "compressor": "ocaml",
@@ -5845,7 +5845,7 @@
 "out_size": 18241312,
 "ratio": 0.3561,
 "compress_mbps": null,
-"decompress_mbps": 116.55
+"decompress_mbps": 116.84
 },
 {
 "compressor": "ocaml",
@@ -5855,7 +5855,7 @@
 "out_size": 19234937,
 "ratio": 0.3755,
 "compress_mbps": null,
-"decompress_mbps": 117.11
+"decompress_mbps": 112.59
 },
 {
 "compressor": "ocaml",
@@ -5865,7 +5865,7 @@
 "out_size": 18805391,
 "ratio": 0.3671,
 "compress_mbps": null,
-"decompress_mbps": 121.81
+"decompress_mbps": 116.2
 },
 {
 "compressor": "ocaml",
@@ -5875,7 +5875,7 @@
 "out_size": 18713659,
 "ratio": 0.3654,
 "compress_mbps": null,
-"decompress_mbps": 123.11
+"decompress_mbps": 120.86
 },
 {
 "compressor": "ocaml",
@@ -5885,7 +5885,7 @@
 "out_size": 18317341,
 "ratio": 0.3576,
 "compress_mbps": null,
-"decompress_mbps": 125.97
+"decompress_mbps": 123.3
 },
 {
 "compressor": "ocaml",
@@ -5895,7 +5895,7 @@
 "out_size": 3740775,
 "ratio": 0.3752,
 "compress_mbps": null,
-"decompress_mbps": 134.23
+"decompress_mbps": 135.81
 },
 {
 "compressor": "ocaml",
@@ -5904,268 +5904,268 @@
 "level": 12,
 "out_size": 3447985,
 "ratio": 0.3458,
+"compress_mbps": null,
+"decompress_mbps": 132.57
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 3,
+"out_size": 3672389,
+"ratio": 0.3683,
+"compress_mbps": null,
+"decompress_mbps": 129.0
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 6,
+"out_size": 3648644,
+"ratio": 0.3659,
+"compress_mbps": null,
+"decompress_mbps": 133.44
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 9,
+"out_size": 3625176,
+"ratio": 0.3636,
+"compress_mbps": null,
+"decompress_mbps": 132.48
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 0,
+"out_size": 3450225,
+"ratio": 0.346,
+"compress_mbps": null,
+"decompress_mbps": 135.63
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 1,
+"out_size": 3837577,
+"ratio": 0.1144,
+"compress_mbps": null,
+"decompress_mbps": 213.53
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 12,
+"out_size": 2748273,
+"ratio": 0.0819,
+"compress_mbps": null,
+"decompress_mbps": 233.62
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 3,
+"out_size": 3599455,
+"ratio": 0.1073,
+"compress_mbps": null,
+"decompress_mbps": 220.32
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 6,
+"out_size": 3091741,
+"ratio": 0.0921,
+"compress_mbps": null,
+"decompress_mbps": 222.14
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 9,
+"out_size": 2925243,
+"ratio": 0.0872,
+"compress_mbps": null,
+"decompress_mbps": 225.08
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 0,
+"out_size": 2740598,
+"ratio": 0.0817,
+"compress_mbps": null,
+"decompress_mbps": 235.5
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 1,
+"out_size": 3275124,
+"ratio": 0.5324,
+"compress_mbps": null,
+"decompress_mbps": 105.75
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 12,
+"out_size": 2994086,
+"ratio": 0.4867,
+"compress_mbps": null,
+"decompress_mbps": 98.03
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 3,
+"out_size": 3137061,
+"ratio": 0.5099,
+"compress_mbps": null,
+"decompress_mbps": 98.21
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 6,
+"out_size": 3072378,
+"ratio": 0.4994,
+"compress_mbps": null,
+"decompress_mbps": 99.44
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 9,
+"out_size": 3066968,
+"ratio": 0.4985,
+"compress_mbps": null,
+"decompress_mbps": 99.62
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 0,
+"out_size": 2992113,
+"ratio": 0.4863,
+"compress_mbps": null,
+"decompress_mbps": 97.22
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 1,
+"out_size": 3868663,
+"ratio": 0.3836,
+"compress_mbps": null,
+"decompress_mbps": 142.69
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 12,
+"out_size": 3608138,
+"ratio": 0.3577,
+"compress_mbps": null,
+"decompress_mbps": 149.33
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 3,
+"out_size": 3818964,
+"ratio": 0.3787,
+"compress_mbps": null,
+"decompress_mbps": 142.62
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 6,
+"out_size": 3660266,
+"ratio": 0.3629,
+"compress_mbps": null,
+"decompress_mbps": 145.65
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 9,
+"out_size": 3654860,
+"ratio": 0.3624,
+"compress_mbps": null,
+"decompress_mbps": 146.05
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 0,
+"out_size": 3607217,
+"ratio": 0.3577,
+"compress_mbps": null,
+"decompress_mbps": 152.57
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 1,
+"out_size": 2197055,
+"ratio": 0.3315,
+"compress_mbps": null,
+"decompress_mbps": 122.54
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 12,
+"out_size": 1696488,
+"ratio": 0.256,
+"compress_mbps": null,
+"decompress_mbps": 147.3
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 3,
+"out_size": 2021047,
+"ratio": 0.305,
 "compress_mbps": null,
 "decompress_mbps": 130.7
 },
 {
 "compressor": "ocaml",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 3,
-"out_size": 3672389,
-"ratio": 0.3683,
-"compress_mbps": null,
-"decompress_mbps": 135.21
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 6,
-"out_size": 3648644,
-"ratio": 0.3659,
-"compress_mbps": null,
-"decompress_mbps": 139.86
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 9,
-"out_size": 3625176,
-"ratio": 0.3636,
-"compress_mbps": null,
-"decompress_mbps": 138.82
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 0,
-"out_size": 3450225,
-"ratio": 0.346,
-"compress_mbps": null,
-"decompress_mbps": 137.65
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 1,
-"out_size": 3837577,
-"ratio": 0.1144,
-"compress_mbps": null,
-"decompress_mbps": 208.27
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 12,
-"out_size": 2748273,
-"ratio": 0.0819,
-"compress_mbps": null,
-"decompress_mbps": 231.08
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 3,
-"out_size": 3599455,
-"ratio": 0.1073,
-"compress_mbps": null,
-"decompress_mbps": 225.72
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 6,
-"out_size": 3091741,
-"ratio": 0.0921,
-"compress_mbps": null,
-"decompress_mbps": 224.72
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 9,
-"out_size": 2925243,
-"ratio": 0.0872,
-"compress_mbps": null,
-"decompress_mbps": 231.32
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 0,
-"out_size": 2740598,
-"ratio": 0.0817,
-"compress_mbps": null,
-"decompress_mbps": 239.89
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 1,
-"out_size": 3275124,
-"ratio": 0.5324,
-"compress_mbps": null,
-"decompress_mbps": 107.33
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 12,
-"out_size": 2994086,
-"ratio": 0.4867,
-"compress_mbps": null,
-"decompress_mbps": 96.95
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 3,
-"out_size": 3137061,
-"ratio": 0.5099,
-"compress_mbps": null,
-"decompress_mbps": 99.98
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 6,
-"out_size": 3072378,
-"ratio": 0.4994,
-"compress_mbps": null,
-"decompress_mbps": 99.76
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 9,
-"out_size": 3066968,
-"ratio": 0.4985,
-"compress_mbps": null,
-"decompress_mbps": 102.9
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 0,
-"out_size": 2992113,
-"ratio": 0.4863,
-"compress_mbps": null,
-"decompress_mbps": 97.08
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 1,
-"out_size": 3868663,
-"ratio": 0.3836,
-"compress_mbps": null,
-"decompress_mbps": 148.54
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 12,
-"out_size": 3608138,
-"ratio": 0.3577,
-"compress_mbps": null,
-"decompress_mbps": 151.65
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 3,
-"out_size": 3818964,
-"ratio": 0.3787,
-"compress_mbps": null,
-"decompress_mbps": 150.76
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 6,
-"out_size": 3660266,
-"ratio": 0.3629,
-"compress_mbps": null,
-"decompress_mbps": 151.46
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 9,
-"out_size": 3654860,
-"ratio": 0.3624,
-"compress_mbps": null,
-"decompress_mbps": 147.01
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 0,
-"out_size": 3607217,
-"ratio": 0.3577,
-"compress_mbps": null,
-"decompress_mbps": 153.61
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 1,
-"out_size": 2197055,
-"ratio": 0.3315,
-"compress_mbps": null,
-"decompress_mbps": 127.13
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 12,
-"out_size": 1696488,
-"ratio": 0.256,
-"compress_mbps": null,
-"decompress_mbps": 150.54
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 3,
-"out_size": 2021047,
-"ratio": 0.305,
-"compress_mbps": null,
-"decompress_mbps": 136.74
-},
-{
-"compressor": "ocaml",
 "pattern": "silesia/reymont",
 "size": 6627202,
 "level": 6,
 "out_size": 1876257,
 "ratio": 0.2831,
 "compress_mbps": null,
-"decompress_mbps": 141.88
+"decompress_mbps": 139.21
 },
 {
 "compressor": "ocaml",
@@ -6175,7 +6175,7 @@
 "out_size": 1806374,
 "ratio": 0.2726,
 "compress_mbps": null,
-"decompress_mbps": 141.6
+"decompress_mbps": 138.26
 },
 {
 "compressor": "ocaml",
@@ -6185,7 +6185,7 @@
 "out_size": 1691994,
 "ratio": 0.2553,
 "compress_mbps": null,
-"decompress_mbps": 144.28
+"decompress_mbps": 144.91
 },
 {
 "compressor": "ocaml",
@@ -6195,7 +6195,7 @@
 "out_size": 5866517,
 "ratio": 0.2715,
 "compress_mbps": null,
-"decompress_mbps": 150.71
+"decompress_mbps": 154.54
 },
 {
 "compressor": "ocaml",
@@ -6205,7 +6205,7 @@
 "out_size": 5118130,
 "ratio": 0.2369,
 "compress_mbps": null,
-"decompress_mbps": 159.3
+"decompress_mbps": 157.5
 },
 {
 "compressor": "ocaml",
@@ -6215,7 +6215,7 @@
 "out_size": 5605878,
 "ratio": 0.2595,
 "compress_mbps": null,
-"decompress_mbps": 150.26
+"decompress_mbps": 151.36
 },
 {
 "compressor": "ocaml",
@@ -6225,7 +6225,7 @@
 "out_size": 5337149,
 "ratio": 0.247,
 "compress_mbps": null,
-"decompress_mbps": 161.58
+"decompress_mbps": 154.36
 },
 {
 "compressor": "ocaml",
@@ -6235,7 +6235,7 @@
 "out_size": 5270405,
 "ratio": 0.2439,
 "compress_mbps": null,
-"decompress_mbps": 163.3
+"decompress_mbps": 161.93
 },
 {
 "compressor": "ocaml",
@@ -6245,7 +6245,7 @@
 "out_size": 5107588,
 "ratio": 0.2364,
 "compress_mbps": null,
-"decompress_mbps": 166.68
+"decompress_mbps": 159.84
 },
 {
 "compressor": "ocaml",
@@ -6255,7 +6255,7 @@
 "out_size": 5575128,
 "ratio": 0.7688,
 "compress_mbps": null,
-"decompress_mbps": 108.77
+"decompress_mbps": 108.47
 },
 {
 "compressor": "ocaml",
@@ -6265,7 +6265,7 @@
 "out_size": 5250745,
 "ratio": 0.724,
 "compress_mbps": null,
-"decompress_mbps": 109.15
+"decompress_mbps": 111.25
 },
 {
 "compressor": "ocaml",
@@ -6275,7 +6275,7 @@
 "out_size": 5397999,
 "ratio": 0.7444,
 "compress_mbps": null,
-"decompress_mbps": 111.59
+"decompress_mbps": 111.49
 },
 {
 "compressor": "ocaml",
@@ -6285,7 +6285,7 @@
 "out_size": 5335405,
 "ratio": 0.7357,
 "compress_mbps": null,
-"decompress_mbps": 111.67
+"decompress_mbps": 114.78
 },
 {
 "compressor": "ocaml",
@@ -6295,7 +6295,7 @@
 "out_size": 5323197,
 "ratio": 0.734,
 "compress_mbps": null,
-"decompress_mbps": 116.1
+"decompress_mbps": 115.99
 },
 {
 "compressor": "ocaml",
@@ -6305,7 +6305,7 @@
 "out_size": 5242394,
 "ratio": 0.7229,
 "compress_mbps": null,
-"decompress_mbps": 105.78
+"decompress_mbps": 107.65
 },
 {
 "compressor": "ocaml",
@@ -6315,7 +6315,7 @@
 "out_size": 13550569,
 "ratio": 0.3268,
 "compress_mbps": null,
-"decompress_mbps": 116.24
+"decompress_mbps": 115.09
 },
 {
 "compressor": "ocaml",
@@ -6325,7 +6325,7 @@
 "out_size": 11520871,
 "ratio": 0.2779,
 "compress_mbps": null,
-"decompress_mbps": 131.8
+"decompress_mbps": 125.88
 },
 {
 "compressor": "ocaml",
@@ -6335,7 +6335,7 @@
 "out_size": 12839361,
 "ratio": 0.3097,
 "compress_mbps": null,
-"decompress_mbps": 125.19
+"decompress_mbps": 123.59
 },
 {
 "compressor": "ocaml",
@@ -6345,7 +6345,7 @@
 "out_size": 12140474,
 "ratio": 0.2928,
 "compress_mbps": null,
-"decompress_mbps": 128.56
+"decompress_mbps": 122.74
 },
 {
 "compressor": "ocaml",
@@ -6355,7 +6355,7 @@
 "out_size": 11882496,
 "ratio": 0.2866,
 "compress_mbps": null,
-"decompress_mbps": 130.02
+"decompress_mbps": 123.85
 },
 {
 "compressor": "ocaml",
@@ -6365,7 +6365,7 @@
 "out_size": 11518290,
 "ratio": 0.2778,
 "compress_mbps": null,
-"decompress_mbps": 130.94
+"decompress_mbps": 128.15
 },
 {
 "compressor": "ocaml",
@@ -6375,7 +6375,7 @@
 "out_size": 6293390,
 "ratio": 0.7426,
 "compress_mbps": null,
-"decompress_mbps": 107.71
+"decompress_mbps": 104.36
 },
 {
 "compressor": "ocaml",
@@ -6385,7 +6385,7 @@
 "out_size": 5747146,
 "ratio": 0.6782,
 "compress_mbps": null,
-"decompress_mbps": 92.86
+"decompress_mbps": 91.78
 },
 {
 "compressor": "ocaml",
@@ -6395,7 +6395,7 @@
 "out_size": 6058381,
 "ratio": 0.7149,
 "compress_mbps": null,
-"decompress_mbps": 90.63
+"decompress_mbps": 91.81
 },
 {
 "compressor": "ocaml",
@@ -6405,7 +6405,7 @@
 "out_size": 5998438,
 "ratio": 0.7078,
 "compress_mbps": null,
-"decompress_mbps": 93.64
+"decompress_mbps": 91.6
 },
 {
 "compressor": "ocaml",
@@ -6415,7 +6415,7 @@
 "out_size": 5986859,
 "ratio": 0.7065,
 "compress_mbps": null,
-"decompress_mbps": 94.67
+"decompress_mbps": 93.99
 },
 {
 "compressor": "ocaml",
@@ -6425,7 +6425,7 @@
 "out_size": 5744697,
 "ratio": 0.6779,
 "compress_mbps": null,
-"decompress_mbps": 93.14
+"decompress_mbps": 92.35
 },
 {
 "compressor": "ocaml",
@@ -6435,7 +6435,7 @@
 "out_size": 887708,
 "ratio": 0.1661,
 "compress_mbps": null,
-"decompress_mbps": 195.78
+"decompress_mbps": 192.55
 },
 {
 "compressor": "ocaml",
@@ -6445,7 +6445,7 @@
 "out_size": 629349,
 "ratio": 0.1177,
 "compress_mbps": null,
-"decompress_mbps": 229.53
+"decompress_mbps": 228.12
 },
 {
 "compressor": "ocaml",
@@ -6455,7 +6455,7 @@
 "out_size": 793388,
 "ratio": 0.1484,
 "compress_mbps": null,
-"decompress_mbps": 206.43
+"decompress_mbps": 195.16
 },
 {
 "compressor": "ocaml",
@@ -6465,7 +6465,7 @@
 "out_size": 684405,
 "ratio": 0.128,
 "compress_mbps": null,
-"decompress_mbps": 217.1
+"decompress_mbps": 216.09
 },
 {
 "compressor": "ocaml",
@@ -6475,7 +6475,7 @@
 "out_size": 649494,
 "ratio": 0.1215,
 "compress_mbps": null,
-"decompress_mbps": 220.41
+"decompress_mbps": 219.58
 },
 {
 "compressor": "ocaml",
@@ -6485,7 +6485,7 @@
 "out_size": 627169,
 "ratio": 0.1173,
 "compress_mbps": null,
-"decompress_mbps": 223.26
+"decompress_mbps": 221.88
 }
 ]
 }


### PR DESCRIPTION
This PR re-records the decode-density dashboard (`bench/results/decode_density.json` and the two Silesia decode SVGs) against the current production tree-free decoder — the merged bind-once (#2808) plus proven-bounds `uget` (#2814) — measured on chungus2 with the full comparator field. The committed snapshot had gone stale (its native rows predate #2808), so the decode "Pareto" was showing an older decoder.

The refreshed ranking places lean-zip native at **313 MB/s** Silesia geomean (over files × encode levels) — ahead of Zig std.flate (294), Go compress/flate (263), JS fflate (147), and OCaml decompress (134), behind zlib (465), miniz_oxide (531), and libdeflate (896), under the ~38 GB/s memcpy ceiling. All decoders are timed in the same run on byte-identical libdeflate/zopfli streams, pinned to the idlest core.

Only the decode dashboard files change; the compress graphs are untouched.

🤖 Prepared with Claude Code