### PR TITLE
perf(decode): wide bit-refill via masked ugetUInt64LE in the tree-free loop

### DIFF
--- a/Zip/Native/Inflate.lean
+++ b/Zip/Native/Inflate.lean
@@ -1020,6 +1020,50 @@ theorem refillGuard_usize (data : ByteArray) (pos cnt : USize) (hsz : data.size 
   rw [USize.le_iff_toNat_le, USize.lt_iff_toNat_lt, toUSize_toNat_of_lt hsz,
       USize.toNat_ofNat_of_lt (Nat.lt_of_lt_of_le (by decide) USize.le_size)]
 
+/-- The wide refill guard read in `USize` (`cnt ≤ 56` and eight bytes remain).
+    The bound is written as `pos ≤ data.size.toUSize - 8` (subtraction, guarded by
+    `8 ≤ data.size.toUSize`) rather than `pos + 8 ≤ …` so it never wraps near the
+    top of the address space, and matches the `Nat` guard `pos.toNat + 8 ≤
+    data.size` once the buffer is `USize`-addressable. -/
+theorem refillGuardWide_usize (data : ByteArray) (pos cnt : USize) (hsz : data.size < USize.size) :
+    (cnt ≤ (56 : USize) ∧ (8 : USize) ≤ data.size.toUSize ∧ pos ≤ data.size.toUSize - 8)
+      ↔ (cnt.toNat ≤ 56 ∧ pos.toNat + 8 ≤ data.size) := by
+  have h56 : (56 : USize).toNat = 56 :=
+    USize.toNat_ofNat_of_lt (Nat.lt_of_lt_of_le (by decide) USize.le_size)
+  have h8 : (8 : USize).toNat = 8 :=
+    USize.toNat_ofNat_of_lt (Nat.lt_of_lt_of_le (by decide) USize.le_size)
+  have hsize : data.size.toUSize.toNat = data.size := toUSize_toNat_of_lt hsz
+  rw [USize.le_iff_toNat_le, USize.le_iff_toNat_le, USize.le_iff_toNat_le, h56, h8, hsize]
+  constructor
+  · rintro ⟨hc, h8le, hp⟩
+    rw [USize.toNat_sub_of_le _ _ (USize.le_iff_toNat_le.mpr (by rw [h8, hsize]; omega)),
+        h8, hsize] at hp
+    exact ⟨hc, by omega⟩
+  · rintro ⟨hc, hp⟩
+    refine ⟨hc, by omega, ?_⟩
+    rw [USize.toNat_sub_of_le _ _ (USize.le_iff_toNat_le.mpr (by rw [h8, hsize]; omega)),
+        h8, hsize]
+    omega
+
+/-- The wide refill loads `k = (56 - cnt)/8 + 1` whole bytes; its `USize`
+    computation round-trips to the `Nat` value under `cnt ≤ 56`. -/
+theorem wideK_toNat (cnt : USize) (hcnt : cnt.toNat ≤ 56) :
+    ((56 - cnt) / 8 + 1 : USize).toNat = (56 - cnt.toNat) / 8 + 1 := by
+  have h56 : (56 : USize).toNat = 56 :=
+    USize.toNat_ofNat_of_lt (Nat.lt_of_lt_of_le (by decide) USize.le_size)
+  have h8 : (8 : USize).toNat = 8 :=
+    USize.toNat_ofNat_of_lt (Nat.lt_of_lt_of_le (by decide) USize.le_size)
+  have h1 : (1 : USize).toNat = 1 := USize.toNat_one
+  have hbig : (64 : Nat) < 2 ^ System.Platform.numBits :=
+    USize.size_eq_two_pow ▸ Nat.lt_of_lt_of_le (by decide) USize.le_size
+  have hsub : (56 - cnt).toNat = 56 - cnt.toNat := by
+    rw [USize.toNat_sub_of_le, h56]; rw [USize.le_iff_toNat_le, h56]; omega
+  have hdiv : ((56 - cnt) / 8).toNat = (56 - cnt.toNat) / 8 := by
+    rw [USize.toNat_div, hsub, h8]
+  rw [USize.toNat_add, hdiv, h1]
+  apply Nat.mod_eq_of_lt
+  omega
+
 /-- The inline-literal guard reads the packed entry **once** (`entryAt`) and tests
     `len`/`sym` in their native `UInt8`/`UInt16` widths; this matches the boxed
     reference's `lenAt`/`symAt` `Nat` guard (the length field round-trips since it is

--- a/Zip/Native/InflateTreeFree.lean
+++ b/Zip/Native/InflateTreeFree.lean
@@ -1,4 +1,5 @@
 import Zip.Native.Inflate
+import Zip.Native.Wide
 
 /-!
 # Tree-free canonical decode — the production DEFLATE decoder
@@ -282,6 +283,144 @@ def goTreeFreeU (litTable distTable : DecodeTable) (litLD distLD : LongDecode)
                 cnt4.toUSize hsz hlp out
   termination_by (data.size - pos.toNat) * 9 + cnt.toNat
   decreasing_by
+    · obtain ⟨hc, hp⟩ := hrc
+      have hbig : (64 : Nat) < 2 ^ System.Platform.numBits :=
+        USize.size_eq_two_pow ▸ Nat.lt_of_lt_of_le (by decide) USize.le_size
+      have hpn : pos.toNat < data.size := by
+        have h := USize.lt_iff_toNat_lt.mp hp; rwa [toUSize_toNat_of_lt hsz] at h
+      have hcn : cnt.toNat ≤ 56 := by
+        have h := USize.le_iff_toNat_le.mp hc
+        rwa [USize.toNat_ofNat_of_lt (Nat.lt_of_lt_of_le (by decide) USize.le_size)] at h
+      have hpa : (pos + 1).toNat = pos.toNat + 1 := by
+        rw [USize.toNat_add, USize.toNat_one]; apply Nat.mod_eq_of_lt
+        have : pos.toNat + 1 < USize.size := by omega
+        exact USize.size_eq_two_pow ▸ this
+      have h8 : (8 : USize).toNat = 8 :=
+        USize.toNat_ofNat_of_lt (Nat.lt_of_lt_of_le (by decide) USize.le_size)
+      have hca : (cnt + 8).toNat = cnt.toNat + 8 := by
+        rw [USize.toNat_add, h8]; apply Nat.mod_eq_of_lt; omega
+      rw [hpa, hca]; omega
+    · obtain ⟨hne, hle, _⟩ := hlit
+      have hne' : (HuffTree.unpackLen e).toNat ≠ 0 := (uint8_ne_zero_iff_toNat _).mp hne
+      have hlen : ((HuffTree.unpackLen e).toUSize).toNat = (HuffTree.unpackLen e).toNat :=
+        UInt8.toNat_toUSize _
+      have hsub : (cnt - (HuffTree.unpackLen e).toUSize).toNat
+          = cnt.toNat - (HuffTree.unpackLen e).toNat := by
+        rw [USize.toNat_sub_of_le _ _ hle, hlen]
+      have hlecnt : (HuffTree.unpackLen e).toNat ≤ cnt.toNat :=
+        hlen ▸ USize.le_iff_toNat_le.mp hle
+      rw [hsub]; omega
+    · have hcsz : cnt.toNat < USize.size := cnt.toNat_lt_two_pow_numBits
+      have hb : cnt'.toUSize.toNat = cnt' := toUSize_toNat_of_lt (by omega)
+      rw [hb]; omega
+    · have hcsz : cnt.toNat < USize.size := cnt.toNat_lt_two_pow_numBits
+      have hb : cnt4.toUSize.toNat = cnt4 := toUSize_toNat_of_lt (by omega)
+      rw [hb]; omega
+
+set_option maxRecDepth 4096 in
+/-- **Wide-refill twin of `goTreeFreeU`.** Identical loop, except the leading
+    per-byte refill is preceded by a wide branch: when eight bytes remain
+    (`pos ≤ data.size.toUSize - 8`) it loads the whole `ugetUInt64LE` word, clears
+    the top `8 - k` bytes (`<<< s >>> s`, `s = 64 - 8k`, `k = (56 - cnt)/8 + 1`) and
+    ORs it in at bit `cnt` — the same `(pos, bitBuf, cnt)` the byte loop reaches in
+    `k` iterations (`refill_eq_wide`). Near the buffer end it falls back to the byte
+    loop. Proven equal to `goTreeFree` (`goTreeFreeUWide_eq`), so it drops into the
+    production decode with the whole correctness chain transferring untouched. -/
+def goTreeFreeUWide (litTable distTable : DecodeTable) (litLD distLD : LongDecode)
+    (maxBits : Nat) (data : ByteArray) (maxOut : Nat)
+    (pos : USize) (bitBuf : UInt64) (cnt : USize)
+    (hsz : data.size < USize.size)
+    (hlp : litTable.packed.size = 2 ^ HuffTree.fastBits) (output : ByteArray) :
+    Except String (ByteArray × USize × UInt64 × USize) := do
+  if hrcw : cnt ≤ 56 ∧ (8 : USize) ≤ data.size.toUSize ∧ pos ≤ data.size.toUSize - 8 then
+    goTreeFreeUWide litTable distTable litLD distLD maxBits data maxOut
+      (pos + ((56 - cnt) / 8 + 1))
+      (bitBuf ||| (((data.ugetUInt64LE pos
+          ((refillGuardWide_usize data pos cnt hsz).mp hrcw).2)
+          <<< (64 - 8 * ((56 - cnt) / 8 + 1)).toUInt64
+          >>> (64 - 8 * ((56 - cnt) / 8 + 1)).toUInt64) <<< cnt.toUInt64))
+      (cnt + 8 * ((56 - cnt) / 8 + 1)) hsz hlp output
+  else
+  if hrc : cnt ≤ 56 ∧ pos < data.size.toUSize then
+    goTreeFreeUWide litTable distTable litLD distLD maxBits data maxOut
+      (pos + 1)
+      (bitBuf ||| ((data.uget pos (by
+          have h := USize.lt_iff_toNat_lt.mp hrc.2
+          rwa [toUSize_toNat_of_lt hsz] at h)).toUInt64 <<< cnt.toUInt64))
+      (cnt + 8) hsz hlp output
+  else
+  let e := litTable.entryAtU (bitBuf &&& 0x7FF).toUSize
+    (by rw [hlp]; exact HuffTree.and_0x7FF_toUSize_toNat_lt bitBuf)
+  if hlit : HuffTree.unpackLen e ≠ 0
+      ∧ (HuffTree.unpackLen e).toUSize ≤ cnt
+      ∧ HuffTree.unpackSym e < 256 then
+    if output.size ≥ maxOut then throw "Inflate: output exceeds maximum size"
+    else
+      goTreeFreeUWide litTable distTable litLD distLD maxBits data maxOut pos
+        (bitBuf >>> (HuffTree.unpackLen e).toUInt64)
+        (cnt - (HuffTree.unpackLen e).toUSize)
+        hsz hlp
+        (output.push (HuffTree.unpackSym e).toUInt8)
+  else
+  let cnt0 := cnt.toNat
+  match decodeSymCanon litLD litTable maxBits bitBuf cnt.toNat with
+  | .error e => .error e
+  | .ok (sym, bitBuf, cnt', _used) =>
+    if sym < 256 then
+      if output.size ≥ maxOut then throw "Inflate: output exceeds maximum size"
+      else if hnp : cnt0 ≤ cnt' then throw "Inflate: no progress in Huffman decode"
+      else
+        goTreeFreeUWide litTable distTable litLD distLD maxBits data maxOut pos bitBuf
+          cnt'.toUSize hsz hlp (output.push sym.toUInt8)
+    else if sym == 256 then .ok (output, pos, bitBuf, cnt'.toUSize)
+    else
+      let idx := sym.toNat - 257
+      if h : idx ≥ Inflate.lengthBase.size then throw s!"Inflate: invalid length code {sym}"
+      else
+        let base := Inflate.lengthBase[idx]
+        let extra := Inflate.lengthExtra[idx]'(by simp [Inflate.lengthExtra_size, Inflate.lengthBase_size] at h ⊢; omega)
+        let (extraBits, bitBuf, cnt'') ← takeBits bitBuf cnt' extra.toNat
+        let length := base.toNat + extraBits
+        match decodeSymCanon distLD distTable maxBits bitBuf cnt'' with
+        | .error e => .error e
+        | .ok (distSym, bitBuf, cnt3, _dused) =>
+          let dIdx := distSym.toNat
+          if h : dIdx ≥ Inflate.distBase.size then throw s!"Inflate: invalid distance code {distSym}"
+          else
+            let dBase := Inflate.distBase[dIdx]
+            let dExtra := Inflate.distExtra[dIdx]'(by simp [Inflate.distExtra_size, Inflate.distBase_size] at h ⊢; omega)
+            let (dExtraBits, bitBuf, cnt4) ← takeBits bitBuf cnt3 dExtra.toNat
+            let distance := dBase.toNat + dExtraBits
+            if hz : distance = 0 then throw s!"Inflate: zero back-reference distance"
+            else if hds : distance > output.size then
+              throw s!"Inflate: distance {distance} exceeds output size {output.size}"
+            else if output.size + length > maxOut then throw "Inflate: output exceeds maximum size"
+            else if hnp : cnt0 ≤ cnt4 then throw "Inflate: no progress in Huffman decode"
+            else
+              let out := Inflate.copyLoop output (output.size - distance) distance 0 length
+                (by omega) (by omega)
+              goTreeFreeUWide litTable distTable litLD distLD maxBits data maxOut pos bitBuf
+                cnt4.toUSize hsz hlp out
+  termination_by (data.size - pos.toNat) * 9 + cnt.toNat
+  decreasing_by
+    · -- wide refill: pos advances by k ≥ 1, cnt by 8k, so measure drops by k
+      have hg := (refillGuardWide_usize data pos cnt hsz).mp hrcw
+      have hcn : cnt.toNat ≤ 56 := hg.1
+      have hpn : pos.toNat + 8 ≤ data.size := hg.2
+      have hbig : (64 : Nat) < 2 ^ System.Platform.numBits :=
+        USize.size_eq_two_pow ▸ Nat.lt_of_lt_of_le (by decide) USize.le_size
+      have hsz2 : data.size < 2 ^ System.Platform.numBits := USize.size_eq_two_pow ▸ hsz
+      have h8u : (8 : USize).toNat = 8 :=
+        USize.toNat_ofNat_of_lt (Nat.lt_of_lt_of_le (by decide) USize.le_size)
+      have hk : ((56 - cnt) / 8 + 1 : USize).toNat = (56 - cnt.toNat) / 8 + 1 :=
+        wideK_toNat cnt hcn
+      have h8k : (8 * ((56 - cnt) / 8 + 1) : USize).toNat = 8 * ((56 - cnt.toNat) / 8 + 1) := by
+        rw [USize.toNat_mul, hk, h8u]; apply Nat.mod_eq_of_lt; omega
+      have hposk : (pos + ((56 - cnt) / 8 + 1)).toNat = pos.toNat + ((56 - cnt.toNat) / 8 + 1) := by
+        rw [USize.toNat_add, hk]; apply Nat.mod_eq_of_lt; omega
+      have hcntk : (cnt + 8 * ((56 - cnt) / 8 + 1)).toNat = cnt.toNat + 8 * ((56 - cnt.toNat) / 8 + 1) := by
+        rw [USize.toNat_add, h8k]; apply Nat.mod_eq_of_lt; omega
+      rw [hposk, hcntk]; omega
     · obtain ⟨hc, hp⟩ := hrc
       have hbig : (64 : Nat) < 2 ^ System.Platform.numBits :=
         USize.size_eq_two_pow ▸ Nat.lt_of_lt_of_le (by decide) USize.le_size

--- a/Zip/Native/InflateTreeFree.lean
+++ b/Zip/Native/InflateTreeFree.lean
@@ -471,7 +471,7 @@ def decodeHuffmanFastBufTables (br : BitReader) (output : ByteArray)
   let (out, pos', bitBuf', cnt') ←
     if hsz : br.data.size.toUSize.toNat = br.data.size then
       Except.map (fun x => (x.1, x.2.1.toNat, x.2.2.1, x.2.2.2.toNat))
-        (goTreeFreeU litTable distTable litLD distLD 15 br.data maxOut
+        (goTreeFreeUWide litTable distTable litLD distLD 15 br.data maxOut
           pos.toUSize bitBuf cnt.toUSize (by rw [← hsz]; exact USize.toNat_lt_two_pow_numBits _)
           hlp output)
     else

--- a/Zip/Spec/InflateTreeFreeCorrect.lean
+++ b/Zip/Spec/InflateTreeFreeCorrect.lean
@@ -2,6 +2,7 @@ import Zip.Spec.InflateCanonical
 import Zip.Spec.InflateBufCorrect
 import Zip.Spec.DynamicTreesCorrect
 import Zip.Native.InflateTreeFree
+import Zip.Spec.RefillWide
 
 /-!
 # Tree-free canonical decode: correctness
@@ -1627,6 +1628,206 @@ theorem goTreeFreeU_eq (litTable distTable : HuffTree.DecodeTable) (data : ByteA
       intro hpos
       have hhc : ¬ sym.toNat - 257 ≥ Inflate.lengthBase.size := hh
       rw [goTreeFreeU, dif_neg hrc, dif_neg hlit,
+          goTreeFree, dif_neg (fun h => hrc ((refillGuard_usize data pos cnt hsz).mpr h)),
+          dif_neg (fun h => hlit ((litGuardU_usize litTable bitBuf cnt _).mpr h))]
+      simp only [hde, if_neg hsym, if_neg hneob, dif_neg hhc]
+      cases hex : takeBits bb c
+          (Inflate.lengthExtra[sym.toNat - 257]'(by
+            simp only [Inflate.lengthExtra_size]
+            simp only [Inflate.lengthBase_size, ge_iff_le, Nat.not_le] at hhc; omega)).toNat with
+      | error e => rfl
+      | ok pe =>
+          obtain ⟨eb, bb2, c2⟩ := pe
+          simp only [bind, Except.bind]
+          cases hdd : decodeSymCanon distLD distTable maxBits bb2 c2 with
+          | error e => rfl
+          | ok pd =>
+              obtain ⟨distSym, bb3, c3, dused⟩ := pd
+              simp only []
+              split
+              · rfl
+              · rename_i hdi
+                cases hex2 : takeBits bb3 c3
+                    (Inflate.distExtra[distSym.toNat]'(by
+                      simp only [Inflate.distExtra_size]
+                      simp only [Inflate.distBase_size, ge_iff_le, Nat.not_le] at hdi; omega)).toNat with
+                | error e => rfl
+                | ok pd2 =>
+                    obtain ⟨deb, bb4, c4⟩ := pd2
+                    simp only [bind, Except.bind]
+                    have hc4le : c4 ≤ cnt.toNat := by
+                      have h1 := takeBits_le bb c _ hex
+                      have h2 := HuffTree.decodeSymCanon_cnt_le distLD distTable maxBits bb2 c2 hdd
+                      have h3 := takeBits_le bb3 c3 _ hex2
+                      have h0 := HuffTree.decodeSymCanon_cnt_le litLD litTable maxBits bitBuf cnt.toNat hde
+                      omega
+                    have hc4rt : c4.toUSize.toNat = c4 :=
+                      toUSize_toNat_of_lt (Nat.lt_of_le_of_lt hc4le cnt.toNat_lt_two_pow_numBits)
+                    repeat' (first | rfl | split)
+                    all_goals exact (ih eb distSym hdi deb bb4 c4 (by assumption) (by assumption)
+                      (by assumption) hpos).trans (by rw [hc4rt])
+
+/-- **`goTreeFree` absorbs a refill** (tree-free mirror of `goFused_absorb_refill`):
+    `goTreeFree` begins each iteration by refilling, so running it from
+    `(pos, bitBuf, cnt)` equals running it from `refill data pos bitBuf cnt` — the
+    leading refill recursion *is* `refill`. Bridge from `refill_eq_wide` to
+    `goTreeFree`. -/
+theorem goTreeFree_absorb_refill (litTable distTable : HuffTree.DecodeTable)
+    (litLD distLD : HuffTree.LongDecode) (maxBits : Nat) (data : ByteArray) (maxOut : Nat)
+    (output : ByteArray) (pos : Nat) (bitBuf : UInt64) (cnt : Nat) :
+    goTreeFree litTable distTable litLD distLD maxBits data maxOut pos bitBuf cnt output
+    = goTreeFree litTable distTable litLD distLD maxBits data maxOut
+        (refill data pos bitBuf cnt).1 (refill data pos bitBuf cnt).2.1
+        (refill data pos bitBuf cnt).2.2 output := by
+  rw [refill]
+  split
+  · rename_i hrc
+    rw [goTreeFree, dif_pos hrc, ← getElem!_pos data pos hrc.2]
+    exact goTreeFree_absorb_refill litTable distTable litLD distLD maxBits data maxOut output
+      (pos + 1) (bitBuf ||| (data[pos]!.toUInt64 <<< cnt.toUInt64)) (cnt + 8)
+  · rfl
+termination_by data.size - pos
+decreasing_by simp_wf; omega
+
+set_option maxHeartbeats 1000000 in
+theorem goTreeFreeUWide_eq (litTable distTable : HuffTree.DecodeTable) (data : ByteArray)
+    (litLD distLD : HuffTree.LongDecode) (maxBits : Nat) (maxOut : Nat)
+    (hsz : data.size < USize.size)
+    (hlp : litTable.packed.size = 2 ^ HuffTree.fastBits) :
+    ∀ (pos : USize) (bitBuf : UInt64) (cnt : USize) (output : ByteArray),
+    pos.toNat ≤ data.size →
+    Except.map (fun x => (x.1, x.2.1.toNat, x.2.2.1, x.2.2.2.toNat))
+        (goTreeFreeUWide litTable distTable litLD distLD maxBits data maxOut pos bitBuf cnt hsz hlp output)
+      = goTreeFree litTable distTable litLD distLD maxBits data maxOut pos.toNat bitBuf cnt.toNat output := by
+  intro pos bitBuf cnt output
+  induction pos, bitBuf, cnt, output using goTreeFreeUWide.induct
+    (litTable := litTable) (litLD := litLD)
+    (maxBits := maxBits) (data := data) (maxOut := maxOut) (hsz := hsz) (hlp := hlp) with
+  | case1 pos bitBuf cnt output hrcw ih =>
+      intro hpos
+      have hg := (refillGuardWide_usize data pos cnt hsz).mp hrcw
+      have hcn : cnt.toNat ≤ 56 := hg.1
+      have hpn : pos.toNat + 8 ≤ data.size := hg.2
+      have hpltU : pos.toNat < USize.size := Nat.lt_of_le_of_lt hpos hsz
+      have hbig : (64 : Nat) < 2 ^ System.Platform.numBits :=
+        USize.size_eq_two_pow ▸ Nat.lt_of_lt_of_le (by decide) USize.le_size
+      have hsz2 : data.size < 2 ^ System.Platform.numBits := USize.size_eq_two_pow ▸ hsz
+      have h8u : (8 : USize).toNat = 8 :=
+        USize.toNat_ofNat_of_lt (Nat.lt_of_lt_of_le (by decide) USize.le_size)
+      have h64u : (64 : USize).toNat = 64 :=
+        USize.toNat_ofNat_of_lt (Nat.lt_of_lt_of_le (by decide) USize.le_size)
+      have hkval : ((56 - cnt) / 8 + 1 : USize).toNat = (56 - cnt.toNat) / 8 + 1 := wideK_toNat cnt hcn
+      have h8k : (8 * ((56 - cnt) / 8 + 1) : USize).toNat = 8 * ((56 - cnt.toNat) / 8 + 1) := by
+        rw [USize.toNat_mul, hkval, h8u]; apply Nat.mod_eq_of_lt; omega
+      have hposk : (pos + ((56 - cnt) / 8 + 1)).toNat = pos.toNat + ((56 - cnt.toNat) / 8 + 1) := by
+        rw [USize.toNat_add, hkval]; apply Nat.mod_eq_of_lt; omega
+      have hcntk : (cnt + 8 * ((56 - cnt) / 8 + 1)).toNat = cnt.toNat + 8 * ((56 - cnt.toNat) / 8 + 1) := by
+        rw [USize.toNat_add, h8k]; apply Nat.mod_eq_of_lt; omega
+      have hshiftN : (64 - 8 * ((56 - cnt) / 8 + 1) : USize).toNat
+          = 64 - 8 * ((56 - cnt.toNat) / 8 + 1) := by
+        rw [USize.toNat_sub_of_le _ _ (by rw [USize.le_iff_toNat_le, h8k, h64u]; omega), h64u, h8k]
+      have hshift : (64 - 8 * ((56 - cnt) / 8 + 1) : USize).toUInt64
+          = (64 - 8 * ((56 - cnt.toNat) / 8 + 1) : Nat).toUInt64 := by
+        rw [usize_toUInt64_toNat, hshiftN]
+      have hue : data.ugetUInt64LE pos hpn
+          = data.ugetUInt64LE (pos.toNat).toUSize (by rw [toUSize_toNat_of_lt hpltU]; exact hpn) :=
+        ugetUInt64LE_congr data pos (pos.toNat).toUSize hpn _ (toUSize_toNat_of_lt hpltU).symm
+      rw [goTreeFreeUWide, dif_pos hrcw, ih (by rw [hposk]; omega),
+          goTreeFree_absorb_refill litTable distTable litLD distLD maxBits data maxOut output
+            pos.toNat bitBuf cnt.toNat,
+          refill_eq_wide data pos.toNat bitBuf cnt.toNat hcn hpn hpltU,
+          hposk, hcntk, hue, hshift, usize_toUInt64_toNat cnt]
+  | case2 pos bitBuf cnt output hnw hrc ih =>
+      intro hpos
+      have hgN := (refillGuard_usize data pos cnt hsz).mp hrc
+      have hpn : pos.toNat < data.size := hgN.2
+      have hbig : (64 : Nat) < 2 ^ System.Platform.numBits :=
+        USize.size_eq_two_pow ▸ Nat.lt_of_lt_of_le (by decide) USize.le_size
+      have h8 : (8 : USize).toNat = 8 :=
+        USize.toNat_ofNat_of_lt (Nat.lt_of_lt_of_le (by decide) USize.le_size)
+      have e1 : (pos + 1).toNat = pos.toNat + 1 := by
+        rw [USize.toNat_add, USize.toNat_one]; apply Nat.mod_eq_of_lt
+        exact USize.size_eq_two_pow ▸ (show pos.toNat + 1 < USize.size by omega)
+      have e2 : (cnt + 8).toNat = cnt.toNat + 8 := by
+        rw [USize.toNat_add, h8]; apply Nat.mod_eq_of_lt; omega
+      rw [goTreeFreeUWide, dif_neg hnw, dif_pos hrc, goTreeFree, dif_pos hgN,
+          ih (by rw [e1]; omega), e1, e2,
+          uget_eq_getElem! data pos hpn, usize_toUInt64_toNat]
+  | case3 pos bitBuf cnt output hnw hrc ent hlit hmax =>
+      intro hpos
+      rw [goTreeFreeUWide, dif_neg hnw, dif_neg hrc, dif_pos hlit, if_pos hmax,
+          goTreeFree, dif_neg (fun h => hrc ((refillGuard_usize data pos cnt hsz).mpr h)),
+          dif_pos ((litGuardU_usize litTable bitBuf cnt _).mp hlit), if_pos hmax]
+      rfl
+  | case4 pos bitBuf cnt output hnw hrc ent hlit hmax ih =>
+      intro hpos
+      obtain ⟨hl0, hl1, hl2⟩ := hlit
+      have hle : litTable.lenAt (bitBuf &&& 0x7FF).toNat = HuffTree.unpackLen ent := by
+        rw [litTable.lenAt_eq_unpackLen_entryAt]; congr 1
+        exact (litTable.entryAtU_window_eq bitBuf _).symm
+      have hse : litTable.symAt (bitBuf &&& 0x7FF).toNat = HuffTree.unpackSym ent := by
+        rw [litTable.symAt_eq_unpackSym_entryAt]; congr 1
+        exact (litTable.entryAtU_window_eq bitBuf _).symm
+      have hsub : (cnt - (HuffTree.unpackLen ent).toUSize).toNat
+          = cnt.toNat - (HuffTree.unpackLen ent).toNat := by
+        rw [USize.toNat_sub_of_le _ _ hl1, UInt8.toNat_toUSize]
+      rw [goTreeFreeUWide, dif_neg hnw, dif_neg hrc, dif_pos ⟨hl0, hl1, hl2⟩, if_neg hmax,
+          goTreeFree, dif_neg (fun h => hrc ((refillGuard_usize data pos cnt hsz).mpr h)),
+          dif_pos ((litGuardU_usize litTable bitBuf cnt _).mp ⟨hl0, hl1, hl2⟩), if_neg hmax,
+          ih hpos, hsub, hle, hse, uint8_toUInt64_toNat]
+  | case5 pos bitBuf cnt output hnw hrc ent hlit e hde =>
+      intro hpos
+      rw [goTreeFreeUWide, dif_neg hnw, dif_neg hrc, dif_neg hlit,
+          goTreeFree, dif_neg (fun h => hrc ((refillGuard_usize data pos cnt hsz).mpr h)),
+          dif_neg (fun h => hlit ((litGuardU_usize litTable bitBuf cnt _).mpr h))]
+      simp only [hde, Except.map]
+  | case6 pos bitBuf cnt output hnw hrc ent hlit sym bb c used hde hsym hmax =>
+      intro hpos
+      rw [goTreeFreeUWide, dif_neg hnw, dif_neg hrc, dif_neg hlit,
+          goTreeFree, dif_neg (fun h => hrc ((refillGuard_usize data pos cnt hsz).mpr h)),
+          dif_neg (fun h => hlit ((litGuardU_usize litTable bitBuf cnt _).mpr h))]
+      simp only [hde, if_pos hsym, if_pos hmax]
+      rfl
+  | case7 pos bitBuf cnt output hnw hrc ent hlit cnt0 sym bb c used hde hsym hmax hnp =>
+      intro hpos
+      have hnp' : cnt.toNat ≤ c := hnp
+      rw [goTreeFreeUWide, dif_neg hnw, dif_neg hrc, dif_neg hlit,
+          goTreeFree, dif_neg (fun h => hrc ((refillGuard_usize data pos cnt hsz).mpr h)),
+          dif_neg (fun h => hlit ((litGuardU_usize litTable bitBuf cnt _).mpr h))]
+      simp only [hde, if_pos hsym, if_neg hmax, dif_pos hnp']
+      rfl
+  | case8 pos bitBuf cnt output hnw hrc ent hlit cnt0 sym bb c used hde hsym hmax hnp ih =>
+      intro hpos
+      have hnp' : ¬ cnt.toNat ≤ c := hnp
+      have hcle : c ≤ cnt.toNat := HuffTree.decodeSymCanon_cnt_le litLD litTable maxBits bitBuf cnt.toNat hde
+      have hcrt : c.toUSize.toNat = c :=
+        toUSize_toNat_of_lt (Nat.lt_of_le_of_lt hcle cnt.toNat_lt_two_pow_numBits)
+      rw [goTreeFreeUWide, dif_neg hnw, dif_neg hrc, dif_neg hlit,
+          goTreeFree, dif_neg (fun h => hrc ((refillGuard_usize data pos cnt hsz).mpr h)),
+          dif_neg (fun h => hlit ((litGuardU_usize litTable bitBuf cnt _).mpr h))]
+      simp only [hde, if_pos hsym, if_neg hmax, dif_neg hnp']
+      rw [ih hpos, hcrt]
+  | case9 pos bitBuf cnt output hnw hrc ent hlit sym bb c used hde hsym heob =>
+      intro hpos
+      have hcle : c ≤ cnt.toNat := HuffTree.decodeSymCanon_cnt_le litLD litTable maxBits bitBuf cnt.toNat hde
+      have hcrt : c.toUSize.toNat = c :=
+        toUSize_toNat_of_lt (Nat.lt_of_le_of_lt hcle cnt.toNat_lt_two_pow_numBits)
+      rw [goTreeFreeUWide, dif_neg hnw, dif_neg hrc, dif_neg hlit,
+          goTreeFree, dif_neg (fun h => hrc ((refillGuard_usize data pos cnt hsz).mpr h)),
+          dif_neg (fun h => hlit ((litGuardU_usize litTable bitBuf cnt _).mpr h))]
+      simp only [hde, if_neg hsym, if_pos heob, Except.map, hcrt]
+  | case10 pos bitBuf cnt output hnw hrc ent hlit sym bb c used hde hsym hneob idx hidx =>
+      intro hpos
+      have hidxc : sym.toNat - 257 ≥ Inflate.lengthBase.size := hidx
+      rw [goTreeFreeUWide, dif_neg hnw, dif_neg hrc, dif_neg hlit,
+          goTreeFree, dif_neg (fun h => hrc ((refillGuard_usize data pos cnt hsz).mpr h)),
+          dif_neg (fun h => hlit ((litGuardU_usize litTable bitBuf cnt _).mpr h))]
+      simp only [hde, if_neg hsym, if_neg hneob, dif_pos hidxc]
+      rfl
+  | case11 pos bitBuf cnt output hnw hrc ent hlit cnt0 sym bb c used hde hsym hneob idx hh base ih =>
+      intro hpos
+      have hhc : ¬ sym.toNat - 257 ≥ Inflate.lengthBase.size := hh
+      rw [goTreeFreeUWide, dif_neg hnw, dif_neg hrc, dif_neg hlit,
           goTreeFree, dif_neg (fun h => hrc ((refillGuard_usize data pos cnt hsz).mpr h)),
           dif_neg (fun h => hlit ((litGuardU_usize litTable bitBuf cnt _).mpr h))]
       simp only [hde, if_neg hsym, if_neg hneob, dif_neg hhc]

--- a/Zip/Spec/InflateTreeFreeCorrect.lean
+++ b/Zip/Spec/InflateTreeFreeCorrect.lean
@@ -1918,7 +1918,7 @@ theorem decodeHuffmanFastBufTreeFree_ok_iff (br : BitReader) (output : ByteArray
     have hsz' : br.data.size < USize.size := by rw [← hsz]; exact USize.toNat_lt_two_pow_numBits _
     have hcsz : (cnt0 - br.bitOff) < USize.size :=
       Nat.lt_of_le_of_lt hbc2.cntLe (Nat.lt_of_lt_of_le (by decide) USize.le_size)
-    rw [goTreeFreeU_eq (fromLengthsTree litLengths 15).buildTable
+    rw [goTreeFreeUWide_eq (fromLengthsTree litLengths 15).buildTable
           (fromLengthsTree distLengths 15).buildTable br.data
           (buildLongDecodeWithCount litLengths (countLengthsFast litLengths 15) 15)
           (buildLongDecodeWithCount distLengths (countLengthsFast distLengths 15) 15) 15 maxOut hsz'

--- a/Zip/Spec/RefillWide.lean
+++ b/Zip/Spec/RefillWide.lean
@@ -1,0 +1,147 @@
+import Std.Tactic.BVDecide
+import Zip.Native.Inflate
+import Zip.Native.Wide
+
+/-!
+# Wide bit-refill: one `ugetUInt64LE` load replaces the per-byte refill loop
+
+`InflateBuf.refill` tops up the bit buffer one byte at a time. When at least
+eight bytes remain (`pos + 8 ≤ data.size`) and the buffer holds `cnt ≤ 56` bits,
+the loop loads exactly `k = (56 - cnt)/8 + 1` whole bytes (bringing the count to
+`cnt + 8k ∈ (56, 64]`). This file proves that those `k` byte-loads equal a single
+little-endian eight-byte load (`ByteArray.ugetUInt64LE`) whose top `8 - k` bytes
+are cleared (via a `<<< s >>> s` shift pair, `s = 64 - 8k`) and shifted into place
+at bit `cnt`.
+
+The masked wide step is **state-equal** to the byte loop: `refill_eq_wide` shows
+`refill` itself produces exactly that `(pos, bitBuf, cnt)`. It is the single fact
+the wide-refill production loops (`goTreeFreeUWide`, `goFusedPUWide`) are proven
+equal through — their equivalence proofs reuse the existing `*_absorb_refill`
+machinery untouched.
+-/
+
+namespace Zip.Native.InflateBuf
+
+/-- The OR of the `j` bytes `data[pos], data[pos+1], …, data[pos+j-1]` shifted to
+    bit positions `cnt, cnt+8, …` — the accumulator the byte-refill loop builds
+    across `j` iterations starting from an empty buffer. -/
+def chainOR (data : ByteArray) (pos cnt : Nat) : Nat → UInt64
+  | 0 => 0
+  | j + 1 => (data[pos]!.toUInt64 <<< cnt.toUInt64) ||| chainOR data (pos + 1) (cnt + 8) j
+
+/-- **`refill` runs exactly `k` byte-loads.** When each of the first `k` steps
+    fires (`cnt + 8i ≤ 56`, `pos + i` in range) and the `k`-th brings the count
+    past 56, `refill` advances the cursor by `k`, ORs the `k` bytes into the
+    buffer (`chainOR`), and raises the count by `8k`. -/
+theorem refill_chain (data : ByteArray) :
+    ∀ (k pos : Nat) (bb : UInt64) (cnt : Nat),
+    (∀ i, i < k → cnt + 8 * i ≤ 56 ∧ pos + i < data.size) →
+    56 < cnt + 8 * k →
+    refill data pos bb cnt = (pos + k, bb ||| chainOR data pos cnt k, cnt + 8 * k) := by
+  intro k
+  induction k with
+  | zero =>
+    intro pos bb cnt _ hgt
+    have hc : ¬ (cnt ≤ 56 ∧ pos < data.size) := by
+      rintro ⟨h, _⟩; omega
+    rw [refill, dif_neg hc]
+    simp [chainOR]
+  | succ k ih =>
+    intro pos bb cnt hfire hgt
+    obtain ⟨hcnt, hpos⟩ := hfire 0 (by omega)
+    simp only [Nat.mul_zero, Nat.add_zero] at hcnt hpos
+    rw [refill, dif_pos ⟨hcnt, hpos⟩, ← getElem!_pos data pos hpos]
+    rw [ih (pos + 1) (bb ||| (data[pos]!.toUInt64 <<< cnt.toUInt64)) (cnt + 8)
+        (by
+          intro i hi
+          obtain ⟨h1, h2⟩ := hfire (i + 1) (by omega)
+          constructor <;> omega)
+        (by omega)]
+    have hpk : pos + 1 + k = pos + (k + 1) := by omega
+    have hck : cnt + 8 + 8 * k = cnt + 8 * (k + 1) := by omega
+    have hor : (bb ||| (data[pos]!.toUInt64 <<< cnt.toUInt64)) ||| chainOR data (pos + 1) (cnt + 8) k
+        = bb ||| chainOR data pos cnt (k + 1) := by
+      rw [chainOR, UInt64.or_assoc]
+    rw [hpk, hck, hor]
+
+/-- `Nat.toUInt64` is additive (both sides reduce mod `2^64`). -/
+private theorem natAdd_toUInt64 (a b : Nat) : (a + b).toUInt64 = a.toUInt64 + b.toUInt64 := by
+  apply UInt64.toNat_inj.mp
+  simp only [Nat.toUInt64, UInt64.toNat_add, UInt64.toNat_ofNat']
+  omega
+
+private theorem tu0  : Nat.toUInt64 0  = 0  := rfl
+private theorem tu8  : Nat.toUInt64 8  = 8  := rfl
+private theorem tu16 : Nat.toUInt64 16 = 16 := rfl
+private theorem tu24 : Nat.toUInt64 24 = 24 := rfl
+private theorem tu32 : Nat.toUInt64 32 = 32 := rfl
+private theorem tu40 : Nat.toUInt64 40 = 40 := rfl
+private theorem tu48 : Nat.toUInt64 48 = 48 := rfl
+private theorem tu56 : Nat.toUInt64 56 = 56 := rfl
+
+set_option maxHeartbeats 2000000 in
+/-- **The `k`-byte OR chain is the masked wide load.** The bytes the byte loop ORs
+    in at `cnt, cnt+8, …` are exactly the low `k` bytes of the eight-byte
+    little-endian word at `pos`, cleared above bit `8k` (by `<<< s >>> s`,
+    `s = 64 - 8k`) and shifted to bit `cnt`. `cnt + 8k ≤ 64` keeps every shift
+    below 64 (no wraparound). Proved per `k ∈ {1,…,8}` by `bv_decide`. -/
+theorem chainOR_eq_recomb (data : ByteArray) (pos cnt k : Nat)
+    (hk1 : 1 ≤ k) (hk8 : k ≤ 8) (hck : cnt + 8 * k ≤ 64) :
+    chainOR data pos cnt k
+      = (((data[pos]!.toUInt64 ||| data[pos+1]!.toUInt64 <<< 8 ||| data[pos+2]!.toUInt64 <<< 16
+          ||| data[pos+3]!.toUInt64 <<< 24 ||| data[pos+4]!.toUInt64 <<< 32
+          ||| data[pos+5]!.toUInt64 <<< 40 ||| data[pos+6]!.toUInt64 <<< 48
+          ||| data[pos+7]!.toUInt64 <<< 56)
+          <<< (64 - 8 * k : Nat).toUInt64) >>> (64 - 8 * k : Nat).toUInt64) <<< cnt.toUInt64 := by
+  have hcU : cnt.toUInt64 ≤ (64 - 8 * k : Nat).toUInt64 := by
+    apply UInt64.le_iff_toNat_le.mpr
+    simp only [Nat.toUInt64, UInt64.toNat_ofNat']
+    omega
+  have hcases : k = 1 ∨ k = 2 ∨ k = 3 ∨ k = 4 ∨ k = 5 ∨ k = 6 ∨ k = 7 ∨ k = 8 := by omega
+  rcases hcases with rfl|rfl|rfl|rfl|rfl|rfl|rfl|rfl <;>
+    simp only [chainOR, Nat.add_assoc, Nat.reduceAdd, Nat.reduceMul, Nat.reduceSub,
+               natAdd_toUInt64, tu0, tu8, tu16, tu24, tu32, tu40, tu48, tu56,
+               UInt64.or_zero] at hcU ⊢ <;>
+    bv_decide
+
+/-- **`ugetUInt64LE` is the eight-byte little-endian recombination.** Its trusted
+    reference body, with the `USize` offset's `toNat` round-trip discharged and
+    the bounds-checked `getElem` reads normalised to `getElem!`. -/
+theorem ugetUInt64LE_recomb (data : ByteArray) (pos : Nat)
+    (hpos : pos + 8 ≤ data.size) (hp : pos < USize.size) :
+    data.ugetUInt64LE pos.toUSize (by rw [toUSize_toNat_of_lt hp]; omega)
+      = data[pos]!.toUInt64 ||| data[pos+1]!.toUInt64 <<< 8 ||| data[pos+2]!.toUInt64 <<< 16
+        ||| data[pos+3]!.toUInt64 <<< 24 ||| data[pos+4]!.toUInt64 <<< 32
+        ||| data[pos+5]!.toUInt64 <<< 40 ||| data[pos+6]!.toUInt64 <<< 48
+        ||| data[pos+7]!.toUInt64 <<< 56 := by
+  rw [ByteArray.ugetUInt64LE]
+  simp only [toUSize_toNat_of_lt hp]
+  rw [getElem!_pos data pos (by omega), getElem!_pos data (pos+1) (by omega),
+      getElem!_pos data (pos+2) (by omega), getElem!_pos data (pos+3) (by omega),
+      getElem!_pos data (pos+4) (by omega), getElem!_pos data (pos+5) (by omega),
+      getElem!_pos data (pos+6) (by omega), getElem!_pos data (pos+7) (by omega)]
+
+/-- **The byte-refill loop equals one masked wide load.** From `cnt ≤ 56` with at
+    least eight bytes remaining, `refill` advances to the same `(pos, bitBuf, cnt)`
+    a single `ugetUInt64LE` load produces: the low `k = (56-cnt)/8 + 1` bytes of the
+    word, cleared above bit `8k` and shifted to bit `cnt`, ORed into the buffer.
+    The wide-refill loops are proven equal to their byte-refill twins through this
+    one equation. -/
+theorem refill_eq_wide (data : ByteArray) (pos : Nat) (bb : UInt64) (cnt : Nat)
+    (hcnt : cnt ≤ 56) (hpos : pos + 8 ≤ data.size) (hp : pos < USize.size) :
+    refill data pos bb cnt
+      = (pos + ((56 - cnt) / 8 + 1),
+         bb ||| (((data.ugetUInt64LE pos.toUSize (by rw [toUSize_toNat_of_lt hp]; omega))
+                    <<< (64 - 8 * ((56 - cnt) / 8 + 1) : Nat).toUInt64
+                    >>> (64 - 8 * ((56 - cnt) / 8 + 1) : Nat).toUInt64)
+                  <<< cnt.toUInt64),
+         cnt + 8 * ((56 - cnt) / 8 + 1)) := by
+  have hk1 : 1 ≤ (56 - cnt) / 8 + 1 := by omega
+  have hk8 : (56 - cnt) / 8 + 1 ≤ 8 := by omega
+  have hck : cnt + 8 * ((56 - cnt) / 8 + 1) ≤ 64 := by omega
+  have hgt : 56 < cnt + 8 * ((56 - cnt) / 8 + 1) := by omega
+  rw [refill_chain data ((56 - cnt) / 8 + 1) pos bb cnt (fun i hi => ⟨by omega, by omega⟩) hgt,
+      chainOR_eq_recomb data pos cnt ((56 - cnt) / 8 + 1) hk1 hk8 hck,
+      ugetUInt64LE_recomb data pos hpos hp]
+
+end Zip.Native.InflateBuf

--- a/Zip/Spec/RefillWide.lean
+++ b/Zip/Spec/RefillWide.lean
@@ -104,6 +104,13 @@ theorem chainOR_eq_recomb (data : ByteArray) (pos cnt k : Nat)
                UInt64.or_zero] at hcU ⊢ <;>
     bv_decide
 
+/-- `ugetUInt64LE` depends only on the offset's `toNat`, so equal `toNat`s (e.g. a
+    `USize`/`Nat`-round-trip of the same offset) give the same word. -/
+theorem ugetUInt64LE_congr (data : ByteArray) (o1 o2 : USize)
+    (h1 : o1.toNat + 8 ≤ data.size) (h2 : o2.toNat + 8 ≤ data.size) (he : o1.toNat = o2.toNat) :
+    data.ugetUInt64LE o1 h1 = data.ugetUInt64LE o2 h2 := by
+  simp only [ByteArray.ugetUInt64LE, he]
+
 /-- **`ugetUInt64LE` is the eight-byte little-endian recombination.** Its trusted
     reference body, with the `USize` offset's `toNat` round-trip discharged and
     the bounds-checked `getElem` reads normalised to `getElem!`. -/

--- a/Zip/Spec/RefillWide.lean
+++ b/Zip/Spec/RefillWide.lean
@@ -15,9 +15,11 @@ at bit `cnt`.
 
 The masked wide step is **state-equal** to the byte loop: `refill_eq_wide` shows
 `refill` itself produces exactly that `(pos, bitBuf, cnt)`. It is the single fact
-the wide-refill production loops (`goTreeFreeUWide`, `goFusedPUWide`) are proven
-equal through — their equivalence proofs reuse the existing `*_absorb_refill`
-machinery untouched.
+the wide-refill production loop `goTreeFreeUWide` is proven equal through — its
+equivalence proof reuses the existing `goTreeFree_absorb_refill` machinery
+untouched. (The reference/spec decoder `goFusedPU`, used only by
+`inflateRawReference`, deliberately stays byte-refill: it is not the production
+path, so widening it would add complexity to the spec anchor for no runtime win.)
 -/
 
 namespace Zip.Native.InflateBuf
@@ -85,7 +87,7 @@ set_option maxHeartbeats 2000000 in
     little-endian word at `pos`, cleared above bit `8k` (by `<<< s >>> s`,
     `s = 64 - 8k`) and shifted to bit `cnt`. `cnt + 8k ≤ 64` keeps every shift
     below 64 (no wraparound). Proved per `k ∈ {1,…,8}` by `bv_decide`. -/
-theorem chainOR_eq_recomb (data : ByteArray) (pos cnt k : Nat)
+private theorem chainOR_eq_recomb (data : ByteArray) (pos cnt k : Nat)
     (hk1 : 1 ≤ k) (hk8 : k ≤ 8) (hck : cnt + 8 * k ≤ 64) :
     chainOR data pos cnt k
       = (((data[pos]!.toUInt64 ||| data[pos+1]!.toUInt64 <<< 8 ||| data[pos+2]!.toUInt64 <<< 16


### PR DESCRIPTION
This PR adds a wide bit-refill to the production tree-free DEFLATE decoder: when at least eight bytes remain and the bit buffer holds `cnt ≤ 56` bits, the per-byte refill loop is replaced by a single little-endian eight-byte load (`ByteArray.ugetUInt64LE`) whose top `8 − k` bytes are cleared (a `<<< s >>> s` shift pair, `s = 64 − 8k`, `k = (56 − cnt)/8 + 1`) and ORed in at bit `cnt`; near the buffer end it falls back to the byte loop. The masked wide step is proven **state-equal** to the byte loop — same `(pos, bitBuf, cnt)` afterwards — so the whole inflate correctness chain transfers untouched.

The verification is contained in one localized lemma. `refill_eq_wide` (`Zip/Spec/RefillWide.lean`) shows the byte-refill `refill` function itself produces exactly the masked wide step, via `refill_chain` (unroll the `k` byte-loads), `chainOR_eq_recomb` (the `k`-byte OR chain equals the masked recombination, `bv_decide` per `k ∈ {1,…,8}`), and `ugetUInt64LE_recomb`. The production loop `goTreeFreeUWide` is then proven equal to the boxed reference `goTreeFree` (`goTreeFreeUWide_eq`) by reusing the existing `goTreeFree_absorb_refill` machinery: its decode cases are the `goTreeFreeU_eq` cases with an extra "not wide" guard threaded through, and only the wide case is new. The wide guard uses subtraction (`pos ≤ data.size.toUSize − 8`, guarded by `8 ≤ data.size.toUSize`) rather than `pos + 8 ≤ …` so it never wraps near the top of the address space.

The measured in-situ decode win is marginal and content-dependent. Pinned, drift-cancelled interleaved A/B (n=15) over canterbury payloads at level 6: lcet10 +1.5%, dickens +1.3%, ptt5 flat, kennedy.xls −1.0% — geomean ≈ +0.5%. Text-heavy streams gain a little; binary/structured data is flat-to-slightly-negative because the masked variant reads eight bytes even when the byte loop would have topped up with one or two. This matches the issue's own "single-digit / dilutes like the hash3 reader" prediction. The change carries no correctness risk (it is proven equal to the byte loop), and it is the masked foundation the giesen-trick follow-up (#2630's deferred variant) would build on — though the marginal in-situ slice here is a fair argument that the giesen bisimulation rework is not yet justified.

The reference/spec decoder `goFusedPU` (used only by `inflateRawReference`) deliberately stays byte-refill: it is not the production path, so widening it would add complexity to the spec anchor for no runtime win. Codex reviewed the diff and found no soundness issues (out-of-bounds, `k`/mask off-by-one, or `USize` wraparound); the `k = 8` / `cnt = 0` full-word case and the `≤ 64` post-refill invariant check out.

🤖 Prepared with Claude Code
