### PR TITLE
perf: USize-native merged insertion loop (updateHashesMergedFastU)

### DIFF
--- a/Zip/Native/Deflate.lean
+++ b/Zip/Native/Deflate.lean
@@ -1765,16 +1765,133 @@ def updateHashesMergedFast (data : ByteArray) (hashSize prevSize : Nat)
 termination_by matchLen - j
 decreasing_by all_goals omega
 
+/-- `lz77Greedy.hash3` with the per-call `USize` bookkeeping hoisted: the caller
+    supplies the already-converted `USize` position `pU` and the buffer
+    addressability witness `hsz` once, so the hot insertion loop pays neither the
+    `data.size.toUSize.toNat = data.size` round-trip check nor the `pos.toUSize`
+    conversion per call, and the final bucket reduction runs as one unboxed
+    `USize` mod instead of a boxed `Nat` mod. Same wide-load / 3-byte-tail
+    fallback structure as `hash3`, so `hash3U_toNat` (in `LZ77MergedCorrect`)
+    shows the value is exactly `hash3`'s whenever the buffer is
+    `USize`-addressable. -/
+@[inline] def hash3U (data : ByteArray) (p : Nat) (pU hashSizeU : USize)
+    (hpU : pU.toNat = p) (h : p + 2 < data.size) : USize :=
+  let word :=
+    if h4 : p + 4 ≤ data.size then
+      ByteArray.ugetUInt32LE data pU (by rw [hpU]; omega)
+    else
+      let a := (data[p]'(by omega)).toUInt32
+      let b := (data[p + 1]'(by omega)).toUInt32
+      let c := (data[p + 2]'(by omega)).toUInt32
+      a ||| (b <<< 8) ||| (c <<< 16)
+  ((word * 2654435761) >>> 16).toUSize % hashSizeU
+
+/-- The `USize` bucket index is in range: `hash3U` ends in `% hashSizeU`, whose
+    `toNat` is the `Nat` mod by `hashSize`. Discharges the write bounds inside
+    `updateHashesMergedFastU`. -/
+theorem hash3U_toNat_lt (data : ByteArray) (p hashSize : Nat) (pU hashSizeU : USize)
+    (hpU : pU.toNat = p) (h : p + 2 < data.size)
+    (hhsU : hashSizeU.toNat = hashSize) (hhs : 0 < hashSize) :
+    (hash3U data p pU hashSizeU hpU h).toNat < hashSize := by
+  unfold hash3U
+  simp only [USize.toNat_mod, hhsU]
+  exact Nat.mod_lt _ hhs
+
+/-- USize-native de-boxed twin of `updateHashesMergedFast` (the interior-hash
+    insertion loop, 13–25% of L4–L8 compress time): the per-insertion index
+    bookkeeping — the loop counter `jU`, the data-bound test, the bucket index
+    `prevSizeU + hshU`, and the chain mask `pjU &&& 0x7FFF` — runs on unboxed
+    `USize` instead of tagged `Nat`, with the two hot writes and the head read as
+    `Array.uset`/`Array.uget` (no per-step bounds branch, no `Nat` untag on the
+    index). The data-bound test is one `USize` compare against the hoisted
+    remaining-bytes bound `rem2U` (`= data.size - pos - 2`, computed once by the
+    guarded wrapper), and the per-step hash goes through `hash3U`, which skips
+    `hash3`'s per-call addressability round-trip. The stored position value stays
+    `Nat` (the array is a `Nat` ring), produced by one `USize.toNat` per
+    insertion. Proven equal to `updateHashesMerged`
+    (`updateHashesMergedFastU_eq` in `LZ77MergedCorrect`). -/
+def updateHashesMergedFastU (data : ByteArray) (hashSize prevSize pos : Nat)
+    (c : Array Nat)
+    (hhs : 0 < hashSize) (hph : prevSize + hashSize ≤ c.size)
+    (hpv : min chainWinSize data.size ≤ prevSize)
+    (hsz : data.size < USize.size) (hphlt : prevSize + hashSize < USize.size)
+    (posU prevSizeU hashSizeU rem2U capU : USize)
+    (hposU : posU.toNat = pos) (hpsU : prevSizeU.toNat = prevSize)
+    (hhsU : hashSizeU.toNat = hashSize)
+    (hrem2U : rem2U.toNat = data.size - pos - 2)
+    (jU matchLenU : USize) : Array Nat :=
+  if jU < matchLenU ∧ jU ≤ capU then
+    if hd : jU < rem2U then
+      have hUS : USize.size = 2 ^ System.Platform.numBits := rfl
+      have hjlt : jU.toNat < data.size - pos - 2 := by
+        rw [← hrem2U]; exact USize.lt_iff_toNat_lt.mp hd
+      have hpjU : (posU + jU).toNat = pos + jU.toNat := by
+        rw [USize.toNat_add, hposU]; exact Nat.mod_eq_of_lt (by omega)
+      have hp2 : (posU + jU).toNat + 2 < data.size := by omega
+      let hshU := hash3U data ((posU + jU).toNat) (posU + jU) hashSizeU rfl hp2
+      have hshlt : hshU.toNat < hashSize :=
+        hash3U_toNat_lt data ((posU + jU).toNat) hashSize (posU + jU) hashSizeU rfl hp2 hhsU hhs
+      have hidx : (prevSizeU + hshU).toNat = prevSize + hshU.toNat := by
+        rw [USize.toNat_add, hpsU]; exact Nat.mod_eq_of_lt (by omega)
+      have hb : (prevSizeU + hshU).toNat < c.size := by rw [hidx]; omega
+      let head := c.uget (prevSizeU + hshU) hb
+      have hmaskb : ((posU + jU) &&& 0x7FFF).toNat < c.size := by
+        rw [USize.toNat_and,
+          USize.toNat_ofNat_of_lt (Nat.lt_of_lt_of_le (by decide) USize.le_size)]
+        show ((posU + jU).toNat &&& 0x7FFF) < c.size
+        have h1 := winMask_lt ((posU + jU).toNat)
+        have h2 := Nat.and_le_left (n := (posU + jU).toNat) (m := 0x7FFF)
+        simp only [chainWinSize] at h1 hpv
+        omega
+      updateHashesMergedFastU data hashSize prevSize pos
+        ((c.uset (prevSizeU + hshU) ((posU + jU).toNat) hb).uset ((posU + jU) &&& 0x7FFF) head
+          (by rw [Array.size_uset]; exact hmaskb))
+        hhs (by rw [Array.size_uset, Array.size_uset]; exact hph) hpv hsz hphlt
+        posU prevSizeU hashSizeU rem2U capU hposU hpsU hhsU hrem2U (jU + 1) matchLenU
+    else
+      updateHashesMergedFastU data hashSize prevSize pos c hhs hph hpv hsz hphlt
+        posU prevSizeU hashSizeU rem2U capU hposU hpsU hhsU hrem2U (jU + 1) matchLenU
+  else c
+termination_by matchLenU.toNat - jU.toNat
+decreasing_by
+  all_goals
+    have hUS : USize.size = 2 ^ System.Platform.numBits := rfl
+    have hc : jU < matchLenU ∧ jU ≤ capU := by assumption
+    have hlt : jU.toNat < matchLenU.toNat := USize.lt_iff_toNat_lt.mp hc.1
+    have hml := USize.toNat_lt_two_pow_numBits matchLenU
+    have hj1 : (jU + 1).toNat = jU.toNat + 1 := by
+      rw [USize.toNat_add, USize.toNat_one]; exact Nat.mod_eq_of_lt (by omega)
+    omega
+
 /-- One runtime `0 < hashSize ∧ prevSize + hashSize ≤ c.size ∧ min chainWinSize
     data.size ≤ prevSize` check guards the whole merged insertion loop, unlocking
-    the proven-bounds walk (`updateHashesMergedFast`); the fallback is the
-    runtime-guarded `updateHashesMerged` (dead in practice — the production
+    the proven-bounds walk; a second `USize`-faithfulness check (one
+    `data.size.toUSize.toNat = data.size` round-trip witnessing addressability,
+    plus round-trips for the small loop arguments — never failing in production:
+    `data.size` fits a `size_t`, `matchLen ≤ 259`, `insertCap` is the fixed knob)
+    then unlocks the de-boxed `USize` walk (`updateHashesMergedFastU`). The
+    fallbacks are the proven-bounds `Nat` walk (`updateHashesMergedFast`) and the
+    runtime-guarded `updateHashesMerged` (both dead in practice — the production
     combined array is a fixed `prevSize + hashSize`-entry `replicate`). Proven
     equal to `updateHashesMerged` (`updateHashesMergedGuarded_eq`). -/
 @[inline] def updateHashesMergedGuarded (data : ByteArray) (hashSize prevSize : Nat)
     (c : Array Nat) (pos j matchLen insertCap : Nat) : Array Nat :=
   if hg : 0 < hashSize ∧ prevSize + hashSize ≤ c.size ∧ min chainWinSize data.size ≤ prevSize then
-    updateHashesMergedFast data hashSize prevSize c pos j matchLen insertCap hg.1 hg.2.1 hg.2.2
+    if hu : data.size.toUSize.toNat = data.size ∧
+        (prevSize + hashSize).toUSize.toNat = prevSize + hashSize ∧
+        pos.toUSize.toNat = pos ∧ j.toUSize.toNat = j ∧
+        matchLen.toUSize.toNat = matchLen ∧ insertCap.toUSize.toNat = insertCap then
+      have hsz : data.size < USize.size := by
+        rw [← hu.1]; exact USize.toNat_lt_two_pow_numBits _
+      have hphlt : prevSize + hashSize < USize.size := by
+        rw [← hu.2.1]; exact USize.toNat_lt_two_pow_numBits _
+      updateHashesMergedFastU data hashSize prevSize pos c hg.1 hg.2.1 hg.2.2 hsz hphlt
+        pos.toUSize prevSize.toUSize hashSize.toUSize (data.size - pos - 2).toUSize
+        insertCap.toUSize hu.2.2.1 (toUSize_toNat_of_lt (by omega))
+        (toUSize_toNat_of_lt (by omega)) (toUSize_toNat_of_lt (by omega))
+        j.toUSize matchLen.toUSize
+    else
+      updateHashesMergedFast data hashSize prevSize c pos j matchLen insertCap hg.1 hg.2.1 hg.2.2
   else
     updateHashesMerged data hashSize prevSize c pos j matchLen insertCap
 

--- a/Zip/Spec/LZ77MergedCorrect.lean
+++ b/Zip/Spec/LZ77MergedCorrect.lean
@@ -203,8 +203,103 @@ private theorem updateHashesMergedFast_eq (data : ByteArray) (hashSize prevSize 
         exact ih _ (by omega) _ _ hph rfl
     · rw [if_neg hcond, if_neg hcond]
 
-/-- The guarded merged walk equals the reference merged walk (fast branch via
-    `updateHashesMergedFast_eq`; the fallback branch is definitionally it). -/
+/-! ## The de-boxed `USize` insertion walk -/
+
+/-- `lz77Greedy.hash3` congruence in the position (the bounds proof transports). -/
+private theorem hash3_congr (data : ByteArray) (hashSize : Nat) {p q : Nat} (e : p = q)
+    (hp : p + 2 < data.size) (hq : q + 2 < data.size) :
+    lz77Greedy.hash3 data p hashSize hp = lz77Greedy.hash3 data q hashSize hq := by
+  subst e; rfl
+
+/-- `hash3U` computes exactly `hash3`'s bucket whenever the buffer is
+    `USize`-addressable: the hoisted witness makes `hash3`'s per-call
+    addressability check always take the wide-load branch (whose reference body
+    `hash3U` shares), and the `USize` mod is the faithful image of the `Nat`
+    mod. -/
+private theorem hash3U_toNat (data : ByteArray) (p hashSize : Nat) (pU hashSizeU : USize)
+    (hpU : pU.toNat = p) (hhsU : hashSizeU.toNat = hashSize)
+    (hsz : data.size < USize.size) (h : p + 2 < data.size) :
+    (hash3U data p pU hashSizeU hpU h).toNat = lz77Greedy.hash3 data p hashSize h := by
+  have hplt : p < USize.size := by omega
+  have hpUe : pU = p.toUSize := by
+    apply USize.toNat_inj.mp; rw [hpU, toUSize_toNat_of_lt hplt]
+  subst hpUe
+  unfold hash3U lz77Greedy.hash3
+  have tail : ∀ w : UInt32,
+      (((w * 2654435761) >>> 16).toUSize % hashSizeU).toNat
+        = ((w * 2654435761) >>> 16).toNat % hashSize := by
+    intro w; rw [USize.toNat_mod, UInt32.toNat_toUSize, hhsU]
+  by_cases h4 : p + 4 ≤ data.size
+  · rw [dif_pos h4, dif_pos h4, dif_pos (toUSize_toNat_of_lt hsz)]
+    exact tail _
+  · rw [dif_neg h4, dif_neg h4]
+    exact tail _
+
+/-- The de-boxed `USize` merged walk equals the reference merged walk: identical
+    control flow (each `USize` compare the faithful image of its `Nat` twin
+    through the `toNat` identities), the hash via `hash3U_toNat`, and the
+    `uget`/`uset` accesses collapsing to `[]!`/`set!` in bounds. -/
+private theorem updateHashesMergedFastU_eq (data : ByteArray) (hashSize prevSize : Nat)
+    (c : Array Nat) (pos j matchLen insertCap : Nat)
+    (hhs : 0 < hashSize) (hph : prevSize + hashSize ≤ c.size)
+    (hpv : min chainWinSize data.size ≤ prevSize)
+    (hsz : data.size < USize.size) (hphlt : prevSize + hashSize < USize.size)
+    (posU prevSizeU hashSizeU rem2U capU jU matchLenU : USize)
+    (hposU : posU.toNat = pos) (hpsU : prevSizeU.toNat = prevSize)
+    (hhsU : hashSizeU.toNat = hashSize) (hrem2U : rem2U.toNat = data.size - pos - 2)
+    (hcapU : capU.toNat = insertCap) (hjU : jU.toNat = j) (hmlU : matchLenU.toNat = matchLen) :
+    updateHashesMergedFastU data hashSize prevSize pos c hhs hph hpv hsz hphlt
+        posU prevSizeU hashSizeU rem2U capU hposU hpsU hhsU hrem2U jU matchLenU =
+      updateHashesMerged data hashSize prevSize c pos j matchLen insertCap := by
+  induction hn : matchLen - j using Nat.strongRecOn generalizing j c jU hph hjU with
+  | _ n ih =>
+    rw [updateHashesMergedFastU, updateHashesMerged]
+    have hUS : USize.size = 2 ^ System.Platform.numBits := rfl
+    have hcond : (jU < matchLenU ∧ jU ≤ capU) ↔ (j < matchLen ∧ j ≤ insertCap) := by
+      rw [USize.lt_iff_toNat_lt, USize.le_iff_toNat_le, hjU, hmlU, hcapU]
+    by_cases hc : j < matchLen ∧ j ≤ insertCap
+    · rw [if_pos (hcond.mpr hc), if_pos hc]
+      have hmllt := USize.toNat_lt_two_pow_numBits matchLenU
+      have hj1 : (jU + 1).toNat = j + 1 := by
+        rw [USize.toNat_add, USize.toNat_one, hjU]
+        exact Nat.mod_eq_of_lt (by omega)
+      have hdata : (jU < rem2U) ↔ (pos + j + 2 < data.size) := by
+        rw [USize.lt_iff_toNat_lt, hjU, hrem2U]; omega
+      by_cases hd : pos + j + 2 < data.size
+      · rw [dif_pos (hdata.mpr hd), dif_pos hd]
+        have e1 : (posU + jU).toNat = pos + j := by
+          rw [USize.toNat_add, hposU, hjU]; exact Nat.mod_eq_of_lt (by omega)
+        have hb3 : lz77Greedy.hash3 data (pos + j) hashSize hd < hashSize := Nat.mod_lt _ hhs
+        -- The bucket index: `USize` add over `hash3U` = the `Nat` index over `hash3`.
+        have eidx : ∀ (hx : (posU + jU).toNat + 2 < data.size),
+            (prevSizeU + hash3U data ((posU + jU).toNat) (posU + jU) hashSizeU rfl hx).toNat
+              = prevSize + lz77Greedy.hash3 data (pos + j) hashSize hd := by
+          intro hx
+          rw [USize.toNat_add, hpsU, hash3U_toNat data _ hashSize _ _ rfl hhsU hsz hx,
+            hash3_congr data hashSize e1 hx hd]
+          exact Nat.mod_eq_of_lt (by omega)
+        -- The chain mask: `USize` and = the `Nat` and.
+        have emask : ((posU + jU) &&& 0x7FFF).toNat = (pos + j) &&& 0x7FFF := by
+          rw [USize.toNat_and,
+            USize.toNat_ofNat_of_lt (Nat.lt_of_lt_of_le (by decide) USize.le_size), e1]
+        -- Collapse `uget`/`uset` to `[]!`/`set!`, then align the indices.
+        have eget : ∀ (a : Array Nat) (i : Nat) (h : i < a.size), a[i]'h = a[i]! :=
+          fun a i h => (getElem!_pos a i h).symm
+        -- Two stages: `eidx` must consume the composite bucket index before `e1`
+        -- can rewrite the `(posU + jU).toNat` inside `hash3U`'s arguments.
+        simp only [Array.uget, Array.uset, set_eq_set!, eget, headProbeGuarded_eq,
+          guardedSet_eq, eidx, emask]
+        simp only [e1]
+        exact ih _ (by omega) _ _
+          (by rw [Array.size_set!, Array.size_set!]; exact hph) _ hj1 rfl
+      · rw [dif_neg (fun hx => hd (hdata.mp hx)), dif_neg hd]
+        exact ih _ (by omega) _ _ hph _ hj1 rfl
+    · rw [if_neg (fun hx => hc (hcond.mp hx)), if_neg hc]
+
+/-- The guarded merged walk equals the reference merged walk (the de-boxed
+    `USize` branch via `updateHashesMergedFastU_eq`, the proven-bounds `Nat`
+    branch via `updateHashesMergedFast_eq`; the fallback branch is definitionally
+    it). -/
 private theorem updateHashesMergedGuarded_eq (data : ByteArray) (hashSize prevSize : Nat)
     (c : Array Nat) (pos j matchLen insertCap : Nat) :
     updateHashesMergedGuarded data hashSize prevSize c pos j matchLen insertCap =
@@ -212,7 +307,19 @@ private theorem updateHashesMergedGuarded_eq (data : ByteArray) (hashSize prevSi
   unfold updateHashesMergedGuarded
   split
   · rename_i hg
-    exact updateHashesMergedFast_eq data hashSize prevSize c pos j matchLen insertCap hg.1 hg.2.1 hg.2.2
+    split
+    · rename_i hu
+      have hsz : data.size < USize.size := by
+        rw [← hu.1]; exact USize.toNat_lt_two_pow_numBits _
+      have hphlt : prevSize + hashSize < USize.size := by
+        rw [← hu.2.1]; exact USize.toNat_lt_two_pow_numBits _
+      exact updateHashesMergedFastU_eq data hashSize prevSize c pos j matchLen insertCap
+        hg.1 hg.2.1 hg.2.2 hsz hphlt pos.toUSize prevSize.toUSize hashSize.toUSize
+        (data.size - pos - 2).toUSize insertCap.toUSize j.toUSize matchLen.toUSize
+        hu.2.2.1 (toUSize_toNat_of_lt (by omega)) (toUSize_toNat_of_lt (by omega))
+        (toUSize_toNat_of_lt (by omega)) hu.2.2.2.2.2 hu.2.2.2.1 hu.2.2.2.2.1
+    · exact updateHashesMergedFast_eq data hashSize prevSize c pos j matchLen insertCap
+        hg.1 hg.2.1 hg.2.2
   · rfl
 
 /-! ## The lockstep loop equality -/

--- a/bench/graphs/canterbury_compress_heatmap.svg
+++ b/bench/graphs/canterbury_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p2cec6f8756)">
+   <g clip-path="url(#pf459e75f72)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJFUlEQVR4nO3YzaqdZx2H4b2StWtjd0MqNBYLQdChpSM7aefOPRCPwEmPwTMQwbkIDhx30qE4sSBIlEBbSdN87L2zsz4cFDyC++HfLK7rCH4vD++77vVsDt/+8XjG6+X6+fSCdV6e5rMdb66nJyyzuXt/esIaP/jh9IJ1NremF6zx6nTfs1M9s+Pj/0xPWOY0TwwAYJDAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCIbR9uHk9vWOJmfz09YZn37v10esIyF4f70xOW2Fw9nZ6wzGdX/5iesMRP3nh3esIy+8NuesISz3aX0xOW2R330xOW+OXb709PWMYNFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMS2F+f3pjcscdgepicsc3H25vSEdZ48nF6wxPHq6fSEZT568PH0hCUud6d7Zi9O9Nl+fvGL6QnL3Gx20xOWOP7rb9MTlnGDBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAALHtndsX0xuWuN5fTk9YZ3PCXfzm3ekFS2xO+MzOd7vpCUuc8pm9tT3N9+zLm0fTE5bZHW6mJyzx/lv3picsc7pfEACAIQILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYpv93z89To+A/zscphfAd275//na8f3ge8QXBAAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGLb33z9cHrDEk9f7qcnLPP5o2fTE5b5868/mZ6wxI/vPJiesMyHv//D9IQlfvWzH01PWOaf31xNT1jizvb29IRl/vSXL6YnLHH5u99OT1jGDRYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDENrvDX4/TI1bYH3bTE5a5tTndLr59fTk9YY3b2+kF67x4PL1gif2996YnLHM4HqYnLHG+Od337NXxNH/Tznen+VxnZ26wAAByAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAILbdH3bTG5bYHW6mJyxz5/nT6QnrPPtqesESx5cvpycss3nwwfSEJV6d8Dfkavd8esIS72wupicsc375ZHrCEsf//nt6wjJusAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACD2P33ciOxuxBeUAAAAAElFTkSuQmCC" id="imageb380e94aee" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJGElEQVR4nO3YzaqdZx2H4b2StbUx2xJCrcVAKuiwkJGd6Nx5D8QjcOIxeAal4LwUHDh24rA4URA0lFAJpDYfe+/sro8OhB7B/fBvFtd1BL+Xh/dd93o2h6//dDzjzXL9cnrBOq9P89mON9fTE5bZvP3u9IQ1fvij6QXrbG5NL1jjm9N9z071zI7PvpiesMxpnhgAwCCBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQ2z7ePJvesMTN/np6wjLv3fv59IRlLg7vTk9YYnP1fHrCMn+9+sf0hCV+9oOfTE9YZn/YTU9Y4sXucnrCMrvjfnrCEr/68YPpCcu4wQIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAIDY9uL83vSGJQ7bw/SEZS7O3pqesM7/Hk8vWOJ49Xx6wjIfPvz19IQlLnene2avTvTZfnnxwfSEZW42u+kJSxz//fn0hGXcYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBse+f2xfSGJa73l9MT1tmccBe/9fb0giU2J3xm57vd9IQlTvnM7m5P8z37782T6QnL7A430xOWeHD33vSEZU73CwIAMERgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQGyz//sfjtMj4DuHw/QC+L9b/n++cXw/+B7xBQEAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAIDY9ndPH09vWOL56/30hGX+9uTF9IRlPvvoN9MTlvjpnYfTE5Z59PEn0xOW+O0v7k9PWOZfX11NT1jizvb29IRlPv3zP6cnLHH5x99PT1jGDRYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDENrvDX47TI1bYH3bTE5a5tTndLr59fTk9YY3b2+kF67x6Nr1gif2996YnLHM4HqYnLHG+Od337Jvjaf6mne9O87nOztxgAQDkBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQGx7s7+e3rDE/ribnrDM3VeX0xPWef7l9IIljq9fT09YZvP+o+kJS5zqt/Hs7Ozsav9yesIS97fvTE9Y5vzls+kJSxyf/md6wjJusAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACD2LVi2iPFSXrVuAAAAAElFTkSuQmCC" id="image00d620f1aa" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m097ee1ac93" d="M 0 0 
+       <path id="m7ff2d43ade" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m097ee1ac93" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7ff2d43ade" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m097ee1ac93" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7ff2d43ade" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m097ee1ac93" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7ff2d43ade" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m097ee1ac93" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7ff2d43ade" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m097ee1ac93" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7ff2d43ade" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m097ee1ac93" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7ff2d43ade" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m097ee1ac93" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7ff2d43ade" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m097ee1ac93" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7ff2d43ade" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m097ee1ac93" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7ff2d43ade" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m097ee1ac93" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7ff2d43ade" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m097ee1ac93" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7ff2d43ade" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="me2dd1e684b" d="M 0 0 
+       <path id="m1da4e89dec" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#me2dd1e684b" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1da4e89dec" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#me2dd1e684b" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1da4e89dec" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#me2dd1e684b" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1da4e89dec" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#me2dd1e684b" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1da4e89dec" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#me2dd1e684b" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1da4e89dec" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#me2dd1e684b" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1da4e89dec" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#me2dd1e684b" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1da4e89dec" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#me2dd1e684b" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1da4e89dec" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1303,7 +1303,7 @@ L 527.435033 49.4355
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_20">
-    <!-- +11 -->
+    <!-- +17 -->
     <g transform="translate(108.442626 68.904519) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-2b" d="M 2944 4013 
@@ -1321,22 +1321,32 @@ L 2419 4013
 L 2944 4013 
 z
 " transform="scale(0.015625)"/>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_21">
-    <!-- +20 -->
+    <!-- +25 -->
     <g transform="translate(147.693424 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_22">
-    <!-- -43 -->
+    <!-- -40 -->
     <g transform="translate(188.495082 68.904519) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
@@ -1358,66 +1368,54 @@ L 313 1709
 L 2253 4666 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-33" d="M 2597 2516 
-Q 3050 2419 3304 2112 
-Q 3559 1806 3559 1356 
-Q 3559 666 3084 287 
-Q 2609 -91 1734 -91 
-Q 1441 -91 1130 -33 
-Q 819 25 488 141 
-L 488 750 
-Q 750 597 1062 519 
-Q 1375 441 1716 441 
-Q 2309 441 2620 675 
-Q 2931 909 2931 1356 
-Q 2931 1769 2642 2001 
-Q 2353 2234 1838 2234 
-L 1294 2234 
-L 1294 2753 
-L 1863 2753 
-Q 2328 2753 2575 2939 
-Q 2822 3125 2822 3475 
-Q 2822 3834 2567 4026 
-Q 2313 4219 1838 4219 
-Q 1578 4219 1281 4162 
-Q 984 4106 628 3988 
-L 628 4550 
-Q 988 4650 1302 4700 
-Q 1616 4750 1894 4750 
-Q 2613 4750 3031 4423 
-Q 3450 4097 3450 3541 
-Q 3450 3153 3228 2886 
-Q 3006 2619 2597 2516 
-z
-" transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_23">
-    <!-- -77 -->
+    <!-- -76 -->
     <g transform="translate(227.74588 68.904519) scale(0.065 -0.065)">
      <defs>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
+      <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_24">
-    <!-- -88 -->
+    <!-- -87 -->
     <g transform="translate(266.996679 68.904519) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
@@ -1462,79 +1460,80 @@ z
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_25">
-    <!-- -16 -->
+    <!-- -13 -->
     <g transform="translate(306.247477 68.904519) scale(0.065 -0.065)">
      <defs>
-      <path id="DejaVuSans-36" d="M 2113 2584 
-Q 1688 2584 1439 2293 
-Q 1191 2003 1191 1497 
-Q 1191 994 1439 701 
-Q 1688 409 2113 409 
-Q 2538 409 2786 701 
-Q 3034 994 3034 1497 
-Q 3034 2003 2786 2293 
-Q 2538 2584 2113 2584 
-z
-M 3366 4563 
-L 3366 3988 
-Q 3128 4100 2886 4159 
-Q 2644 4219 2406 4219 
-Q 1781 4219 1451 3797 
-Q 1122 3375 1075 2522 
-Q 1259 2794 1537 2939 
-Q 1816 3084 2150 3084 
-Q 2853 3084 3261 2657 
-Q 3669 2231 3669 1497 
-Q 3669 778 3244 343 
-Q 2819 -91 2113 -91 
-Q 1303 -91 875 529 
-Q 447 1150 447 2328 
-Q 447 3434 972 4092 
-Q 1497 4750 2381 4750 
-Q 2619 4750 2861 4703 
-Q 3103 4656 3366 4563 
+      <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_26">
-    <!-- +16 -->
+    <!-- +21 -->
     <g transform="translate(343.947416 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_27">
-    <!-- +36 -->
+    <!-- +40 -->
     <g transform="translate(383.198215 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_28">
-    <!-- -17 -->
-    <g transform="translate(423.999873 68.904519) scale(0.065 -0.065)">
+    <!-- -8 -->
+    <g transform="translate(426.067685 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_29">
-    <!-- -41 -->
+    <!-- -39 -->
     <g transform="translate(463.250671 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_30">
@@ -2181,18 +2180,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="image3f11eb0739" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
+iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="image5375827f94" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="m909d6473aa" d="M 0 0 
+       <path id="m868698eca0" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m909d6473aa" x="547.779688" y="276.293905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m868698eca0" x="547.779688" y="276.293905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
@@ -2215,7 +2214,7 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m909d6473aa" x="547.779688" y="247.808905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m868698eca0" x="547.779688" y="247.808905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
@@ -2229,7 +2228,7 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m909d6473aa" x="547.779688" y="219.323905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m868698eca0" x="547.779688" y="219.323905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
@@ -2243,7 +2242,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m909d6473aa" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m868698eca0" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
@@ -2256,7 +2255,7 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m909d6473aa" x="547.779688" y="162.353904" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m868698eca0" x="547.779688" y="162.353904" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_112">
@@ -2269,7 +2268,7 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m909d6473aa" x="547.779688" y="133.868904" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m868698eca0" x="547.779688" y="133.868904" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
@@ -2282,7 +2281,7 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m909d6473aa" x="547.779688" y="105.383904" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m868698eca0" x="547.779688" y="105.383904" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
@@ -2943,8 +2942,8 @@ z
    </g>
   </g>
   <g id="text_117">
-   <!-- 2026-07-08T15:47:33Z  ·  Linux chungus2 x86_64  ·  commit f2026e66  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(17.448437 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-08T20:00:36Z  ·  Linux chungus2 x86_64  ·  commit 29539fd5  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(17.380078 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -3013,14 +3012,14 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-38" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
     <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3060,109 +3059,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3107.080078 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3170.703125 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3234.326172 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3297.949219 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3361.572266 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3423.095703 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3486.71875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3550.341797 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3582.128906 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3613.916016 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3645.703125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3677.490234 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3709.277344 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3737.060547 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3798.583984 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3859.863281 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3923.242188 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3986.71875 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4025.582031 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4086.763672 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4145.943359 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4207.466797 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4248.580078 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4282.271484 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4310.054688 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4371.578125 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4432.857422 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4496.236328 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4559.859375 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4593.550781 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4652.730469 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4716.353516 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4748.140625 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4811.763672 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4875.386719 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4907.173828 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4970.796875 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5006.880859 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5045.744141 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5100.724609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5164.347656 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5196.134766 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5227.921875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5259.708984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5291.496094 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5323.283203 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5362.492188 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5425.871094 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5464.734375 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5525.916016 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5589.294922 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5652.771484 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5716.150391 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5779.626953 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5843.005859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5882.214844 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5914.001953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5997.791016 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6029.578125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6126.990234 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6188.513672 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6251.990234 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6279.773438 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6341.052734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6404.431641 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6436.21875 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6488.318359 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6551.697266 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6612.976562 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6676.453125 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6728.552734 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6791.931641 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6853.113281 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6892.322266 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6926.013672 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6957.800781 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6998.914062 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7060.193359 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7099.402344 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7127.185547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7188.367188 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7220.154297 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7247.9375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7300.037109 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7331.824219 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7395.300781 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7456.824219 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7496.033203 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7557.556641 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7596.919922 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7694.332031 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7722.115234 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7785.494141 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7813.277344 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7865.376953 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7904.585938 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7932.369141 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3262.744141 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3326.367188 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3389.990234 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3425.195312 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3488.671875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3552.294922 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3584.082031 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3615.869141 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3647.65625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3679.443359 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3711.230469 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3739.013672 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3800.537109 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3861.816406 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3925.195312 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3988.671875 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4027.535156 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4088.716797 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4147.896484 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4209.419922 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4250.533203 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4284.224609 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4312.007812 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4373.53125 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4434.810547 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4498.189453 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4561.8125 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4595.503906 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4654.683594 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4718.306641 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4750.09375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4813.716797 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4877.339844 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4909.126953 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4972.75 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5008.833984 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5047.697266 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5102.677734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5166.300781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5198.087891 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5229.875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5261.662109 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5293.449219 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5325.236328 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5364.445312 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5427.824219 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5466.6875 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5527.869141 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5591.248047 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5654.724609 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5718.103516 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5781.580078 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5844.958984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5884.167969 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5915.955078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5999.744141 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6031.53125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6128.943359 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6190.466797 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6253.943359 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6281.726562 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6343.005859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6406.384766 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6438.171875 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6490.271484 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6553.650391 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6614.929688 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6678.40625 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6730.505859 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6793.884766 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6855.066406 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6894.275391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6927.966797 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6959.753906 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7000.867188 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7062.146484 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7101.355469 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7129.138672 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7190.320312 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7222.107422 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7249.890625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7301.990234 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7333.777344 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7397.253906 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7458.777344 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7497.986328 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7559.509766 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7598.873047 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7696.285156 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7724.068359 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7787.447266 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7815.230469 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7867.330078 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7906.539062 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7934.322266 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p2cec6f8756">
+  <clipPath id="pf459e75f72">
    <rect x="95.67625" y="49.4355" width="431.758783" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_compress_pareto.svg
+++ b/bench/graphs/canterbury_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 79.118387 412.80375 
 L 79.118387 48.323125 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="mb2667e4cd3" d="M 0 0 
+       <path id="m1547b4d489" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mb2667e4cd3" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1547b4d489" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -161,11 +161,11 @@ z
      <g id="line2d_3">
       <path d="M 166.481434 412.80375 
 L 166.481434 48.323125 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mb2667e4cd3" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1547b4d489" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -216,11 +216,11 @@ z
      <g id="line2d_5">
       <path d="M 253.844481 412.80375 
 L 253.844481 48.323125 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#mb2667e4cd3" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1547b4d489" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -237,11 +237,11 @@ L 253.844481 48.323125
      <g id="line2d_7">
       <path d="M 341.207528 412.80375 
 L 341.207528 48.323125 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#mb2667e4cd3" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1547b4d489" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -279,11 +279,11 @@ z
      <g id="line2d_9">
       <path d="M 428.570575 412.80375 
 L 428.570575 48.323125 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#mb2667e4cd3" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1547b4d489" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -332,11 +332,11 @@ z
      <g id="line2d_11">
       <path d="M 515.933622 412.80375 
 L 515.933622 48.323125 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#mb2667e4cd3" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1547b4d489" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -353,11 +353,11 @@ L 515.933622 48.323125
      <g id="line2d_13">
       <path d="M 603.296669 412.80375 
 L 603.296669 48.323125 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mb2667e4cd3" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1547b4d489" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -854,16 +854,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 347.786382 
 L 637.2 347.786382 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="m43496cbc69" d="M 0 0 
+       <path id="m6e8f10cda5" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m43496cbc69" x="49.078125" y="347.786382" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6e8f10cda5" x="49.078125" y="347.786382" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -895,11 +895,11 @@ z
      <g id="line2d_17">
       <path d="M 49.078125 238.646289 
 L 637.2 238.646289 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m43496cbc69" x="49.078125" y="238.646289" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6e8f10cda5" x="49.078125" y="238.646289" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -915,11 +915,11 @@ L 637.2 238.646289
      <g id="line2d_19">
       <path d="M 49.078125 129.506196 
 L 637.2 129.506196 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m43496cbc69" x="49.078125" y="129.506196" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6e8f10cda5" x="49.078125" y="129.506196" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -935,16 +935,16 @@ L 637.2 129.506196
      <g id="line2d_21">
       <path d="M 49.078125 404.853417 
 L 637.2 404.853417 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="mb058e9b162" d="M 0 0 
+       <path id="m1899d02072" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#mb058e9b162" x="49.078125" y="404.853417" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1899d02072" x="49.078125" y="404.853417" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -952,11 +952,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 391.217592 
 L 637.2 391.217592 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mb058e9b162" x="49.078125" y="391.217592" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1899d02072" x="49.078125" y="391.217592" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -964,11 +964,11 @@ L 637.2 391.217592
      <g id="line2d_25">
       <path d="M 49.078125 380.640824 
 L 637.2 380.640824 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mb058e9b162" x="49.078125" y="380.640824" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1899d02072" x="49.078125" y="380.640824" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -976,11 +976,11 @@ L 637.2 380.640824
      <g id="line2d_27">
       <path d="M 49.078125 371.998975 
 L 637.2 371.998975 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#mb058e9b162" x="49.078125" y="371.998975" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1899d02072" x="49.078125" y="371.998975" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -988,11 +988,11 @@ L 637.2 371.998975
      <g id="line2d_29">
       <path d="M 49.078125 364.692396 
 L 637.2 364.692396 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#mb058e9b162" x="49.078125" y="364.692396" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1899d02072" x="49.078125" y="364.692396" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1000,11 +1000,11 @@ L 637.2 364.692396
      <g id="line2d_31">
       <path d="M 49.078125 358.36315 
 L 637.2 358.36315 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#mb058e9b162" x="49.078125" y="358.36315" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1899d02072" x="49.078125" y="358.36315" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1012,11 +1012,11 @@ L 637.2 358.36315
      <g id="line2d_33">
       <path d="M 49.078125 352.780359 
 L 637.2 352.780359 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#mb058e9b162" x="49.078125" y="352.780359" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1899d02072" x="49.078125" y="352.780359" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1024,11 +1024,11 @@ L 637.2 352.780359
      <g id="line2d_35">
       <path d="M 49.078125 314.93194 
 L 637.2 314.93194 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#mb058e9b162" x="49.078125" y="314.93194" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1899d02072" x="49.078125" y="314.93194" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1036,11 +1036,11 @@ L 637.2 314.93194
      <g id="line2d_37">
       <path d="M 49.078125 295.713324 
 L 637.2 295.713324 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#mb058e9b162" x="49.078125" y="295.713324" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1899d02072" x="49.078125" y="295.713324" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1048,11 +1048,11 @@ L 637.2 295.713324
      <g id="line2d_39">
       <path d="M 49.078125 282.077499 
 L 637.2 282.077499 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#mb058e9b162" x="49.078125" y="282.077499" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1899d02072" x="49.078125" y="282.077499" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1060,11 +1060,11 @@ L 637.2 282.077499
      <g id="line2d_41">
       <path d="M 49.078125 271.500731 
 L 637.2 271.500731 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#mb058e9b162" x="49.078125" y="271.500731" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1899d02072" x="49.078125" y="271.500731" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1072,11 +1072,11 @@ L 637.2 271.500731
      <g id="line2d_43">
       <path d="M 49.078125 262.858882 
 L 637.2 262.858882 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#mb058e9b162" x="49.078125" y="262.858882" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1899d02072" x="49.078125" y="262.858882" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1084,11 +1084,11 @@ L 637.2 262.858882
      <g id="line2d_45">
       <path d="M 49.078125 255.552304 
 L 637.2 255.552304 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#mb058e9b162" x="49.078125" y="255.552304" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1899d02072" x="49.078125" y="255.552304" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1096,11 +1096,11 @@ L 637.2 255.552304
      <g id="line2d_47">
       <path d="M 49.078125 249.223057 
 L 637.2 249.223057 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#mb058e9b162" x="49.078125" y="249.223057" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1899d02072" x="49.078125" y="249.223057" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1108,11 +1108,11 @@ L 637.2 249.223057
      <g id="line2d_49">
       <path d="M 49.078125 243.640266 
 L 637.2 243.640266 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#mb058e9b162" x="49.078125" y="243.640266" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1899d02072" x="49.078125" y="243.640266" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1120,11 +1120,11 @@ L 637.2 243.640266
      <g id="line2d_51">
       <path d="M 49.078125 205.791848 
 L 637.2 205.791848 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#mb058e9b162" x="49.078125" y="205.791848" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1899d02072" x="49.078125" y="205.791848" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1132,11 +1132,11 @@ L 637.2 205.791848
      <g id="line2d_53">
       <path d="M 49.078125 186.573231 
 L 637.2 186.573231 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#mb058e9b162" x="49.078125" y="186.573231" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1899d02072" x="49.078125" y="186.573231" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1144,11 +1144,11 @@ L 637.2 186.573231
      <g id="line2d_55">
       <path d="M 49.078125 172.937406 
 L 637.2 172.937406 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#mb058e9b162" x="49.078125" y="172.937406" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1899d02072" x="49.078125" y="172.937406" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1156,11 +1156,11 @@ L 637.2 172.937406
      <g id="line2d_57">
       <path d="M 49.078125 162.360638 
 L 637.2 162.360638 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#mb058e9b162" x="49.078125" y="162.360638" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1899d02072" x="49.078125" y="162.360638" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1168,11 +1168,11 @@ L 637.2 162.360638
      <g id="line2d_59">
       <path d="M 49.078125 153.71879 
 L 637.2 153.71879 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#mb058e9b162" x="49.078125" y="153.71879" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1899d02072" x="49.078125" y="153.71879" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1180,11 +1180,11 @@ L 637.2 153.71879
      <g id="line2d_61">
       <path d="M 49.078125 146.412211 
 L 637.2 146.412211 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#mb058e9b162" x="49.078125" y="146.412211" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1899d02072" x="49.078125" y="146.412211" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1192,11 +1192,11 @@ L 637.2 146.412211
      <g id="line2d_63">
       <path d="M 49.078125 140.082964 
 L 637.2 140.082964 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#mb058e9b162" x="49.078125" y="140.082964" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1899d02072" x="49.078125" y="140.082964" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1204,11 +1204,11 @@ L 637.2 140.082964
      <g id="line2d_65">
       <path d="M 49.078125 134.500173 
 L 637.2 134.500173 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#mb058e9b162" x="49.078125" y="134.500173" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1899d02072" x="49.078125" y="134.500173" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1216,11 +1216,11 @@ L 637.2 134.500173
      <g id="line2d_67">
       <path d="M 49.078125 96.651755 
 L 637.2 96.651755 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_68">
       <g>
-       <use xlink:href="#mb058e9b162" x="49.078125" y="96.651755" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1899d02072" x="49.078125" y="96.651755" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1228,11 +1228,11 @@ L 637.2 96.651755
      <g id="line2d_69">
       <path d="M 49.078125 77.433138 
 L 637.2 77.433138 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_70">
       <g>
-       <use xlink:href="#mb058e9b162" x="49.078125" y="77.433138" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1899d02072" x="49.078125" y="77.433138" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1240,11 +1240,11 @@ L 637.2 77.433138
      <g id="line2d_71">
       <path d="M 49.078125 63.797313 
 L 637.2 63.797313 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_72">
       <g>
-       <use xlink:href="#mb058e9b162" x="49.078125" y="63.797313" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1899d02072" x="49.078125" y="63.797313" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1252,11 +1252,11 @@ L 637.2 63.797313
      <g id="line2d_73">
       <path d="M 49.078125 53.220545 
 L 637.2 53.220545 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_74">
       <g>
-       <use xlink:href="#mb058e9b162" x="49.078125" y="53.220545" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1899d02072" x="49.078125" y="53.220545" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1378,7 +1378,7 @@ L 637.2 48.323125
    </g>
    <g id="text_13">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(294.669676 144.610306) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(294.669676 144.450565) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1410,7 +1410,7 @@ z
    </g>
    <g id="text_14">
     <!-- L10 -->
-    <g style="fill: #d62728" transform="translate(104.852312 295.336792) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(104.852312 295.665435) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1732,23 +1732,23 @@ z
    </g>
    <g id="line2d_75">
     <defs>
-     <path id="ma6a4cfb2c2" d="M -2.5 2.5 
+     <path id="mcc7f57953a" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p6652a911cf)">
-     <use xlink:href="#ma6a4cfb2c2" x="355.479835" y="95.382063" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma6a4cfb2c2" x="308.273931" y="102.754513" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma6a4cfb2c2" x="271.230161" y="116.528062" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma6a4cfb2c2" x="217.83458" y="120.013651" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma6a4cfb2c2" x="177.077692" y="138.43462" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma6a4cfb2c2" x="162.880539" y="157.778627" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma6a4cfb2c2" x="160.741445" y="165.196647" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma6a4cfb2c2" x="153.966678" y="183.405761" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma6a4cfb2c2" x="151.589614" y="194.488118" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p27197ae956)">
+     <use xlink:href="#mcc7f57953a" x="355.479835" y="95.382063" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcc7f57953a" x="308.273931" y="102.754513" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcc7f57953a" x="271.230161" y="116.528062" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcc7f57953a" x="217.83458" y="120.013651" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcc7f57953a" x="177.077692" y="138.43462" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcc7f57953a" x="162.880539" y="157.778627" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcc7f57953a" x="160.741445" y="165.196647" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcc7f57953a" x="153.966678" y="183.405761" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcc7f57953a" x="151.589614" y="194.488118" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_76">
@@ -1801,7 +1801,7 @@ L 311.2243 102.325849
 L 310.240844 102.469168 
 L 309.257387 102.612055 
 L 308.273931 102.754513 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_77">
     <path d="M 308.273931 102.754513 
@@ -1853,7 +1853,7 @@ L 273.545396 115.775058
 L 272.773651 116.027391 
 L 272.001906 116.278388 
 L 271.230161 116.528062 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_78">
     <path d="M 271.230161 116.528062 
@@ -1905,7 +1905,7 @@ L 221.171803 119.803152
 L 220.059395 119.873422 
 L 218.946988 119.943588 
 L 217.83458 120.013651 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_79">
     <path d="M 217.83458 120.013651 
@@ -1957,7 +1957,7 @@ L 179.624997 137.470928
 L 178.775895 137.79434 
 L 177.926794 138.115561 
 L 177.077692 138.43462 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_80">
     <path d="M 177.077692 138.43462 
@@ -2009,7 +2009,7 @@ L 163.767861 156.775388
 L 163.472087 157.112166 
 L 163.176313 157.446568 
 L 162.880539 157.778627 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_81">
     <path d="M 162.880539 157.778627 
@@ -2061,7 +2061,7 @@ L 160.875139 164.765525
 L 160.830574 164.909668 
 L 160.78601 165.053375 
 L 160.741445 165.196647 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_82">
     <path d="M 160.741445 165.196647 
@@ -2113,7 +2113,7 @@ L 154.390101 182.45125
 L 154.24896 182.771561 
 L 154.107819 183.089721 
 L 153.966678 183.405761 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_83">
     <path d="M 153.966678 183.405761 
@@ -2165,26 +2165,26 @@ L 151.73818 193.866427
 L 151.688658 194.074564 
 L 151.639136 194.281792 
 L 151.589614 194.488118 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_84">
     <defs>
-     <path id="mddee50189a" d="M 0 -2.5 
+     <path id="md17940d300" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p6652a911cf)">
-     <use xlink:href="#mddee50189a" x="531.649087" y="75.963093" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mddee50189a" x="283.721324" y="99.020035" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mddee50189a" x="218.882044" y="121.069315" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mddee50189a" x="187.447228" y="127.10685" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mddee50189a" x="176.342474" y="138.36311" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mddee50189a" x="163.054314" y="161.312135" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mddee50189a" x="162.210539" y="168.753955" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mddee50189a" x="159.303811" y="175.753345" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mddee50189a" x="157.793928" y="179.494802" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p27197ae956)">
+     <use xlink:href="#md17940d300" x="531.649087" y="75.963093" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md17940d300" x="283.721324" y="99.020035" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md17940d300" x="218.882044" y="121.069315" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md17940d300" x="187.447228" y="127.10685" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md17940d300" x="176.342474" y="138.36311" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md17940d300" x="163.054314" y="161.312135" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md17940d300" x="162.210539" y="168.753955" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md17940d300" x="159.303811" y="175.753345" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md17940d300" x="157.793928" y="179.494802" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_85">
@@ -2237,7 +2237,7 @@ L 299.21681 97.864971
 L 294.051648 98.253128 
 L 288.886486 98.638133 
 L 283.721324 99.020035 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_86">
     <path d="M 283.721324 99.020035 
@@ -2289,7 +2289,7 @@ L 222.934499 119.954333
 L 221.583681 120.328916 
 L 220.232863 120.700561 
 L 218.882044 121.069315 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_87">
     <path d="M 218.882044 121.069315 
@@ -2341,7 +2341,7 @@ L 189.411904 126.751217
 L 188.757012 126.870058 
 L 188.10212 126.988602 
 L 187.447228 127.10685 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_88">
     <path d="M 187.447228 127.10685 
@@ -2393,7 +2393,7 @@ L 177.036521 137.732718
 L 176.805172 137.943781 
 L 176.573823 138.153909 
 L 176.342474 138.36311 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_89">
     <path d="M 176.342474 138.36311 
@@ -2445,7 +2445,7 @@ L 163.884824 160.161325
 L 163.607987 160.548041 
 L 163.33115 160.931628 
 L 163.054314 161.312135 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_90">
     <path d="M 163.054314 161.312135 
@@ -2497,7 +2497,7 @@ L 162.263275 168.321549
 L 162.245696 168.466124 
 L 162.228118 168.610258 
 L 162.210539 168.753955 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_91">
     <path d="M 162.210539 168.753955 
@@ -2549,7 +2549,7 @@ L 159.485481 175.344896
 L 159.424925 175.481437 
 L 159.364368 175.617586 
 L 159.303811 175.753345 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_92">
     <path d="M 159.303811 175.753345 
@@ -2601,30 +2601,30 @@ L 157.888296 179.269417
 L 157.85684 179.344665 
 L 157.825384 179.419793 
 L 157.793928 179.494802 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_93">
     <defs>
-     <path id="m77b5932206" d="M -0 3.535534 
+     <path id="m1781017fe3" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p6652a911cf)">
-     <use xlink:href="#m77b5932206" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m77b5932206" x="203.775848" y="81.750179" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m77b5932206" x="186.982691" y="88.344921" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m77b5932206" x="179.779306" y="91.045312" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m77b5932206" x="157.610419" y="99.395085" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m77b5932206" x="148.722526" y="107.864022" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m77b5932206" x="144.388162" y="121.237794" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m77b5932206" x="127.071247" y="144.560664" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m77b5932206" x="124.491988" y="152.083585" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m77b5932206" x="92.613662" y="207.637263" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m77b5932206" x="87.348715" y="225.457654" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m77b5932206" x="86.053433" y="242.017529" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p27197ae956)">
+     <use xlink:href="#m1781017fe3" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1781017fe3" x="203.775848" y="81.750179" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1781017fe3" x="186.982691" y="88.344921" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1781017fe3" x="179.779306" y="91.045312" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1781017fe3" x="157.610419" y="99.395085" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1781017fe3" x="148.722526" y="107.864022" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1781017fe3" x="144.388162" y="121.237794" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1781017fe3" x="127.071247" y="144.560664" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1781017fe3" x="124.491988" y="152.083585" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1781017fe3" x="92.613662" y="207.637263" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1781017fe3" x="87.348715" y="225.457654" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1781017fe3" x="86.053433" y="242.017529" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_94">
@@ -2677,7 +2677,7 @@ L 206.762331 80.855075
 L 205.766837 81.155325 
 L 204.771342 81.453685 
 L 203.775848 81.750179 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_95">
     <path d="M 203.775848 81.750179 
@@ -2729,7 +2729,7 @@ L 188.032264 87.958568
 L 187.682406 88.087703 
 L 187.332549 88.216487 
 L 186.982691 88.344921 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_96">
     <path d="M 186.982691 88.344921 
@@ -2781,7 +2781,7 @@ L 180.229518 90.88097
 L 180.079447 90.935814 
 L 179.929376 90.990595 
 L 179.779306 91.045312 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_97">
     <path d="M 179.779306 91.045312 
@@ -2833,7 +2833,7 @@ L 158.995974 98.914174
 L 158.534122 99.075021 
 L 158.07227 99.235323 
 L 157.610419 99.395085 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_98">
     <path d="M 157.610419 99.395085 
@@ -2885,7 +2885,7 @@ L 149.27802 107.37681
 L 149.092855 107.539771 
 L 148.907691 107.702174 
 L 148.722526 107.864022 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_99">
     <path d="M 148.722526 107.864022 
@@ -2937,7 +2937,7 @@ L 144.65906 120.50385
 L 144.568761 120.749763 
 L 144.478462 120.994407 
 L 144.388162 121.237794 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_100">
     <path d="M 144.388162 121.237794 
@@ -2989,7 +2989,7 @@ L 128.153555 143.395158
 L 127.792786 143.786853 
 L 127.432016 144.175338 
 L 127.071247 144.560664 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_101">
     <path d="M 127.071247 144.560664 
@@ -3041,7 +3041,7 @@ L 124.653192 151.646811
 L 124.599457 151.79285 
 L 124.545723 151.93844 
 L 124.491988 152.083585 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_102">
     <path d="M 124.491988 152.083585 
@@ -3093,7 +3093,7 @@ L 94.606058 205.546972
 L 93.941926 206.254028 
 L 93.277794 206.950691 
 L 92.613662 207.637263 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_103">
     <path d="M 92.613662 207.637263 
@@ -3145,7 +3145,7 @@ L 87.677774 224.520091
 L 87.568088 224.834677 
 L 87.458402 225.147189 
 L 87.348715 225.457654 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_104">
     <path d="M 87.348715 225.457654 
@@ -3197,23 +3197,23 @@ L 86.134388 241.135848
 L 86.107403 241.431568 
 L 86.080418 241.725454 
 L 86.053433 242.017529 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_105">
     <defs>
-     <path id="ma7c25d9a97" d="M -0 2.5 
+     <path id="ma5cf3353e4" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p6652a911cf)">
-     <use xlink:href="#ma7c25d9a97" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p27197ae956)">
+     <use xlink:href="#ma5cf3353e4" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_106">
     <defs>
-     <path id="m79b355ad29" d="M -0.833333 2.5 
+     <path id="mf27cb95702" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -3228,16 +3228,16 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p6652a911cf)">
-     <use xlink:href="#m79b355ad29" x="362.865999" y="115.428618" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m79b355ad29" x="278.798176" y="122.858526" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m79b355ad29" x="251.17632" y="128.261574" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m79b355ad29" x="200.806828" y="131.522849" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m79b355ad29" x="169.803221" y="147.931404" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m79b355ad29" x="161.916638" y="160.718659" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m79b355ad29" x="158.697104" y="167.705569" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m79b355ad29" x="154.26679" y="181.026105" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m79b355ad29" x="153.096464" y="191.924265" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p27197ae956)">
+     <use xlink:href="#mf27cb95702" x="362.865999" y="115.428618" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf27cb95702" x="278.798176" y="122.858526" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf27cb95702" x="251.17632" y="128.261574" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf27cb95702" x="200.806828" y="131.522849" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf27cb95702" x="169.803221" y="147.931404" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf27cb95702" x="161.916638" y="160.718659" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf27cb95702" x="158.697104" y="167.705569" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf27cb95702" x="154.26679" y="181.026105" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf27cb95702" x="153.096464" y="191.924265" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_107">
@@ -3290,7 +3290,7 @@ L 284.052415 122.426763
 L 282.301002 122.571121 
 L 280.549589 122.715042 
 L 278.798176 122.858526 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_108">
     <path d="M 278.798176 122.858526 
@@ -3342,7 +3342,7 @@ L 252.902686 127.94134
 L 252.327231 128.048325 
 L 251.751776 128.155069 
 L 251.17632 128.261574 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_109">
     <path d="M 251.17632 128.261574 
@@ -3394,7 +3394,7 @@ L 203.954921 131.325463
 L 202.905557 131.39135 
 L 201.856192 131.457145 
 L 200.806828 131.522849 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_110">
     <path d="M 200.806828 131.522849 
@@ -3446,7 +3446,7 @@ L 171.740947 147.056528
 L 171.095038 147.349951 
 L 170.44913 147.64157 
 L 169.803221 147.931404 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_111">
     <path d="M 169.803221 147.931404 
@@ -3498,7 +3498,7 @@ L 162.409549 160.012958
 L 162.245246 160.249361 
 L 162.080942 160.484591 
 L 161.916638 160.718659 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_112">
     <path d="M 161.916638 160.718659 
@@ -3550,7 +3550,7 @@ L 158.898325 167.297798
 L 158.831251 167.434112 
 L 158.764178 167.570034 
 L 158.697104 167.705569 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_113">
     <path d="M 158.697104 167.705569 
@@ -3602,7 +3602,7 @@ L 154.543684 180.294711
 L 154.451386 180.539765 
 L 154.359088 180.783558 
 L 154.26679 181.026105 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_114">
     <path d="M 154.26679 181.026105 
@@ -3654,11 +3654,11 @@ L 153.16961 191.311823
 L 153.145228 191.516851 
 L 153.120846 191.720996 
 L 153.096464 191.924265 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_115">
     <defs>
-     <path id="m353579a97d" d="M -1.25 2.5 
+     <path id="me94916b7c5" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -3673,16 +3673,16 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p6652a911cf)">
-     <use xlink:href="#m353579a97d" x="301.619021" y="150.561849" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m353579a97d" x="250.236474" y="156.671134" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m353579a97d" x="225.418659" y="160.842551" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m353579a97d" x="212.328936" y="161.382211" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m353579a97d" x="209.030149" y="166.25091" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m353579a97d" x="197.547749" y="171.432451" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m353579a97d" x="194.819287" y="175.129495" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m353579a97d" x="193.12279" y="181.606362" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m353579a97d" x="192.79794" y="189.451167" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p27197ae956)">
+     <use xlink:href="#me94916b7c5" x="301.619021" y="150.561849" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me94916b7c5" x="250.236474" y="156.671134" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me94916b7c5" x="225.418659" y="160.842551" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me94916b7c5" x="212.328936" y="161.382211" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me94916b7c5" x="209.030149" y="166.25091" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me94916b7c5" x="197.547749" y="171.432451" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me94916b7c5" x="194.819287" y="175.129495" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me94916b7c5" x="193.12279" y="181.606362" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me94916b7c5" x="192.79794" y="189.451167" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_116">
@@ -3735,7 +3735,7 @@ L 253.447883 156.311526
 L 252.377414 156.431699 
 L 251.306944 156.551567 
 L 250.236474 156.671134 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_117">
     <path d="M 250.236474 156.671134 
@@ -3787,7 +3787,7 @@ L 226.969772 160.592321
 L 226.452735 160.675878 
 L 225.935697 160.759287 
 L 225.418659 160.842551 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_118">
     <path d="M 225.418659 160.842551 
@@ -3839,7 +3839,7 @@ L 213.147044 161.348661
 L 212.874341 161.359847 
 L 212.601639 161.37103 
 L 212.328936 161.382211 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_119">
     <path d="M 212.328936 161.382211 
@@ -3891,7 +3891,7 @@ L 209.236323 165.960837
 L 209.167599 166.057725 
 L 209.098874 166.154416 
 L 209.030149 166.25091 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_120">
     <path d="M 209.030149 166.25091 
@@ -3943,7 +3943,7 @@ L 198.265399 171.124681
 L 198.026182 171.227493 
 L 197.786966 171.330083 
 L 197.547749 171.432451 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_121">
     <path d="M 197.547749 171.432451 
@@ -3995,7 +3995,7 @@ L 194.989815 174.906688
 L 194.932972 174.981074 
 L 194.876129 175.055342 
 L 194.819287 175.129495 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_122">
     <path d="M 194.819287 175.129495 
@@ -4047,7 +4047,7 @@ L 193.228821 181.226479
 L 193.193478 181.353445 
 L 193.158134 181.480072 
 L 193.12279 181.606362 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_123">
     <path d="M 193.12279 181.606362 
@@ -4099,11 +4099,11 @@ L 192.818243 188.997124
 L 192.811475 189.148955 
 L 192.804707 189.300302 
 L 192.79794 189.451167 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_124">
     <defs>
-     <path id="m3ed957900c" d="M 0 -2.5 
+     <path id="mebc971e2c8" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -4116,16 +4116,16 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p6652a911cf)">
-     <use xlink:href="#m3ed957900c" x="206.45578" y="118.584066" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m3ed957900c" x="206.45578" y="118.258949" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m3ed957900c" x="206.45578" y="118.759361" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m3ed957900c" x="206.45578" y="118.234957" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m3ed957900c" x="171.767499" y="134.097889" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m3ed957900c" x="163.54283" y="144.663903" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m3ed957900c" x="160.174881" y="151.505345" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m3ed957900c" x="154.179217" y="169.303726" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m3ed957900c" x="152.4406" y="178.584542" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p27197ae956)">
+     <use xlink:href="#mebc971e2c8" x="206.45578" y="118.584066" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mebc971e2c8" x="206.45578" y="118.258949" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mebc971e2c8" x="206.45578" y="118.759361" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mebc971e2c8" x="206.45578" y="118.234957" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mebc971e2c8" x="171.767499" y="134.097889" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mebc971e2c8" x="163.54283" y="144.663903" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mebc971e2c8" x="160.174881" y="151.505345" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mebc971e2c8" x="154.179217" y="169.303726" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mebc971e2c8" x="152.4406" y="178.584542" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_125">
@@ -4178,7 +4178,7 @@ L 206.45578 118.279335
 L 206.45578 118.27254 
 L 206.45578 118.265745 
 L 206.45578 118.258949 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_126">
     <path d="M 206.45578 118.258949 
@@ -4230,7 +4230,7 @@ L 206.45578 118.728239
 L 206.45578 118.738615 
 L 206.45578 118.748989 
 L 206.45578 118.759361 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_127">
     <path d="M 206.45578 118.759361 
@@ -4282,7 +4282,7 @@ L 206.45578 118.267903
 L 206.45578 118.256924 
 L 206.45578 118.245942 
 L 206.45578 118.234957 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_128">
     <path d="M 206.45578 118.234957 
@@ -4334,7 +4334,7 @@ L 173.935517 133.247721
 L 173.212844 133.532808 
 L 172.490172 133.816191 
 L 171.767499 134.097889 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_129">
     <path d="M 171.767499 134.097889 
@@ -4386,7 +4386,7 @@ L 164.056872 144.068227
 L 163.885524 144.267619 
 L 163.714177 144.466175 
 L 163.54283 144.663903 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_130">
     <path d="M 163.54283 144.663903 
@@ -4438,7 +4438,7 @@ L 160.385378 151.105499
 L 160.315212 151.239156 
 L 160.245047 151.372438 
 L 160.174881 151.505345 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_131">
     <path d="M 160.174881 151.505345 
@@ -4490,7 +4490,7 @@ L 154.553946 168.367127
 L 154.429036 168.681387 
 L 154.304126 168.993578 
 L 154.179217 169.303726 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_132">
     <path d="M 154.179217 169.303726 
@@ -4542,11 +4542,11 @@ L 152.549264 178.054798
 L 152.513043 178.232038 
 L 152.476822 178.408618 
 L 152.4406 178.584542 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_133">
     <defs>
-     <path id="mfee84be412" d="M 0 -2.5 
+     <path id="mfe2e0b1a84" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -4555,16 +4555,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p6652a911cf)">
-     <use xlink:href="#mfee84be412" x="610.467188" y="172.829682" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfee84be412" x="592.067397" y="173.763838" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfee84be412" x="534.807821" y="180.385179" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfee84be412" x="327.802209" y="176.172104" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfee84be412" x="275.83761" y="186.734601" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfee84be412" x="258.25125" y="198.783148" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfee84be412" x="256.777056" y="203.737732" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfee84be412" x="248.769854" y="217.74136" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfee84be412" x="246.264594" y="227.740017" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p27197ae956)">
+     <use xlink:href="#mfe2e0b1a84" x="610.467188" y="172.829682" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfe2e0b1a84" x="592.067397" y="173.763838" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfe2e0b1a84" x="534.807821" y="180.385179" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfe2e0b1a84" x="327.802209" y="176.172104" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfe2e0b1a84" x="275.83761" y="186.734601" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfe2e0b1a84" x="258.25125" y="198.783148" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfe2e0b1a84" x="256.777056" y="203.737732" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfe2e0b1a84" x="248.769854" y="217.74136" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfe2e0b1a84" x="246.264594" y="227.740017" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_134">
@@ -4617,7 +4617,7 @@ L 593.217384 173.705989
 L 592.834055 173.72528 
 L 592.450726 173.744563 
 L 592.067397 173.763838 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_135">
     <path d="M 592.067397 173.763838 
@@ -4669,7 +4669,7 @@ L 538.386544 179.997367
 L 537.193636 180.126991 
 L 536.000728 180.25626 
 L 534.807821 180.385179 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_136">
     <path d="M 534.807821 180.385179 
@@ -4721,7 +4721,7 @@ L 340.74006 176.446681
 L 336.427443 176.355332 
 L 332.114826 176.263806 
 L 327.802209 176.172104 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_137">
     <path d="M 327.802209 176.172104 
@@ -4773,7 +4773,7 @@ L 279.085397 186.139102
 L 278.002801 186.338434 
 L 276.920205 186.536931 
 L 275.83761 186.734601 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_138">
     <path d="M 275.83761 186.734601 
@@ -4825,7 +4825,7 @@ L 259.350398 198.113494
 L 258.984015 198.337765 
 L 258.617633 198.560979 
 L 258.25125 198.783148 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_139">
     <path d="M 258.25125 198.783148 
@@ -4877,7 +4877,7 @@ L 256.869193 203.442789
 L 256.838481 203.541307 
 L 256.807768 203.639621 
 L 256.777056 203.737732 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_140">
     <path d="M 256.777056 203.737732 
@@ -4929,7 +4929,7 @@ L 249.270304 216.977455
 L 249.103487 217.23346 
 L 248.93667 217.48809 
 L 248.769854 217.74136 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_141">
     <path d="M 248.769854 217.74136 
@@ -4981,7 +4981,7 @@ L 246.421172 227.173237
 L 246.368979 227.362918 
 L 246.316786 227.551842 
 L 246.264594 227.740017 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="legend_1">
     <g id="patch_7">
@@ -4999,7 +4999,7 @@ z
     </g>
     <g id="line2d_142">
      <defs>
-      <path id="m456359a00c" d="M 0 3.5 
+      <path id="m1b020c8409" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -5012,7 +5012,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m456359a00c" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m1b020c8409" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -5071,7 +5071,7 @@ z
     </g>
     <g id="line2d_143">
      <g>
-      <use xlink:href="#ma6a4cfb2c2" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mcc7f57953a" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -5085,7 +5085,7 @@ z
     </g>
     <g id="line2d_144">
      <g>
-      <use xlink:href="#mddee50189a" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#md17940d300" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -5130,7 +5130,7 @@ z
     </g>
     <g id="line2d_145">
      <g>
-      <use xlink:href="#m77b5932206" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m1781017fe3" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -5173,7 +5173,7 @@ z
     </g>
     <g id="line2d_146">
      <g>
-      <use xlink:href="#ma7c25d9a97" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#ma5cf3353e4" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -5189,7 +5189,7 @@ z
     </g>
     <g id="line2d_147">
      <g>
-      <use xlink:href="#m79b355ad29" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mf27cb95702" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -5243,7 +5243,7 @@ z
     </g>
     <g id="line2d_148">
      <g>
-      <use xlink:href="#m353579a97d" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#me94916b7c5" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -5308,7 +5308,7 @@ z
     </g>
     <g id="line2d_149">
      <g>
-      <use xlink:href="#m3ed957900c" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#mebc971e2c8" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -5346,7 +5346,7 @@ z
     </g>
     <g id="line2d_150">
      <g>
-      <use xlink:href="#mfee84be412" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mfe2e0b1a84" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -5416,486 +5416,486 @@ z
     </g>
    </g>
    <g id="line2d_151">
-    <g clip-path="url(#p6652a911cf)">
-     <use xlink:href="#m456359a00c" x="289.669676" y="149.610306" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m456359a00c" x="223.847406" y="159.886151" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m456359a00c" x="212.215046" y="163.98228" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m456359a00c" x="181.367844" y="171.586964" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m456359a00c" x="165.231972" y="179.494638" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m456359a00c" x="153.327587" y="185.380514" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m456359a00c" x="148.576453" y="191.342448" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m456359a00c" x="145.287154" y="194.257162" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m456359a00c" x="115.00257" y="273.95723" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m456359a00c" x="99.852312" y="300.336792" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <g clip-path="url(#p27197ae956)">
+     <use xlink:href="#m1b020c8409" x="289.669676" y="149.450565" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m1b020c8409" x="223.847406" y="159.848498" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m1b020c8409" x="212.215046" y="163.815848" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m1b020c8409" x="181.367844" y="168.643335" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m1b020c8409" x="165.231972" y="177.092266" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m1b020c8409" x="153.327587" y="183.323176" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m1b020c8409" x="148.576453" y="189.616311" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m1b020c8409" x="145.287154" y="192.635039" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m1b020c8409" x="115.00257" y="273.533072" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m1b020c8409" x="99.852312" y="300.665435" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
    <g id="line2d_152">
-    <path d="M 289.669676 149.610306 
-L 288.298379 149.848763 
-L 286.927082 150.086026 
-L 285.555784 150.322108 
-L 284.184487 150.557019 
-L 282.81319 150.790772 
-L 281.441892 151.023378 
-L 280.070595 151.254848 
-L 278.699298 151.485193 
-L 277.328 151.714424 
-L 275.956703 151.942552 
-L 274.585406 152.169587 
-L 273.214109 152.39554 
-L 271.842811 152.620421 
-L 270.471514 152.84424 
-L 269.100217 153.067007 
-L 267.728919 153.288732 
-L 266.357622 153.509424 
-L 264.986325 153.729094 
-L 263.615028 153.947751 
-L 262.24373 154.165403 
-L 260.872433 154.38206 
-L 259.501136 154.597732 
-L 258.129838 154.812427 
-L 256.758541 155.026153 
-L 255.387244 155.238921 
-L 254.015947 155.450737 
-L 252.644649 155.661611 
-L 251.273352 155.871551 
-L 249.902055 156.080566 
-L 248.530757 156.288662 
-L 247.15946 156.495849 
-L 245.788163 156.702135 
-L 244.416866 156.907526 
-L 243.045568 157.112032 
-L 241.674271 157.315658 
-L 240.302974 157.518414 
-L 238.931676 157.720306 
-L 237.560379 157.921342 
-L 236.189082 158.121529 
-L 234.817784 158.320873 
-L 233.446487 158.519383 
-L 232.07519 158.717065 
-L 230.703893 158.913926 
-L 229.332595 159.109973 
-L 227.961298 159.305212 
-L 226.590001 159.499651 
-L 225.218703 159.693294 
-L 223.847406 159.886151 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 289.669676 149.450565 
+L 288.298379 149.692169 
+L 286.927082 149.932548 
+L 285.555784 150.171715 
+L 284.184487 150.40968 
+L 282.81319 150.646457 
+L 281.441892 150.882056 
+L 280.070595 151.116491 
+L 278.699298 151.349771 
+L 277.328 151.58191 
+L 275.956703 151.812916 
+L 274.585406 152.042803 
+L 273.214109 152.271579 
+L 271.842811 152.499257 
+L 270.471514 152.725847 
+L 269.100217 152.951358 
+L 267.728919 153.175802 
+L 266.357622 153.399188 
+L 264.986325 153.621526 
+L 263.615028 153.842825 
+L 262.24373 154.063097 
+L 260.872433 154.282349 
+L 259.501136 154.500592 
+L 258.129838 154.717835 
+L 256.758541 154.934087 
+L 255.387244 155.149356 
+L 254.015947 155.363652 
+L 252.644649 155.576984 
+L 251.273352 155.78936 
+L 249.902055 156.000788 
+L 248.530757 156.211278 
+L 247.15946 156.420837 
+L 245.788163 156.629474 
+L 244.416866 156.837196 
+L 243.045568 157.044012 
+L 241.674271 157.249929 
+L 240.302974 157.454956 
+L 238.931676 157.659099 
+L 237.560379 157.862368 
+L 236.189082 158.064768 
+L 234.817784 158.266307 
+L 233.446487 158.466994 
+L 232.07519 158.666834 
+L 230.703893 158.865835 
+L 229.332595 159.064004 
+L 227.961298 159.261348 
+L 226.590001 159.457874 
+L 225.218703 159.653588 
+L 223.847406 159.848498 
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_153">
-    <path d="M 223.847406 159.886151 
-L 223.605065 159.975199 
-L 223.362724 160.06408 
-L 223.120384 160.152795 
-L 222.878043 160.241344 
-L 222.635702 160.329728 
-L 222.393361 160.417947 
-L 222.15102 160.506003 
-L 221.908679 160.593895 
-L 221.666339 160.681625 
-L 221.423998 160.769192 
-L 221.181657 160.856599 
-L 220.939316 160.943844 
-L 220.696975 161.030929 
-L 220.454635 161.117854 
-L 220.212294 161.20462 
-L 219.969953 161.291227 
-L 219.727612 161.377677 
-L 219.485271 161.463969 
-L 219.24293 161.550105 
-L 219.00059 161.636084 
-L 218.758249 161.721907 
-L 218.515908 161.807576 
-L 218.273567 161.893089 
-L 218.031226 161.978449 
-L 217.788885 162.063655 
-L 217.546545 162.148709 
-L 217.304204 162.23361 
-L 217.061863 162.318359 
-L 216.819522 162.402957 
-L 216.577181 162.487405 
-L 216.33484 162.571702 
-L 216.0925 162.655849 
-L 215.850159 162.739847 
-L 215.607818 162.823697 
-L 215.365477 162.907399 
-L 215.123136 162.990953 
-L 214.880795 163.07436 
-L 214.638455 163.157621 
-L 214.396114 163.240735 
-L 214.153773 163.323704 
-L 213.911432 163.406529 
-L 213.669091 163.489208 
-L 213.42675 163.571744 
-L 213.18441 163.654136 
-L 212.942069 163.736385 
-L 212.699728 163.818492 
-L 212.457387 163.900457 
-L 212.215046 163.98228 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 223.847406 159.848498 
+L 223.605065 159.93463 
+L 223.362724 160.020607 
+L 223.120384 160.106427 
+L 222.878043 160.192093 
+L 222.635702 160.277604 
+L 222.393361 160.362961 
+L 222.15102 160.448164 
+L 221.908679 160.533215 
+L 221.666339 160.618113 
+L 221.423998 160.702859 
+L 221.181657 160.787455 
+L 220.939316 160.871899 
+L 220.696975 160.956193 
+L 220.454635 161.040338 
+L 220.212294 161.124334 
+L 219.969953 161.208181 
+L 219.727612 161.29188 
+L 219.485271 161.375431 
+L 219.24293 161.458835 
+L 219.00059 161.542093 
+L 218.758249 161.625205 
+L 218.515908 161.708171 
+L 218.273567 161.790993 
+L 218.031226 161.87367 
+L 217.788885 161.956203 
+L 217.546545 162.038592 
+L 217.304204 162.120839 
+L 217.061863 162.202943 
+L 216.819522 162.284905 
+L 216.577181 162.366726 
+L 216.33484 162.448406 
+L 216.0925 162.529945 
+L 215.850159 162.611344 
+L 215.607818 162.692603 
+L 215.365477 162.773724 
+L 215.123136 162.854706 
+L 214.880795 162.93555 
+L 214.638455 163.016256 
+L 214.396114 163.096825 
+L 214.153773 163.177257 
+L 213.911432 163.257553 
+L 213.669091 163.337713 
+L 213.42675 163.417738 
+L 213.18441 163.497628 
+L 212.942069 163.577383 
+L 212.699728 163.657005 
+L 212.457387 163.736493 
+L 212.215046 163.815848 
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_154">
-    <path d="M 212.215046 163.98228 
-L 211.572396 164.153817 
-L 210.929746 164.324736 
-L 210.287096 164.495041 
-L 209.644446 164.664736 
-L 209.001796 164.833825 
-L 208.359146 165.002314 
-L 207.716496 165.170206 
-L 207.073846 165.337505 
-L 206.431196 165.504215 
-L 205.788546 165.670342 
-L 205.145896 165.835888 
-L 204.503246 166.000858 
-L 203.860596 166.165256 
-L 203.217946 166.329086 
-L 202.575296 166.492351 
-L 201.932645 166.655056 
-L 201.289995 166.817204 
-L 200.647345 166.978799 
-L 200.004695 167.139846 
-L 199.362045 167.300347 
-L 198.719395 167.460306 
-L 198.076745 167.619728 
-L 197.434095 167.778615 
-L 196.791445 167.936971 
-L 196.148795 168.0948 
-L 195.506145 168.252105 
-L 194.863495 168.40889 
-L 194.220845 168.565157 
-L 193.578195 168.720912 
-L 192.935545 168.876156 
-L 192.292895 169.030893 
-L 191.650245 169.185127 
-L 191.007595 169.338861 
-L 190.364945 169.492098 
-L 189.722294 169.644841 
-L 189.079644 169.797093 
-L 188.436994 169.948858 
-L 187.794344 170.100138 
-L 187.151694 170.250937 
-L 186.509044 170.401258 
-L 185.866394 170.551103 
-L 185.223744 170.700477 
-L 184.581094 170.849381 
-L 183.938444 170.997819 
-L 183.295794 171.145793 
-L 182.653144 171.293307 
-L 182.010494 171.440363 
-L 181.367844 171.586964 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 212.215046 163.815848 
+L 211.572396 163.921602 
+L 210.929746 164.027122 
+L 210.287096 164.132406 
+L 209.644446 164.237458 
+L 209.001796 164.342277 
+L 208.359146 164.446865 
+L 207.716496 164.551222 
+L 207.073846 164.65535 
+L 206.431196 164.75925 
+L 205.788546 164.862923 
+L 205.145896 164.966369 
+L 204.503246 165.069591 
+L 203.860596 165.172588 
+L 203.217946 165.275361 
+L 202.575296 165.377912 
+L 201.932645 165.480242 
+L 201.289995 165.582352 
+L 200.647345 165.684241 
+L 200.004695 165.785913 
+L 199.362045 165.887367 
+L 198.719395 165.988604 
+L 198.076745 166.089625 
+L 197.434095 166.190431 
+L 196.791445 166.291024 
+L 196.148795 166.391403 
+L 195.506145 166.49157 
+L 194.863495 166.591526 
+L 194.220845 166.691272 
+L 193.578195 166.790808 
+L 192.935545 166.890136 
+L 192.292895 166.989256 
+L 191.650245 167.088169 
+L 191.007595 167.186876 
+L 190.364945 167.285378 
+L 189.722294 167.383676 
+L 189.079644 167.48177 
+L 188.436994 167.579662 
+L 187.794344 167.677352 
+L 187.151694 167.774841 
+L 186.509044 167.87213 
+L 185.866394 167.96922 
+L 185.223744 168.066111 
+L 184.581094 168.162804 
+L 183.938444 168.259301 
+L 183.295794 168.355602 
+L 182.653144 168.451707 
+L 182.010494 168.547618 
+L 181.367844 168.643335 
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_155">
-    <path d="M 181.367844 171.586964 
-L 181.03168 171.765909 
-L 180.695516 171.94418 
-L 180.359352 172.121784 
-L 180.023188 172.298724 
-L 179.687024 172.475006 
-L 179.35086 172.650636 
-L 179.014696 172.825616 
-L 178.678532 172.999954 
-L 178.342368 173.173652 
-L 178.006204 173.346716 
-L 177.67004 173.51915 
-L 177.333876 173.69096 
-L 176.997712 173.862149 
-L 176.661548 174.032722 
-L 176.325384 174.202683 
-L 175.98922 174.372037 
-L 175.653056 174.540788 
-L 175.316892 174.708941 
-L 174.980728 174.876499 
-L 174.644564 175.043466 
-L 174.3084 175.209848 
-L 173.972236 175.375648 
-L 173.636072 175.540869 
-L 173.299908 175.705517 
-L 172.963744 175.869595 
-L 172.62758 176.033107 
-L 172.291416 176.196056 
-L 171.955252 176.358448 
-L 171.619088 176.520285 
-L 171.282924 176.681571 
-L 170.94676 176.84231 
-L 170.610596 177.002506 
-L 170.274432 177.162163 
-L 169.938268 177.321283 
-L 169.602104 177.479871 
-L 169.26594 177.637931 
-L 168.929776 177.795465 
-L 168.593612 177.952477 
-L 168.257448 178.10897 
-L 167.921284 178.264949 
-L 167.58512 178.420416 
-L 167.248956 178.575375 
-L 166.912792 178.729829 
-L 166.576628 178.883781 
-L 166.240464 179.037235 
-L 165.9043 179.190194 
-L 165.568136 179.34266 
-L 165.231972 179.494638 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 181.367844 168.643335 
+L 181.03168 168.835627 
+L 180.695516 169.027142 
+L 180.359352 169.217886 
+L 180.023188 169.407866 
+L 179.687024 169.597087 
+L 179.35086 169.785556 
+L 179.014696 169.973278 
+L 178.678532 170.16026 
+L 178.342368 170.346507 
+L 178.006204 170.532026 
+L 177.67004 170.716821 
+L 177.333876 170.900898 
+L 176.997712 171.084263 
+L 176.661548 171.266921 
+L 176.325384 171.448879 
+L 175.98922 171.63014 
+L 175.653056 171.810711 
+L 175.316892 171.990597 
+L 174.980728 172.169803 
+L 174.644564 172.348333 
+L 174.3084 172.526194 
+L 173.972236 172.70339 
+L 173.636072 172.879925 
+L 173.299908 173.055806 
+L 172.963744 173.231037 
+L 172.62758 173.405622 
+L 172.291416 173.579566 
+L 171.955252 173.752874 
+L 171.619088 173.925551 
+L 171.282924 174.097602 
+L 170.94676 174.26903 
+L 170.610596 174.43984 
+L 170.274432 174.610037 
+L 169.938268 174.779624 
+L 169.602104 174.948608 
+L 169.26594 175.116991 
+L 168.929776 175.284778 
+L 168.593612 175.451973 
+L 168.257448 175.61858 
+L 167.921284 175.784604 
+L 167.58512 175.950048 
+L 167.248956 176.114917 
+L 166.912792 176.279215 
+L 166.576628 176.442944 
+L 166.240464 176.606111 
+L 165.9043 176.768717 
+L 165.568136 176.930768 
+L 165.231972 177.092266 
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_156">
-    <path d="M 165.231972 179.494638 
-L 164.983964 179.625019 
-L 164.735956 179.755043 
-L 164.487948 179.884711 
-L 164.23994 180.014026 
-L 163.991932 180.142989 
-L 163.743924 180.271601 
-L 163.495916 180.399866 
-L 163.247908 180.527784 
-L 162.9999 180.655359 
-L 162.751892 180.78259 
-L 162.503884 180.909481 
-L 162.255876 181.036034 
-L 162.007868 181.162249 
-L 161.75986 181.288129 
-L 161.511852 181.413676 
-L 161.263844 181.538891 
-L 161.015836 181.663776 
-L 160.767828 181.788333 
-L 160.51982 181.912564 
-L 160.271812 182.03647 
-L 160.023804 182.160052 
-L 159.775796 182.283314 
-L 159.527788 182.406255 
-L 159.27978 182.528879 
-L 159.031772 182.651186 
-L 158.783764 182.773178 
-L 158.535756 182.894858 
-L 158.287748 183.016225 
-L 158.03974 183.137283 
-L 157.791732 183.258032 
-L 157.543724 183.378475 
-L 157.295716 183.498612 
-L 157.047708 183.618445 
-L 156.7997 183.737976 
-L 156.551691 183.857207 
-L 156.303683 183.976138 
-L 156.055675 184.094772 
-L 155.807667 184.21311 
-L 155.559659 184.331152 
-L 155.311651 184.448902 
-L 155.063643 184.56636 
-L 154.815635 184.683527 
-L 154.567627 184.800406 
-L 154.319619 184.916997 
-L 154.071611 185.033302 
-L 153.823603 185.149322 
-L 153.575595 185.265059 
-L 153.327587 185.380514 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 165.231972 177.092266 
+L 164.983964 177.230793 
+L 164.735956 177.368916 
+L 164.487948 177.506637 
+L 164.23994 177.64396 
+L 163.991932 177.780886 
+L 163.743924 177.917418 
+L 163.495916 178.053557 
+L 163.247908 178.189307 
+L 162.9999 178.324669 
+L 162.751892 178.459645 
+L 162.503884 178.594238 
+L 162.255876 178.72845 
+L 162.007868 178.862283 
+L 161.75986 178.99574 
+L 161.511852 179.128821 
+L 161.263844 179.26153 
+L 161.015836 179.393869 
+L 160.767828 179.525839 
+L 160.51982 179.657442 
+L 160.271812 179.788681 
+L 160.023804 179.919558 
+L 159.775796 180.050075 
+L 159.527788 180.180233 
+L 159.27978 180.310034 
+L 159.031772 180.439481 
+L 158.783764 180.568576 
+L 158.535756 180.69732 
+L 158.287748 180.825715 
+L 158.03974 180.953763 
+L 157.791732 181.081466 
+L 157.543724 181.208827 
+L 157.295716 181.335845 
+L 157.047708 181.462525 
+L 156.7997 181.588866 
+L 156.551691 181.714872 
+L 156.303683 181.840544 
+L 156.055675 181.965884 
+L 155.807667 182.090892 
+L 155.559659 182.215572 
+L 155.311651 182.339925 
+L 155.063643 182.463953 
+L 154.815635 182.587657 
+L 154.567627 182.711039 
+L 154.319619 182.8341 
+L 154.071611 182.956843 
+L 153.823603 183.079269 
+L 153.575595 183.201379 
+L 153.327587 183.323176 
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_157">
-    <path d="M 153.327587 185.380514 
-L 153.228605 185.512686 
-L 153.129623 185.644491 
-L 153.030641 185.77593 
-L 152.931659 185.907005 
-L 152.832678 186.037719 
-L 152.733696 186.168074 
-L 152.634714 186.298071 
-L 152.535732 186.427713 
-L 152.43675 186.557001 
-L 152.337768 186.685937 
-L 152.238786 186.814523 
-L 152.139804 186.942762 
-L 152.040822 187.070654 
-L 151.94184 187.198203 
-L 151.842858 187.325409 
-L 151.743876 187.452274 
-L 151.644894 187.578801 
-L 151.545912 187.704991 
-L 151.44693 187.830846 
-L 151.347948 187.956368 
-L 151.248966 188.081558 
-L 151.149984 188.206419 
-L 151.051002 188.330951 
-L 150.95202 188.455157 
-L 150.853038 188.579039 
-L 150.754056 188.702597 
-L 150.655074 188.825834 
-L 150.556093 188.948752 
-L 150.457111 189.071352 
-L 150.358129 189.193635 
-L 150.259147 189.315604 
-L 150.160165 189.43726 
-L 150.061183 189.558604 
-L 149.962201 189.679638 
-L 149.863219 189.800365 
-L 149.764237 189.920784 
-L 149.665255 190.040898 
-L 149.566273 190.160709 
-L 149.467291 190.280218 
-L 149.368309 190.399426 
-L 149.269327 190.518334 
-L 149.170345 190.636946 
-L 149.071363 190.755261 
-L 148.972381 190.873282 
-L 148.873399 190.99101 
-L 148.774417 191.108445 
-L 148.675435 191.225591 
-L 148.576453 191.342448 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 153.327587 183.323176 
+L 153.228605 183.463178 
+L 153.129623 183.602767 
+L 153.030641 183.741947 
+L 152.931659 183.880719 
+L 152.832678 184.019086 
+L 152.733696 184.15705 
+L 152.634714 184.294614 
+L 152.535732 184.43178 
+L 152.43675 184.56855 
+L 152.337768 184.704927 
+L 152.238786 184.840912 
+L 152.139804 184.976508 
+L 152.040822 185.111718 
+L 151.94184 185.246542 
+L 151.842858 185.380985 
+L 151.743876 185.515047 
+L 151.644894 185.648731 
+L 151.545912 185.782039 
+L 151.44693 185.914973 
+L 151.347948 186.047536 
+L 151.248966 186.179728 
+L 151.149984 186.311553 
+L 151.051002 186.443013 
+L 150.95202 186.574109 
+L 150.853038 186.704843 
+L 150.754056 186.835218 
+L 150.655074 186.965235 
+L 150.556093 187.094896 
+L 150.457111 187.224204 
+L 150.358129 187.353159 
+L 150.259147 187.481765 
+L 150.160165 187.610023 
+L 150.061183 187.737935 
+L 149.962201 187.865503 
+L 149.863219 187.992728 
+L 149.764237 188.119613 
+L 149.665255 188.246158 
+L 149.566273 188.372367 
+L 149.467291 188.498241 
+L 149.368309 188.623781 
+L 149.269327 188.74899 
+L 149.170345 188.873869 
+L 149.071363 188.99842 
+L 148.972381 189.122644 
+L 148.873399 189.246543 
+L 148.774417 189.37012 
+L 148.675435 189.493375 
+L 148.576453 189.616311 
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_158">
-    <path d="M 148.576453 191.342448 
-L 148.507926 191.405036 
-L 148.439399 191.467541 
-L 148.370872 191.529964 
-L 148.302345 191.592305 
-L 148.233818 191.654564 
-L 148.165291 191.716741 
-L 148.096764 191.778837 
-L 148.028237 191.840851 
-L 147.95971 191.902785 
-L 147.891183 191.964637 
-L 147.822656 192.02641 
-L 147.754129 192.088101 
-L 147.685602 192.149713 
-L 147.617074 192.211244 
-L 147.548547 192.272696 
-L 147.48002 192.334068 
-L 147.411493 192.395361 
-L 147.342966 192.456575 
-L 147.274439 192.517709 
-L 147.205912 192.578765 
-L 147.137385 192.639743 
-L 147.068858 192.700642 
-L 147.000331 192.761463 
-L 146.931804 192.822206 
-L 146.863277 192.882871 
-L 146.79475 192.943459 
-L 146.726223 193.003969 
-L 146.657696 193.064402 
-L 146.589169 193.124759 
-L 146.520641 193.185038 
-L 146.452114 193.245241 
-L 146.383587 193.305368 
-L 146.31506 193.365418 
-L 146.246533 193.425392 
-L 146.178006 193.485291 
-L 146.109479 193.545114 
-L 146.040952 193.604862 
-L 145.972425 193.664534 
-L 145.903898 193.724131 
-L 145.835371 193.783654 
-L 145.766844 193.843102 
-L 145.698317 193.902475 
-L 145.62979 193.961774 
-L 145.561263 194.020999 
-L 145.492735 194.08015 
-L 145.424208 194.139228 
-L 145.355681 194.198231 
-L 145.287154 194.257162 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 148.576453 189.616311 
+L 148.507926 189.681202 
+L 148.439399 189.746005 
+L 148.370872 189.810719 
+L 148.302345 189.875346 
+L 148.233818 189.939884 
+L 148.165291 190.004334 
+L 148.096764 190.068697 
+L 148.028237 190.132973 
+L 147.95971 190.197161 
+L 147.891183 190.261263 
+L 147.822656 190.325278 
+L 147.754129 190.389207 
+L 147.685602 190.45305 
+L 147.617074 190.516807 
+L 147.548547 190.580478 
+L 147.48002 190.644064 
+L 147.411493 190.707564 
+L 147.342966 190.77098 
+L 147.274439 190.834311 
+L 147.205912 190.897557 
+L 147.137385 190.96072 
+L 147.068858 191.023798 
+L 147.000331 191.086792 
+L 146.931804 191.149703 
+L 146.863277 191.21253 
+L 146.79475 191.275274 
+L 146.726223 191.337935 
+L 146.657696 191.400514 
+L 146.589169 191.46301 
+L 146.520641 191.525423 
+L 146.452114 191.587755 
+L 146.383587 191.650004 
+L 146.31506 191.712172 
+L 146.246533 191.774259 
+L 146.178006 191.836264 
+L 146.109479 191.898189 
+L 146.040952 191.960032 
+L 145.972425 192.021795 
+L 145.903898 192.083478 
+L 145.835371 192.14508 
+L 145.766844 192.206603 
+L 145.698317 192.268046 
+L 145.62979 192.329409 
+L 145.561263 192.390693 
+L 145.492735 192.451897 
+L 145.424208 192.513023 
+L 145.355681 192.57407 
+L 145.287154 192.635039 
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_159">
-    <path d="M 145.287154 194.257162 
-L 144.656225 198.390308 
-L 144.025297 202.191777 
-L 143.394368 205.710868 
-L 142.763439 208.986648 
-L 142.13251 212.050598 
-L 141.501581 214.928457 
-L 140.870652 217.641541 
-L 140.239723 220.207702 
-L 139.608795 222.642038 
-L 138.977866 224.957434 
-L 138.346937 227.164974 
-L 137.716008 229.274259 
-L 137.085079 231.293666 
-L 136.45415 233.230541 
-L 135.823222 235.091366 
-L 135.192293 236.881889 
-L 134.561364 238.607228 
-L 133.930435 240.271965 
-L 133.299506 241.880211 
-L 132.668577 243.435675 
-L 132.037648 244.941712 
-L 131.40672 246.401367 
-L 130.775791 247.817411 
-L 130.144862 249.192376 
-L 129.513933 250.528576 
-L 128.883004 251.828139 
-L 128.252075 253.09302 
-L 127.621147 254.325022 
-L 126.990218 255.525811 
-L 126.359289 256.69693 
-L 125.72836 257.839809 
-L 125.097431 258.95578 
-L 124.466502 260.046078 
-L 123.835573 261.11186 
-L 123.204645 262.154204 
-L 122.573716 263.174117 
-L 121.942787 264.172546 
-L 121.311858 265.150377 
-L 120.680929 266.108443 
-L 120.05 267.047526 
-L 119.419071 267.968365 
-L 118.788143 268.871655 
-L 118.157214 269.758052 
-L 117.526285 270.628177 
-L 116.895356 271.482616 
-L 116.264427 272.321924 
-L 115.633498 273.146629 
-L 115.00257 273.95723 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 145.287154 192.635039 
+L 144.656225 196.892499 
+L 144.025297 200.798865 
+L 143.394368 204.407658 
+L 142.763439 207.761023 
+L 142.13251 210.89274 
+L 141.501581 213.830301 
+L 140.870652 216.596383 
+L 140.239723 219.209905 
+L 139.608795 221.68682 
+L 138.977866 224.040702 
+L 138.346937 226.283198 
+L 137.716008 228.424374 
+L 137.085079 230.472992 
+L 136.45415 232.436723 
+L 135.823222 234.322323 
+L 135.192293 236.135773 
+L 134.561364 237.88239 
+L 133.930435 239.566927 
+L 133.299506 241.193645 
+L 132.668577 242.766382 
+L 132.037648 244.288605 
+L 131.40672 245.76346 
+L 130.775791 247.193805 
+L 130.144862 248.582248 
+L 129.513933 249.931175 
+L 128.883004 251.242772 
+L 128.252075 252.519051 
+L 127.621147 253.761863 
+L 126.990218 254.97292 
+L 126.359289 256.153803 
+L 125.72836 257.305979 
+L 125.097431 258.430812 
+L 124.466502 259.529569 
+L 123.835573 260.603431 
+L 123.204645 261.653502 
+L 122.573716 262.680813 
+L 121.942787 263.686331 
+L 121.311858 264.670959 
+L 120.680929 265.635549 
+L 120.05 266.580901 
+L 119.419071 267.507765 
+L 118.788143 268.416853 
+L 118.157214 269.308832 
+L 117.526285 270.184335 
+L 116.895356 271.043959 
+L 116.264427 271.888271 
+L 115.633498 272.717806 
+L 115.00257 273.533072 
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_160">
-    <path d="M 115.00257 273.95723 
-L 114.686939 274.686892 
-L 114.371309 275.405491 
-L 114.055678 276.113359 
-L 113.740048 276.81081 
-L 113.424418 277.498148 
-L 113.108787 278.17566 
-L 112.793157 278.843625 
-L 112.477527 279.502307 
-L 112.161896 280.151961 
-L 111.846266 280.792831 
-L 111.530636 281.425152 
-L 111.215005 282.049148 
-L 110.899375 282.665035 
-L 110.583745 283.273023 
-L 110.268114 283.873311 
-L 109.952484 284.466091 
-L 109.636853 285.051549 
-L 109.321223 285.629865 
-L 109.005593 286.201209 
-L 108.689962 286.765748 
-L 108.374332 287.323642 
-L 108.058702 287.875046 
-L 107.743071 288.420109 
-L 107.427441 288.958975 
-L 107.111811 289.491784 
-L 106.79618 290.01867 
-L 106.48055 290.539764 
-L 106.16492 291.055191 
-L 105.849289 291.565073 
-L 105.533659 292.069529 
-L 105.218028 292.568673 
-L 104.902398 293.062615 
-L 104.586768 293.551462 
-L 104.271137 294.03532 
-L 103.955507 294.514287 
-L 103.639877 294.988464 
-L 103.324246 295.457943 
-L 103.008616 295.922818 
-L 102.692986 296.383178 
-L 102.377355 296.83911 
-L 102.061725 297.290698 
-L 101.746095 297.738024 
-L 101.430464 298.181167 
-L 101.114834 298.620206 
-L 100.799203 299.055216 
-L 100.483573 299.48627 
-L 100.167943 299.913438 
-L 99.852312 300.336792 
-" clip-path="url(#p6652a911cf)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 115.00257 273.533072 
+L 114.686939 274.289885 
+L 114.371309 275.034804 
+L 114.055678 275.768196 
+L 113.740048 276.490414 
+L 113.424418 277.201792 
+L 113.108787 277.902651 
+L 112.793157 278.593298 
+L 112.477527 279.274026 
+L 112.161896 279.945115 
+L 111.846266 280.606836 
+L 111.530636 281.259445 
+L 111.215005 281.903192 
+L 110.899375 282.538312 
+L 110.583745 283.165034 
+L 110.268114 283.783578 
+L 109.952484 284.394153 
+L 109.636853 284.996963 
+L 109.321223 285.592204 
+L 109.005593 286.180061 
+L 108.689962 286.760717 
+L 108.374332 287.334346 
+L 108.058702 287.901116 
+L 107.743071 288.461188 
+L 107.427441 289.01472 
+L 107.111811 289.561862 
+L 106.79618 290.10276 
+L 106.48055 290.637555 
+L 106.16492 291.166384 
+L 105.849289 291.689378 
+L 105.533659 292.206663 
+L 105.218028 292.718365 
+L 104.902398 293.224601 
+L 104.586768 293.725487 
+L 104.271137 294.221136 
+L 103.955507 294.711655 
+L 103.639877 295.19715 
+L 103.324246 295.677722 
+L 103.008616 296.153471 
+L 102.692986 296.624492 
+L 102.377355 297.090879 
+L 102.061725 297.552721 
+L 101.746095 298.010106 
+L 101.430464 298.46312 
+L 101.114834 298.911846 
+L 100.799203 299.356362 
+L 100.483573 299.796749 
+L 100.167943 300.233082 
+L 99.852312 300.665435 
+" clip-path="url(#p27197ae956)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
   </g>
   <g id="text_25">
@@ -6254,8 +6254,8 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-07-08T15:47:33Z  ·  Linux chungus2 x86_64  ·  commit f2026e66  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(44.448437 465.66) scale(0.07 -0.07)">
+   <!-- 2026-07-08T20:00:36Z  ·  Linux chungus2 x86_64  ·  commit 29539fd5  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(44.380078 465.66) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -6276,31 +6276,6 @@ L 1638 0
 L 1638 4134 
 L -19 4134 
 L -19 4666 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-3a" d="M 750 794 
@@ -6373,6 +6348,61 @@ Q 2894 3584 3203 3211
 Q 3513 2838 3513 2113 
 z
 " transform="scale(0.015625)"/>
+     <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
      <path id="DejaVuSans-3d" d="M 678 2906 
 L 4684 2906 
 L 4684 2381 
@@ -6413,14 +6443,14 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-38" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
     <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -6460,109 +6490,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3107.080078 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3170.703125 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3234.326172 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3297.949219 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3361.572266 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3423.095703 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3486.71875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3550.341797 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3582.128906 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3613.916016 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3645.703125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3677.490234 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3709.277344 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3737.060547 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3798.583984 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3859.863281 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3923.242188 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3986.71875 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4025.582031 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4086.763672 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4145.943359 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4207.466797 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4248.580078 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4282.271484 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4310.054688 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4371.578125 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4432.857422 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4496.236328 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4559.859375 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4593.550781 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4652.730469 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4716.353516 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4748.140625 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4811.763672 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4875.386719 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4907.173828 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4970.796875 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5006.880859 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5045.744141 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5100.724609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5164.347656 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5196.134766 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5227.921875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5259.708984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5291.496094 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5323.283203 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5362.492188 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5425.871094 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5464.734375 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5525.916016 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5589.294922 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5652.771484 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5716.150391 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5779.626953 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5843.005859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5882.214844 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5914.001953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5997.791016 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6029.578125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6126.990234 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6188.513672 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6251.990234 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6279.773438 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6341.052734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6404.431641 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6436.21875 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6488.318359 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6551.697266 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6612.976562 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6676.453125 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6728.552734 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6791.931641 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6853.113281 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6892.322266 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6926.013672 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6957.800781 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6998.914062 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7060.193359 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7099.402344 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7127.185547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7188.367188 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7220.154297 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7247.9375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7300.037109 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7331.824219 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7395.300781 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7456.824219 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7496.033203 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7557.556641 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7596.919922 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7694.332031 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7722.115234 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7785.494141 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7813.277344 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7865.376953 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7904.585938 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7932.369141 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3262.744141 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3326.367188 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3389.990234 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3425.195312 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3488.671875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3552.294922 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3584.082031 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3615.869141 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3647.65625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3679.443359 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3711.230469 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3739.013672 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3800.537109 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3861.816406 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3925.195312 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3988.671875 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4027.535156 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4088.716797 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4147.896484 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4209.419922 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4250.533203 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4284.224609 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4312.007812 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4373.53125 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4434.810547 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4498.189453 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4561.8125 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4595.503906 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4654.683594 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4718.306641 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4750.09375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4813.716797 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4877.339844 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4909.126953 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4972.75 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5008.833984 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5047.697266 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5102.677734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5166.300781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5198.087891 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5229.875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5261.662109 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5293.449219 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5325.236328 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5364.445312 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5427.824219 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5466.6875 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5527.869141 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5591.248047 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5654.724609 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5718.103516 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5781.580078 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5844.958984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5884.167969 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5915.955078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5999.744141 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6031.53125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6128.943359 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6190.466797 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6253.943359 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6281.726562 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6343.005859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6406.384766 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6438.171875 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6490.271484 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6553.650391 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6614.929688 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6678.40625 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6730.505859 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6793.884766 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6855.066406 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6894.275391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6927.966797 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6959.753906 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7000.867188 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7062.146484 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7101.355469 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7129.138672 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7190.320312 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7222.107422 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7249.890625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7301.990234 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7333.777344 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7397.253906 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7458.777344 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7497.986328 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7559.509766 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7598.873047 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7696.285156 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7724.068359 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7787.447266 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7815.230469 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7867.330078 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7906.539062 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7934.322266 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p6652a911cf">
+  <clipPath id="p27197ae956">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_ratio_heatmap.svg
+++ b/bench/graphs/canterbury_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#pd295bb7cec)">
+   <g clip-path="url(#pff9aea0db8)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAI/UlEQVR4nO3YwYqkVx2H4aqe7qYn4oAyashScCfBhRtn49o7yRW4DNl7HcYbEEQk2Yjixo24E3ciISRjnMyE7p7q78sljMKRv9T7PFfwO3zUqZdz3P71y/1wbl5+Nr1gqf3z8zrP4XA4/OPnv56esNTf//JqesJyP/3wZ9MTljv+6MfTE9Y6XkwvWO/FJ9ML1rt5Mr1gqV997xfTE5Y7w18SAMB/TgwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKQd706/2adHrLYftukJSx3PsFmvLq6nJyx1v91OT1ju6q9/mp6w3OmHz6YnLHXa7qcnLPfq9GJ6wnJPz+x6eP3k6fSE5c7vXxYA4L8ghgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0i6vXn0xvWG9u6+mF6y1b9ML1nv8ZHrBUtfTA/4H9hevpicsd/Xl8+kJS11tp+kJyz0+x/vu9uX0gqWuLs/vxvMyBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgLTjafvdPj1itX3fpicstZ3ZeQ6Hw+Hq4np6wlIP+2l6wnKPXj6fnrDeN787vWCp19v99ITlPr/95/SE5d6+u5yesNT2rXemJyznZQgASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASLv886d/mN6w3MXhOD1hqe+89XR6wnIP22l6wlLXj26mJyz33se/n56w3Ac/+cH0hKVO+zY9Ybn3//i36QnLPXvnG9MTlnrv3WfTE5bzMgQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIC04+uH3+7TI1a7f7idnrDU4+PN9ATe4P54mp6w3L/vPpuesNy3b96enrDUtm/TE5b74u7T6QnLPb/7ZHrCUt9/8u70hOW8DAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACDtuG0f7dMjgP9Dp/vpBetdXk8v4A1uH76anrDczaO3pifwBl6GAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkHZ5v91Ob1juYTtNT1jq8uJ6esJyV2d2ptfb/fSE5faLbXrCcscz+04P+3nddYfD4fDl/fPpCctdP76ZnrDUvp/f3eBlCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGlfA43TkfjdNPLgAAAAAElFTkSuQmCC" id="imageaa90d1f60d" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAI/UlEQVR4nO3YwYqkVx2H4aqe7qYn4oAyashScCfBhRtn49o7yRW4DNl7HcYbEEQk2Yjixo24E3ciISRjnMyE7p7q78sljMKRv9T7PFfwO3zUqZdz3P71y/1wbl5+Nr1gqf3z8zrP4XA4/OPnv56esNTf//JqesJyP/3wZ9MTljv+6MfTE9Y6XkwvWO/FJ9ML1rt5Mr1gqV997xfTE5Y7w18SAMB/TgwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKQd706/2adHrLYftukJSx3PsFmvLq6nJyx1v91OT1ju6q9/mp6w3OmHz6YnLHXa7qcnLPfq9GJ6wnJPz+x6eP3k6fSE5c7vXxYA4L8ghgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0i6vXn0xvWG9u6+mF6y1b9ML1nv8ZHrBUtfTA/4H9hevpicsd/Xl8+kJS11tp+kJyz0+x/vu9uX0gqWuLs/vxvMyBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgLTjafvdPj1itX3fpicstZ3ZeQ6Hw+Hq4np6wlIP+2l6wnKPXj6fnrDeN787vWCp19v99ITlPr/95/SE5d6+u5yesNT2rXemJyznZQgASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASLv886d/mN6w3MXhOD1hqe+89XR6wnIP22l6wlLXj26mJyz33se/n56w3Ac/+cH0hKVO+zY9Ybn3//i36QnLPXvnG9MTlnrv3WfTE5bzMgQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIC04+uH3+7TI1a7f7idnrDU4+PN9ATe4P54mp6w3L/vPpuesNy3b96enrDUtm/TE5b74u7T6QnLPb/7ZHrCUt9/8u70hOW8DAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACDtuG0f7dMjgP9Dp/vpBetdXk8v4A1uH76anrDczaO3pifwBl6GAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkHZ5v91Ob1juYTtNT1jq8uJ6esJyV2d2ptfb/fSE5faLbXrCcscz+04P+3nddYfD4fDl/fPpCctdP76ZnrDUvp/f3eBlCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGlfA43TkfjdNPLgAAAAAElFTkSuQmCC" id="imageeb7b243aeb" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m5bf989e3b0" d="M 0 0 
+       <path id="m7abf2286b3" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m5bf989e3b0" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7abf2286b3" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m5bf989e3b0" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7abf2286b3" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m5bf989e3b0" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7abf2286b3" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m5bf989e3b0" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7abf2286b3" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m5bf989e3b0" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7abf2286b3" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m5bf989e3b0" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7abf2286b3" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m5bf989e3b0" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7abf2286b3" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m5bf989e3b0" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7abf2286b3" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m5bf989e3b0" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7abf2286b3" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m5bf989e3b0" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7abf2286b3" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m5bf989e3b0" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7abf2286b3" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="mf611572638" d="M 0 0 
+       <path id="m41efdef2e3" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mf611572638" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m41efdef2e3" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#mf611572638" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m41efdef2e3" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mf611572638" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m41efdef2e3" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#mf611572638" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m41efdef2e3" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#mf611572638" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m41efdef2e3" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#mf611572638" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m41efdef2e3" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mf611572638" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m41efdef2e3" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#mf611572638" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m41efdef2e3" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -2092,18 +2092,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="image6dd72eee2a" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
+iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="image55ecd70f3c" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="m6b46d0cd4d" d="M 0 0 
+       <path id="m7eed2e0b61" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m6b46d0cd4d" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7eed2e0b61" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
@@ -2129,7 +2129,7 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m6b46d0cd4d" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7eed2e0b61" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
@@ -2146,7 +2146,7 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m6b46d0cd4d" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7eed2e0b61" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
@@ -2163,7 +2163,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m6b46d0cd4d" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7eed2e0b61" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
@@ -2180,7 +2180,7 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m6b46d0cd4d" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7eed2e0b61" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_112">
@@ -2196,7 +2196,7 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m6b46d0cd4d" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7eed2e0b61" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
@@ -2212,7 +2212,7 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m6b46d0cd4d" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7eed2e0b61" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
@@ -2228,7 +2228,7 @@ z
     <g id="ytick_16">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#m6b46d0cd4d" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7eed2e0b61" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_115">
@@ -2244,7 +2244,7 @@ z
     <g id="ytick_17">
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m6b46d0cd4d" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7eed2e0b61" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_116">
@@ -2882,8 +2882,8 @@ z
    </g>
   </g>
   <g id="text_119">
-   <!-- 2026-07-08T15:47:33Z  ·  Linux chungus2 x86_64  ·  commit f2026e66  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(17.448437 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-08T20:00:36Z  ·  Linux chungus2 x86_64  ·  commit 29539fd5  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(17.380078 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2952,14 +2952,14 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-38" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
     <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2999,109 +2999,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3107.080078 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3170.703125 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3234.326172 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3297.949219 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3361.572266 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3423.095703 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3486.71875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3550.341797 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3582.128906 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3613.916016 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3645.703125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3677.490234 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3709.277344 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3737.060547 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3798.583984 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3859.863281 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3923.242188 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3986.71875 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4025.582031 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4086.763672 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4145.943359 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4207.466797 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4248.580078 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4282.271484 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4310.054688 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4371.578125 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4432.857422 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4496.236328 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4559.859375 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4593.550781 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4652.730469 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4716.353516 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4748.140625 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4811.763672 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4875.386719 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4907.173828 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4970.796875 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5006.880859 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5045.744141 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5100.724609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5164.347656 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5196.134766 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5227.921875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5259.708984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5291.496094 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5323.283203 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5362.492188 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5425.871094 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5464.734375 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5525.916016 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5589.294922 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5652.771484 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5716.150391 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5779.626953 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5843.005859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5882.214844 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5914.001953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5997.791016 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6029.578125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6126.990234 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6188.513672 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6251.990234 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6279.773438 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6341.052734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6404.431641 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6436.21875 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6488.318359 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6551.697266 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6612.976562 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6676.453125 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6728.552734 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6791.931641 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6853.113281 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6892.322266 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6926.013672 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6957.800781 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6998.914062 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7060.193359 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7099.402344 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7127.185547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7188.367188 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7220.154297 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7247.9375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7300.037109 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7331.824219 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7395.300781 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7456.824219 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7496.033203 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7557.556641 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7596.919922 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7694.332031 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7722.115234 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7785.494141 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7813.277344 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7865.376953 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7904.585938 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7932.369141 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3262.744141 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3326.367188 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3389.990234 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3425.195312 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3488.671875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3552.294922 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3584.082031 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3615.869141 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3647.65625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3679.443359 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3711.230469 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3739.013672 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3800.537109 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3861.816406 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3925.195312 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3988.671875 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4027.535156 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4088.716797 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4147.896484 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4209.419922 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4250.533203 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4284.224609 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4312.007812 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4373.53125 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4434.810547 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4498.189453 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4561.8125 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4595.503906 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4654.683594 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4718.306641 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4750.09375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4813.716797 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4877.339844 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4909.126953 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4972.75 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5008.833984 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5047.697266 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5102.677734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5166.300781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5198.087891 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5229.875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5261.662109 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5293.449219 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5325.236328 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5364.445312 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5427.824219 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5466.6875 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5527.869141 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5591.248047 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5654.724609 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5718.103516 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5781.580078 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5844.958984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5884.167969 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5915.955078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5999.744141 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6031.53125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6128.943359 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6190.466797 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6253.943359 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6281.726562 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6343.005859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6406.384766 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6438.171875 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6490.271484 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6553.650391 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6614.929688 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6678.40625 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6730.505859 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6793.884766 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6855.066406 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6894.275391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6927.966797 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6959.753906 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7000.867188 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7062.146484 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7101.355469 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7129.138672 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7190.320312 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7222.107422 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7249.890625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7301.990234 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7333.777344 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7397.253906 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7458.777344 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7497.986328 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7559.509766 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7598.873047 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7696.285156 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7724.068359 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7787.447266 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7815.230469 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7867.330078 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7906.539062 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7934.322266 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pd295bb7cec">
+  <clipPath id="pff9aea0db8">
    <rect x="95.67625" y="49.4355" width="416.571298" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_summary.svg
+++ b/bench/graphs/canterbury_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="573.503125pt" height="386.202469pt" viewBox="0 0 573.503125 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="573.639844pt" height="386.202469pt" viewBox="0 0 573.639844 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,232 +22,232 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 386.202469 
-L 573.503125 386.202469 
-L 573.503125 0 
+L 573.639844 386.202469 
+L 573.639844 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 188.876563 104.1264 
-L 293.501563 104.1264 
-L 293.501563 74.7432 
-L 188.876563 74.7432 
+    <path d="M 188.944922 104.1264 
+L 293.569922 104.1264 
+L 293.569922 74.7432 
+L 188.944922 74.7432 
 z
-" clip-path="url(#p25d2ad8c0f)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc3c08d5fa9)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 293.501563 104.1264 
-L 398.126563 104.1264 
-L 398.126563 74.7432 
-L 293.501563 74.7432 
+    <path d="M 293.569922 104.1264 
+L 398.194922 104.1264 
+L 398.194922 74.7432 
+L 293.569922 74.7432 
 z
-" clip-path="url(#p25d2ad8c0f)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc3c08d5fa9)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 398.126563 104.1264 
-L 502.751563 104.1264 
-L 502.751563 74.7432 
-L 398.126563 74.7432 
+    <path d="M 398.194922 104.1264 
+L 502.819922 104.1264 
+L 502.819922 74.7432 
+L 398.194922 74.7432 
 z
-" clip-path="url(#p25d2ad8c0f)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc3c08d5fa9)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 188.876563 133.5096 
-L 293.501563 133.5096 
-L 293.501563 104.1264 
-L 188.876563 104.1264 
+    <path d="M 188.944922 133.5096 
+L 293.569922 133.5096 
+L 293.569922 104.1264 
+L 188.944922 104.1264 
 z
-" clip-path="url(#p25d2ad8c0f)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc3c08d5fa9)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 293.501563 133.5096 
-L 398.126563 133.5096 
-L 398.126563 104.1264 
-L 293.501563 104.1264 
+    <path d="M 293.569922 133.5096 
+L 398.194922 133.5096 
+L 398.194922 104.1264 
+L 293.569922 104.1264 
 z
-" clip-path="url(#p25d2ad8c0f)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc3c08d5fa9)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 398.126563 133.5096 
-L 502.751563 133.5096 
-L 502.751563 104.1264 
-L 398.126563 104.1264 
+    <path d="M 398.194922 133.5096 
+L 502.819922 133.5096 
+L 502.819922 104.1264 
+L 398.194922 104.1264 
 z
-" clip-path="url(#p25d2ad8c0f)" style="fill: #fdb768; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc3c08d5fa9)" style="fill: #fdb768; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 188.876563 162.8928 
-L 293.501563 162.8928 
-L 293.501563 133.5096 
-L 188.876563 133.5096 
+    <path d="M 188.944922 162.8928 
+L 293.569922 162.8928 
+L 293.569922 133.5096 
+L 188.944922 133.5096 
 z
-" clip-path="url(#p25d2ad8c0f)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc3c08d5fa9)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 293.501563 162.8928 
-L 398.126563 162.8928 
-L 398.126563 133.5096 
-L 293.501563 133.5096 
+    <path d="M 293.569922 162.8928 
+L 398.194922 162.8928 
+L 398.194922 133.5096 
+L 293.569922 133.5096 
 z
-" clip-path="url(#p25d2ad8c0f)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc3c08d5fa9)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 398.126563 162.8928 
-L 502.751563 162.8928 
-L 502.751563 133.5096 
-L 398.126563 133.5096 
+    <path d="M 398.194922 162.8928 
+L 502.819922 162.8928 
+L 502.819922 133.5096 
+L 398.194922 133.5096 
 z
-" clip-path="url(#p25d2ad8c0f)" style="fill: #bbe278; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc3c08d5fa9)" style="fill: #bbe278; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 188.876563 192.276 
-L 293.501563 192.276 
-L 293.501563 162.8928 
-L 188.876563 162.8928 
+    <path d="M 188.944922 192.276 
+L 293.569922 192.276 
+L 293.569922 162.8928 
+L 188.944922 162.8928 
 z
-" clip-path="url(#p25d2ad8c0f)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc3c08d5fa9)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 293.501563 192.276 
-L 398.126563 192.276 
-L 398.126563 162.8928 
-L 293.501563 162.8928 
+    <path d="M 293.569922 192.276 
+L 398.194922 192.276 
+L 398.194922 162.8928 
+L 293.569922 162.8928 
 z
-" clip-path="url(#p25d2ad8c0f)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc3c08d5fa9)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 398.126563 192.276 
-L 502.751563 192.276 
-L 502.751563 162.8928 
-L 398.126563 162.8928 
+    <path d="M 398.194922 192.276 
+L 502.819922 192.276 
+L 502.819922 162.8928 
+L 398.194922 162.8928 
 z
-" clip-path="url(#p25d2ad8c0f)" style="fill: #fdc776; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc3c08d5fa9)" style="fill: #fdc776; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 188.876563 221.6592 
-L 293.501563 221.6592 
-L 293.501563 192.276 
-L 188.876563 192.276 
+    <path d="M 188.944922 221.6592 
+L 293.569922 221.6592 
+L 293.569922 192.276 
+L 188.944922 192.276 
 z
-" clip-path="url(#p25d2ad8c0f)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc3c08d5fa9)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 293.501563 221.6592 
-L 398.126563 221.6592 
-L 398.126563 192.276 
-L 293.501563 192.276 
+    <path d="M 293.569922 221.6592 
+L 398.194922 221.6592 
+L 398.194922 192.276 
+L 293.569922 192.276 
 z
-" clip-path="url(#p25d2ad8c0f)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc3c08d5fa9)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 398.126563 221.6592 
-L 502.751563 221.6592 
-L 502.751563 192.276 
-L 398.126563 192.276 
+    <path d="M 398.194922 221.6592 
+L 502.819922 221.6592 
+L 502.819922 192.276 
+L 398.194922 192.276 
 z
-" clip-path="url(#p25d2ad8c0f)" style="fill: #addc6f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc3c08d5fa9)" style="fill: #addc6f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 188.876563 251.0424 
-L 293.501563 251.0424 
-L 293.501563 221.6592 
-L 188.876563 221.6592 
+    <path d="M 188.944922 251.0424 
+L 293.569922 251.0424 
+L 293.569922 221.6592 
+L 188.944922 221.6592 
 z
-" clip-path="url(#p25d2ad8c0f)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc3c08d5fa9)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 293.501563 251.0424 
-L 398.126563 251.0424 
-L 398.126563 221.6592 
-L 293.501563 221.6592 
+    <path d="M 293.569922 251.0424 
+L 398.194922 251.0424 
+L 398.194922 221.6592 
+L 293.569922 221.6592 
 z
-" clip-path="url(#p25d2ad8c0f)" style="fill: #fdbd6d; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc3c08d5fa9)" style="fill: #fdbd6d; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 398.126563 251.0424 
-L 502.751563 251.0424 
-L 502.751563 221.6592 
-L 398.126563 221.6592 
+    <path d="M 398.194922 251.0424 
+L 502.819922 251.0424 
+L 502.819922 221.6592 
+L 398.194922 221.6592 
 z
-" clip-path="url(#p25d2ad8c0f)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc3c08d5fa9)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 188.876563 280.4256 
-L 293.501563 280.4256 
-L 293.501563 251.0424 
-L 188.876563 251.0424 
+    <path d="M 188.944922 280.4256 
+L 293.569922 280.4256 
+L 293.569922 251.0424 
+L 188.944922 251.0424 
 z
-" clip-path="url(#p25d2ad8c0f)" style="fill: #ebf7a3; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc3c08d5fa9)" style="fill: #ebf7a3; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 293.501563 280.4256 
-L 398.126563 280.4256 
-L 398.126563 251.0424 
-L 293.501563 251.0424 
+    <path d="M 293.569922 280.4256 
+L 398.194922 280.4256 
+L 398.194922 251.0424 
+L 293.569922 251.0424 
 z
-" clip-path="url(#p25d2ad8c0f)" style="fill: #fba35c; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc3c08d5fa9)" style="fill: #fca85e; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 398.126563 280.4256 
-L 502.751563 280.4256 
-L 502.751563 251.0424 
-L 398.126563 251.0424 
+    <path d="M 398.194922 280.4256 
+L 502.819922 280.4256 
+L 502.819922 251.0424 
+L 398.194922 251.0424 
 z
-" clip-path="url(#p25d2ad8c0f)" style="fill: #fba35c; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc3c08d5fa9)" style="fill: #fca55d; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 188.876563 309.8088 
-L 293.501563 309.8088 
-L 293.501563 280.4256 
-L 188.876563 280.4256 
+    <path d="M 188.944922 309.8088 
+L 293.569922 309.8088 
+L 293.569922 280.4256 
+L 188.944922 280.4256 
 z
-" clip-path="url(#p25d2ad8c0f)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc3c08d5fa9)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 293.501563 309.8088 
-L 398.126563 309.8088 
-L 398.126563 280.4256 
-L 293.501563 280.4256 
+    <path d="M 293.569922 309.8088 
+L 398.194922 309.8088 
+L 398.194922 280.4256 
+L 293.569922 280.4256 
 z
-" clip-path="url(#p25d2ad8c0f)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc3c08d5fa9)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 398.126563 309.8088 
-L 502.751563 309.8088 
-L 502.751563 280.4256 
-L 398.126563 280.4256 
+    <path d="M 398.194922 309.8088 
+L 502.819922 309.8088 
+L 502.819922 280.4256 
+L 398.194922 280.4256 
 z
-" clip-path="url(#p25d2ad8c0f)" style="fill: #ee613e; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc3c08d5fa9)" style="fill: #ee613e; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 188.876563 339.192 
-L 293.501563 339.192 
-L 293.501563 309.8088 
-L 188.876563 309.8088 
+    <path d="M 188.944922 339.192 
+L 293.569922 339.192 
+L 293.569922 309.8088 
+L 188.944922 309.8088 
 z
-" clip-path="url(#p25d2ad8c0f)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc3c08d5fa9)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 293.501563 339.192 
-L 398.126563 339.192 
-L 398.126563 309.8088 
-L 293.501563 309.8088 
+    <path d="M 293.569922 339.192 
+L 398.194922 339.192 
+L 398.194922 309.8088 
+L 293.569922 309.8088 
 z
-" clip-path="url(#p25d2ad8c0f)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc3c08d5fa9)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 398.126563 339.192 
-L 502.751563 339.192 
-L 502.751563 309.8088 
-L 398.126563 309.8088 
+    <path d="M 398.194922 339.192 
+L 502.819922 339.192 
+L 502.819922 309.8088 
+L 398.194922 309.8088 
 z
-" clip-path="url(#p25d2ad8c0f)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc3c08d5fa9)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(121.863828 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(121.932188 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(229.148047 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(229.216406 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(307.720156 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(307.788516 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(406.071875 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(406.140234 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(117.801563 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(117.869922 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.296 -->
-    <g transform="translate(229.737813 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(229.806172 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -946,7 +946,7 @@ z
    </g>
    <g id="text_7">
     <!-- 158 -->
-    <g transform="translate(338.179063 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(338.247422 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -1034,7 +1034,7 @@ z
    </g>
    <g id="text_8">
     <!-- 925 -->
-    <g transform="translate(442.804063 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(442.872422 91.6423) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-39"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
@@ -1042,7 +1042,7 @@ z
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(112.439688 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(112.508047 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1141,7 +1141,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.299 -->
-    <g transform="translate(229.737813 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(229.806172 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1151,7 +1151,7 @@ z
    </g>
    <g id="text_11">
     <!-- 73 -->
-    <g transform="translate(340.724063 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(340.792422 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -1202,7 +1202,7 @@ z
    </g>
    <g id="text_12">
     <!-- 283 -->
-    <g transform="translate(442.804063 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(442.872422 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(127.246094 0)"/>
@@ -1210,7 +1210,7 @@ z
    </g>
    <g id="text_13">
     <!-- zlib -->
-    <g transform="translate(129.702813 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(129.771172 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1234,7 +1234,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.299 -->
-    <g transform="translate(229.737813 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(229.806172 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1244,14 +1244,14 @@ z
    </g>
    <g id="text_15">
     <!-- 55 -->
-    <g transform="translate(340.724063 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(340.792422 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
     <!-- 692 -->
-    <g transform="translate(442.804063 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(442.872422 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-36"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
@@ -1259,7 +1259,7 @@ z
    </g>
    <g id="text_17">
     <!-- Go compress/flate -->
-    <g transform="translate(100.132813 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(100.201172 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -1430,7 +1430,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.299 -->
-    <g transform="translate(229.737813 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(229.806172 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1440,14 +1440,14 @@ z
    </g>
    <g id="text_19">
     <!-- 52 -->
-    <g transform="translate(340.724063 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(340.792422 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
     <!-- 323 -->
-    <g transform="translate(442.804063 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(442.872422 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(127.246094 0)"/>
@@ -1455,7 +1455,7 @@ z
    </g>
    <g id="text_21">
     <!-- miniz_oxide -->
-    <g transform="translate(113.009063 209.06385) scale(0.08 -0.08)">
+    <g transform="translate(113.077422 209.06385) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6e" d="M 3513 2113 
 L 3513 0 
@@ -1514,7 +1514,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.299 -->
-    <g transform="translate(229.737813 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(229.806172 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1524,14 +1524,14 @@ z
    </g>
    <g id="text_23">
     <!-- 51 -->
-    <g transform="translate(340.724063 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(340.792422 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_24">
     <!-- 729 -->
-    <g transform="translate(442.804063 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(442.872422 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-37"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(127.246094 0)"/>
@@ -1539,7 +1539,7 @@ z
    </g>
    <g id="text_25">
     <!-- JS fflate -->
-    <g transform="translate(121.165313 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(121.233672 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1599,7 +1599,7 @@ z
    </g>
    <g id="text_26">
     <!-- 0.307 -->
-    <g transform="translate(229.737813 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(229.806172 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1609,7 +1609,7 @@ z
    </g>
    <g id="text_27">
     <!-- 41 -->
-    <g transform="translate(340.724063 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(340.792422 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1637,14 +1637,14 @@ z
    </g>
    <g id="text_28">
     <!-- 80 -->
-    <g transform="translate(445.349063 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(445.417422 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-38"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_29">
     <!-- lean-zip (native) -->
-    <g transform="translate(99.510938 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(99.579297 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1753,7 +1753,7 @@ z
    </g>
    <g id="text_30">
     <!-- 0.297 -->
-    <g transform="translate(228.537188 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(228.605547 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1854,8 +1854,8 @@ z
     </g>
    </g>
    <g id="text_31">
-    <!-- 31 -->
-    <g transform="translate(340.247813 267.9415) scale(0.08 -0.08)">
+    <!-- 32 -->
+    <g transform="translate(340.316172 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-33" d="M 2981 2516 
 Q 3453 2394 3698 2092 
@@ -1889,36 +1889,43 @@ Q 3834 3144 3618 2883
 Q 3403 2622 2981 2516 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-31" d="M 750 831 
-L 1813 831 
-L 1813 3847 
-L 722 3622 
-L 722 4441 
-L 1806 4666 
-L 2950 4666 
-L 2950 831 
-L 4013 831 
-L 4013 0 
-L 750 0 
-L 750 831 
-z
-" transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-Bold-33"/>
-     <use xlink:href="#DejaVuSans-Bold-31" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-32" transform="translate(69.580078 0)"/>
     </g>
    </g>
    <g id="text_32">
-    <!-- 239 -->
-    <g transform="translate(442.089688 267.9415) scale(0.08 -0.08)">
+    <!-- 247 -->
+    <g transform="translate(442.158047 267.9415) scale(0.08 -0.08)">
+     <defs>
+      <path id="DejaVuSans-Bold-34" d="M 2356 3675 
+L 1038 1722 
+L 2356 1722 
+L 2356 3675 
+z
+M 2156 4666 
+L 3494 4666 
+L 3494 1722 
+L 4159 1722 
+L 4159 850 
+L 3494 850 
+L 3494 0 
+L 2356 0 
+L 2356 850 
+L 288 850 
+L 288 1881 
+L 2156 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-Bold-32"/>
-     <use xlink:href="#DejaVuSans-Bold-33" transform="translate(69.580078 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-39" transform="translate(139.160156 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-34" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-37" transform="translate(139.160156 0)"/>
     </g>
    </g>
    <g id="text_33">
     <!-- OCaml decompress -->
-    <g transform="translate(97.625938 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(97.694297 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -1983,7 +1990,7 @@ z
    </g>
    <g id="text_34">
     <!-- 0.321 -->
-    <g transform="translate(229.737813 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(229.806172 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1993,14 +2000,14 @@ z
    </g>
    <g id="text_35">
     <!-- 23 -->
-    <g transform="translate(340.724063 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(340.792422 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_36">
     <!-- 117 -->
-    <g transform="translate(442.804063 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(442.872422 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
@@ -2008,7 +2015,7 @@ z
    </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(125.847188 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(125.915547 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -2019,7 +2026,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.279 -->
-    <g transform="translate(229.737813 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(229.806172 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -2029,13 +2036,13 @@ z
    </g>
    <g id="text_39">
     <!-- 0 -->
-    <g transform="translate(343.269063 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(343.337422 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(446.439063 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(446.507422 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2051,7 +2058,7 @@ z
   </g>
   <g id="text_41">
    <!-- canterbury — geomean over files, level 6 -->
-   <g transform="translate(136.260313 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(136.328672 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-62" d="M 2400 722 
 Q 2759 722 2948 984 
@@ -2264,7 +2271,7 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-07-08T15:47:33Z  ·  Linux chungus2 x86_64  ·  commit f2026e66  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-07-08T20:00:36Z  ·  Linux chungus2 x86_64  ·  commit 29539fd5  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2405,14 +2412,14 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-38" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
     <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2452,110 +2459,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3107.080078 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3170.703125 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3234.326172 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3297.949219 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3361.572266 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3423.095703 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3486.71875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3550.341797 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3582.128906 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3613.916016 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3645.703125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3677.490234 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3709.277344 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3737.060547 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3798.583984 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3859.863281 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3923.242188 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3986.71875 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4025.582031 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4086.763672 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4145.943359 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4207.466797 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4248.580078 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4282.271484 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4310.054688 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4371.578125 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4432.857422 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4496.236328 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4559.859375 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4593.550781 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4652.730469 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4716.353516 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4748.140625 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4811.763672 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4875.386719 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4907.173828 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4970.796875 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5006.880859 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5045.744141 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5100.724609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5164.347656 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5196.134766 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5227.921875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5259.708984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5291.496094 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5323.283203 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5362.492188 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5425.871094 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5464.734375 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5525.916016 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5589.294922 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5652.771484 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5716.150391 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5779.626953 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5843.005859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5882.214844 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5914.001953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5997.791016 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6029.578125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6126.990234 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6188.513672 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6251.990234 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6279.773438 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6341.052734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6404.431641 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6436.21875 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6488.318359 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6551.697266 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6612.976562 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6676.453125 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6728.552734 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6791.931641 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6853.113281 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6892.322266 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6926.013672 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6957.800781 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6998.914062 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7060.193359 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7099.402344 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7127.185547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7188.367188 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7220.154297 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7247.9375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7300.037109 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7331.824219 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7395.300781 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7456.824219 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7496.033203 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7557.556641 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7596.919922 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7694.332031 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7722.115234 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7785.494141 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7813.277344 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7865.376953 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7904.585938 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7932.369141 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3262.744141 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3326.367188 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3389.990234 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3425.195312 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3488.671875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3552.294922 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3584.082031 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3615.869141 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3647.65625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3679.443359 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3711.230469 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3739.013672 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3800.537109 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3861.816406 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3925.195312 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3988.671875 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4027.535156 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4088.716797 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4147.896484 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4209.419922 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4250.533203 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4284.224609 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4312.007812 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4373.53125 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4434.810547 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4498.189453 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4561.8125 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4595.503906 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4654.683594 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4718.306641 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4750.09375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4813.716797 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4877.339844 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4909.126953 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4972.75 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5008.833984 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5047.697266 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5102.677734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5166.300781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5198.087891 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5229.875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5261.662109 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5293.449219 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5325.236328 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5364.445312 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5427.824219 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5466.6875 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5527.869141 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5591.248047 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5654.724609 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5718.103516 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5781.580078 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5844.958984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5884.167969 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5915.955078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5999.744141 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6031.53125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6128.943359 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6190.466797 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6253.943359 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6281.726562 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6343.005859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6406.384766 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6438.171875 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6490.271484 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6553.650391 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6614.929688 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6678.40625 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6730.505859 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6793.884766 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6855.066406 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6894.275391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6927.966797 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6959.753906 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7000.867188 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7062.146484 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7101.355469 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7129.138672 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7190.320312 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7222.107422 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7249.890625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7301.990234 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7333.777344 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7397.253906 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7458.777344 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7497.986328 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7559.509766 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7598.873047 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7696.285156 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7724.068359 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7787.447266 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7815.230469 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7867.330078 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7906.539062 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7934.322266 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p25d2ad8c0f">
-   <rect x="84.251563" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="pc3c08d5fa9">
+   <rect x="84.319922" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/graphs/silesia_compress_heatmap.svg
+++ b/bench/graphs/silesia_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.34175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p18e35a4b65)">
+   <g clip-path="url(#pc2016efa0c)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAqAAAAGaCAYAAADQNfGTAAAJ90lEQVR4nO3YP25l5R3H4bF9x3iMNAyQWBlEQxqEUiCQEGIbrCNV2qwhG6CjZAEUaSgoIpGGDqog8ScIDQISNAzGvrZZBHo/P3P0PCv4Hr3n3Ps55+D6u3dv7mzZxZPpBWsdHE4vWOt6P71gra2f3/5iesFapw+mF6z1y+PpBfwWR8fTC9ba+v1592R6wVIb//cDAOC2EaAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKR2H++/mN6w1PHd3fSEpc73F9MTlnp4/4XpCUt9/uOX0xOW2h9cTU9Y6pV7z01PWGr/1Mn0hKX++/ir6QlLnd07m56w1PnxfnrCUgd3nkxPWMoXUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAILU7Oz2b3rDUw6f/PD1hqUdPvpiesNSfzrf9jnT/+VenJyx1fHQyPWGpq+v99ISltn5+m7++w21f3+7wxekJS52cn09PWGrb/+4AANw6AhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgNTuqaPT6Q1LfX/+zfSEpbZ+flfPPjc9Yakv//fx9ISlHl+eT09Y6o1n35iesNTFzX56wlKf//jZ9ISl/vL869MTlvrom39NT1jqtT9u+/x8AQUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBIHVx9+Leb6RFLXV9PL+C32Pr5HXoHhDFbf/78fv6+7ffTC5ba+OkBAHDbCFAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFK7s48+nd6w1NHx0fSEpR59+u30hKXe+etr0xOW+se/t31+b714f3rCUu998Nn0hKX+/vbL0xOWev8//5+esNRLD+5NT1jq+58vpycs9ebD0+kJS/kCCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApA4ur/55Mz1ipaPLi+kJax0dTy9Ya38+vWCt3cn0grWOdtML1rq5nl6w1uXGn7+DjX+DOdz283d5sO3n7+5+Pz1hqY0/fQAA3DYCFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACA1O6HXx5Nb1jqD9en0xOWutht+x3i+OLJ9IS1jrd9f9652k8vWOqnm23fn0//vO3ru37mbHrCUocb/8Z09+tPpies9eCF6QVLbfvuBADg1hGgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkfgXanHzC+rW0OAAAAABJRU5ErkJggg==" id="imaged1c9e1fee9" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="483.84" height="295.2"/>
+iVBORw0KGgoAAAANSUhEUgAAAqAAAAGaCAYAAADQNfGTAAAJ90lEQVR4nO3YMY5kVxmG4emumnZPWxrGtmg8yAkICSECy0gWYhusg4iUNbABModeAAEJAQGSSRw6AUu2AY0MjLA1DEV3dTeLGJ33b189zwq+0ql7661zcvuvD+4ebNnVy+kFa52cTi9Y6/Y4vWCtrZ/f8Wp6wVoXT6YXrPW/F9MLeBW7s+kFa239+/nwfHrBUhv/9QMA4L4RoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApPYfHz+f3rDU2cP99ISlDser6QlLPX383ekJS3329RfTE5Y6ntxMT1jqR4/enJ6w1PG18+kJS/3txV+nJyx1+ehyesJSh7Pj9ISlTh68nJ6wlBtQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgtb+8uJzesNTT178/PWGpL19+Pj1hqbcP2/6P9Pitd6cnLHW2O5+esNTN7XF6wlJbP7/Nf77TbX++/ek70xOWOj8cpicste1fdwAA7h0BCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBAav/a7mJ6w1LPD8+mJyy19fO7eePN6QlLffHvj6cnLPXi+jA9Yan333h/esJSV3fH6QlLffb1p9MTlvrxWz+ZnrDUR8/+OD1hqfe+ve3zcwMKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkDq5+cMv76ZHLHV7O72AV7H18zv1HxDGbP358/78ZjsepxcstfHTAwDgvhGgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACk9pcffTK9Yand2W56wlJffvKP6QlL/eYX701PWOrXf9r2+f3sncfTE5b68PefTk9Y6lc//+H0hKV++5evpics9b0nj6YnLPX8v9fTE5b66dOL6QlLuQEFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSJ9c3v7ubHrHS7vpqesJau7PpBWsdD9ML1tqfTy9Ya7efXrDW3e30grWuN/78nWz8DuZ028/f9cm2n7+Hx+P0hKU2/vQBAHDfCFAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFL7fx7+Pr1hqe88eDI9Yan/nB6nJyz1+u30gsV2++kFvIKvrp9PT1jqW9fbvqO4uXg8PWGp27ttv0AfPvvz9IS1Ln8wvWCpbb9dAAC4dwQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAACp/wOn/XvO0MvcQwAAAABJRU5ErkJggg==" id="imaged6a9a0f1d8" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="483.84" height="295.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="me9908c3d04" d="M 0 0 
+       <path id="m44834e04e1" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#me9908c3d04" x="115.814949" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m44834e04e1" x="115.814949" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#me9908c3d04" x="156.092348" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m44834e04e1" x="156.092348" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#me9908c3d04" x="196.369746" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m44834e04e1" x="196.369746" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#me9908c3d04" x="236.647145" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m44834e04e1" x="236.647145" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#me9908c3d04" x="276.924544" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m44834e04e1" x="276.924544" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#me9908c3d04" x="317.201942" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m44834e04e1" x="317.201942" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#me9908c3d04" x="357.479341" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m44834e04e1" x="357.479341" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#me9908c3d04" x="397.756739" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m44834e04e1" x="397.756739" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#me9908c3d04" x="438.034138" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m44834e04e1" x="438.034138" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#me9908c3d04" x="478.311536" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m44834e04e1" x="478.311536" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#me9908c3d04" x="518.588935" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m44834e04e1" x="518.588935" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#me9908c3d04" x="558.866334" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m44834e04e1" x="558.866334" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="m0f870b9436" d="M 0 0 
+       <path id="m95f8f61b39" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m0f870b9436" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m95f8f61b39" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m0f870b9436" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m95f8f61b39" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m0f870b9436" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m95f8f61b39" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m0f870b9436" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m95f8f61b39" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -836,7 +836,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m0f870b9436" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m95f8f61b39" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -899,7 +899,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m0f870b9436" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m95f8f61b39" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -966,7 +966,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m0f870b9436" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m95f8f61b39" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1047,7 +1047,7 @@ z
     <g id="ytick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m0f870b9436" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m95f8f61b39" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -1138,7 +1138,7 @@ L 579.005033 49.34175
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_21">
-    <!-- +33 -->
+    <!-- +38 -->
     <g transform="translate(108.955926 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-2b" d="M 2944 4013 
@@ -1188,95 +1188,6 @@ Q 3450 3153 3228 2886
 Q 3006 2619 2597 2516 
 z
 " transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_22">
-    <!-- -20 -->
-    <g transform="translate(150.784184 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-32" d="M 1228 531 
-L 3431 531 
-L 3431 0 
-L 469 0 
-L 469 531 
-Q 828 903 1448 1529 
-Q 2069 2156 2228 2338 
-Q 2531 2678 2651 2914 
-Q 2772 3150 2772 3378 
-Q 2772 3750 2511 3984 
-Q 2250 4219 1831 4219 
-Q 1534 4219 1204 4116 
-Q 875 4013 500 3803 
-L 500 4441 
-Q 881 4594 1212 4672 
-Q 1544 4750 1819 4750 
-Q 2544 4750 2975 4387 
-Q 3406 4025 3406 3419 
-Q 3406 3131 3298 2873 
-Q 3191 2616 2906 2266 
-Q 2828 2175 2409 1742 
-Q 1991 1309 1228 531 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-30" d="M 2034 4250 
-Q 1547 4250 1301 3770 
-Q 1056 3291 1056 2328 
-Q 1056 1369 1301 889 
-Q 1547 409 2034 409 
-Q 2525 409 2770 889 
-Q 3016 1369 3016 2328 
-Q 3016 3291 2770 3770 
-Q 2525 4250 2034 4250 
-z
-M 2034 4750 
-Q 2819 4750 3233 4129 
-Q 3647 3509 3647 2328 
-Q 3647 1150 3233 529 
-Q 2819 -91 2034 -91 
-Q 1250 -91 836 529 
-Q 422 1150 422 2328 
-Q 422 3509 836 4129 
-Q 1250 4750 2034 4750 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_23">
-    <!-- +12 -->
-    <g transform="translate(189.510723 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-31" d="M 794 531 
-L 1825 531 
-L 1825 4091 
-L 703 3866 
-L 703 4441 
-L 1819 4666 
-L 2450 4666 
-L 2450 531 
-L 3481 531 
-L 3481 0 
-L 794 0 
-L 794 531 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_24">
-    <!-- -28 -->
-    <g transform="translate(231.338981 69.553235) scale(0.065 -0.065)">
-     <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
 Q 1069 1734 1069 1313 
@@ -1317,14 +1228,104 @@ Q 1172 3844 1172 3481
 z
 " transform="scale(0.015625)"/>
      </defs>
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_22">
+    <!-- -17 -->
+    <g transform="translate(150.784184 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_23">
+    <!-- +17 -->
+    <g transform="translate(189.510723 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_24">
+    <!-- -17 -->
+    <g transform="translate(231.338981 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_25">
-    <!-- -4 -->
+    <!-- -1 -->
     <g transform="translate(273.684192 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_26">
+    <!-- +2 -->
+    <g transform="translate(312.410731 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_27">
+    <!-- +24 -->
+    <g transform="translate(350.620317 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1346,13 +1347,22 @@ L 2253 4666
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
     </g>
    </g>
-   <g id="text_26">
-    <!-- -5 -->
-    <g transform="translate(313.961591 69.553235) scale(0.065 -0.065)">
+   <g id="text_28">
+    <!-- -23 -->
+    <g transform="translate(392.448575 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_29">
+    <!-- +5 -->
+    <g transform="translate(433.242927 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-35" d="M 691 4666 
 L 3169 4666 
@@ -1380,21 +1390,51 @@ L 691 4666
 z
 " transform="scale(0.015625)"/>
      </defs>
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_30">
+    <!-- +8 -->
+    <g transform="translate(473.520325 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_31">
+    <!-- -50 -->
+    <g transform="translate(513.280771 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
     </g>
    </g>
-   <g id="text_27">
-    <!-- +18 -->
-    <g transform="translate(350.620317 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_28">
-    <!-- -29 -->
-    <g transform="translate(392.448575 69.553235) scale(0.065 -0.065)">
+   <g id="text_32">
+    <!-- -9 -->
+    <g transform="translate(555.625982 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-39" d="M 703 97 
 L 703 672 
@@ -1428,55 +1468,12 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_29">
-    <!-- +4 -->
-    <g transform="translate(433.242927 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_30">
-    <!-- +2 -->
-    <g transform="translate(473.520325 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_31">
-    <!-- -50 -->
-    <g transform="translate(513.280771 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_32">
-    <!-- -20 -->
-    <g transform="translate(553.558169 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_33">
     <!-- +7 -->
     <g transform="translate(111.023738 106.389018) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
     </g>
@@ -2192,18 +2189,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB1ElEQVR4nO2b0a3DMAwD7cSzvM3fmI47gvpxCK6ENABhnkQ5aZH5P/7OAGpdFyEzBiQDnija2qSEghnZhIIZCa3NyWQkmZFOKJhRsDXsOopmJJwjaEPOmxHirE3MWjOqhSBr2EAGMyKtMVpc+ynYwe3viNQVbA0LrZDRFbxGbNbWyM3auG0RGbo1Qp0IZCSMiG2OgtNvbL+Oke6BvddIWaQ1qP3RjGSTLXypwdaIMP2ctWb0olAzKkr4LhLMCPvnOJiRbo6CrTWjF4WCGYHWJtU1TKgZvSZkfNAKZhRsDftFa96MkJCRrf29ausyWrOtWiMjmxDH6FAfDJzzIEKctQc60ToDEqJOBLbfZs04RxQjobWOSFXrjM0IdURqIaG1jkhVPmvGOUqOCPLJMdh+6kRk+zFGMtjKOdK13zbZ2EBGMxLOkSz90YygK9tozSbUa6Qu4RxtRifZ2np0jDY32YiOc44gIQo2aI1ZkB2Rb4SiIyJbtcr0Q0IPdCQyIpCQDnZHpC5uQ27uOtJFBBptH2zlHOnab+uaMSK29htXrW2NKK0hOtlrxLaPjIxys4a99x9dRKgTgUK69gsZ9RxVFWzNyIi6RZIZtbXfE+qI1BU8R5i1D2e5X2tFkZmlAAAAAElFTkSuQmCC" id="image1c38bdd3c7" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-69.84" width="12.96" height="253.44"/>
+iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB1ElEQVR4nO2b0a3DMAwD7cSzvM3fmI47gvpxCK6ENABhnkQ5aZH5P/7OAGpdFyEzBiQDnija2qSEghnZhIIZCa3NyWQkmZFOKJhRsDXsOopmJJwjaEPOmxHirE3MWjOqhSBr2EAGMyKtMVpc+ynYwe3viNQVbA0LrZDRFbxGbNbWyM3auG0RGbo1Qp0IZCSMiG2OgtNvbL+Oke6BvddIWaQ1qP3RjGSTLXypwdaIMP2ctWb0olAzKkr4LhLMCPvnOJiRbo6CrTWjF4WCGYHWJtU1TKgZvSZkfNAKZhRsDftFa96MkJCRrf29ausyWrOtWiMjmxDH6FAfDJzzIEKctQc60ToDEqJOBLbfZs04RxQjobWOSFXrjM0IdURqIaG1jkhVPmvGOUqOCPLJMdh+6kRk+zFGMtjKOdK13zbZ2EBGMxLOkSz90YygK9tozSbUa6Qu4RxtRifZ2np0jDY32YiOc44gIQo2aI1ZkB2Rb4SiIyJbtcr0Q0IPdCQyIpCQDnZHpC5uQ27uOtJFBBptH2zlHOnab+uaMSK29htXrW2NKK0hOtlrxLaPjIxys4a99x9dRKgTgUK69gsZ9RxVFWzNyIi6RZIZtbXfE+qI1BU8R5i1D2e5X2tFkZmlAAAAAElFTkSuQmCC" id="imageefd82aa64f" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-69.84" width="12.96" height="253.44"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_21">
       <defs>
-       <path id="m4cdb40f425" d="M 0 0 
+       <path id="md2e26757d4" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m4cdb40f425" x="601.779688" y="322.507463" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md2e26757d4" x="601.779688" y="322.507463" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_117">
@@ -2226,7 +2223,7 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m4cdb40f425" x="601.779688" y="280.566603" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md2e26757d4" x="601.779688" y="280.566603" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_118">
@@ -2240,7 +2237,7 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m4cdb40f425" x="601.779688" y="238.625742" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md2e26757d4" x="601.779688" y="238.625742" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_119">
@@ -2254,7 +2251,7 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m4cdb40f425" x="601.779688" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md2e26757d4" x="601.779688" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_120">
@@ -2267,7 +2264,7 @@ z
     <g id="ytick_13">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m4cdb40f425" x="601.779688" y="154.74402" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md2e26757d4" x="601.779688" y="154.74402" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_121">
@@ -2280,7 +2277,7 @@ z
     <g id="ytick_14">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m4cdb40f425" x="601.779688" y="112.803159" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md2e26757d4" x="601.779688" y="112.803159" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_122">
@@ -2293,7 +2290,7 @@ z
     <g id="ytick_15">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#m4cdb40f425" x="601.779688" y="70.862298" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md2e26757d4" x="601.779688" y="70.862298" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_123">
@@ -2909,8 +2906,8 @@ z
    </g>
   </g>
   <g id="text_126">
-   <!-- 2026-07-08T15:47:33Z  ·  Linux chungus2 x86_64  ·  commit f2026e66  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(44.448437 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-08T20:00:36Z  ·  Linux chungus2 x86_64  ·  commit 29539fd5  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(44.380078 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -3001,14 +2998,14 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-38" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
     <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3048,109 +3045,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3107.080078 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3170.703125 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3234.326172 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3297.949219 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3361.572266 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3423.095703 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3486.71875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3550.341797 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3582.128906 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3613.916016 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3645.703125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3677.490234 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3709.277344 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3737.060547 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3798.583984 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3859.863281 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3923.242188 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3986.71875 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4025.582031 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4086.763672 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4145.943359 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4207.466797 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4248.580078 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4282.271484 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4310.054688 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4371.578125 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4432.857422 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4496.236328 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4559.859375 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4593.550781 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4652.730469 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4716.353516 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4748.140625 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4811.763672 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4875.386719 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4907.173828 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4970.796875 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5006.880859 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5045.744141 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5100.724609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5164.347656 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5196.134766 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5227.921875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5259.708984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5291.496094 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5323.283203 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5362.492188 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5425.871094 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5464.734375 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5525.916016 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5589.294922 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5652.771484 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5716.150391 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5779.626953 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5843.005859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5882.214844 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5914.001953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5997.791016 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6029.578125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6126.990234 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6188.513672 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6251.990234 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6279.773438 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6341.052734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6404.431641 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6436.21875 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6488.318359 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6551.697266 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6612.976562 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6676.453125 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6728.552734 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6791.931641 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6853.113281 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6892.322266 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6926.013672 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6957.800781 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6998.914062 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7060.193359 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7099.402344 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7127.185547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7188.367188 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7220.154297 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7247.9375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7300.037109 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7331.824219 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7395.300781 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7456.824219 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7496.033203 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7557.556641 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7596.919922 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7694.332031 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7722.115234 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7785.494141 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7813.277344 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7865.376953 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7904.585938 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7932.369141 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3262.744141 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3326.367188 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3389.990234 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3425.195312 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3488.671875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3552.294922 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3584.082031 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3615.869141 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3647.65625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3679.443359 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3711.230469 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3739.013672 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3800.537109 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3861.816406 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3925.195312 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3988.671875 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4027.535156 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4088.716797 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4147.896484 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4209.419922 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4250.533203 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4284.224609 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4312.007812 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4373.53125 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4434.810547 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4498.189453 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4561.8125 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4595.503906 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4654.683594 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4718.306641 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4750.09375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4813.716797 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4877.339844 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4909.126953 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4972.75 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5008.833984 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5047.697266 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5102.677734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5166.300781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5198.087891 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5229.875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5261.662109 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5293.449219 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5325.236328 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5364.445312 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5427.824219 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5466.6875 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5527.869141 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5591.248047 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5654.724609 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5718.103516 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5781.580078 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5844.958984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5884.167969 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5915.955078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5999.744141 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6031.53125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6128.943359 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6190.466797 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6253.943359 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6281.726562 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6343.005859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6406.384766 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6438.171875 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6490.271484 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6553.650391 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6614.929688 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6678.40625 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6730.505859 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6793.884766 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6855.066406 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6894.275391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6927.966797 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6959.753906 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7000.867188 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7062.146484 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7101.355469 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7129.138672 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7190.320312 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7222.107422 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7249.890625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7301.990234 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7333.777344 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7397.253906 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7458.777344 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7497.986328 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7559.509766 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7598.873047 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7696.285156 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7724.068359 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7787.447266 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7815.230469 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7867.330078 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7906.539062 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7934.322266 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p18e35a4b65">
+  <clipPath id="pc2016efa0c">
    <rect x="95.67625" y="49.34175" width="483.328783" height="294.686261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_compress_pareto.svg
+++ b/bench/graphs/silesia_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 61.085542 412.80375 
 L 61.085542 48.323125 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m79f87d447f" d="M 0 0 
+       <path id="ma62549c883" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m79f87d447f" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma62549c883" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -130,11 +130,11 @@ z
      <g id="line2d_3">
       <path d="M 145.270284 412.80375 
 L 145.270284 48.323125 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m79f87d447f" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma62549c883" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -177,11 +177,11 @@ z
      <g id="line2d_5">
       <path d="M 229.455026 412.80375 
 L 229.455026 48.323125 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m79f87d447f" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma62549c883" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -219,11 +219,11 @@ z
      <g id="line2d_7">
       <path d="M 313.639768 412.80375 
 L 313.639768 48.323125 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m79f87d447f" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma62549c883" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -272,11 +272,11 @@ z
      <g id="line2d_9">
       <path d="M 397.82451 412.80375 
 L 397.82451 48.323125 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m79f87d447f" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma62549c883" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -334,11 +334,11 @@ z
      <g id="line2d_11">
       <path d="M 482.009253 412.80375 
 L 482.009253 48.323125 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m79f87d447f" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma62549c883" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -355,11 +355,11 @@ L 482.009253 48.323125
      <g id="line2d_13">
       <path d="M 566.193995 412.80375 
 L 566.193995 48.323125 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m79f87d447f" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma62549c883" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -856,16 +856,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 368.08164 
 L 637.2 368.08164 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="m9c677cfa76" d="M 0 0 
+       <path id="m403beea01e" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m9c677cfa76" x="49.078125" y="368.08164" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m403beea01e" x="49.078125" y="368.08164" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -897,11 +897,11 @@ z
      <g id="line2d_17">
       <path d="M 49.078125 243.439835 
 L 637.2 243.439835 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m9c677cfa76" x="49.078125" y="243.439835" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m403beea01e" x="49.078125" y="243.439835" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -917,11 +917,11 @@ L 637.2 243.439835
      <g id="line2d_19">
       <path d="M 49.078125 118.798029 
 L 637.2 118.798029 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m9c677cfa76" x="49.078125" y="118.798029" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m403beea01e" x="49.078125" y="118.798029" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -937,16 +937,16 @@ L 637.2 118.798029
      <g id="line2d_21">
       <path d="M 49.078125 405.602562 
 L 637.2 405.602562 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="maca583f6d6" d="M 0 0 
+       <path id="m1016849102" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#maca583f6d6" x="49.078125" y="405.602562" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1016849102" x="49.078125" y="405.602562" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -954,11 +954,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 395.733268 
 L 637.2 395.733268 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#maca583f6d6" x="49.078125" y="395.733268" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1016849102" x="49.078125" y="395.733268" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -966,11 +966,11 @@ L 637.2 395.733268
      <g id="line2d_25">
       <path d="M 49.078125 387.3889 
 L 637.2 387.3889 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#maca583f6d6" x="49.078125" y="387.3889" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1016849102" x="49.078125" y="387.3889" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -978,11 +978,11 @@ L 637.2 387.3889
      <g id="line2d_27">
       <path d="M 49.078125 380.160679 
 L 637.2 380.160679 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#maca583f6d6" x="49.078125" y="380.160679" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1016849102" x="49.078125" y="380.160679" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -990,11 +990,11 @@ L 637.2 380.160679
      <g id="line2d_29">
       <path d="M 49.078125 373.784936 
 L 637.2 373.784936 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#maca583f6d6" x="49.078125" y="373.784936" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1016849102" x="49.078125" y="373.784936" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1002,11 +1002,11 @@ L 637.2 373.784936
      <g id="line2d_31">
       <path d="M 49.078125 330.560718 
 L 637.2 330.560718 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#maca583f6d6" x="49.078125" y="330.560718" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1016849102" x="49.078125" y="330.560718" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1014,11 +1014,11 @@ L 637.2 330.560718
      <g id="line2d_33">
       <path d="M 49.078125 308.612385 
 L 637.2 308.612385 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#maca583f6d6" x="49.078125" y="308.612385" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1016849102" x="49.078125" y="308.612385" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1026,11 +1026,11 @@ L 637.2 308.612385
      <g id="line2d_35">
       <path d="M 49.078125 293.039796 
 L 637.2 293.039796 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#maca583f6d6" x="49.078125" y="293.039796" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1016849102" x="49.078125" y="293.039796" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1038,11 +1038,11 @@ L 637.2 293.039796
      <g id="line2d_37">
       <path d="M 49.078125 280.960757 
 L 637.2 280.960757 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#maca583f6d6" x="49.078125" y="280.960757" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1016849102" x="49.078125" y="280.960757" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1050,11 +1050,11 @@ L 637.2 280.960757
      <g id="line2d_39">
       <path d="M 49.078125 271.091463 
 L 637.2 271.091463 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#maca583f6d6" x="49.078125" y="271.091463" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1016849102" x="49.078125" y="271.091463" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1062,11 +1062,11 @@ L 637.2 271.091463
      <g id="line2d_41">
       <path d="M 49.078125 262.747094 
 L 637.2 262.747094 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#maca583f6d6" x="49.078125" y="262.747094" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1016849102" x="49.078125" y="262.747094" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1074,11 +1074,11 @@ L 637.2 262.747094
      <g id="line2d_43">
       <path d="M 49.078125 255.518874 
 L 637.2 255.518874 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#maca583f6d6" x="49.078125" y="255.518874" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1016849102" x="49.078125" y="255.518874" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1086,11 +1086,11 @@ L 637.2 255.518874
      <g id="line2d_45">
       <path d="M 49.078125 249.143131 
 L 637.2 249.143131 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#maca583f6d6" x="49.078125" y="249.143131" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1016849102" x="49.078125" y="249.143131" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1098,11 +1098,11 @@ L 637.2 249.143131
      <g id="line2d_47">
       <path d="M 49.078125 205.918912 
 L 637.2 205.918912 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#maca583f6d6" x="49.078125" y="205.918912" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1016849102" x="49.078125" y="205.918912" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1110,11 +1110,11 @@ L 637.2 205.918912
      <g id="line2d_49">
       <path d="M 49.078125 183.97058 
 L 637.2 183.97058 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#maca583f6d6" x="49.078125" y="183.97058" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1016849102" x="49.078125" y="183.97058" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1122,11 +1122,11 @@ L 637.2 183.97058
      <g id="line2d_51">
       <path d="M 49.078125 168.39799 
 L 637.2 168.39799 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#maca583f6d6" x="49.078125" y="168.39799" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1016849102" x="49.078125" y="168.39799" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1134,11 +1134,11 @@ L 637.2 168.39799
      <g id="line2d_53">
       <path d="M 49.078125 156.318951 
 L 637.2 156.318951 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#maca583f6d6" x="49.078125" y="156.318951" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1016849102" x="49.078125" y="156.318951" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1146,11 +1146,11 @@ L 637.2 156.318951
      <g id="line2d_55">
       <path d="M 49.078125 146.449658 
 L 637.2 146.449658 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#maca583f6d6" x="49.078125" y="146.449658" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1016849102" x="49.078125" y="146.449658" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1158,11 +1158,11 @@ L 637.2 146.449658
      <g id="line2d_57">
       <path d="M 49.078125 138.105289 
 L 637.2 138.105289 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#maca583f6d6" x="49.078125" y="138.105289" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1016849102" x="49.078125" y="138.105289" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1170,11 +1170,11 @@ L 637.2 138.105289
      <g id="line2d_59">
       <path d="M 49.078125 130.877068 
 L 637.2 130.877068 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#maca583f6d6" x="49.078125" y="130.877068" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1016849102" x="49.078125" y="130.877068" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1182,11 +1182,11 @@ L 637.2 130.877068
      <g id="line2d_61">
       <path d="M 49.078125 124.501326 
 L 637.2 124.501326 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#maca583f6d6" x="49.078125" y="124.501326" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1016849102" x="49.078125" y="124.501326" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1194,11 +1194,11 @@ L 637.2 124.501326
      <g id="line2d_63">
       <path d="M 49.078125 81.277107 
 L 637.2 81.277107 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#maca583f6d6" x="49.078125" y="81.277107" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1016849102" x="49.078125" y="81.277107" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1206,11 +1206,11 @@ L 637.2 81.277107
      <g id="line2d_65">
       <path d="M 49.078125 59.328775 
 L 637.2 59.328775 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#maca583f6d6" x="49.078125" y="59.328775" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1016849102" x="49.078125" y="59.328775" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1332,7 +1332,7 @@ L 637.2 48.323125
    </g>
    <g id="text_13">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(324.643112 118.779184) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(324.643112 118.461471) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1364,7 +1364,7 @@ z
    </g>
    <g id="text_14">
     <!-- L10 -->
-    <g style="fill: #d62728" transform="translate(102.799363 309.724011) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(102.799363 309.867541) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1686,23 +1686,23 @@ z
    </g>
    <g id="line2d_67">
     <defs>
-     <path id="m8021e33023" d="M -2.5 2.5 
+     <path id="mc56fce18eb" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p21d9583499)">
-     <use xlink:href="#m8021e33023" x="377.110281" y="104.685421" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8021e33023" x="323.801439" y="110.409833" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8021e33023" x="272.665744" y="126.308323" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8021e33023" x="235.168828" y="128.026741" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8021e33023" x="186.228265" y="149.377587" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8021e33023" x="158.303164" y="171.457731" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8021e33023" x="149.489547" y="182.192614" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8021e33023" x="140.563162" y="202.482797" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8021e33023" x="138.984853" y="209.328911" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pd7db26d2c3)">
+     <use xlink:href="#mc56fce18eb" x="377.110281" y="104.685421" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc56fce18eb" x="323.801439" y="110.409833" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc56fce18eb" x="272.665744" y="126.308323" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc56fce18eb" x="235.168828" y="128.026741" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc56fce18eb" x="186.228265" y="149.377587" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc56fce18eb" x="158.303164" y="171.457731" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc56fce18eb" x="149.489547" y="182.192614" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc56fce18eb" x="140.563162" y="202.482797" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc56fce18eb" x="138.984853" y="209.328911" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_68">
@@ -1755,7 +1755,7 @@ L 327.133241 110.069256
 L 326.02264 110.18302 
 L 324.91204 110.296545 
 L 323.801439 110.409833 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_69">
     <path d="M 323.801439 110.409833 
@@ -1807,7 +1807,7 @@ L 275.861725 125.44037
 L 274.796398 125.731236 
 L 273.731071 126.020548 
 L 272.665744 126.308323 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_70">
     <path d="M 272.665744 126.308323 
@@ -1859,7 +1859,7 @@ L 237.512385 127.920923
 L 236.7312 127.956219 
 L 235.950014 127.991491 
 L 235.168828 128.026741 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_71">
     <path d="M 235.168828 128.026741 
@@ -1911,7 +1911,7 @@ L 189.28705 148.263499
 L 188.267455 148.637415 
 L 187.24786 149.008766 
 L 186.228265 149.377587 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_72">
     <path d="M 186.228265 149.377587 
@@ -1963,7 +1963,7 @@ L 160.048483 170.312481
 L 159.46671 170.696929 
 L 158.884937 171.078667 
 L 158.303164 171.457731 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_73">
     <path d="M 158.303164 171.457731 
@@ -2015,7 +2015,7 @@ L 150.040398 181.580576
 L 149.856781 181.785359 
 L 149.673164 181.989369 
 L 149.489547 182.192614 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_74">
     <path d="M 149.489547 182.192614 
@@ -2067,7 +2067,7 @@ L 141.121061 201.414753
 L 140.935095 201.773114 
 L 140.749129 202.129119 
 L 140.563162 202.482797 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_75">
     <path d="M 140.563162 202.482797 
@@ -2119,26 +2119,26 @@ L 139.083497 208.925481
 L 139.050616 209.060292 
 L 139.017734 209.194768 
 L 138.984853 209.328911 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_76">
     <defs>
-     <path id="m1e1abfc02b" d="M 0 -2.5 
+     <path id="mba75ea4ead" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p21d9583499)">
-     <use xlink:href="#m1e1abfc02b" x="610.467187" y="71.939349" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1e1abfc02b" x="319.880958" y="101.884157" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1e1abfc02b" x="210.281253" y="129.778154" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1e1abfc02b" x="196.287076" y="133.586625" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1e1abfc02b" x="176.054419" y="147.38645" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1e1abfc02b" x="152.161413" y="174.753272" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1e1abfc02b" x="146.720208" y="186.587648" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1e1abfc02b" x="143.994022" y="196.356323" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1e1abfc02b" x="142.666037" y="200.180971" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pd7db26d2c3)">
+     <use xlink:href="#mba75ea4ead" x="610.467187" y="71.939349" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mba75ea4ead" x="319.880958" y="101.884157" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mba75ea4ead" x="210.281253" y="129.778154" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mba75ea4ead" x="196.287076" y="133.586625" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mba75ea4ead" x="176.054419" y="147.38645" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mba75ea4ead" x="152.161413" y="174.753272" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mba75ea4ead" x="146.720208" y="186.587648" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mba75ea4ead" x="143.994022" y="196.356323" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mba75ea4ead" x="142.666037" y="200.180971" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_77">
@@ -2191,7 +2191,7 @@ L 338.042598 100.427247
 L 331.988718 100.917253 
 L 325.934838 101.402864 
 L 319.880958 101.884157 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_78">
     <path d="M 319.880958 101.884157 
@@ -2243,7 +2243,7 @@ L 217.131235 128.398367
 L 214.847908 128.862215 
 L 212.564581 129.322122 
 L 210.281253 129.778154 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_79">
     <path d="M 210.281253 129.778154 
@@ -2295,7 +2295,7 @@ L 197.161712 133.356286
 L 196.870166 133.433175 
 L 196.578621 133.509954 
 L 196.287076 133.586625 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_80">
     <path d="M 196.287076 133.586625 
@@ -2347,7 +2347,7 @@ L 177.31896 146.619719
 L 176.897447 146.876504 
 L 176.475933 147.132078 
 L 176.054419 147.38645 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_81">
     <path d="M 176.054419 147.38645 
@@ -2399,7 +2399,7 @@ L 153.654726 173.393769
 L 153.156955 173.850741 
 L 152.659184 174.303887 
 L 152.161413 174.753272 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_82">
     <path d="M 152.161413 174.753272 
@@ -2451,7 +2451,7 @@ L 147.060283 185.919158
 L 146.946925 186.142906 
 L 146.833566 186.365734 
 L 146.720208 186.587648 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_83">
     <path d="M 146.720208 186.587648 
@@ -2503,7 +2503,7 @@ L 144.164409 195.794799
 L 144.107613 195.982622 
 L 144.050817 196.169795 
 L 143.994022 196.356323 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_84">
     <path d="M 143.994022 196.356323 
@@ -2555,30 +2555,30 @@ L 142.749036 199.949687
 L 142.72137 200.026891 
 L 142.693704 200.103986 
 L 142.666037 200.180971 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_85">
     <defs>
-     <path id="m5a7f2031e7" d="M -0 3.535534 
+     <path id="md4542bef4d" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p21d9583499)">
-     <use xlink:href="#m5a7f2031e7" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5a7f2031e7" x="242.839153" y="80.778898" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5a7f2031e7" x="218.251194" y="86.377096" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5a7f2031e7" x="197.814984" y="90.309617" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5a7f2031e7" x="166.378359" y="99.066934" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5a7f2031e7" x="145.830392" y="110.431955" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5a7f2031e7" x="134.598477" y="126.026287" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5a7f2031e7" x="124.077268" y="149.033155" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5a7f2031e7" x="122.462976" y="157.476606" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5a7f2031e7" x="81.012077" y="220.06889" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5a7f2031e7" x="77.44276" y="239.652656" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5a7f2031e7" x="76.953425" y="252.706566" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pd7db26d2c3)">
+     <use xlink:href="#md4542bef4d" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md4542bef4d" x="242.839153" y="80.778898" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md4542bef4d" x="218.251194" y="86.377096" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md4542bef4d" x="197.814984" y="90.309617" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md4542bef4d" x="166.378359" y="99.066934" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md4542bef4d" x="145.830392" y="110.431955" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md4542bef4d" x="134.598477" y="126.026287" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md4542bef4d" x="124.077268" y="149.033155" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md4542bef4d" x="122.462976" y="157.476606" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md4542bef4d" x="81.012077" y="220.06889" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md4542bef4d" x="77.44276" y="239.652656" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md4542bef4d" x="76.953425" y="252.706566" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_86">
@@ -2631,7 +2631,7 @@ L 245.91379 79.91142
 L 244.888911 80.202126 
 L 243.864032 80.49128 
 L 242.839153 80.778898 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_87">
     <path d="M 242.839153 80.778898 
@@ -2683,7 +2683,7 @@ L 219.787941 86.043669
 L 219.275692 86.155039 
 L 218.763443 86.266182 
 L 218.251194 86.377096 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_88">
     <path d="M 218.251194 86.377096 
@@ -2735,7 +2735,7 @@ L 199.092247 90.072029
 L 198.666492 90.151341 
 L 198.240738 90.230537 
 L 197.814984 90.309617 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_89">
     <path d="M 197.814984 90.309617 
@@ -2787,7 +2787,7 @@ L 168.343148 98.559208
 L 167.688219 98.72898 
 L 167.033289 98.898221 
 L 166.378359 99.066934 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_90">
     <path d="M 166.378359 99.066934 
@@ -2839,7 +2839,7 @@ L 147.11464 109.78743
 L 146.686557 110.003126 
 L 146.258475 110.217965 
 L 145.830392 110.431955 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_91">
     <path d="M 145.830392 110.431955 
@@ -2891,7 +2891,7 @@ L 135.300472 125.172774
 L 135.066474 125.458776 
 L 134.832476 125.743276 
 L 134.598477 126.026287 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_92">
     <path d="M 134.598477 126.026287 
@@ -2943,7 +2943,7 @@ L 124.734843 147.848882
 L 124.515652 148.246526 
 L 124.29646 148.641269 
 L 124.077268 149.033155 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_93">
     <path d="M 124.077268 149.033155 
@@ -2995,7 +2995,7 @@ L 122.56387 156.985769
 L 122.530239 157.149876 
 L 122.496607 157.313488 
 L 122.462976 157.476606 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_94">
     <path d="M 122.462976 157.476606 
@@ -3047,7 +3047,7 @@ L 83.602758 217.699074
 L 82.739198 218.500595 
 L 81.875637 219.290422 
 L 81.012077 220.06889 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_95">
     <path d="M 81.012077 220.06889 
@@ -3099,7 +3099,7 @@ L 77.665842 238.615761
 L 77.591481 238.963605 
 L 77.517121 239.309227 
 L 77.44276 239.652656 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_96">
     <path d="M 77.44276 239.652656 
@@ -3151,23 +3151,23 @@ L 76.984008 251.97672
 L 76.973814 252.221097 
 L 76.96362 252.464376 
 L 76.953425 252.706566 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_97">
     <defs>
-     <path id="m39d336fd0f" d="M -0 2.5 
+     <path id="m2407f1bdb2" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p21d9583499)">
-     <use xlink:href="#m39d336fd0f" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pd7db26d2c3)">
+     <use xlink:href="#m2407f1bdb2" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_98">
     <defs>
-     <path id="mc70085bc84" d="M -0.833333 2.5 
+     <path id="m5056de2257" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -3182,16 +3182,16 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p21d9583499)">
-     <use xlink:href="#mc70085bc84" x="432.495268" y="96.067622" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc70085bc84" x="300.62247" y="112.493412" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc70085bc84" x="266.967623" y="120.8136" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc70085bc84" x="226.040946" y="122.099593" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc70085bc84" x="180.985721" y="141.85872" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc70085bc84" x="164.441833" y="156.106179" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc70085bc84" x="157.761315" y="165.23787" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc70085bc84" x="151.269082" y="178.700983" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc70085bc84" x="150.327087" y="185.23695" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pd7db26d2c3)">
+     <use xlink:href="#m5056de2257" x="432.495268" y="96.067622" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5056de2257" x="300.62247" y="112.493412" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5056de2257" x="266.967623" y="120.8136" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5056de2257" x="226.040946" y="122.099593" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5056de2257" x="180.985721" y="141.85872" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5056de2257" x="164.441833" y="156.106179" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5056de2257" x="157.761315" y="165.23787" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5056de2257" x="151.269082" y="178.700983" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5056de2257" x="150.327087" y="185.23695" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_99">
@@ -3244,7 +3244,7 @@ L 308.86452 111.600609
 L 306.11717 111.899849 
 L 303.36982 112.197444 
 L 300.62247 112.493412 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_100">
     <path d="M 300.62247 112.493412 
@@ -3296,7 +3296,7 @@ L 269.071051 120.329422
 L 268.369908 120.491297 
 L 267.668766 120.652688 
 L 266.967623 120.8136 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_101">
     <path d="M 266.967623 120.8136 
@@ -3348,7 +3348,7 @@ L 228.598863 122.020108
 L 227.746224 122.046616 
 L 226.893585 122.073111 
 L 226.040946 122.099593 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_102">
     <path d="M 226.040946 122.099593 
@@ -3400,7 +3400,7 @@ L 183.801673 140.814056
 L 182.863022 141.164522 
 L 181.924372 141.512734 
 L 180.985721 141.85872 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_103">
     <path d="M 180.985721 141.85872 
@@ -3452,7 +3452,7 @@ L 165.475826 155.317544
 L 165.131161 155.581701 
 L 164.786497 155.844575 
 L 164.441833 156.106179 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_104">
     <path d="M 164.441833 156.106179 
@@ -3504,7 +3504,7 @@ L 158.178848 164.710119
 L 158.03967 164.886608 
 L 157.900493 165.062524 
 L 157.761315 165.23787 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_105">
     <path d="M 157.761315 165.23787 
@@ -3556,7 +3556,7 @@ L 151.674847 177.950842
 L 151.539592 178.202046 
 L 151.404337 178.452089 
 L 151.269082 178.700983 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_106">
     <path d="M 151.269082 178.700983 
@@ -3608,11 +3608,11 @@ L 150.385962 184.850776
 L 150.366337 184.979807 
 L 150.346712 185.108531 
 L 150.327087 185.23695 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_107">
     <defs>
-     <path id="mee1785d91c" d="M -1.25 2.5 
+     <path id="m0dc743cc7b" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -3627,16 +3627,16 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p21d9583499)">
-     <use xlink:href="#mee1785d91c" x="345.030867" y="136.859359" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mee1785d91c" x="273.364924" y="143.571257" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mee1785d91c" x="240.719951" y="149.310846" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mee1785d91c" x="221.353978" y="154.160538" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mee1785d91c" x="207.129625" y="156.092215" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mee1785d91c" x="181.064802" y="166.758473" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mee1785d91c" x="179.282169" y="170.289343" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mee1785d91c" x="177.719335" y="175.489948" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mee1785d91c" x="177.643939" y="181.552088" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pd7db26d2c3)">
+     <use xlink:href="#m0dc743cc7b" x="345.030867" y="136.859359" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0dc743cc7b" x="273.364924" y="143.571257" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0dc743cc7b" x="240.719951" y="149.310846" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0dc743cc7b" x="221.353978" y="154.160538" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0dc743cc7b" x="207.129625" y="156.092215" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0dc743cc7b" x="181.064802" y="166.758473" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0dc743cc7b" x="179.282169" y="170.289343" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0dc743cc7b" x="177.719335" y="175.489948" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0dc743cc7b" x="177.643939" y="181.552088" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_108">
@@ -3689,7 +3689,7 @@ L 277.844045 143.175283
 L 276.351005 143.307597 
 L 274.857964 143.439587 
 L 273.364924 143.571257 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_109">
     <path d="M 273.364924 143.571257 
@@ -3741,7 +3741,7 @@ L 242.760262 148.96941
 L 242.080158 149.083462 
 L 241.400055 149.197273 
 L 240.719951 149.310846 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_110">
     <path d="M 240.719951 149.310846 
@@ -3793,7 +3793,7 @@ L 222.564351 153.869835
 L 222.160893 153.966909 
 L 221.757435 154.06381 
 L 221.353978 154.160538 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_111">
     <path d="M 221.353978 154.160538 
@@ -3845,7 +3845,7 @@ L 208.018647 155.973483
 L 207.722306 156.013089 
 L 207.425965 156.052666 
 L 207.129625 156.092215 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_112">
     <path d="M 207.129625 156.092215 
@@ -3897,7 +3897,7 @@ L 182.693853 166.149994
 L 182.150836 166.353581 
 L 181.607819 166.556405 
 L 181.064802 166.758473 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_113">
     <path d="M 181.064802 166.758473 
@@ -3949,7 +3949,7 @@ L 179.393584 170.075284
 L 179.356445 170.146731 
 L 179.319307 170.218084 
 L 179.282169 170.289343 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_114">
     <path d="M 179.282169 170.289343 
@@ -4001,7 +4001,7 @@ L 177.817012 175.179146
 L 177.784453 175.282945 
 L 177.751894 175.386546 
 L 177.719335 175.489948 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_115">
     <path d="M 177.719335 175.489948 
@@ -4053,11 +4053,11 @@ L 177.648651 181.192458
 L 177.64708 181.3126 
 L 177.645509 181.432477 
 L 177.643939 181.552088 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_116">
     <defs>
-     <path id="m6a5ab4ae5d" d="M 0 -2.5 
+     <path id="m436259ff96" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -4070,16 +4070,16 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p21d9583499)">
-     <use xlink:href="#m6a5ab4ae5d" x="226.871027" y="113.224491" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m6a5ab4ae5d" x="226.871027" y="113.066324" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m6a5ab4ae5d" x="226.871027" y="113.178221" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m6a5ab4ae5d" x="226.871027" y="113.089884" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m6a5ab4ae5d" x="177.768423" y="132.327899" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m6a5ab4ae5d" x="160.37503" y="145.652356" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m6a5ab4ae5d" x="153.995779" y="152.678629" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m6a5ab4ae5d" x="147.106887" y="168.143801" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m6a5ab4ae5d" x="145.871703" y="175.118358" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#pd7db26d2c3)">
+     <use xlink:href="#m436259ff96" x="226.871027" y="113.224491" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m436259ff96" x="226.871027" y="113.066324" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m436259ff96" x="226.871027" y="113.178221" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m436259ff96" x="226.871027" y="113.089884" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m436259ff96" x="177.768423" y="132.327899" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m436259ff96" x="160.37503" y="145.652356" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m436259ff96" x="153.995779" y="152.678629" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m436259ff96" x="147.106887" y="168.143801" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m436259ff96" x="145.871703" y="175.118358" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_117">
@@ -4132,7 +4132,7 @@ L 226.871027 113.076223
 L 226.871027 113.072924 
 L 226.871027 113.069624 
 L 226.871027 113.066324 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_118">
     <path d="M 226.871027 113.066324 
@@ -4184,7 +4184,7 @@ L 226.871027 113.171234
 L 226.871027 113.173563 
 L 226.871027 113.175892 
 L 226.871027 113.178221 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_119">
     <path d="M 226.871027 113.178221 
@@ -4236,7 +4236,7 @@ L 226.871027 113.09541
 L 226.871027 113.093568 
 L 226.871027 113.091726 
 L 226.871027 113.089884 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_120">
     <path d="M 226.871027 113.089884 
@@ -4288,7 +4288,7 @@ L 180.837336 131.306392
 L 179.814365 131.649041 
 L 178.791394 131.989534 
 L 177.768423 132.327899 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_121">
     <path d="M 177.768423 132.327899 
@@ -4340,7 +4340,7 @@ L 161.462117 144.909076
 L 161.099755 145.157972 
 L 160.737393 145.405728 
 L 160.37503 145.652356 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_122">
     <path d="M 160.37503 145.652356 
@@ -4392,7 +4392,7 @@ L 154.394483 152.265218
 L 154.261581 152.403373 
 L 154.12868 152.541176 
 L 153.995779 152.678629 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_123">
     <path d="M 153.995779 152.678629 
@@ -4444,7 +4444,7 @@ L 147.537442 167.296442
 L 147.393924 167.580372 
 L 147.250405 167.862819 
 L 147.106887 168.143801 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_124">
     <path d="M 147.106887 168.143801 
@@ -4496,11 +4496,11 @@ L 145.948902 174.70781
 L 145.923169 174.845005 
 L 145.897436 174.981854 
 L 145.871703 175.118358 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_125">
     <defs>
-     <path id="m1d2551259d" d="M 0 -2.5 
+     <path id="ma985c8d7cd" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -4509,16 +4509,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p21d9583499)">
-     <use xlink:href="#m1d2551259d" x="585.66883" y="173.051371" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1d2551259d" x="527.144592" y="175.326465" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1d2551259d" x="457.339427" y="183.688849" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1d2551259d" x="292.124837" y="178.486631" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1d2551259d" x="243.129344" y="190.369032" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1d2551259d" x="213.541392" y="204.43395" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1d2551259d" x="204.551957" y="212.140784" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1d2551259d" x="195.860087" y="228.582256" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1d2551259d" x="194.019853" y="234.294862" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pd7db26d2c3)">
+     <use xlink:href="#ma985c8d7cd" x="585.66883" y="173.051371" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma985c8d7cd" x="527.144592" y="175.326465" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma985c8d7cd" x="457.339427" y="183.688849" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma985c8d7cd" x="292.124837" y="178.486631" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma985c8d7cd" x="243.129344" y="190.369032" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma985c8d7cd" x="213.541392" y="204.43395" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma985c8d7cd" x="204.551957" y="212.140784" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma985c8d7cd" x="195.860087" y="228.582256" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma985c8d7cd" x="194.019853" y="234.294862" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_126">
@@ -4571,7 +4571,7 @@ L 530.802357 175.187039
 L 529.583102 175.233554 
 L 528.363847 175.28003 
 L 527.144592 175.326465 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_127">
     <path d="M 527.144592 175.326465 
@@ -4623,7 +4623,7 @@ L 461.70225 183.20239
 L 460.247976 183.36503 
 L 458.793701 183.527182 
 L 457.339427 183.688849 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_128">
     <path d="M 457.339427 183.688849 
@@ -4675,7 +4675,7 @@ L 302.450749 178.826834
 L 299.008779 178.713671 
 L 295.566808 178.60027 
 L 292.124837 178.486631 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_129">
     <path d="M 292.124837 178.486631 
@@ -4727,7 +4727,7 @@ L 246.191563 189.6981
 L 245.170823 189.922669 
 L 244.150084 190.146311 
 L 243.129344 190.369032 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_130">
     <path d="M 243.129344 190.369032 
@@ -4779,7 +4779,7 @@ L 215.390639 203.654226
 L 214.774224 203.915384 
 L 214.157808 204.175288 
 L 213.541392 204.43395 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_131">
     <path d="M 213.541392 204.43395 
@@ -4831,7 +4831,7 @@ L 205.113797 211.689953
 L 204.926517 211.840648 
 L 204.739237 211.990924 
 L 204.551957 212.140784 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_132">
     <path d="M 204.551957 212.140784 
@@ -4883,7 +4883,7 @@ L 196.403329 227.688717
 L 196.222248 227.988205 
 L 196.041168 228.286045 
 L 195.860087 228.582256 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_133">
     <path d="M 195.860087 228.582256 
@@ -4935,7 +4935,7 @@ L 194.134867 233.954953
 L 194.096529 234.068494 
 L 194.058191 234.181796 
 L 194.019853 234.294862 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="legend_1">
     <g id="patch_7">
@@ -4953,7 +4953,7 @@ z
     </g>
     <g id="line2d_134">
      <defs>
-      <path id="m7af52bbf39" d="M 0 3.5 
+      <path id="m22ec9a9984" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -4966,7 +4966,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m7af52bbf39" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m22ec9a9984" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -5025,7 +5025,7 @@ z
     </g>
     <g id="line2d_135">
      <g>
-      <use xlink:href="#m8021e33023" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mc56fce18eb" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -5039,7 +5039,7 @@ z
     </g>
     <g id="line2d_136">
      <g>
-      <use xlink:href="#m1e1abfc02b" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mba75ea4ead" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -5084,7 +5084,7 @@ z
     </g>
     <g id="line2d_137">
      <g>
-      <use xlink:href="#m5a7f2031e7" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#md4542bef4d" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -5127,7 +5127,7 @@ z
     </g>
     <g id="line2d_138">
      <g>
-      <use xlink:href="#m39d336fd0f" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m2407f1bdb2" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -5143,7 +5143,7 @@ z
     </g>
     <g id="line2d_139">
      <g>
-      <use xlink:href="#mc70085bc84" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m5056de2257" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -5197,7 +5197,7 @@ z
     </g>
     <g id="line2d_140">
      <g>
-      <use xlink:href="#mee1785d91c" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m0dc743cc7b" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -5262,7 +5262,7 @@ z
     </g>
     <g id="line2d_141">
      <g>
-      <use xlink:href="#m6a5ab4ae5d" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#m436259ff96" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -5300,7 +5300,7 @@ z
     </g>
     <g id="line2d_142">
      <g>
-      <use xlink:href="#m1d2551259d" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#ma985c8d7cd" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -5370,486 +5370,486 @@ z
     </g>
    </g>
    <g id="line2d_143">
-    <g clip-path="url(#p21d9583499)">
-     <use xlink:href="#m7af52bbf39" x="319.643112" y="123.779184" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m7af52bbf39" x="269.129958" y="139.427151" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m7af52bbf39" x="247.452898" y="144.401126" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m7af52bbf39" x="192.820547" y="156.792234" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m7af52bbf39" x="180.389901" y="167.242695" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m7af52bbf39" x="156.350594" y="177.250032" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m7af52bbf39" x="147.843012" y="186.309462" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m7af52bbf39" x="146.231533" y="190.194023" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m7af52bbf39" x="119.590386" y="286.756333" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m7af52bbf39" x="97.799363" y="314.724011" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <g clip-path="url(#pd7db26d2c3)">
+     <use xlink:href="#m22ec9a9984" x="319.643112" y="123.461471" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m22ec9a9984" x="269.129958" y="138.871439" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m22ec9a9984" x="247.452898" y="143.997761" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m22ec9a9984" x="192.820547" y="152.686437" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m22ec9a9984" x="180.389901" y="163.860986" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m22ec9a9984" x="156.350594" y="174.058052" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m22ec9a9984" x="147.843012" y="183.802047" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m22ec9a9984" x="146.231533" y="187.809062" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m22ec9a9984" x="119.590386" y="285.972112" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m22ec9a9984" x="97.799363" y="314.867541" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
    <g id="line2d_144">
-    <path d="M 319.643112 123.779184 
-L 318.590755 124.155877 
-L 317.538397 124.529967 
-L 316.48604 124.901489 
-L 315.433682 125.270479 
-L 314.381325 125.63697 
-L 313.328968 126.000997 
-L 312.27661 126.362592 
-L 311.224253 126.721788 
-L 310.171896 127.078616 
-L 309.119538 127.433107 
-L 308.067181 127.785292 
-L 307.014823 128.1352 
-L 305.962466 128.482861 
-L 304.910109 128.828303 
-L 303.857751 129.171555 
-L 302.805394 129.512644 
-L 301.753037 129.851597 
-L 300.700679 130.188441 
-L 299.648322 130.523202 
-L 298.595965 130.855905 
-L 297.543607 131.186576 
-L 296.49125 131.515239 
-L 295.438892 131.841919 
-L 294.386535 132.166639 
-L 293.334178 132.489422 
-L 292.28182 132.810293 
-L 291.229463 133.129272 
-L 290.177106 133.446383 
-L 289.124748 133.761647 
-L 288.072391 134.075086 
-L 287.020033 134.38672 
-L 285.967676 134.69657 
-L 284.915319 135.004657 
-L 283.862961 135.311 
-L 282.810604 135.615619 
-L 281.758247 135.918534 
-L 280.705889 136.219763 
-L 279.653532 136.519324 
-L 278.601175 136.817238 
-L 277.548817 137.11352 
-L 276.49646 137.40819 
-L 275.444102 137.701265 
-L 274.391745 137.992761 
-L 273.339388 138.282696 
-L 272.28703 138.571086 
-L 271.234673 138.857948 
-L 270.182316 139.143298 
-L 269.129958 139.427151 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 319.643112 123.461471 
+L 318.590755 123.831603 
+L 317.538397 124.199222 
+L 316.48604 124.564362 
+L 315.433682 124.927054 
+L 314.381325 125.287333 
+L 313.328968 125.64523 
+L 312.27661 126.000776 
+L 311.224253 126.354001 
+L 310.171896 126.704937 
+L 309.119538 127.053613 
+L 308.067181 127.400057 
+L 307.014823 127.744297 
+L 305.962466 128.086362 
+L 304.910109 128.42628 
+L 303.857751 128.764076 
+L 302.805394 129.099777 
+L 301.753037 129.433409 
+L 300.700679 129.764998 
+L 299.648322 130.094567 
+L 298.595965 130.422143 
+L 297.543607 130.747747 
+L 296.49125 131.071405 
+L 295.438892 131.39314 
+L 294.386535 131.712973 
+L 293.334178 132.030928 
+L 292.28182 132.347026 
+L 291.229463 132.661288 
+L 290.177106 132.973737 
+L 289.124748 133.284393 
+L 288.072391 133.593276 
+L 287.020033 133.900407 
+L 285.967676 134.205804 
+L 284.915319 134.509489 
+L 283.862961 134.811479 
+L 282.810604 135.111794 
+L 281.758247 135.410452 
+L 280.705889 135.707471 
+L 279.653532 136.002869 
+L 278.601175 136.296664 
+L 277.548817 136.588873 
+L 276.49646 136.879514 
+L 275.444102 137.168601 
+L 274.391745 137.456154 
+L 273.339388 137.742187 
+L 272.28703 138.026716 
+L 271.234673 138.309758 
+L 270.182316 138.591327 
+L 269.129958 138.871439 
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_145">
-    <path d="M 269.129958 139.427151 
-L 268.678353 139.535577 
-L 268.226747 139.643786 
-L 267.775142 139.75178 
-L 267.323537 139.859558 
-L 266.871931 139.967122 
-L 266.420326 140.074473 
-L 265.96872 140.181611 
-L 265.517115 140.288538 
-L 265.065509 140.395254 
-L 264.613904 140.50176 
-L 264.162299 140.608057 
-L 263.710693 140.714145 
-L 263.259088 140.820026 
-L 262.807482 140.9257 
-L 262.355877 141.031169 
-L 261.904271 141.136432 
-L 261.452666 141.241491 
-L 261.001061 141.346346 
-L 260.549455 141.450999 
-L 260.09785 141.55545 
-L 259.646244 141.659699 
-L 259.194639 141.763749 
-L 258.743034 141.867598 
-L 258.291428 141.971249 
-L 257.839823 142.074702 
-L 257.388217 142.177957 
-L 256.936612 142.281016 
-L 256.485006 142.383879 
-L 256.033401 142.486547 
-L 255.581796 142.58902 
-L 255.13019 142.6913 
-L 254.678585 142.793387 
-L 254.226979 142.895282 
-L 253.775374 142.996985 
-L 253.323769 143.098498 
-L 252.872163 143.19982 
-L 252.420558 143.300954 
-L 251.968952 143.401899 
-L 251.517347 143.502655 
-L 251.065741 143.603225 
-L 250.614136 143.703608 
-L 250.162531 143.803806 
-L 249.710925 143.903818 
-L 249.25932 144.003646 
-L 248.807714 144.10329 
-L 248.356109 144.20275 
-L 247.904503 144.302029 
-L 247.452898 144.401126 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 269.129958 138.871439 
+L 268.678353 138.983342 
+L 268.226747 139.095015 
+L 267.775142 139.206457 
+L 267.323537 139.31767 
+L 266.871931 139.428656 
+L 266.420326 139.539414 
+L 265.96872 139.649946 
+L 265.517115 139.760253 
+L 265.065509 139.870336 
+L 264.613904 139.980195 
+L 264.162299 140.089831 
+L 263.710693 140.199246 
+L 263.259088 140.308441 
+L 262.807482 140.417415 
+L 262.355877 140.526171 
+L 261.904271 140.634708 
+L 261.452666 140.743028 
+L 261.001061 140.851132 
+L 260.549455 140.959021 
+L 260.09785 141.066695 
+L 259.646244 141.174155 
+L 259.194639 141.281402 
+L 258.743034 141.388437 
+L 258.291428 141.495261 
+L 257.839823 141.601875 
+L 257.388217 141.708279 
+L 256.936612 141.814474 
+L 256.485006 141.920462 
+L 256.033401 142.026242 
+L 255.581796 142.131816 
+L 255.13019 142.237184 
+L 254.678585 142.342348 
+L 254.226979 142.447308 
+L 253.775374 142.552064 
+L 253.323769 142.656619 
+L 252.872163 142.760971 
+L 252.420558 142.865123 
+L 251.968952 142.969075 
+L 251.517347 143.072828 
+L 251.065741 143.176382 
+L 250.614136 143.279739 
+L 250.162531 143.382898 
+L 249.710925 143.485862 
+L 249.25932 143.58863 
+L 248.807714 143.691203 
+L 248.356109 143.793582 
+L 247.904503 143.895768 
+L 247.452898 143.997761 
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_146">
-    <path d="M 247.452898 144.401126 
-L 246.314724 144.690435 
-L 245.17655 144.978206 
-L 244.038376 145.264456 
-L 242.900202 145.5492 
-L 241.762028 145.832454 
-L 240.623854 146.114233 
-L 239.48568 146.394553 
-L 238.347506 146.673429 
-L 237.209332 146.950876 
-L 236.071158 147.226908 
-L 234.932984 147.501539 
-L 233.79481 147.774784 
-L 232.656636 148.046657 
-L 231.518462 148.317171 
-L 230.380288 148.58634 
-L 229.242114 148.854177 
-L 228.10394 149.120696 
-L 226.965766 149.385908 
-L 225.827592 149.649828 
-L 224.689418 149.912467 
-L 223.551244 150.173838 
-L 222.41307 150.433953 
-L 221.274896 150.692824 
-L 220.136722 150.950463 
-L 218.998548 151.206881 
-L 217.860374 151.462091 
-L 216.7222 151.716103 
-L 215.584026 151.968928 
-L 214.445852 152.220578 
-L 213.307678 152.471064 
-L 212.169505 152.720396 
-L 211.031331 152.968585 
-L 209.893157 153.215641 
-L 208.754983 153.461574 
-L 207.616809 153.706396 
-L 206.478635 153.950115 
-L 205.340461 154.192741 
-L 204.202287 154.434285 
-L 203.064113 154.674756 
-L 201.925939 154.914164 
-L 200.787765 155.152517 
-L 199.649591 155.389825 
-L 198.511417 155.626098 
-L 197.373243 155.861344 
-L 196.235069 156.095571 
-L 195.096895 156.32879 
-L 193.958721 156.561008 
-L 192.820547 156.792234 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 247.452898 143.997761 
+L 246.314724 144.193757 
+L 245.17655 144.389045 
+L 244.038376 144.583632 
+L 242.900202 144.777522 
+L 241.762028 144.970719 
+L 240.623854 145.16323 
+L 239.48568 145.355058 
+L 238.347506 145.546209 
+L 237.209332 145.736687 
+L 236.071158 145.926498 
+L 234.932984 146.115645 
+L 233.79481 146.304134 
+L 232.656636 146.491968 
+L 231.518462 146.679153 
+L 230.380288 146.865693 
+L 229.242114 147.051592 
+L 228.10394 147.236855 
+L 226.965766 147.421487 
+L 225.827592 147.60549 
+L 224.689418 147.78887 
+L 223.551244 147.971631 
+L 222.41307 148.153777 
+L 221.274896 148.335313 
+L 220.136722 148.516241 
+L 218.998548 148.696567 
+L 217.860374 148.876294 
+L 216.7222 149.055426 
+L 215.584026 149.233968 
+L 214.445852 149.411922 
+L 213.307678 149.589294 
+L 212.169505 149.766086 
+L 211.031331 149.942302 
+L 209.893157 150.117947 
+L 208.754983 150.293024 
+L 207.616809 150.467536 
+L 206.478635 150.641488 
+L 205.340461 150.814882 
+L 204.202287 150.987722 
+L 203.064113 151.160013 
+L 201.925939 151.331757 
+L 200.787765 151.502958 
+L 199.649591 151.673618 
+L 198.511417 151.843743 
+L 197.373243 152.013335 
+L 196.235069 152.182397 
+L 195.096895 152.350932 
+L 193.958721 152.518945 
+L 192.820547 152.686437 
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_147">
-    <path d="M 192.820547 156.792234 
-L 192.561575 157.031858 
-L 192.302603 157.270425 
-L 192.043631 157.507945 
-L 191.78466 157.744428 
-L 191.525688 157.979882 
-L 191.266716 158.214316 
-L 191.007744 158.447739 
-L 190.748773 158.68016 
-L 190.489801 158.911588 
-L 190.230829 159.14203 
-L 189.971857 159.371495 
-L 189.712885 159.599992 
-L 189.453914 159.827529 
-L 189.194942 160.054112 
-L 188.93597 160.279752 
-L 188.676998 160.504455 
-L 188.418027 160.728228 
-L 188.159055 160.951081 
-L 187.900083 161.17302 
-L 187.641111 161.394052 
-L 187.382139 161.614186 
-L 187.123168 161.833428 
-L 186.864196 162.051786 
-L 186.605224 162.269267 
-L 186.346252 162.485877 
-L 186.087281 162.701624 
-L 185.828309 162.916514 
-L 185.569337 163.130555 
-L 185.310365 163.343753 
-L 185.051393 163.556114 
-L 184.792422 163.767646 
-L 184.53345 163.978354 
-L 184.274478 164.188245 
-L 184.015506 164.397325 
-L 183.756535 164.605601 
-L 183.497563 164.813079 
-L 183.238591 165.019764 
-L 182.979619 165.225663 
-L 182.720647 165.430782 
-L 182.461676 165.635127 
-L 182.202704 165.838703 
-L 181.943732 166.041517 
-L 181.68476 166.243573 
-L 181.425789 166.444878 
-L 181.166817 166.645437 
-L 180.907845 166.845256 
-L 180.648873 167.04434 
-L 180.389901 167.242695 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 192.820547 152.686437 
+L 192.561575 152.944396 
+L 192.302603 153.201132 
+L 192.043631 153.456656 
+L 191.78466 153.710979 
+L 191.525688 153.964113 
+L 191.266716 154.216069 
+L 191.007744 154.466858 
+L 190.748773 154.71649 
+L 190.489801 154.964976 
+L 190.230829 155.212326 
+L 189.971857 155.458552 
+L 189.712885 155.703662 
+L 189.453914 155.947668 
+L 189.194942 156.190579 
+L 188.93597 156.432404 
+L 188.676998 156.673154 
+L 188.418027 156.912838 
+L 188.159055 157.151466 
+L 187.900083 157.389046 
+L 187.641111 157.625588 
+L 187.382139 157.8611 
+L 187.123168 158.095593 
+L 186.864196 158.329074 
+L 186.605224 158.561552 
+L 186.346252 158.793037 
+L 186.087281 159.023535 
+L 185.828309 159.253056 
+L 185.569337 159.481608 
+L 185.310365 159.709199 
+L 185.051393 159.935838 
+L 184.792422 160.161531 
+L 184.53345 160.386287 
+L 184.274478 160.610114 
+L 184.015506 160.833019 
+L 183.756535 161.05501 
+L 183.497563 161.276095 
+L 183.238591 161.49628 
+L 182.979619 161.715573 
+L 182.720647 161.933981 
+L 182.461676 162.151512 
+L 182.202704 162.368172 
+L 181.943732 162.583968 
+L 181.68476 162.798908 
+L 181.425789 163.012997 
+L 181.166817 163.226243 
+L 180.907845 163.438652 
+L 180.648873 163.650231 
+L 180.389901 163.860986 
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_148">
-    <path d="M 180.389901 167.242695 
-L 179.889083 167.471214 
-L 179.388264 167.698773 
-L 178.887445 167.925379 
-L 178.386626 168.15104 
-L 177.885807 168.375765 
-L 177.384988 168.59956 
-L 176.884169 168.822434 
-L 176.38335 169.044394 
-L 175.882531 169.265448 
-L 175.381713 169.485603 
-L 174.880894 169.704866 
-L 174.380075 169.923244 
-L 173.879256 170.140745 
-L 173.378437 170.357376 
-L 172.877618 170.573143 
-L 172.376799 170.788053 
-L 171.87598 171.002114 
-L 171.375161 171.215331 
-L 170.874342 171.427712 
-L 170.373524 171.639263 
-L 169.872705 171.84999 
-L 169.371886 172.0599 
-L 168.871067 172.268999 
-L 168.370248 172.477294 
-L 167.869429 172.68479 
-L 167.36861 172.891494 
-L 166.867791 173.097412 
-L 166.366972 173.302549 
-L 165.866154 173.506912 
-L 165.365335 173.710506 
-L 164.864516 173.913337 
-L 164.363697 174.115411 
-L 163.862878 174.316734 
-L 163.362059 174.51731 
-L 162.86124 174.717146 
-L 162.360421 174.916247 
-L 161.859602 175.114619 
-L 161.358783 175.312266 
-L 160.857965 175.509194 
-L 160.357146 175.705408 
-L 159.856327 175.900914 
-L 159.355508 176.095716 
-L 158.854689 176.28982 
-L 158.35387 176.48323 
-L 157.853051 176.675951 
-L 157.352232 176.867989 
-L 156.851413 177.059347 
-L 156.350594 177.250032 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 180.389901 163.860986 
+L 179.889083 164.094249 
+L 179.388264 164.32651 
+L 178.887445 164.55778 
+L 178.386626 164.788066 
+L 177.885807 165.017376 
+L 177.384988 165.245719 
+L 176.884169 165.473102 
+L 176.38335 165.699535 
+L 175.882531 165.925024 
+L 175.381713 166.149578 
+L 174.880894 166.373204 
+L 174.380075 166.59591 
+L 173.879256 166.817704 
+L 173.378437 167.038593 
+L 172.877618 167.258584 
+L 172.376799 167.477684 
+L 171.87598 167.695901 
+L 171.375161 167.913242 
+L 170.874342 168.129714 
+L 170.373524 168.345324 
+L 169.872705 168.560078 
+L 169.371886 168.773984 
+L 168.871067 168.987048 
+L 168.370248 169.199276 
+L 167.869429 169.410676 
+L 167.36861 169.621253 
+L 166.867791 169.831014 
+L 166.366972 170.039966 
+L 165.866154 170.248114 
+L 165.365335 170.455464 
+L 164.864516 170.662024 
+L 164.363697 170.867798 
+L 163.862878 171.072793 
+L 163.362059 171.277015 
+L 162.86124 171.480469 
+L 162.360421 171.683161 
+L 161.859602 171.885097 
+L 161.358783 172.086283 
+L 160.857965 172.286723 
+L 160.357146 172.486424 
+L 159.856327 172.685391 
+L 159.355508 172.88363 
+L 158.854689 173.081145 
+L 158.35387 173.277942 
+L 157.853051 173.474026 
+L 157.352232 173.669402 
+L 156.851413 173.864076 
+L 156.350594 174.058052 
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_149">
-    <path d="M 156.350594 177.250032 
-L 156.173353 177.455094 
-L 155.996112 177.659382 
-L 155.818871 177.862903 
-L 155.641629 178.06566 
-L 155.464388 178.267661 
-L 155.287147 178.468912 
-L 155.109905 178.669416 
-L 154.932664 178.869181 
-L 154.755423 179.068211 
-L 154.578182 179.266513 
-L 154.40094 179.46409 
-L 154.223699 179.660949 
-L 154.046458 179.857094 
-L 153.869216 180.052532 
-L 153.691975 180.247266 
-L 153.514734 180.441302 
-L 153.337492 180.634645 
-L 153.160251 180.8273 
-L 152.98301 181.019272 
-L 152.805769 181.210566 
-L 152.628527 181.401185 
-L 152.451286 181.591136 
-L 152.274045 181.780423 
-L 152.096803 181.96905 
-L 151.919562 182.157022 
-L 151.742321 182.344344 
-L 151.56508 182.531019 
-L 151.387838 182.717053 
-L 151.210597 182.90245 
-L 151.033356 183.087214 
-L 150.856114 183.27135 
-L 150.678873 183.454861 
-L 150.501632 183.637753 
-L 150.32439 183.820028 
-L 150.147149 184.001692 
-L 149.969908 184.182748 
-L 149.792667 184.3632 
-L 149.615425 184.543053 
-L 149.438184 184.722311 
-L 149.260943 184.900977 
-L 149.083701 185.079055 
-L 148.90646 185.256549 
-L 148.729219 185.433463 
-L 148.551977 185.6098 
-L 148.374736 185.785565 
-L 148.197495 185.960762 
-L 148.020254 186.135393 
-L 147.843012 186.309462 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 156.350594 174.058052 
+L 156.173353 174.280015 
+L 155.996112 174.501071 
+L 155.818871 174.721227 
+L 155.641629 174.940492 
+L 155.464388 175.158873 
+L 155.287147 175.376376 
+L 155.109905 175.593009 
+L 154.932664 175.808778 
+L 154.755423 176.02369 
+L 154.578182 176.237753 
+L 154.40094 176.450972 
+L 154.223699 176.663355 
+L 154.046458 176.874907 
+L 153.869216 177.085637 
+L 153.691975 177.295549 
+L 153.514734 177.50465 
+L 153.337492 177.712946 
+L 153.160251 177.920445 
+L 152.98301 178.12715 
+L 152.805769 178.33307 
+L 152.628527 178.538209 
+L 152.451286 178.742573 
+L 152.274045 178.946169 
+L 152.096803 179.149002 
+L 151.919562 179.351078 
+L 151.742321 179.552402 
+L 151.56508 179.752981 
+L 151.387838 179.952819 
+L 151.210597 180.151921 
+L 151.033356 180.350295 
+L 150.856114 180.547943 
+L 150.678873 180.744873 
+L 150.501632 180.941089 
+L 150.32439 181.136596 
+L 150.147149 181.3314 
+L 149.969908 181.525505 
+L 149.792667 181.718917 
+L 149.615425 181.91164 
+L 149.438184 182.103679 
+L 149.260943 182.29504 
+L 149.083701 182.485726 
+L 148.90646 182.675743 
+L 148.729219 182.865095 
+L 148.551977 183.053787 
+L 148.374736 183.241824 
+L 148.197495 183.42921 
+L 148.020254 183.615949 
+L 147.843012 183.802047 
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_150">
-    <path d="M 147.843012 186.309462 
-L 147.80944 186.3933 
-L 147.775867 186.477008 
-L 147.742295 186.560587 
-L 147.708722 186.644037 
-L 147.67515 186.727359 
-L 147.641577 186.810553 
-L 147.608005 186.893619 
-L 147.574432 186.976558 
-L 147.54086 187.059369 
-L 147.507287 187.142055 
-L 147.473715 187.224614 
-L 147.440142 187.307047 
-L 147.40657 187.389356 
-L 147.372997 187.471539 
-L 147.339425 187.553597 
-L 147.305852 187.635532 
-L 147.27228 187.717342 
-L 147.238707 187.79903 
-L 147.205135 187.880594 
-L 147.171562 187.962035 
-L 147.13799 188.043354 
-L 147.104417 188.124551 
-L 147.070845 188.205626 
-L 147.037273 188.286581 
-L 147.0037 188.367414 
-L 146.970128 188.448127 
-L 146.936555 188.528719 
-L 146.902983 188.609192 
-L 146.86941 188.689545 
-L 146.835838 188.769779 
-L 146.802265 188.849895 
-L 146.768693 188.929892 
-L 146.73512 189.009771 
-L 146.701548 189.089532 
-L 146.667975 189.169176 
-L 146.634403 189.248703 
-L 146.60083 189.328113 
-L 146.567258 189.407407 
-L 146.533685 189.486585 
-L 146.500113 189.565647 
-L 146.46654 189.644595 
-L 146.432968 189.723427 
-L 146.399395 189.802144 
-L 146.365823 189.880747 
-L 146.33225 189.959236 
-L 146.298678 190.037612 
-L 146.265105 190.115874 
-L 146.231533 190.194023 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 147.843012 183.802047 
+L 147.80944 183.888624 
+L 147.775867 183.975064 
+L 147.742295 184.061365 
+L 147.708722 184.147529 
+L 147.67515 184.233557 
+L 147.641577 184.319447 
+L 147.608005 184.405202 
+L 147.574432 184.490821 
+L 147.54086 184.576305 
+L 147.507287 184.661654 
+L 147.473715 184.746869 
+L 147.440142 184.83195 
+L 147.40657 184.916897 
+L 147.372997 185.001711 
+L 147.339425 185.086392 
+L 147.305852 185.170942 
+L 147.27228 185.255359 
+L 147.238707 185.339645 
+L 147.205135 185.4238 
+L 147.171562 185.507824 
+L 147.13799 185.591718 
+L 147.104417 185.675482 
+L 147.070845 185.759117 
+L 147.037273 185.842623 
+L 147.0037 185.926 
+L 146.970128 186.009249 
+L 146.936555 186.09237 
+L 146.902983 186.175364 
+L 146.86941 186.25823 
+L 146.835838 186.34097 
+L 146.802265 186.423584 
+L 146.768693 186.506072 
+L 146.73512 186.588434 
+L 146.701548 186.670671 
+L 146.667975 186.752783 
+L 146.634403 186.834771 
+L 146.60083 186.916635 
+L 146.567258 186.998376 
+L 146.533685 187.079993 
+L 146.500113 187.161487 
+L 146.46654 187.242859 
+L 146.432968 187.324109 
+L 146.399395 187.405236 
+L 146.365823 187.486243 
+L 146.33225 187.567128 
+L 146.298678 187.647893 
+L 146.265105 187.728538 
+L 146.231533 187.809062 
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_151">
-    <path d="M 146.231533 190.194023 
-L 145.676509 195.509669 
-L 145.121485 200.349682 
-L 144.566461 204.792231 
-L 144.011437 208.897673 
-L 143.456413 212.713579 
-L 142.901389 216.27811 
-L 142.346365 219.62235 
-L 141.791342 222.771948 
-L 141.236318 225.748321 
-L 140.681294 228.569535 
-L 140.12627 231.250968 
-L 139.571246 233.805819 
-L 139.016222 236.245504 
-L 138.461198 238.579958 
-L 137.906174 240.817885 
-L 137.35115 242.966952 
-L 136.796126 245.033947 
-L 136.241103 247.024908 
-L 135.686079 248.945232 
-L 135.131055 250.799759 
-L 134.576031 252.592849 
-L 134.021007 254.328443 
-L 133.465983 256.010113 
-L 132.910959 257.641111 
-L 132.355935 259.224399 
-L 131.800911 260.762691 
-L 131.245887 262.258473 
-L 130.690864 263.714032 
-L 130.13584 265.131474 
-L 129.580816 266.512746 
-L 129.025792 267.859646 
-L 128.470768 269.173845 
-L 127.915744 270.456893 
-L 127.36072 271.710232 
-L 126.805696 272.935207 
-L 126.250672 274.133073 
-L 125.695648 275.305005 
-L 125.140625 276.452101 
-L 124.585601 277.575393 
-L 124.030577 278.675848 
-L 123.475553 279.754377 
-L 122.920529 280.811836 
-L 122.365505 281.849032 
-L 121.810481 282.866728 
-L 121.255457 283.865644 
-L 120.700433 284.846459 
-L 120.145409 285.809818 
-L 119.590386 286.756333 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 146.231533 187.809062 
+L 145.676509 193.307037 
+L 145.121485 198.297725 
+L 144.566461 202.866881 
+L 144.011437 207.080201 
+L 143.456413 210.989126 
+L 142.901389 214.634692 
+L 142.346365 218.050155 
+L 141.791342 221.262847 
+L 141.236318 224.295501 
+L 140.681294 227.167229 
+L 140.12627 229.894253 
+L 139.571246 232.490459 
+L 139.016222 234.967825 
+L 138.461198 237.336758 
+L 137.906174 239.606351 
+L 137.35115 241.784602 
+L 136.796126 243.878581 
+L 136.241103 245.894565 
+L 135.686079 247.838157 
+L 135.131055 249.714376 
+L 134.576031 251.527736 
+L 134.021007 253.282314 
+L 133.465983 254.981802 
+L 132.910959 256.629553 
+L 132.355935 258.228624 
+L 131.800911 259.781811 
+L 131.245887 261.291672 
+L 130.690864 262.760559 
+L 130.13584 264.190638 
+L 129.580816 265.583907 
+L 129.025792 266.942212 
+L 128.470768 268.267267 
+L 127.915744 269.560659 
+L 127.36072 270.823868 
+L 126.805696 272.058269 
+L 126.250672 273.265147 
+L 125.695648 274.445704 
+L 125.140625 275.601062 
+L 124.585601 276.732275 
+L 124.030577 277.840332 
+L 123.475553 278.926161 
+L 122.920529 279.990636 
+L 122.365505 281.034583 
+L 121.810481 282.058776 
+L 121.255457 283.063951 
+L 120.700433 284.0508 
+L 120.145409 285.019979 
+L 119.590386 285.972112 
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_152">
-    <path d="M 119.590386 286.756333 
-L 119.136406 287.513837 
-L 118.682426 288.260886 
-L 118.228447 288.997766 
-L 117.774467 289.72475 
-L 117.320487 290.442099 
-L 116.866508 291.150067 
-L 116.412528 291.848894 
-L 115.958549 292.538814 
-L 115.504569 293.220052 
-L 115.050589 293.892823 
-L 114.59661 294.557335 
-L 114.14263 295.213788 
-L 113.68865 295.862376 
-L 113.234671 296.503284 
-L 112.780691 297.136693 
-L 112.326712 297.762776 
-L 111.872732 298.3817 
-L 111.418752 298.993627 
-L 110.964773 299.598714 
-L 110.510793 300.197112 
-L 110.056813 300.788967 
-L 109.602834 301.374421 
-L 109.148854 301.953611 
-L 108.694874 302.526669 
-L 108.240895 303.093724 
-L 107.786915 303.654901 
-L 107.332936 304.210319 
-L 106.878956 304.760096 
-L 106.424976 305.304346 
-L 105.970997 305.843178 
-L 105.517017 306.376699 
-L 105.063037 306.905013 
-L 104.609058 307.42822 
-L 104.155078 307.946419 
-L 103.701099 308.459704 
-L 103.247119 308.968168 
-L 102.793139 309.4719 
-L 102.33916 309.970987 
-L 101.88518 310.465515 
-L 101.4312 310.955566 
-L 100.977221 311.441221 
-L 100.523241 311.922556 
-L 100.069262 312.39965 
-L 99.615282 312.872575 
-L 99.161302 313.341405 
-L 98.707323 313.806208 
-L 98.253343 314.267055 
-L 97.799363 314.724011 
-" clip-path="url(#p21d9583499)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 119.590386 285.972112 
+L 119.136406 286.761833 
+L 118.682426 287.540199 
+L 118.228447 288.307531 
+L 117.774467 289.064138 
+L 117.320487 289.810315 
+L 116.866508 290.546346 
+L 116.412528 291.272503 
+L 115.958549 291.989048 
+L 115.504569 292.696231 
+L 115.050589 293.394295 
+L 114.59661 294.083471 
+L 114.14263 294.763983 
+L 113.68865 295.436046 
+L 113.234671 296.099867 
+L 112.780691 296.755646 
+L 112.326712 297.403576 
+L 111.872732 298.043842 
+L 111.418752 298.676623 
+L 110.964773 299.302093 
+L 110.510793 299.920418 
+L 110.056813 300.53176 
+L 109.602834 301.136274 
+L 109.148854 301.734112 
+L 108.694874 302.325419 
+L 108.240895 302.910337 
+L 107.786915 303.489002 
+L 107.332936 304.061547 
+L 106.878956 304.628099 
+L 106.424976 305.188783 
+L 105.970997 305.743718 
+L 105.517017 306.293023 
+L 105.063037 306.836809 
+L 104.609058 307.375187 
+L 104.155078 307.908263 
+L 103.701099 308.43614 
+L 103.247119 308.958919 
+L 102.793139 309.476698 
+L 102.33916 309.989571 
+L 101.88518 310.49763 
+L 101.4312 311.000965 
+L 100.977221 311.499663 
+L 100.523241 311.993809 
+L 100.069262 312.483484 
+L 99.615282 312.968769 
+L 99.161302 313.449743 
+L 98.707323 313.92648 
+L 98.253343 314.399056 
+L 97.799363 314.867541 
+" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
   </g>
   <g id="text_25">
@@ -6166,8 +6166,8 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-07-08T15:47:33Z  ·  Linux chungus2 x86_64  ·  commit f2026e66  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(44.448437 465.66) scale(0.07 -0.07)">
+   <!-- 2026-07-08T20:00:36Z  ·  Linux chungus2 x86_64  ·  commit 29539fd5  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(44.380078 465.66) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -6188,31 +6188,6 @@ L 1638 0
 L 1638 4134 
 L -19 4134 
 L -19 4666 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-3a" d="M 750 794 
@@ -6285,6 +6260,61 @@ Q 2894 3584 3203 3211
 Q 3513 2838 3513 2113 
 z
 " transform="scale(0.015625)"/>
+     <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
      <path id="DejaVuSans-3d" d="M 678 2906 
 L 4684 2906 
 L 4684 2381 
@@ -6325,14 +6355,14 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-38" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
     <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -6372,109 +6402,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3107.080078 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3170.703125 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3234.326172 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3297.949219 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3361.572266 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3423.095703 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3486.71875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3550.341797 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3582.128906 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3613.916016 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3645.703125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3677.490234 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3709.277344 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3737.060547 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3798.583984 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3859.863281 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3923.242188 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3986.71875 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4025.582031 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4086.763672 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4145.943359 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4207.466797 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4248.580078 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4282.271484 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4310.054688 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4371.578125 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4432.857422 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4496.236328 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4559.859375 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4593.550781 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4652.730469 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4716.353516 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4748.140625 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4811.763672 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4875.386719 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4907.173828 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4970.796875 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5006.880859 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5045.744141 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5100.724609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5164.347656 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5196.134766 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5227.921875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5259.708984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5291.496094 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5323.283203 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5362.492188 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5425.871094 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5464.734375 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5525.916016 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5589.294922 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5652.771484 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5716.150391 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5779.626953 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5843.005859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5882.214844 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5914.001953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5997.791016 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6029.578125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6126.990234 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6188.513672 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6251.990234 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6279.773438 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6341.052734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6404.431641 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6436.21875 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6488.318359 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6551.697266 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6612.976562 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6676.453125 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6728.552734 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6791.931641 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6853.113281 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6892.322266 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6926.013672 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6957.800781 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6998.914062 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7060.193359 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7099.402344 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7127.185547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7188.367188 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7220.154297 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7247.9375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7300.037109 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7331.824219 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7395.300781 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7456.824219 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7496.033203 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7557.556641 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7596.919922 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7694.332031 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7722.115234 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7785.494141 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7813.277344 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7865.376953 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7904.585938 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7932.369141 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3262.744141 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3326.367188 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3389.990234 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3425.195312 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3488.671875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3552.294922 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3584.082031 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3615.869141 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3647.65625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3679.443359 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3711.230469 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3739.013672 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3800.537109 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3861.816406 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3925.195312 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3988.671875 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4027.535156 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4088.716797 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4147.896484 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4209.419922 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4250.533203 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4284.224609 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4312.007812 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4373.53125 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4434.810547 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4498.189453 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4561.8125 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4595.503906 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4654.683594 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4718.306641 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4750.09375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4813.716797 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4877.339844 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4909.126953 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4972.75 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5008.833984 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5047.697266 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5102.677734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5166.300781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5198.087891 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5229.875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5261.662109 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5293.449219 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5325.236328 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5364.445312 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5427.824219 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5466.6875 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5527.869141 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5591.248047 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5654.724609 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5718.103516 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5781.580078 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5844.958984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5884.167969 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5915.955078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5999.744141 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6031.53125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6128.943359 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6190.466797 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6253.943359 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6281.726562 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6343.005859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6406.384766 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6438.171875 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6490.271484 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6553.650391 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6614.929688 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6678.40625 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6730.505859 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6793.884766 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6855.066406 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6894.275391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6927.966797 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6959.753906 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7000.867188 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7062.146484 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7101.355469 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7129.138672 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7190.320312 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7222.107422 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7249.890625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7301.990234 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7333.777344 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7397.253906 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7458.777344 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7497.986328 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7559.509766 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7598.873047 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7696.285156 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7724.068359 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7787.447266 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7815.230469 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7867.330078 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7906.539062 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7934.322266 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p21d9583499">
+  <clipPath id="pd7db26d2c3">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_decode_density.svg
+++ b/bench/graphs/silesia_decode_density.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 82.373685 412.80375 
 L 82.373685 47.3475 
-" clip-path="url(#pc247673945)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p74e1a3303b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="md813dfe720" d="M 0 0 
+       <path id="m23c9bc81cc" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#md813dfe720" x="82.373685" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m23c9bc81cc" x="82.373685" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -111,11 +111,11 @@ z
      <g id="line2d_3">
       <path d="M 165.44644 412.80375 
 L 165.44644 47.3475 
-" clip-path="url(#pc247673945)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p74e1a3303b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#md813dfe720" x="165.44644" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m23c9bc81cc" x="165.44644" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -157,11 +157,11 @@ z
      <g id="line2d_5">
       <path d="M 248.519195 412.80375 
 L 248.519195 47.3475 
-" clip-path="url(#pc247673945)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p74e1a3303b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#md813dfe720" x="248.519195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m23c9bc81cc" x="248.519195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -211,11 +211,11 @@ z
      <g id="line2d_7">
       <path d="M 331.59195 412.80375 
 L 331.59195 47.3475 
-" clip-path="url(#pc247673945)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p74e1a3303b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#md813dfe720" x="331.59195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m23c9bc81cc" x="331.59195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -252,11 +252,11 @@ z
      <g id="line2d_9">
       <path d="M 414.664704 412.80375 
 L 414.664704 47.3475 
-" clip-path="url(#pc247673945)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p74e1a3303b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#md813dfe720" x="414.664704" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m23c9bc81cc" x="414.664704" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -299,11 +299,11 @@ z
      <g id="line2d_11">
       <path d="M 497.737459 412.80375 
 L 497.737459 47.3475 
-" clip-path="url(#pc247673945)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p74e1a3303b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#md813dfe720" x="497.737459" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m23c9bc81cc" x="497.737459" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -351,11 +351,11 @@ z
      <g id="line2d_13">
       <path d="M 580.810214 412.80375 
 L 580.810214 47.3475 
-" clip-path="url(#pc247673945)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p74e1a3303b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#md813dfe720" x="580.810214" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m23c9bc81cc" x="580.810214" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -897,16 +897,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 391.33747 
 L 637.2 391.33747 
-" clip-path="url(#pc247673945)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p74e1a3303b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="m0ec2c8db9e" d="M 0 0 
+       <path id="m4527163a49" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m0ec2c8db9e" x="49.078125" y="391.33747" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4527163a49" x="49.078125" y="391.33747" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -922,11 +922,11 @@ L -3.5 0
      <g id="line2d_17">
       <path d="M 49.078125 263.934445 
 L 637.2 263.934445 
-" clip-path="url(#pc247673945)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p74e1a3303b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m0ec2c8db9e" x="49.078125" y="263.934445" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4527163a49" x="49.078125" y="263.934445" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -942,11 +942,11 @@ L 637.2 263.934445
      <g id="line2d_19">
       <path d="M 49.078125 136.53142 
 L 637.2 136.53142 
-" clip-path="url(#pc247673945)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p74e1a3303b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m0ec2c8db9e" x="49.078125" y="136.53142" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4527163a49" x="49.078125" y="136.53142" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -962,16 +962,16 @@ L 637.2 136.53142
      <g id="line2d_21">
       <path d="M 49.078125 411.072449 
 L 637.2 411.072449 
-" clip-path="url(#pc247673945)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p74e1a3303b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="m24e6e8a922" d="M 0 0 
+       <path id="m94ab70279b" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m24e6e8a922" x="49.078125" y="411.072449" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m94ab70279b" x="49.078125" y="411.072449" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -979,11 +979,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 403.684099 
 L 637.2 403.684099 
-" clip-path="url(#pc247673945)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p74e1a3303b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m24e6e8a922" x="49.078125" y="403.684099" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m94ab70279b" x="49.078125" y="403.684099" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -991,11 +991,11 @@ L 637.2 403.684099
      <g id="line2d_25">
       <path d="M 49.078125 397.167113 
 L 637.2 397.167113 
-" clip-path="url(#pc247673945)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p74e1a3303b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m24e6e8a922" x="49.078125" y="397.167113" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m94ab70279b" x="49.078125" y="397.167113" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1003,11 +1003,11 @@ L 637.2 397.167113
      <g id="line2d_27">
       <path d="M 49.078125 352.985338 
 L 637.2 352.985338 
-" clip-path="url(#pc247673945)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p74e1a3303b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m24e6e8a922" x="49.078125" y="352.985338" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m94ab70279b" x="49.078125" y="352.985338" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1015,11 +1015,11 @@ L 637.2 352.985338
      <g id="line2d_29">
       <path d="M 49.078125 330.550779 
 L 637.2 330.550779 
-" clip-path="url(#pc247673945)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p74e1a3303b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m24e6e8a922" x="49.078125" y="330.550779" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m94ab70279b" x="49.078125" y="330.550779" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1027,11 +1027,11 @@ L 637.2 330.550779
      <g id="line2d_31">
       <path d="M 49.078125 314.633206 
 L 637.2 314.633206 
-" clip-path="url(#pc247673945)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p74e1a3303b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m24e6e8a922" x="49.078125" y="314.633206" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m94ab70279b" x="49.078125" y="314.633206" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1039,11 +1039,11 @@ L 637.2 314.633206
      <g id="line2d_33">
       <path d="M 49.078125 302.286577 
 L 637.2 302.286577 
-" clip-path="url(#pc247673945)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p74e1a3303b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m24e6e8a922" x="49.078125" y="302.286577" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m94ab70279b" x="49.078125" y="302.286577" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1051,11 +1051,11 @@ L 637.2 302.286577
      <g id="line2d_35">
       <path d="M 49.078125 292.198647 
 L 637.2 292.198647 
-" clip-path="url(#pc247673945)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p74e1a3303b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m24e6e8a922" x="49.078125" y="292.198647" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m94ab70279b" x="49.078125" y="292.198647" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1063,11 +1063,11 @@ L 637.2 292.198647
      <g id="line2d_37">
       <path d="M 49.078125 283.669424 
 L 637.2 283.669424 
-" clip-path="url(#pc247673945)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p74e1a3303b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m24e6e8a922" x="49.078125" y="283.669424" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m94ab70279b" x="49.078125" y="283.669424" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1075,11 +1075,11 @@ L 637.2 283.669424
      <g id="line2d_39">
       <path d="M 49.078125 276.281074 
 L 637.2 276.281074 
-" clip-path="url(#pc247673945)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p74e1a3303b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m24e6e8a922" x="49.078125" y="276.281074" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m94ab70279b" x="49.078125" y="276.281074" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1087,11 +1087,11 @@ L 637.2 276.281074
      <g id="line2d_41">
       <path d="M 49.078125 269.764088 
 L 637.2 269.764088 
-" clip-path="url(#pc247673945)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p74e1a3303b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m24e6e8a922" x="49.078125" y="269.764088" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m94ab70279b" x="49.078125" y="269.764088" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1099,11 +1099,11 @@ L 637.2 269.764088
      <g id="line2d_43">
       <path d="M 49.078125 225.582313 
 L 637.2 225.582313 
-" clip-path="url(#pc247673945)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p74e1a3303b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m24e6e8a922" x="49.078125" y="225.582313" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m94ab70279b" x="49.078125" y="225.582313" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1111,11 +1111,11 @@ L 637.2 225.582313
      <g id="line2d_45">
       <path d="M 49.078125 203.147754 
 L 637.2 203.147754 
-" clip-path="url(#pc247673945)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p74e1a3303b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m24e6e8a922" x="49.078125" y="203.147754" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m94ab70279b" x="49.078125" y="203.147754" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1123,11 +1123,11 @@ L 637.2 203.147754
      <g id="line2d_47">
       <path d="M 49.078125 187.230181 
 L 637.2 187.230181 
-" clip-path="url(#pc247673945)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p74e1a3303b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m24e6e8a922" x="49.078125" y="187.230181" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m94ab70279b" x="49.078125" y="187.230181" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1135,11 +1135,11 @@ L 637.2 187.230181
      <g id="line2d_49">
       <path d="M 49.078125 174.883552 
 L 637.2 174.883552 
-" clip-path="url(#pc247673945)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p74e1a3303b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m24e6e8a922" x="49.078125" y="174.883552" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m94ab70279b" x="49.078125" y="174.883552" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1147,11 +1147,11 @@ L 637.2 174.883552
      <g id="line2d_51">
       <path d="M 49.078125 164.795622 
 L 637.2 164.795622 
-" clip-path="url(#pc247673945)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p74e1a3303b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m24e6e8a922" x="49.078125" y="164.795622" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m94ab70279b" x="49.078125" y="164.795622" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1159,11 +1159,11 @@ L 637.2 164.795622
      <g id="line2d_53">
       <path d="M 49.078125 156.266399 
 L 637.2 156.266399 
-" clip-path="url(#pc247673945)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p74e1a3303b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#m24e6e8a922" x="49.078125" y="156.266399" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m94ab70279b" x="49.078125" y="156.266399" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1171,11 +1171,11 @@ L 637.2 156.266399
      <g id="line2d_55">
       <path d="M 49.078125 148.878049 
 L 637.2 148.878049 
-" clip-path="url(#pc247673945)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p74e1a3303b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#m24e6e8a922" x="49.078125" y="148.878049" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m94ab70279b" x="49.078125" y="148.878049" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1183,11 +1183,11 @@ L 637.2 148.878049
      <g id="line2d_57">
       <path d="M 49.078125 142.361063 
 L 637.2 142.361063 
-" clip-path="url(#pc247673945)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p74e1a3303b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#m24e6e8a922" x="49.078125" y="142.361063" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m94ab70279b" x="49.078125" y="142.361063" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1195,11 +1195,11 @@ L 637.2 142.361063
      <g id="line2d_59">
       <path d="M 49.078125 98.179288 
 L 637.2 98.179288 
-" clip-path="url(#pc247673945)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p74e1a3303b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#m24e6e8a922" x="49.078125" y="98.179288" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m94ab70279b" x="49.078125" y="98.179288" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1207,11 +1207,11 @@ L 637.2 98.179288
      <g id="line2d_61">
       <path d="M 49.078125 75.744729 
 L 637.2 75.744729 
-" clip-path="url(#pc247673945)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p74e1a3303b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#m24e6e8a922" x="49.078125" y="75.744729" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m94ab70279b" x="49.078125" y="75.744729" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1219,11 +1219,11 @@ L 637.2 75.744729
      <g id="line2d_63">
       <path d="M 49.078125 59.827156 
 L 637.2 59.827156 
-" clip-path="url(#pc247673945)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p74e1a3303b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#m24e6e8a922" x="49.078125" y="59.827156" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m94ab70279b" x="49.078125" y="59.827156" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1231,11 +1231,11 @@ L 637.2 59.827156
      <g id="line2d_65">
       <path d="M 49.078125 47.480527 
 L 637.2 47.480527 
-" clip-path="url(#pc247673945)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p74e1a3303b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#m24e6e8a922" x="49.078125" y="47.480527" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m94ab70279b" x="49.078125" y="47.480527" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1398,7 +1398,7 @@ z
    <g id="line2d_67">
     <path d="M 49.078125 63.959148 
 L 637.2 63.959148 
-" clip-path="url(#pc247673945)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
+" clip-path="url(#p74e1a3303b)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
    </g>
    <g id="patch_3">
     <path d="M 49.078125 412.80375 
@@ -1762,78 +1762,78 @@ z
    </g>
    <g id="line2d_68">
     <defs>
-     <path id="m13b3c49756" d="M -2.5 2.5 
+     <path id="m111343f80f" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pc247673945)">
-     <use xlink:href="#m13b3c49756" x="75.810937" y="263.190298" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m13b3c49756" x="105.634056" y="267.887378" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m13b3c49756" x="204.490635" y="300.240046" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m13b3c49756" x="234.479899" y="306.367428" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m13b3c49756" x="242.537956" y="316.909198" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m13b3c49756" x="300.771958" y="297.352079" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m13b3c49756" x="303.26414" y="310.698625" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m13b3c49756" x="304.261013" y="317.548512" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m13b3c49756" x="313.897453" y="317.953886" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m13b3c49756" x="414.166268" y="334.149272" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m13b3c49756" x="587.289889" y="327.780982" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m13b3c49756" x="610.467187" y="318.981257" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p74e1a3303b)">
+     <use xlink:href="#m111343f80f" x="75.810937" y="263.190298" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m111343f80f" x="105.634056" y="267.887378" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m111343f80f" x="204.490635" y="300.240046" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m111343f80f" x="234.479899" y="306.367428" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m111343f80f" x="242.537956" y="316.909198" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m111343f80f" x="300.771958" y="297.352079" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m111343f80f" x="303.26414" y="310.698625" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m111343f80f" x="304.261013" y="317.548512" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m111343f80f" x="313.897453" y="317.953886" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m111343f80f" x="414.166268" y="334.149272" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m111343f80f" x="587.289889" y="327.780982" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m111343f80f" x="610.467187" y="318.981257" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_69">
     <defs>
-     <path id="m82612a4688" d="M 0 -2.5 
+     <path id="me85919f9d7" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pc247673945)">
-     <use xlink:href="#m82612a4688" x="75.810937" y="260.629553" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m82612a4688" x="105.634056" y="253.888028" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m82612a4688" x="204.490635" y="301.454063" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m82612a4688" x="234.479899" y="296.198152" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m82612a4688" x="242.537956" y="306.497434" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m82612a4688" x="300.771958" y="285.157082" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m82612a4688" x="303.26414" y="299.127298" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m82612a4688" x="304.261013" y="312.289143" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m82612a4688" x="313.897453" y="305.55147" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m82612a4688" x="414.166268" y="323.799851" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m82612a4688" x="587.289889" y="327.192921" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m82612a4688" x="610.467187" y="316.49707" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p74e1a3303b)">
+     <use xlink:href="#me85919f9d7" x="75.810937" y="260.629553" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me85919f9d7" x="105.634056" y="253.888028" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me85919f9d7" x="204.490635" y="301.454063" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me85919f9d7" x="234.479899" y="296.198152" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me85919f9d7" x="242.537956" y="306.497434" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me85919f9d7" x="300.771958" y="285.157082" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me85919f9d7" x="303.26414" y="299.127298" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me85919f9d7" x="304.261013" y="312.289143" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me85919f9d7" x="313.897453" y="305.55147" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me85919f9d7" x="414.166268" y="323.799851" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me85919f9d7" x="587.289889" y="327.192921" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me85919f9d7" x="610.467187" y="316.49707" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_70">
     <defs>
-     <path id="m0c54aca1fd" d="M -0 3.535534 
+     <path id="m9d5cee1b73" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pc247673945)">
-     <use xlink:href="#m0c54aca1fd" x="75.810937" y="229.675972" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0c54aca1fd" x="105.634056" y="230.807252" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0c54aca1fd" x="204.490635" y="262.817606" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0c54aca1fd" x="234.479899" y="260.308889" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0c54aca1fd" x="242.537956" y="274.651617" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0c54aca1fd" x="300.771958" y="258.820574" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0c54aca1fd" x="303.26414" y="270.569757" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0c54aca1fd" x="304.261013" y="279.042037" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0c54aca1fd" x="313.897453" y="275.908162" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0c54aca1fd" x="414.166268" y="294.938772" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0c54aca1fd" x="587.289889" y="301.872049" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0c54aca1fd" x="610.467187" y="298.545064" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p74e1a3303b)">
+     <use xlink:href="#m9d5cee1b73" x="75.810937" y="229.675972" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9d5cee1b73" x="105.634056" y="230.807252" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9d5cee1b73" x="204.490635" y="262.817606" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9d5cee1b73" x="234.479899" y="260.308889" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9d5cee1b73" x="242.537956" y="274.651617" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9d5cee1b73" x="300.771958" y="258.820574" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9d5cee1b73" x="303.26414" y="270.569757" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9d5cee1b73" x="304.261013" y="279.042037" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9d5cee1b73" x="313.897453" y="275.908162" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9d5cee1b73" x="414.166268" y="294.938772" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9d5cee1b73" x="587.289889" y="301.872049" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9d5cee1b73" x="610.467187" y="298.545064" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_71">
     <defs>
-     <path id="mfd9dc0e48d" d="M -0.833333 2.5 
+     <path id="m53f2183930" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -1848,24 +1848,24 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pc247673945)">
-     <use xlink:href="#mfd9dc0e48d" x="75.810937" y="286.028664" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfd9dc0e48d" x="105.634056" y="293.887771" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfd9dc0e48d" x="204.490635" y="326.335201" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfd9dc0e48d" x="234.479899" y="337.903307" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfd9dc0e48d" x="242.537956" y="341.092058" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfd9dc0e48d" x="300.771958" y="336.485034" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfd9dc0e48d" x="303.26414" y="344.754119" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfd9dc0e48d" x="304.261013" y="344.606502" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfd9dc0e48d" x="313.897453" y="351.527394" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfd9dc0e48d" x="414.166268" y="363.295034" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfd9dc0e48d" x="587.289889" y="368.159128" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfd9dc0e48d" x="610.467187" y="356.976913" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p74e1a3303b)">
+     <use xlink:href="#m53f2183930" x="75.810937" y="286.028664" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m53f2183930" x="105.634056" y="293.887771" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m53f2183930" x="204.490635" y="326.335201" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m53f2183930" x="234.479899" y="337.903307" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m53f2183930" x="242.537956" y="341.092058" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m53f2183930" x="300.771958" y="336.485034" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m53f2183930" x="303.26414" y="344.754119" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m53f2183930" x="304.261013" y="344.606502" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m53f2183930" x="313.897453" y="351.527394" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m53f2183930" x="414.166268" y="363.295034" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m53f2183930" x="587.289889" y="368.159128" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m53f2183930" x="610.467187" y="356.976913" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_72">
     <defs>
-     <path id="m03541d0757" d="M -1.25 2.5 
+     <path id="mb61db27148" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -1880,24 +1880,24 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pc247673945)">
-     <use xlink:href="#m03541d0757" x="75.810937" y="327.723121" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m03541d0757" x="105.634056" y="342.646685" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m03541d0757" x="204.490635" y="362.850184" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m03541d0757" x="234.479899" y="371.338643" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m03541d0757" x="242.537956" y="367.245927" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m03541d0757" x="300.771958" y="360.026985" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m03541d0757" x="303.26414" y="374.683393" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m03541d0757" x="304.261013" y="357.457726" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m03541d0757" x="313.897453" y="374.58929" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m03541d0757" x="414.166268" y="385.027438" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m03541d0757" x="587.289889" y="394.333029" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m03541d0757" x="610.467187" y="391.249012" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p74e1a3303b)">
+     <use xlink:href="#mb61db27148" x="75.810937" y="327.723121" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb61db27148" x="105.634056" y="342.646685" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb61db27148" x="204.490635" y="362.850184" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb61db27148" x="234.479899" y="371.338643" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb61db27148" x="242.537956" y="367.245927" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb61db27148" x="300.771958" y="360.026985" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb61db27148" x="303.26414" y="374.683393" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb61db27148" x="304.261013" y="357.457726" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb61db27148" x="313.897453" y="374.58929" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb61db27148" x="414.166268" y="385.027438" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb61db27148" x="587.289889" y="394.333029" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb61db27148" x="610.467187" y="391.249012" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_73">
     <defs>
-     <path id="m26d72faad0" d="M 0 -2.5 
+     <path id="m1100545eaf" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -1910,24 +1910,24 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#pc247673945)">
-     <use xlink:href="#m26d72faad0" x="75.810937" y="273.778134" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m26d72faad0" x="105.634056" y="286.227815" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m26d72faad0" x="204.490635" y="319.608779" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m26d72faad0" x="234.479899" y="321.188418" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m26d72faad0" x="242.537956" y="325.921453" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m26d72faad0" x="300.771958" y="333.05015" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m26d72faad0" x="303.26414" y="336.951003" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m26d72faad0" x="304.261013" y="345.759761" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m26d72faad0" x="313.897453" y="336.754653" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m26d72faad0" x="414.166268" y="357.454726" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m26d72faad0" x="587.289889" y="366.280671" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m26d72faad0" x="610.467187" y="360.878702" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p74e1a3303b)">
+     <use xlink:href="#m1100545eaf" x="75.810937" y="273.778134" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m1100545eaf" x="105.634056" y="286.227815" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m1100545eaf" x="204.490635" y="319.608779" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m1100545eaf" x="234.479899" y="321.188418" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m1100545eaf" x="242.537956" y="325.921453" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m1100545eaf" x="300.771958" y="333.05015" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m1100545eaf" x="303.26414" y="336.951003" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m1100545eaf" x="304.261013" y="345.759761" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m1100545eaf" x="313.897453" y="336.754653" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m1100545eaf" x="414.166268" y="357.454726" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m1100545eaf" x="587.289889" y="366.280671" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m1100545eaf" x="610.467187" y="360.878702" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_74">
     <defs>
-     <path id="mf653614d22" d="M 0 -2.5 
+     <path id="mf573266066" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -1936,19 +1936,19 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pc247673945)">
-     <use xlink:href="#mf653614d22" x="75.810937" y="347.176172" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf653614d22" x="105.634056" y="348.704001" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf653614d22" x="204.490635" y="367.31757" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf653614d22" x="234.479899" y="373.033423" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf653614d22" x="242.537956" y="380.00037" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf653614d22" x="300.771958" y="370.53122" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf653614d22" x="303.26414" y="375.375651" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf653614d22" x="304.261013" y="383.030012" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf653614d22" x="313.897453" y="385.215351" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf653614d22" x="414.166268" y="391.648192" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf653614d22" x="587.289889" y="396.192102" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf653614d22" x="610.467187" y="383.710333" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p74e1a3303b)">
+     <use xlink:href="#mf573266066" x="75.810937" y="347.176172" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf573266066" x="105.634056" y="348.704001" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf573266066" x="204.490635" y="367.31757" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf573266066" x="234.479899" y="373.033423" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf573266066" x="242.537956" y="380.00037" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf573266066" x="300.771958" y="370.53122" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf573266066" x="303.26414" y="375.375651" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf573266066" x="304.261013" y="383.030012" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf573266066" x="313.897453" y="385.215351" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf573266066" x="414.166268" y="391.648192" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf573266066" x="587.289889" y="396.192102" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf573266066" x="610.467187" y="383.710333" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="legend_1">
@@ -1967,7 +1967,7 @@ z
     </g>
     <g id="line2d_75">
      <defs>
-      <path id="m8d89c5c5f1" d="M 0 3.5 
+      <path id="m439afb6d8e" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -1980,7 +1980,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m8d89c5c5f1" x="434.04625" y="211.758125" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m439afb6d8e" x="434.04625" y="211.758125" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_15">
@@ -2039,7 +2039,7 @@ z
     </g>
     <g id="line2d_76">
      <g>
-      <use xlink:href="#m13b3c49756" x="434.04625" y="223.500625" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m111343f80f" x="434.04625" y="223.500625" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_16">
@@ -2053,7 +2053,7 @@ z
     </g>
     <g id="line2d_77">
      <g>
-      <use xlink:href="#m82612a4688" x="434.04625" y="235.243125" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#me85919f9d7" x="434.04625" y="235.243125" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -2098,7 +2098,7 @@ z
     </g>
     <g id="line2d_78">
      <g>
-      <use xlink:href="#m0c54aca1fd" x="434.04625" y="247.208125" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m9d5cee1b73" x="434.04625" y="247.208125" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -2118,7 +2118,7 @@ z
     </g>
     <g id="line2d_79">
      <g>
-      <use xlink:href="#mfd9dc0e48d" x="537.72375" y="211.758125" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m53f2183930" x="537.72375" y="211.758125" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -2145,7 +2145,7 @@ z
     </g>
     <g id="line2d_80">
      <g>
-      <use xlink:href="#m03541d0757" x="537.72375" y="223.500625" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mb61db27148" x="537.72375" y="223.500625" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -2210,7 +2210,7 @@ z
     </g>
     <g id="line2d_81">
      <g>
-      <use xlink:href="#m26d72faad0" x="537.72375" y="235.243125" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#m1100545eaf" x="537.72375" y="235.243125" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_21">
@@ -2248,7 +2248,7 @@ z
     </g>
     <g id="line2d_82">
      <g>
-      <use xlink:href="#mf653614d22" x="537.72375" y="246.985625" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mf573266066" x="537.72375" y="246.985625" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -2318,19 +2318,19 @@ z
     </g>
    </g>
    <g id="line2d_83">
-    <g clip-path="url(#pc247673945)">
-     <use xlink:href="#m8d89c5c5f1" x="75.810937" y="272.143954" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m8d89c5c5f1" x="105.634056" y="288.399073" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m8d89c5c5f1" x="204.490635" y="322.103822" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m8d89c5c5f1" x="234.479899" y="324.29343" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m8d89c5c5f1" x="242.537956" y="324.418753" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m8d89c5c5f1" x="300.771958" y="312.453798" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m8d89c5c5f1" x="303.26414" y="333.249253" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m8d89c5c5f1" x="304.261013" y="351.748791" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m8d89c5c5f1" x="313.897453" y="337.048403" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m8d89c5c5f1" x="414.166268" y="356.441315" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m8d89c5c5f1" x="587.289889" y="359.296601" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m8d89c5c5f1" x="610.467187" y="343.193293" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <g clip-path="url(#p74e1a3303b)">
+     <use xlink:href="#m439afb6d8e" x="75.810937" y="272.143954" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m439afb6d8e" x="105.634056" y="288.399073" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m439afb6d8e" x="204.490635" y="322.103822" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m439afb6d8e" x="234.479899" y="324.29343" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m439afb6d8e" x="242.537956" y="324.418753" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m439afb6d8e" x="300.771958" y="312.453798" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m439afb6d8e" x="303.26414" y="333.249253" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m439afb6d8e" x="304.261013" y="351.748791" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m439afb6d8e" x="313.897453" y="337.048403" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m439afb6d8e" x="414.166268" y="356.441315" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m439afb6d8e" x="587.289889" y="359.296601" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m439afb6d8e" x="610.467187" y="343.193293" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
   </g>
@@ -3154,7 +3154,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="pc247673945">
+  <clipPath id="p74e1a3303b">
    <rect x="49.078125" y="47.3475" width="588.121875" height="365.45625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_decode_ranking.svg
+++ b/bench/graphs/silesia_decode_ranking.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 292.269187 308.04375 
 L 292.269187 56.7075 
-" clip-path="url(#pf794edbc1e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe2f80bcf71)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m8b94943077" d="M 0 0 
+       <path id="m2f581f6f22" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m8b94943077" x="292.269187" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2f581f6f22" x="292.269187" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -136,11 +136,11 @@ z
      <g id="line2d_3">
       <path d="M 449.991563 308.04375 
 L 449.991563 56.7075 
-" clip-path="url(#pf794edbc1e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe2f80bcf71)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m8b94943077" x="449.991563" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2f581f6f22" x="449.991563" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -177,16 +177,16 @@ z
      <g id="line2d_5">
       <path d="M 182.025977 308.04375 
 L 182.025977 56.7075 
-" clip-path="url(#pf794edbc1e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe2f80bcf71)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <defs>
-       <path id="m3dbbaa9b54" d="M 0 0 
+       <path id="mcda166c4cf" d="M 0 0 
 L 0 2 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m3dbbaa9b54" x="182.025977" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mcda166c4cf" x="182.025977" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -194,11 +194,11 @@ L 0 2
      <g id="line2d_7">
       <path d="M 209.799509 308.04375 
 L 209.799509 56.7075 
-" clip-path="url(#pf794edbc1e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe2f80bcf71)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m3dbbaa9b54" x="209.799509" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mcda166c4cf" x="209.799509" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -206,11 +206,11 @@ L 209.799509 56.7075
      <g id="line2d_9">
       <path d="M 229.505143 308.04375 
 L 229.505143 56.7075 
-" clip-path="url(#pf794edbc1e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe2f80bcf71)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m3dbbaa9b54" x="229.505143" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mcda166c4cf" x="229.505143" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -218,11 +218,11 @@ L 229.505143 56.7075
      <g id="line2d_11">
       <path d="M 244.790021 308.04375 
 L 244.790021 56.7075 
-" clip-path="url(#pf794edbc1e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe2f80bcf71)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m3dbbaa9b54" x="244.790021" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mcda166c4cf" x="244.790021" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -230,11 +230,11 @@ L 244.790021 56.7075
      <g id="line2d_13">
       <path d="M 257.278675 308.04375 
 L 257.278675 56.7075 
-" clip-path="url(#pf794edbc1e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe2f80bcf71)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m3dbbaa9b54" x="257.278675" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mcda166c4cf" x="257.278675" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -242,11 +242,11 @@ L 257.278675 56.7075
      <g id="line2d_15">
       <path d="M 267.837682 308.04375 
 L 267.837682 56.7075 
-" clip-path="url(#pf794edbc1e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe2f80bcf71)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m3dbbaa9b54" x="267.837682" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mcda166c4cf" x="267.837682" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -254,11 +254,11 @@ L 267.837682 56.7075
      <g id="line2d_17">
       <path d="M 276.984309 308.04375 
 L 276.984309 56.7075 
-" clip-path="url(#pf794edbc1e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe2f80bcf71)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m3dbbaa9b54" x="276.984309" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mcda166c4cf" x="276.984309" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -266,11 +266,11 @@ L 276.984309 56.7075
      <g id="line2d_19">
       <path d="M 285.052207 308.04375 
 L 285.052207 56.7075 
-" clip-path="url(#pf794edbc1e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe2f80bcf71)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m3dbbaa9b54" x="285.052207" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mcda166c4cf" x="285.052207" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -278,11 +278,11 @@ L 285.052207 56.7075
      <g id="line2d_21">
       <path d="M 339.748353 308.04375 
 L 339.748353 56.7075 
-" clip-path="url(#pf794edbc1e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe2f80bcf71)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m3dbbaa9b54" x="339.748353" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mcda166c4cf" x="339.748353" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -290,11 +290,11 @@ L 339.748353 56.7075
      <g id="line2d_23">
       <path d="M 367.521885 308.04375 
 L 367.521885 56.7075 
-" clip-path="url(#pf794edbc1e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe2f80bcf71)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m3dbbaa9b54" x="367.521885" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mcda166c4cf" x="367.521885" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -302,11 +302,11 @@ L 367.521885 56.7075
      <g id="line2d_25">
       <path d="M 387.227519 308.04375 
 L 387.227519 56.7075 
-" clip-path="url(#pf794edbc1e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe2f80bcf71)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m3dbbaa9b54" x="387.227519" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mcda166c4cf" x="387.227519" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -314,11 +314,11 @@ L 387.227519 56.7075
      <g id="line2d_27">
       <path d="M 402.512397 308.04375 
 L 402.512397 56.7075 
-" clip-path="url(#pf794edbc1e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe2f80bcf71)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m3dbbaa9b54" x="402.512397" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mcda166c4cf" x="402.512397" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -326,11 +326,11 @@ L 402.512397 56.7075
      <g id="line2d_29">
       <path d="M 415.001051 308.04375 
 L 415.001051 56.7075 
-" clip-path="url(#pf794edbc1e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe2f80bcf71)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m3dbbaa9b54" x="415.001051" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mcda166c4cf" x="415.001051" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -338,11 +338,11 @@ L 415.001051 56.7075
      <g id="line2d_31">
       <path d="M 425.560057 308.04375 
 L 425.560057 56.7075 
-" clip-path="url(#pf794edbc1e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe2f80bcf71)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m3dbbaa9b54" x="425.560057" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mcda166c4cf" x="425.560057" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -350,11 +350,11 @@ L 425.560057 56.7075
      <g id="line2d_33">
       <path d="M 434.706685 308.04375 
 L 434.706685 56.7075 
-" clip-path="url(#pf794edbc1e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe2f80bcf71)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m3dbbaa9b54" x="434.706685" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mcda166c4cf" x="434.706685" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -362,11 +362,11 @@ L 434.706685 56.7075
      <g id="line2d_35">
       <path d="M 442.774583 308.04375 
 L 442.774583 56.7075 
-" clip-path="url(#pf794edbc1e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe2f80bcf71)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m3dbbaa9b54" x="442.774583" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mcda166c4cf" x="442.774583" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -374,11 +374,11 @@ L 442.774583 56.7075
      <g id="line2d_37">
       <path d="M 497.470729 308.04375 
 L 497.470729 56.7075 
-" clip-path="url(#pf794edbc1e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe2f80bcf71)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m3dbbaa9b54" x="497.470729" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mcda166c4cf" x="497.470729" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -386,11 +386,11 @@ L 497.470729 56.7075
      <g id="line2d_39">
       <path d="M 525.24426 308.04375 
 L 525.24426 56.7075 
-" clip-path="url(#pf794edbc1e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe2f80bcf71)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m3dbbaa9b54" x="525.24426" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mcda166c4cf" x="525.24426" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -398,11 +398,11 @@ L 525.24426 56.7075
      <g id="line2d_41">
       <path d="M 544.949895 308.04375 
 L 544.949895 56.7075 
-" clip-path="url(#pf794edbc1e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe2f80bcf71)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m3dbbaa9b54" x="544.949895" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mcda166c4cf" x="544.949895" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -410,11 +410,11 @@ L 544.949895 56.7075
      <g id="line2d_43">
       <path d="M 560.234772 308.04375 
 L 560.234772 56.7075 
-" clip-path="url(#pf794edbc1e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe2f80bcf71)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m3dbbaa9b54" x="560.234772" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mcda166c4cf" x="560.234772" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1016,12 +1016,12 @@ z
     <g id="ytick_1">
      <g id="line2d_45">
       <defs>
-       <path id="m0e2ebd563b" d="M 0 0 
+       <path id="md27d4d5f07" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m0e2ebd563b" x="139.360469" y="296.619375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md27d4d5f07" x="139.360469" y="296.619375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -1093,7 +1093,7 @@ z
     <g id="ytick_2">
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m0e2ebd563b" x="139.360469" y="263.978304" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md27d4d5f07" x="139.360469" y="263.978304" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -1160,7 +1160,7 @@ z
     <g id="ytick_3">
      <g id="line2d_47">
       <g>
-       <use xlink:href="#m0e2ebd563b" x="139.360469" y="231.337232" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md27d4d5f07" x="139.360469" y="231.337232" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -1216,7 +1216,7 @@ z
     <g id="ytick_4">
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m0e2ebd563b" x="139.360469" y="198.696161" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md27d4d5f07" x="139.360469" y="198.696161" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -1263,7 +1263,7 @@ z
     <g id="ytick_5">
      <g id="line2d_49">
       <g>
-       <use xlink:href="#m0e2ebd563b" x="139.360469" y="166.055089" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md27d4d5f07" x="139.360469" y="166.055089" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -1376,7 +1376,7 @@ z
     <g id="ytick_6">
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m0e2ebd563b" x="139.360469" y="133.414018" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md27d4d5f07" x="139.360469" y="133.414018" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -1392,7 +1392,7 @@ z
     <g id="ytick_7">
      <g id="line2d_51">
       <g>
-       <use xlink:href="#m0e2ebd563b" x="139.360469" y="100.772946" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md27d4d5f07" x="139.360469" y="100.772946" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -1439,7 +1439,7 @@ z
     <g id="ytick_8">
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m0e2ebd563b" x="139.360469" y="68.131875" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md27d4d5f07" x="139.360469" y="68.131875" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -1462,47 +1462,47 @@ z
    <g id="LineCollection_1">
     <path d="M 139.360469 296.619375 
 L 154.645346 296.619375 
-" clip-path="url(#pf794edbc1e)" style="fill: none; stroke: #17becf; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#pe2f80bcf71)" style="fill: none; stroke: #17becf; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_2">
     <path d="M 139.360469 263.978304 
 L 161.142927 263.978304 
-" clip-path="url(#pf794edbc1e)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#pe2f80bcf71)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_3">
     <path d="M 139.360469 231.337232 
 L 200.65327 231.337232 
-" clip-path="url(#pf794edbc1e)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#pe2f80bcf71)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_4">
     <path d="M 139.360469 198.696161 
 L 208.426981 198.696161 
-" clip-path="url(#pf794edbc1e)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#pe2f80bcf71)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_5">
     <path d="M 139.360469 166.055089 
 L 212.673671 166.055089 
-" clip-path="url(#pf794edbc1e)" style="fill: none; stroke: #d62728; stroke-opacity: 0.9; stroke-width: 2.4"/>
+" clip-path="url(#pe2f80bcf71)" style="fill: none; stroke: #d62728; stroke-opacity: 0.9; stroke-width: 2.4"/>
    </g>
    <g id="LineCollection_6">
     <path d="M 139.360469 133.414018 
 L 239.878265 133.414018 
-" clip-path="url(#pf794edbc1e)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#pe2f80bcf71)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_7">
     <path d="M 139.360469 100.772946 
 L 248.943982 100.772946 
-" clip-path="url(#pf794edbc1e)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#pe2f80bcf71)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_8">
     <path d="M 139.360469 68.131875 
 L 284.774562 68.131875 
-" clip-path="url(#pf794edbc1e)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#pe2f80bcf71)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="line2d_53">
     <path d="M 542.152339 308.04375 
 L 542.152339 56.7075 
-" clip-path="url(#pf794edbc1e)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
+" clip-path="url(#pe2f80bcf71)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
    </g>
    <g id="patch_3">
     <path d="M 139.360469 308.04375 
@@ -1888,7 +1888,7 @@ z
    </g>
    <g id="line2d_54">
     <defs>
-     <path id="ma95fb566a0" d="M 0 3 
+     <path id="mfc337bc62c" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1900,13 +1900,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #17becf"/>
     </defs>
-    <g clip-path="url(#pf794edbc1e)">
-     <use xlink:href="#ma95fb566a0" x="154.645346" y="296.619375" style="fill: #17becf; stroke: #17becf"/>
+    <g clip-path="url(#pe2f80bcf71)">
+     <use xlink:href="#mfc337bc62c" x="154.645346" y="296.619375" style="fill: #17becf; stroke: #17becf"/>
     </g>
    </g>
    <g id="line2d_55">
     <defs>
-     <path id="mb636c73521" d="M 0 3 
+     <path id="m3041c60d46" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1918,13 +1918,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #e377c2"/>
     </defs>
-    <g clip-path="url(#pf794edbc1e)">
-     <use xlink:href="#mb636c73521" x="161.142927" y="263.978304" style="fill: #e377c2; stroke: #e377c2"/>
+    <g clip-path="url(#pe2f80bcf71)">
+     <use xlink:href="#m3041c60d46" x="161.142927" y="263.978304" style="fill: #e377c2; stroke: #e377c2"/>
     </g>
    </g>
    <g id="line2d_56">
     <defs>
-     <path id="m36e487e295" d="M 0 3 
+     <path id="m7fa0b158de" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1936,13 +1936,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #8c564b"/>
     </defs>
-    <g clip-path="url(#pf794edbc1e)">
-     <use xlink:href="#m36e487e295" x="200.65327" y="231.337232" style="fill: #8c564b; stroke: #8c564b"/>
+    <g clip-path="url(#pe2f80bcf71)">
+     <use xlink:href="#m7fa0b158de" x="200.65327" y="231.337232" style="fill: #8c564b; stroke: #8c564b"/>
     </g>
    </g>
    <g id="line2d_57">
     <defs>
-     <path id="m354b75e604" d="M 0 3 
+     <path id="m921519ae90" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1954,13 +1954,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #bcbd22"/>
     </defs>
-    <g clip-path="url(#pf794edbc1e)">
-     <use xlink:href="#m354b75e604" x="208.426981" y="198.696161" style="fill: #bcbd22; stroke: #bcbd22"/>
+    <g clip-path="url(#pe2f80bcf71)">
+     <use xlink:href="#m921519ae90" x="208.426981" y="198.696161" style="fill: #bcbd22; stroke: #bcbd22"/>
     </g>
    </g>
    <g id="line2d_58">
     <defs>
-     <path id="m417978cbe7" d="M 0 5 
+     <path id="mba3e866370" d="M 0 5 
 C 1.326016 5 2.597899 4.473168 3.535534 3.535534 
 C 4.473168 2.597899 5 1.326016 5 0 
 C 5 -1.326016 4.473168 -2.597899 3.535534 -3.535534 
@@ -1972,13 +1972,13 @@ C -2.597899 4.473168 -1.326016 5 0 5
 z
 " style="stroke: #d62728"/>
     </defs>
-    <g clip-path="url(#pf794edbc1e)">
-     <use xlink:href="#m417978cbe7" x="212.673671" y="166.055089" style="fill: #d62728; stroke: #d62728"/>
+    <g clip-path="url(#pe2f80bcf71)">
+     <use xlink:href="#mba3e866370" x="212.673671" y="166.055089" style="fill: #d62728; stroke: #d62728"/>
     </g>
    </g>
    <g id="line2d_59">
     <defs>
-     <path id="m856784679e" d="M 0 3 
+     <path id="m8ae57a6488" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1990,13 +1990,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #1f77b4"/>
     </defs>
-    <g clip-path="url(#pf794edbc1e)">
-     <use xlink:href="#m856784679e" x="239.878265" y="133.414018" style="fill: #1f77b4; stroke: #1f77b4"/>
+    <g clip-path="url(#pe2f80bcf71)">
+     <use xlink:href="#m8ae57a6488" x="239.878265" y="133.414018" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_60">
     <defs>
-     <path id="mb3fe1fe665" d="M 0 3 
+     <path id="m722586ba8b" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -2008,13 +2008,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #2ca02c"/>
     </defs>
-    <g clip-path="url(#pf794edbc1e)">
-     <use xlink:href="#mb3fe1fe665" x="248.943982" y="100.772946" style="fill: #2ca02c; stroke: #2ca02c"/>
+    <g clip-path="url(#pe2f80bcf71)">
+     <use xlink:href="#m722586ba8b" x="248.943982" y="100.772946" style="fill: #2ca02c; stroke: #2ca02c"/>
     </g>
    </g>
    <g id="line2d_61">
     <defs>
-     <path id="m3a03e0623e" d="M 0 3 
+     <path id="m77d75128cb" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -2026,8 +2026,8 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #9467bd"/>
     </defs>
-    <g clip-path="url(#pf794edbc1e)">
-     <use xlink:href="#m3a03e0623e" x="284.774562" y="68.131875" style="fill: #9467bd; stroke: #9467bd"/>
+    <g clip-path="url(#pe2f80bcf71)">
+     <use xlink:href="#m77d75128cb" x="284.774562" y="68.131875" style="fill: #9467bd; stroke: #9467bd"/>
     </g>
    </g>
   </g>
@@ -2967,7 +2967,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="pf794edbc1e">
+  <clipPath id="pe2f80bcf71">
    <rect x="139.360469" y="56.7075" width="425.839531" height="251.33625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_ratio_heatmap.svg
+++ b/bench/graphs/silesia_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.34175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#pbbc55f6494)">
+   <g clip-path="url(#p05aa98dd99)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAosAAAGaCAYAAABniAm0AAAJ/klEQVR4nO3Yu45eVx2H4ZnM+IDHmbEtSCLCQcJRQAqBEoWCKhWCgmvgCmioqBB3QMUN0KGI0k1KpACBEAogSkIQB1lDjB1jGXs8Mx9X8BYoWvqjT89zBT9pb6397rV7fvsnm50tdPLTW9MTlrjw6svTE5bZfebT0xOW2Lz1u+kJS+x+5aXpCUtsHt6fnrDM8fdfm56wxDM/+tb0hCV2bzw7PWGNk4fTC5Y5/+V2nvdPTQ8AAOD/l1gEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACDt/vvktc30iBUO/nU8PWGJDw+vTE9Y5j+nD6YnLPHZj06mJyzx0aeem56wxPnmfHrCMtf3b0xPWOPOB9MLlrh/fTuf19N//tP0hGU2L35tesISbhYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEj7B3duT29Y48q16QVLbDYn0xOW+czrv56esMar35xesMTRh/+YnrDG+en0gnUOtvT8uHR1esESh//czu/z3c/fnJ6wzPW/vj09YQk3iwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEDafXJ2azM9YoW94/enJyxx++mL0xOWefDk3vSEJW7+5d70hCVOv/z16QlLPDy9Pz1hmaO9a9MTlti896vpCUs8+sLL0xOWuPz2G9MTlnn81VemJyzhZhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIuz9/73ub6REr3Lh8MD1hiXfu3ZmesMx3f/yb6QlL/PaH356esMTRpaPpCUv84BdvTk9Y5hvPX56esMR3br4yPWGJ1//2xvSEJa5e2M73cGdnZ+dn796dnrCEm0UAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAg7T45u7WZHrHC3cfH0xOWONg/nJ6wzDv3fj89YYkXrr00PWGJzeZ8esISV0+39x/67+fbeS4+f/DC9IQlHp09nJ6wxLaeHTs7Ozt7T+1PT1hie09FAAA+NrEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAApP293f3pDUt8cu/G9IQ19i5OL1jm6NLR9IQlDvYPpycscbY5nZ6wxPmF7f2Hfm5zZXoC/4Nt/T6fbB5NT1jm/uPj6QlLbO+pCADAxyYWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBI+4/OHk5vWOLy7v70hCU+ePDH6QnLnJ6fTE9Y4/jd6QVL3D86nJ6wxOHFG9MTljk5ezQ9YYlP3H5/esISj5/93PSEJQ7+8Nb0hGUef/FL0xOWcLMIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAApP8Cc6OciHDVLsgAAAAASUVORK5CYII=" id="image06c67b48f9" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="468.72" height="295.2"/>
+iVBORw0KGgoAAAANSUhEUgAAAosAAAGaCAYAAABniAm0AAAJ/klEQVR4nO3Yu45eVx2H4ZnM+IDHmbEtSCLCQcJRQAqBEoWCKhWCgmvgCmioqBB3QMUN0KGI0k1KpACBEAogSkIQB1lDjB1jGXs8Mx9X8BYoWvqjT89zBT9pb6397rV7fvsnm50tdPLTW9MTlrjw6svTE5bZfebT0xOW2Lz1u+kJS+x+5aXpCUtsHt6fnrDM8fdfm56wxDM/+tb0hCV2bzw7PWGNk4fTC5Y5/+V2nvdPTQ8AAOD/l1gEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACDt/vvktc30iBUO/nU8PWGJDw+vTE9Y5j+nD6YnLPHZj06mJyzx0aeem56wxPnmfHrCMtf3b0xPWOPOB9MLlrh/fTuf19N//tP0hGU2L35tesISbhYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEj7B3duT29Y48q16QVLbDYn0xOW+czrv56esMar35xesMTRh/+YnrDG+en0gnUOtvT8uHR1esESh//czu/z3c/fnJ6wzPW/vj09YQk3iwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEDafXJ2azM9YoW94/enJyxx++mL0xOWefDk3vSEJW7+5d70hCVOv/z16QlLPDy9Pz1hmaO9a9MTlti896vpCUs8+sLL0xOWuPz2G9MTlnn81VemJyzhZhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIuz9/73ub6REr3Lh8MD1hiXfu3ZmesMx3f/yb6QlL/PaH356esMTRpaPpCUv84BdvTk9Y5hvPX56esMR3br4yPWGJ1//2xvSEJa5e2M73cGdnZ+dn796dnrCEm0UAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAg7T45u7WZHrHC3cfH0xOWONg/nJ6wzDv3fj89YYkXrr00PWGJzeZ8esISV0+39x/67+fbeS4+f/DC9IQlHp09nJ6wxLaeHTs7Ozt7T+1PT1hie09FAAA+NrEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAApP293f3pDUt8cu/G9IQ19i5OL1jm6NLR9IQlDvYPpycscbY5nZ6wxPmF7f2Hfm5zZXoC/4Nt/T6fbB5NT1jm/uPj6QlLbO+pCADAxyYWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBI+4/OHk5vWOLy7v70hCU+ePDH6QnLnJ6fTE9Y4/jd6QVL3D86nJ6wxOHFG9MTljk5ezQ9YYlP3H5/esISj5/93PSEJQ7+8Nb0hGUef/FL0xOWcLMIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAApP8Cc6OciHDVLsgAAAAASUVORK5CYII=" id="imagea2b04bf5f3" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="468.72" height="295.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m0fb8f66542" d="M 0 0 
+       <path id="ma885b7056f" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m0fb8f66542" x="115.182137" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma885b7056f" x="115.182137" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m0fb8f66542" x="154.193912" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma885b7056f" x="154.193912" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m0fb8f66542" x="193.205687" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma885b7056f" x="193.205687" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m0fb8f66542" x="232.217462" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma885b7056f" x="232.217462" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m0fb8f66542" x="271.229237" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma885b7056f" x="271.229237" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m0fb8f66542" x="310.241012" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma885b7056f" x="310.241012" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m0fb8f66542" x="349.252787" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma885b7056f" x="349.252787" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m0fb8f66542" x="388.264562" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma885b7056f" x="388.264562" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m0fb8f66542" x="427.276336" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma885b7056f" x="427.276336" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m0fb8f66542" x="466.288111" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma885b7056f" x="466.288111" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m0fb8f66542" x="505.299886" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma885b7056f" x="505.299886" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m0fb8f66542" x="544.311661" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma885b7056f" x="544.311661" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="m01af5769d8" d="M 0 0 
+       <path id="mbad40e8655" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m01af5769d8" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbad40e8655" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m01af5769d8" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbad40e8655" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m01af5769d8" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbad40e8655" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m01af5769d8" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbad40e8655" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -836,7 +836,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m01af5769d8" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbad40e8655" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -899,7 +899,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m01af5769d8" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbad40e8655" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -966,7 +966,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m01af5769d8" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbad40e8655" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1047,7 +1047,7 @@ z
     <g id="ytick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m01af5769d8" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbad40e8655" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -2060,18 +2060,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABEAAAFUCAYAAADCj9eRAAAB2ElEQVR4nO2aQY7EIAwEIeFP+6X9/33C3MPcKKSS1TygZRftNlLS2//fbJtn9KvvajAi17ZCM7Uzeg+TEyJhsh4TE8D25ZhYRMJkPSYmmZ0zIhfQEMPkJq74JpgQlUBMABkIrOV2KLMRItXMhrQjqcQUSszsbGuomFSbHULEAlblE0klor1zMaG0XwnDBDAsBVY0O4CIBizlE4ntEbCijK3mE8vKUPkEEIF8YslYje2RZFP5BJkdCxOonf1i6jEhRICOyjEBzFaPiWd2iChoYbKKhMkqgmSsh4kkHkU+6UyeACJEJaLZ6QQTzy7WtGPyicX2Kp/c+yKaATTliSWoTXsnPllEEtTLGX37f+7WRpuPQ4RhomlntCdMTohATIDbKceEaGfOD1BJZueIiImJZQBNTCxgw2Q91N7Zf7RBsxMmR0TqMdmvxPRmI0TmDJNVJExWkTBZRcJkFSnFZH6Q5aVhQrQzkYUOVEIxIXxSjAnRDjQ7mndsZud9VEwsPtFcsWjvaNZofHKoEpFPELCPJmORdqblMWxiYjEbw+QJk/dR+SQD+BbROFbEJAP4Q4RgQpiNCupKIhAT4gewakws7YTJIREoY4FPeNWYaNoJk18iQNqXY1LKJ1/07Ct/l+QCQgAAAABJRU5ErkJggg==" id="imagefd9c7c52de" transform="scale(1 -1) translate(0 -244.8)" x="573.84" y="-74.16" width="12.24" height="244.8"/>
+iVBORw0KGgoAAAANSUhEUgAAABEAAAFUCAYAAADCj9eRAAAB2ElEQVR4nO2aQY7EIAwEIeFP+6X9/33C3MPcKKSS1TygZRftNlLS2//fbJtn9KvvajAi17ZCM7Uzeg+TEyJhsh4TE8D25ZhYRMJkPSYmmZ0zIhfQEMPkJq74JpgQlUBMABkIrOV2KLMRItXMhrQjqcQUSszsbGuomFSbHULEAlblE0klor1zMaG0XwnDBDAsBVY0O4CIBizlE4ntEbCijK3mE8vKUPkEEIF8YslYje2RZFP5BJkdCxOonf1i6jEhRICOyjEBzFaPiWd2iChoYbKKhMkqgmSsh4kkHkU+6UyeACJEJaLZ6QQTzy7WtGPyicX2Kp/c+yKaATTliSWoTXsnPllEEtTLGX37f+7WRpuPQ4RhomlntCdMTohATIDbKceEaGfOD1BJZueIiImJZQBNTCxgw2Q91N7Zf7RBsxMmR0TqMdmvxPRmI0TmDJNVJExWkTBZRcJkFSnFZH6Q5aVhQrQzkYUOVEIxIXxSjAnRDjQ7mndsZud9VEwsPtFcsWjvaNZofHKoEpFPELCPJmORdqblMWxiYjEbw+QJk/dR+SQD+BbROFbEJAP4Q4RgQpiNCupKIhAT4gewakws7YTJIREoY4FPeNWYaNoJk18iQNqXY1LKJ1/07Ct/l+QCQgAAAABJRU5ErkJggg==" id="image54096a7caf" transform="scale(1 -1) translate(0 -244.8)" x="573.84" y="-74.16" width="12.24" height="244.8"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_21">
       <defs>
-       <path id="md1da1329d5" d="M 0 0 
+       <path id="m831af795b8" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#md1da1329d5" x="585.876562" y="282.022672" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m831af795b8" x="585.876562" y="282.022672" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_117">
@@ -2097,7 +2097,7 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#md1da1329d5" x="585.876562" y="239.353777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m831af795b8" x="585.876562" y="239.353777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_118">
@@ -2114,7 +2114,7 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#md1da1329d5" x="585.876562" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m831af795b8" x="585.876562" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_119">
@@ -2130,7 +2130,7 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#md1da1329d5" x="585.876562" y="154.015985" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m831af795b8" x="585.876562" y="154.015985" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_120">
@@ -2146,7 +2146,7 @@ z
     <g id="ytick_13">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#md1da1329d5" x="585.876562" y="111.347089" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m831af795b8" x="585.876562" y="111.347089" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_121">
@@ -2739,8 +2739,8 @@ z
    </g>
   </g>
   <g id="text_124">
-   <!-- 2026-07-08T15:47:33Z  ·  Linux chungus2 x86_64  ·  commit f2026e66  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(44.448437 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-08T20:00:36Z  ·  Linux chungus2 x86_64  ·  commit 29539fd5  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(44.380078 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -2870,14 +2870,14 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-38" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
     <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2917,109 +2917,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3107.080078 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3170.703125 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3234.326172 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3297.949219 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3361.572266 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3423.095703 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3486.71875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3550.341797 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3582.128906 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3613.916016 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3645.703125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3677.490234 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3709.277344 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3737.060547 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3798.583984 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3859.863281 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3923.242188 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3986.71875 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4025.582031 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4086.763672 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4145.943359 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4207.466797 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4248.580078 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4282.271484 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4310.054688 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4371.578125 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4432.857422 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4496.236328 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4559.859375 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4593.550781 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4652.730469 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4716.353516 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4748.140625 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4811.763672 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4875.386719 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4907.173828 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4970.796875 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5006.880859 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5045.744141 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5100.724609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5164.347656 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5196.134766 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5227.921875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5259.708984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5291.496094 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5323.283203 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5362.492188 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5425.871094 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5464.734375 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5525.916016 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5589.294922 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5652.771484 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5716.150391 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5779.626953 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5843.005859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5882.214844 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5914.001953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5997.791016 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6029.578125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6126.990234 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6188.513672 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6251.990234 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6279.773438 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6341.052734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6404.431641 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6436.21875 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6488.318359 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6551.697266 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6612.976562 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6676.453125 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6728.552734 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6791.931641 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6853.113281 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6892.322266 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6926.013672 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6957.800781 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6998.914062 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7060.193359 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7099.402344 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7127.185547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7188.367188 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7220.154297 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7247.9375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7300.037109 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7331.824219 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7395.300781 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7456.824219 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7496.033203 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7557.556641 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7596.919922 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7694.332031 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7722.115234 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7785.494141 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7813.277344 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7865.376953 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7904.585938 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7932.369141 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3262.744141 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3326.367188 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3389.990234 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3425.195312 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3488.671875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3552.294922 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3584.082031 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3615.869141 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3647.65625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3679.443359 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3711.230469 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3739.013672 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3800.537109 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3861.816406 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3925.195312 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3988.671875 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4027.535156 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4088.716797 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4147.896484 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4209.419922 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4250.533203 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4284.224609 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4312.007812 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4373.53125 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4434.810547 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4498.189453 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4561.8125 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4595.503906 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4654.683594 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4718.306641 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4750.09375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4813.716797 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4877.339844 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4909.126953 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4972.75 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5008.833984 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5047.697266 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5102.677734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5166.300781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5198.087891 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5229.875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5261.662109 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5293.449219 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5325.236328 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5364.445312 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5427.824219 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5466.6875 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5527.869141 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5591.248047 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5654.724609 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5718.103516 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5781.580078 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5844.958984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5884.167969 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5915.955078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5999.744141 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6031.53125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6128.943359 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6190.466797 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6253.943359 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6281.726562 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6343.005859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6406.384766 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6438.171875 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6490.271484 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6553.650391 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6614.929688 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6678.40625 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6730.505859 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6793.884766 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6855.066406 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6894.275391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6927.966797 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6959.753906 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7000.867188 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7062.146484 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7101.355469 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7129.138672 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7190.320312 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7222.107422 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7249.890625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7301.990234 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7333.777344 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7397.253906 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7458.777344 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7497.986328 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7559.509766 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7598.873047 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7696.285156 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7724.068359 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7787.447266 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7815.230469 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7867.330078 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7906.539062 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7934.322266 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pbbc55f6494">
+  <clipPath id="p05aa98dd99">
    <rect x="95.67625" y="49.34175" width="468.141298" height="294.686261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_summary.svg
+++ b/bench/graphs/silesia_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="573.503125pt" height="386.202469pt" viewBox="0 0 573.503125 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="573.639844pt" height="386.202469pt" viewBox="0 0 573.639844 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,232 +22,232 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 386.202469 
-L 573.503125 386.202469 
-L 573.503125 0 
+L 573.639844 386.202469 
+L 573.639844 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 188.876563 104.1264 
-L 293.501563 104.1264 
-L 293.501563 74.7432 
-L 188.876563 74.7432 
+    <path d="M 188.944922 104.1264 
+L 293.569922 104.1264 
+L 293.569922 74.7432 
+L 188.944922 74.7432 
 z
-" clip-path="url(#p31c24e8678)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p735a86a554)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 293.501563 104.1264 
-L 398.126563 104.1264 
-L 398.126563 74.7432 
-L 293.501563 74.7432 
+    <path d="M 293.569922 104.1264 
+L 398.194922 104.1264 
+L 398.194922 74.7432 
+L 293.569922 74.7432 
 z
-" clip-path="url(#p31c24e8678)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p735a86a554)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 398.126563 104.1264 
-L 502.751563 104.1264 
-L 502.751563 74.7432 
-L 398.126563 74.7432 
+    <path d="M 398.194922 104.1264 
+L 502.819922 104.1264 
+L 502.819922 74.7432 
+L 398.194922 74.7432 
 z
-" clip-path="url(#p31c24e8678)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p735a86a554)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 188.876563 133.5096 
-L 293.501563 133.5096 
-L 293.501563 104.1264 
-L 188.876563 104.1264 
+    <path d="M 188.944922 133.5096 
+L 293.569922 133.5096 
+L 293.569922 104.1264 
+L 188.944922 104.1264 
 z
-" clip-path="url(#p31c24e8678)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p735a86a554)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 293.501563 133.5096 
-L 398.126563 133.5096 
-L 398.126563 104.1264 
-L 293.501563 104.1264 
+    <path d="M 293.569922 133.5096 
+L 398.194922 133.5096 
+L 398.194922 104.1264 
+L 293.569922 104.1264 
 z
-" clip-path="url(#p31c24e8678)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p735a86a554)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 398.126563 133.5096 
-L 502.751563 133.5096 
-L 502.751563 104.1264 
-L 398.126563 104.1264 
+    <path d="M 398.194922 133.5096 
+L 502.819922 133.5096 
+L 502.819922 104.1264 
+L 398.194922 104.1264 
 z
-" clip-path="url(#p31c24e8678)" style="fill: #fece7c; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p735a86a554)" style="fill: #fece7c; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 188.876563 162.8928 
-L 293.501563 162.8928 
-L 293.501563 133.5096 
-L 188.876563 133.5096 
+    <path d="M 188.944922 162.8928 
+L 293.569922 162.8928 
+L 293.569922 133.5096 
+L 188.944922 133.5096 
 z
-" clip-path="url(#p31c24e8678)" style="fill: #fee08b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p735a86a554)" style="fill: #fee08b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 293.501563 162.8928 
-L 398.126563 162.8928 
-L 398.126563 133.5096 
-L 293.501563 133.5096 
+    <path d="M 293.569922 162.8928 
+L 398.194922 162.8928 
+L 398.194922 133.5096 
+L 293.569922 133.5096 
 z
-" clip-path="url(#p31c24e8678)" style="fill: #feefa3; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p735a86a554)" style="fill: #feefa3; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 398.126563 162.8928 
-L 502.751563 162.8928 
-L 502.751563 133.5096 
-L 398.126563 133.5096 
+    <path d="M 398.194922 162.8928 
+L 502.819922 162.8928 
+L 502.819922 133.5096 
+L 398.194922 133.5096 
 z
-" clip-path="url(#p31c24e8678)" style="fill: #fdbf6f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p735a86a554)" style="fill: #fdbf6f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 188.876563 192.276 
-L 293.501563 192.276 
-L 293.501563 162.8928 
-L 188.876563 162.8928 
+    <path d="M 188.944922 192.276 
+L 293.569922 192.276 
+L 293.569922 162.8928 
+L 188.944922 162.8928 
 z
-" clip-path="url(#p31c24e8678)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p735a86a554)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 293.501563 192.276 
-L 398.126563 192.276 
-L 398.126563 162.8928 
-L 293.501563 162.8928 
+    <path d="M 293.569922 192.276 
+L 398.194922 192.276 
+L 398.194922 162.8928 
+L 293.569922 162.8928 
 z
-" clip-path="url(#p31c24e8678)" style="fill: #fede89; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p735a86a554)" style="fill: #fede89; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 398.126563 192.276 
-L 502.751563 192.276 
-L 502.751563 162.8928 
-L 398.126563 162.8928 
+    <path d="M 398.194922 192.276 
+L 502.819922 192.276 
+L 502.819922 162.8928 
+L 398.194922 162.8928 
 z
-" clip-path="url(#p31c24e8678)" style="fill: #f7814c; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p735a86a554)" style="fill: #f7814c; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 188.876563 221.6592 
-L 293.501563 221.6592 
-L 293.501563 192.276 
-L 188.876563 192.276 
+    <path d="M 188.944922 221.6592 
+L 293.569922 221.6592 
+L 293.569922 192.276 
+L 188.944922 192.276 
 z
-" clip-path="url(#p31c24e8678)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p735a86a554)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 293.501563 221.6592 
-L 398.126563 221.6592 
-L 398.126563 192.276 
-L 293.501563 192.276 
+    <path d="M 293.569922 221.6592 
+L 398.194922 221.6592 
+L 398.194922 192.276 
+L 293.569922 192.276 
 z
-" clip-path="url(#p31c24e8678)" style="fill: #fed27f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p735a86a554)" style="fill: #fed27f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 398.126563 221.6592 
-L 502.751563 221.6592 
-L 502.751563 192.276 
-L 398.126563 192.276 
+    <path d="M 398.194922 221.6592 
+L 502.819922 221.6592 
+L 502.819922 192.276 
+L 398.194922 192.276 
 z
-" clip-path="url(#p31c24e8678)" style="fill: #fffcba; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p735a86a554)" style="fill: #fffcba; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 188.876563 251.0424 
-L 293.501563 251.0424 
-L 293.501563 221.6592 
-L 188.876563 221.6592 
+    <path d="M 188.944922 251.0424 
+L 293.569922 251.0424 
+L 293.569922 221.6592 
+L 188.944922 221.6592 
 z
-" clip-path="url(#p31c24e8678)" style="fill: #fff3ac; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p735a86a554)" style="fill: #feec9f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 293.501563 251.0424 
-L 398.126563 251.0424 
-L 398.126563 221.6592 
-L 293.501563 221.6592 
+    <path d="M 293.569922 251.0424 
+L 398.194922 251.0424 
+L 398.194922 221.6592 
+L 293.569922 221.6592 
 z
-" clip-path="url(#p31c24e8678)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p735a86a554)" style="fill: #fece7c; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 398.126563 251.0424 
-L 502.751563 251.0424 
-L 502.751563 221.6592 
-L 398.126563 221.6592 
+    <path d="M 398.194922 251.0424 
+L 502.819922 251.0424 
+L 502.819922 221.6592 
+L 398.194922 221.6592 
 z
-" clip-path="url(#p31c24e8678)" style="fill: #e8f59f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p735a86a554)" style="fill: #fec877; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 188.876563 280.4256 
-L 293.501563 280.4256 
-L 293.501563 251.0424 
-L 188.876563 251.0424 
+    <path d="M 188.944922 280.4256 
+L 293.569922 280.4256 
+L 293.569922 251.0424 
+L 188.944922 251.0424 
 z
-" clip-path="url(#p31c24e8678)" style="fill: #feec9f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p735a86a554)" style="fill: #fff3ac; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 293.501563 280.4256 
-L 398.126563 280.4256 
-L 398.126563 251.0424 
-L 293.501563 251.0424 
+    <path d="M 293.569922 280.4256 
+L 398.194922 280.4256 
+L 398.194922 251.0424 
+L 293.569922 251.0424 
 z
-" clip-path="url(#p31c24e8678)" style="fill: #fdc776; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p735a86a554)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 398.126563 280.4256 
-L 502.751563 280.4256 
-L 502.751563 251.0424 
-L 398.126563 251.0424 
+    <path d="M 398.194922 280.4256 
+L 502.819922 280.4256 
+L 502.819922 251.0424 
+L 398.194922 251.0424 
 z
-" clip-path="url(#p31c24e8678)" style="fill: #fdc574; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p735a86a554)" style="fill: #e8f59f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 188.876563 309.8088 
-L 293.501563 309.8088 
-L 293.501563 280.4256 
-L 188.876563 280.4256 
+    <path d="M 188.944922 309.8088 
+L 293.569922 309.8088 
+L 293.569922 280.4256 
+L 188.944922 280.4256 
 z
-" clip-path="url(#p31c24e8678)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p735a86a554)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 293.501563 309.8088 
-L 398.126563 309.8088 
-L 398.126563 280.4256 
-L 293.501563 280.4256 
+    <path d="M 293.569922 309.8088 
+L 398.194922 309.8088 
+L 398.194922 280.4256 
+L 293.569922 280.4256 
 z
-" clip-path="url(#p31c24e8678)" style="fill: #fa9b58; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p735a86a554)" style="fill: #fa9b58; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 398.126563 309.8088 
-L 502.751563 309.8088 
-L 502.751563 280.4256 
-L 398.126563 280.4256 
+    <path d="M 398.194922 309.8088 
+L 502.819922 309.8088 
+L 502.819922 280.4256 
+L 398.194922 280.4256 
 z
-" clip-path="url(#p31c24e8678)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p735a86a554)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 188.876563 339.192 
-L 293.501563 339.192 
-L 293.501563 309.8088 
-L 188.876563 309.8088 
+    <path d="M 188.944922 339.192 
+L 293.569922 339.192 
+L 293.569922 309.8088 
+L 188.944922 309.8088 
 z
-" clip-path="url(#p31c24e8678)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p735a86a554)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 293.501563 339.192 
-L 398.126563 339.192 
-L 398.126563 309.8088 
-L 293.501563 309.8088 
+    <path d="M 293.569922 339.192 
+L 398.194922 339.192 
+L 398.194922 309.8088 
+L 293.569922 309.8088 
 z
-" clip-path="url(#p31c24e8678)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p735a86a554)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 398.126563 339.192 
-L 502.751563 339.192 
-L 502.751563 309.8088 
-L 398.126563 309.8088 
+    <path d="M 398.194922 339.192 
+L 502.819922 339.192 
+L 502.819922 309.8088 
+L 398.194922 309.8088 
 z
-" clip-path="url(#p31c24e8678)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p735a86a554)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(121.863828 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(121.932188 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(229.148047 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(229.216406 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(307.720156 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(307.788516 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(406.071875 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(406.140234 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(117.801563 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(117.869922 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.320 -->
-    <g transform="translate(229.737813 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(229.806172 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -918,7 +918,7 @@ z
    </g>
    <g id="text_7">
     <!-- 117 -->
-    <g transform="translate(338.179063 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(338.247422 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -952,7 +952,7 @@ z
    </g>
    <g id="text_8">
     <!-- 852 -->
-    <g transform="translate(442.804063 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(442.872422 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -1026,7 +1026,7 @@ z
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(112.439688 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(112.508047 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1125,7 +1125,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.324 -->
-    <g transform="translate(229.737813 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(229.806172 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1156,7 +1156,7 @@ z
    </g>
    <g id="text_11">
     <!-- 61 -->
-    <g transform="translate(340.724063 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(340.792422 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -1195,7 +1195,7 @@ z
    </g>
    <g id="text_12">
     <!-- 312 -->
-    <g transform="translate(442.804063 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(442.872422 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
@@ -1203,7 +1203,7 @@ z
    </g>
    <g id="text_13">
     <!-- Go compress/flate -->
-    <g transform="translate(100.132813 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(100.201172 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -1374,7 +1374,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.325 -->
-    <g transform="translate(229.737813 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(229.806172 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1384,14 +1384,14 @@ z
    </g>
    <g id="text_15">
     <!-- 50 -->
-    <g transform="translate(340.724063 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(340.792422 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
     <!-- 275 -->
-    <g transform="translate(442.804063 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(442.872422 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
@@ -1399,7 +1399,7 @@ z
    </g>
    <g id="text_17">
     <!-- JS fflate -->
-    <g transform="translate(121.165313 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(121.233672 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1459,7 +1459,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.329 -->
-    <g transform="translate(229.737813 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(229.806172 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-39" d="M 703 97 
 L 703 672 
@@ -1501,14 +1501,14 @@ z
    </g>
    <g id="text_19">
     <!-- 41 -->
-    <g transform="translate(340.724063 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(340.792422 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
     <!-- 160 -->
-    <g transform="translate(442.804063 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(442.872422 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -1516,7 +1516,7 @@ z
    </g>
    <g id="text_21">
     <!-- zlib -->
-    <g transform="translate(129.702813 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(129.771172 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1540,7 +1540,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.323 -->
-    <g transform="translate(229.737813 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(229.806172 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1550,106 +1550,22 @@ z
    </g>
    <g id="text_23">
     <!-- 38 -->
-    <g transform="translate(340.724063 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(340.792422 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_24">
     <!-- 448 -->
-    <g transform="translate(442.804063 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(442.872422 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_25">
-    <!-- miniz_oxide -->
-    <g transform="translate(113.009063 238.44705) scale(0.08 -0.08)">
-     <defs>
-      <path id="DejaVuSans-6e" d="M 3513 2113 
-L 3513 0 
-L 2938 0 
-L 2938 2094 
-Q 2938 2591 2744 2837 
-Q 2550 3084 2163 3084 
-Q 1697 3084 1428 2787 
-Q 1159 2491 1159 1978 
-L 1159 0 
-L 581 0 
-L 581 3500 
-L 1159 3500 
-L 1159 2956 
-Q 1366 3272 1645 3428 
-Q 1925 3584 2291 3584 
-Q 2894 3584 3203 3211 
-Q 3513 2838 3513 2113 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-5f" d="M 3263 -1063 
-L 3263 -1509 
-L -63 -1509 
-L -63 -1063 
-L 3263 -1063 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-78" d="M 3513 3500 
-L 2247 1797 
-L 3578 0 
-L 2900 0 
-L 1881 1375 
-L 863 0 
-L 184 0 
-L 1544 1831 
-L 300 3500 
-L 978 3500 
-L 1906 2253 
-L 2834 3500 
-L 3513 3500 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-6d"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(97.412109 0)"/>
-     <use xlink:href="#DejaVuSans-6e" transform="translate(125.195312 0)"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(188.574219 0)"/>
-     <use xlink:href="#DejaVuSans-7a" transform="translate(216.357422 0)"/>
-     <use xlink:href="#DejaVuSans-5f" transform="translate(268.847656 0)"/>
-     <use xlink:href="#DejaVuSans-6f" transform="translate(318.847656 0)"/>
-     <use xlink:href="#DejaVuSans-78" transform="translate(376.904297 0)"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(436.083984 0)"/>
-     <use xlink:href="#DejaVuSans-64" transform="translate(463.867188 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(527.34375 0)"/>
-    </g>
-   </g>
-   <g id="text_26">
-    <!-- 0.322 -->
-    <g transform="translate(229.737813 238.5583) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-30"/>
-     <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(159.033203 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(222.65625 0)"/>
-    </g>
-   </g>
-   <g id="text_27">
-    <!-- 36 -->
-    <g transform="translate(340.724063 238.5583) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-33"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
-    </g>
-   </g>
-   <g id="text_28">
-    <!-- 527 -->
-    <g transform="translate(442.804063 238.5583) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
-    </g>
-   </g>
-   <g id="text_29">
     <!-- lean-zip (native) -->
-    <g transform="translate(99.510938 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(99.579297 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1756,9 +1672,9 @@ z
      <use xlink:href="#DejaVuSans-Bold-29" transform="translate(880.615234 0)"/>
     </g>
    </g>
-   <g id="text_30">
+   <g id="text_26">
     <!-- 0.323 -->
-    <g transform="translate(228.537188 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(228.605547 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1850,38 +1766,79 @@ z
      <use xlink:href="#DejaVuSans-Bold-33" transform="translate(246.728516 0)"/>
     </g>
    </g>
-   <g id="text_31">
-    <!-- 34 -->
-    <g transform="translate(340.247813 267.9415) scale(0.08 -0.08)">
+   <g id="text_27">
+    <!-- 36 -->
+    <g transform="translate(340.316172 238.5583) scale(0.08 -0.08)">
      <defs>
-      <path id="DejaVuSans-Bold-34" d="M 2356 3675 
-L 1038 1722 
-L 2356 1722 
-L 2356 3675 
+      <path id="DejaVuSans-Bold-36" d="M 2316 2303 
+Q 2000 2303 1842 2098 
+Q 1684 1894 1684 1484 
+Q 1684 1075 1842 870 
+Q 2000 666 2316 666 
+Q 2634 666 2792 870 
+Q 2950 1075 2950 1484 
+Q 2950 1894 2792 2098 
+Q 2634 2303 2316 2303 
 z
-M 2156 4666 
-L 3494 4666 
-L 3494 1722 
-L 4159 1722 
-L 4159 850 
-L 3494 850 
-L 3494 0 
-L 2356 0 
-L 2356 850 
-L 288 850 
-L 288 1881 
-L 2156 4666 
+M 3803 4544 
+L 3803 3681 
+Q 3506 3822 3243 3889 
+Q 2981 3956 2731 3956 
+Q 2194 3956 1894 3657 
+Q 1594 3359 1544 2772 
+Q 1750 2925 1990 3001 
+Q 2231 3078 2516 3078 
+Q 3231 3078 3670 2659 
+Q 4109 2241 4109 1563 
+Q 4109 813 3618 361 
+Q 3128 -91 2303 -91 
+Q 1394 -91 895 523 
+Q 397 1138 397 2266 
+Q 397 3422 980 4083 
+Q 1563 4744 2578 4744 
+Q 2900 4744 3203 4694 
+Q 3506 4644 3803 4544 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-Bold-33"/>
-     <use xlink:href="#DejaVuSans-Bold-34" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-36" transform="translate(69.580078 0)"/>
     </g>
    </g>
-   <g id="text_32">
-    <!-- 286 -->
-    <g transform="translate(442.089688 267.9415) scale(0.08 -0.08)">
+   <g id="text_28">
+    <!-- 298 -->
+    <g transform="translate(442.158047 238.5583) scale(0.08 -0.08)">
      <defs>
+      <path id="DejaVuSans-Bold-39" d="M 641 103 
+L 641 966 
+Q 928 831 1190 764 
+Q 1453 697 1709 697 
+Q 2247 697 2547 995 
+Q 2847 1294 2900 1881 
+Q 2688 1725 2447 1647 
+Q 2206 1569 1925 1569 
+Q 1209 1569 770 1986 
+Q 331 2403 331 3084 
+Q 331 3838 820 4291 
+Q 1309 4744 2131 4744 
+Q 3044 4744 3544 4128 
+Q 4044 3513 4044 2388 
+Q 4044 1231 3459 570 
+Q 2875 -91 1856 -91 
+Q 1528 -91 1228 -42 
+Q 928 6 641 103 
+z
+M 2125 2350 
+Q 2441 2350 2600 2554 
+Q 2759 2759 2759 3169 
+Q 2759 3575 2600 3781 
+Q 2441 3988 2125 3988 
+Q 1809 3988 1650 3781 
+Q 1491 3575 1491 3169 
+Q 1491 2759 1650 2554 
+Q 1809 2350 2125 2350 
+z
+" transform="scale(0.015625)"/>
       <path id="DejaVuSans-Bold-38" d="M 2228 2088 
 Q 1891 2088 1709 1903 
 Q 1528 1719 1528 1375 
@@ -1921,45 +1878,99 @@ Q 1941 3994 1786 3844
 Q 1631 3694 1631 3419 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-36" d="M 2316 2303 
-Q 2000 2303 1842 2098 
-Q 1684 1894 1684 1484 
-Q 1684 1075 1842 870 
-Q 2000 666 2316 666 
-Q 2634 666 2792 870 
-Q 2950 1075 2950 1484 
-Q 2950 1894 2792 2098 
-Q 2634 2303 2316 2303 
+     </defs>
+     <use xlink:href="#DejaVuSans-Bold-32"/>
+     <use xlink:href="#DejaVuSans-Bold-39" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-38" transform="translate(139.160156 0)"/>
+    </g>
+   </g>
+   <g id="text_29">
+    <!-- miniz_oxide -->
+    <g transform="translate(113.077422 267.83025) scale(0.08 -0.08)">
+     <defs>
+      <path id="DejaVuSans-6e" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
 z
-M 3803 4544 
-L 3803 3681 
-Q 3506 3822 3243 3889 
-Q 2981 3956 2731 3956 
-Q 2194 3956 1894 3657 
-Q 1594 3359 1544 2772 
-Q 1750 2925 1990 3001 
-Q 2231 3078 2516 3078 
-Q 3231 3078 3670 2659 
-Q 4109 2241 4109 1563 
-Q 4109 813 3618 361 
-Q 3128 -91 2303 -91 
-Q 1394 -91 895 523 
-Q 397 1138 397 2266 
-Q 397 3422 980 4083 
-Q 1563 4744 2578 4744 
-Q 2900 4744 3203 4694 
-Q 3506 4644 3803 4544 
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-5f" d="M 3263 -1063 
+L 3263 -1509 
+L -63 -1509 
+L -63 -1063 
+L 3263 -1063 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-78" d="M 3513 3500 
+L 2247 1797 
+L 3578 0 
+L 2900 0 
+L 1881 1375 
+L 863 0 
+L 184 0 
+L 1544 1831 
+L 300 3500 
+L 978 3500 
+L 1906 2253 
+L 2834 3500 
+L 3513 3500 
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-Bold-32"/>
-     <use xlink:href="#DejaVuSans-Bold-38" transform="translate(69.580078 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-36" transform="translate(139.160156 0)"/>
+     <use xlink:href="#DejaVuSans-6d"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(97.412109 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(125.195312 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(188.574219 0)"/>
+     <use xlink:href="#DejaVuSans-7a" transform="translate(216.357422 0)"/>
+     <use xlink:href="#DejaVuSans-5f" transform="translate(268.847656 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(318.847656 0)"/>
+     <use xlink:href="#DejaVuSans-78" transform="translate(376.904297 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(436.083984 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(463.867188 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(527.34375 0)"/>
+    </g>
+   </g>
+   <g id="text_30">
+    <!-- 0.322 -->
+    <g transform="translate(229.806172 267.9415) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-30"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(159.033203 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(222.65625 0)"/>
+    </g>
+   </g>
+   <g id="text_31">
+    <!-- 36 -->
+    <g transform="translate(340.792422 267.9415) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-33"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
+    </g>
+   </g>
+   <g id="text_32">
+    <!-- 527 -->
+    <g transform="translate(442.872422 267.9415) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-35"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_33">
     <!-- OCaml decompress -->
-    <g transform="translate(97.625938 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(97.694297 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -2024,7 +2035,7 @@ z
    </g>
    <g id="text_34">
     <!-- 0.336 -->
-    <g transform="translate(229.737813 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(229.806172 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -2034,21 +2045,21 @@ z
    </g>
    <g id="text_35">
     <!-- 21 -->
-    <g transform="translate(340.724063 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(340.792422 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_36">
     <!-- 69 -->
-    <g transform="translate(445.349063 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(445.417422 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-36"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(125.847188 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(125.915547 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -2059,7 +2070,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.303 -->
-    <g transform="translate(229.737813 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(229.806172 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -2069,13 +2080,13 @@ z
    </g>
    <g id="text_39">
     <!-- 1 -->
-    <g transform="translate(343.269063 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(343.337422 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(446.439063 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(446.507422 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2091,7 +2102,7 @@ z
   </g>
   <g id="text_41">
    <!-- silesia — geomean over files, level 6 -->
-   <g transform="translate(153.353281 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(153.421641 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-2014" d="M 344 2156 
 L 6056 2156 
@@ -2205,7 +2216,7 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-07-08T15:47:33Z  ·  Linux chungus2 x86_64  ·  commit f2026e66  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-07-08T20:00:36Z  ·  Linux chungus2 x86_64  ·  commit 29539fd5  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2346,14 +2357,14 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-38" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
     <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2393,110 +2404,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3107.080078 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3170.703125 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3234.326172 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3297.949219 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3361.572266 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3423.095703 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3486.71875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3550.341797 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3582.128906 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3613.916016 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3645.703125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3677.490234 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3709.277344 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3737.060547 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3798.583984 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3859.863281 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3923.242188 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3986.71875 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4025.582031 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4086.763672 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4145.943359 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4207.466797 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4248.580078 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4282.271484 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4310.054688 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4371.578125 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4432.857422 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4496.236328 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4559.859375 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4593.550781 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4652.730469 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4716.353516 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4748.140625 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4811.763672 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4875.386719 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4907.173828 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4970.796875 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5006.880859 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5045.744141 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5100.724609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5164.347656 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5196.134766 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5227.921875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5259.708984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5291.496094 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5323.283203 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5362.492188 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5425.871094 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5464.734375 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5525.916016 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5589.294922 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5652.771484 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5716.150391 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5779.626953 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5843.005859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5882.214844 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5914.001953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5997.791016 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6029.578125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6126.990234 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6188.513672 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6251.990234 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6279.773438 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6341.052734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6404.431641 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6436.21875 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6488.318359 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6551.697266 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6612.976562 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6676.453125 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6728.552734 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6791.931641 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6853.113281 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6892.322266 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6926.013672 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6957.800781 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6998.914062 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7060.193359 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7099.402344 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7127.185547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7188.367188 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7220.154297 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7247.9375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7300.037109 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7331.824219 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7395.300781 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7456.824219 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7496.033203 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7557.556641 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7596.919922 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7694.332031 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7722.115234 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7785.494141 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7813.277344 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7865.376953 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7904.585938 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7932.369141 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3262.744141 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3326.367188 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3389.990234 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3425.195312 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3488.671875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3552.294922 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3584.082031 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3615.869141 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3647.65625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3679.443359 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3711.230469 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3739.013672 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3800.537109 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3861.816406 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3925.195312 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3988.671875 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4027.535156 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4088.716797 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4147.896484 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4209.419922 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4250.533203 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4284.224609 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4312.007812 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4373.53125 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4434.810547 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4498.189453 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4561.8125 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4595.503906 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4654.683594 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4718.306641 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4750.09375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4813.716797 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4877.339844 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4909.126953 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4972.75 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5008.833984 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5047.697266 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5102.677734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5166.300781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5198.087891 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5229.875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5261.662109 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5293.449219 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5325.236328 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5364.445312 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5427.824219 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5466.6875 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5527.869141 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5591.248047 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5654.724609 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5718.103516 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5781.580078 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5844.958984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5884.167969 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5915.955078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5999.744141 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6031.53125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6128.943359 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6190.466797 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6253.943359 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6281.726562 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6343.005859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6406.384766 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6438.171875 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6490.271484 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6553.650391 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6614.929688 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6678.40625 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6730.505859 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6793.884766 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6855.066406 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6894.275391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6927.966797 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6959.753906 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7000.867188 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7062.146484 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7101.355469 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7129.138672 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7190.320312 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7222.107422 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7249.890625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7301.990234 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7333.777344 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7397.253906 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7458.777344 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7497.986328 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7559.509766 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7598.873047 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7696.285156 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7724.068359 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7787.447266 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7815.230469 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7867.330078 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7906.539062 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7934.322266 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p31c24e8678">
-   <rect x="84.251563" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="p735a86a554">
+   <rect x="84.319922" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/results/latest.json
+++ b/bench/results/latest.json
@@ -1,8 +1,8 @@
 {
  "meta": {
-  "date": "2026-07-08T15:47:33Z",
+  "date": "2026-07-08T20:00:36Z",
   "machine": "Linux chungus2 x86_64",
-  "git_commit": "f2026e66",
+  "git_commit": "29539fd5",
   "toolchain": "leanprover/lean4:v4.30.0-rc2",
   "note": "compress_mbps/decompress_mbps are a median-of-5 snapshot on the machine above; ratio is deterministic"
  },
@@ -14,8 +14,8 @@
    "level": 1,
    "out_size": 60455,
    "ratio": 0.3975,
-   "compress_mbps": 72.24,
-   "decompress_mbps": 205.62
+   "compress_mbps": 74.44,
+   "decompress_mbps": 213.59
   },
   {
    "compressor": "native",
@@ -24,8 +24,8 @@
    "level": 2,
    "out_size": 56316,
    "ratio": 0.3703,
-   "compress_mbps": 52.02,
-   "decompress_mbps": 235.72
+   "compress_mbps": 52.58,
+   "decompress_mbps": 245.65
   },
   {
    "compressor": "native",
@@ -34,8 +34,8 @@
    "level": 3,
    "out_size": 55646,
    "ratio": 0.3659,
-   "compress_mbps": 46.09,
-   "decompress_mbps": 257.11
+   "compress_mbps": 47.33,
+   "decompress_mbps": 268.44
   },
   {
    "compressor": "native",
@@ -44,8 +44,8 @@
    "level": 4,
    "out_size": 54357,
    "ratio": 0.3574,
-   "compress_mbps": 36.11,
-   "decompress_mbps": 260.56
+   "compress_mbps": 38.14,
+   "decompress_mbps": 271.88
   },
   {
    "compressor": "native",
@@ -54,8 +54,8 @@
    "level": 5,
    "out_size": 54078,
    "ratio": 0.3556,
-   "compress_mbps": 29.02,
-   "decompress_mbps": 261.0
+   "compress_mbps": 30.28,
+   "decompress_mbps": 271.92
   },
   {
    "compressor": "native",
@@ -64,8 +64,8 @@
    "level": 6,
    "out_size": 54013,
    "ratio": 0.3551,
-   "compress_mbps": 28.46,
-   "decompress_mbps": 267.84
+   "compress_mbps": 29.81,
+   "decompress_mbps": 279.03
   },
   {
    "compressor": "native",
@@ -74,8 +74,8 @@
    "level": 7,
    "out_size": 53772,
    "ratio": 0.3536,
-   "compress_mbps": 23.83,
-   "decompress_mbps": 267.95
+   "compress_mbps": 24.83,
+   "decompress_mbps": 278.85
   },
   {
    "compressor": "native",
@@ -84,8 +84,8 @@
    "level": 8,
    "out_size": 53753,
    "ratio": 0.3534,
-   "compress_mbps": 22.85,
-   "decompress_mbps": 268.69
+   "compress_mbps": 23.77,
+   "decompress_mbps": 279.92
   },
   {
    "compressor": "native",
@@ -94,8 +94,8 @@
    "level": 9,
    "out_size": 52732,
    "ratio": 0.3467,
-   "compress_mbps": 4.27,
-   "decompress_mbps": 268.76
+   "compress_mbps": 4.28,
+   "decompress_mbps": 279.83
   },
   {
    "compressor": "native",
@@ -104,7 +104,7 @@
    "level": 10,
    "out_size": 52078,
    "ratio": 0.3424,
-   "compress_mbps": 2.4,
+   "compress_mbps": 2.35,
    "decompress_mbps": null
   },
   {
@@ -114,8 +114,8 @@
    "level": 1,
    "out_size": 53135,
    "ratio": 0.4245,
-   "compress_mbps": 65.84,
-   "decompress_mbps": 199.39
+   "compress_mbps": 66.57,
+   "decompress_mbps": 207.0
   },
   {
    "compressor": "native",
@@ -124,8 +124,8 @@
    "level": 2,
    "out_size": 50187,
    "ratio": 0.4009,
-   "compress_mbps": 49.07,
-   "decompress_mbps": 215.45
+   "compress_mbps": 49.7,
+   "decompress_mbps": 224.57
   },
   {
    "compressor": "native",
@@ -134,8 +134,8 @@
    "level": 3,
    "out_size": 49810,
    "ratio": 0.3979,
-   "compress_mbps": 44.51,
-   "decompress_mbps": 236.5
+   "compress_mbps": 44.77,
+   "decompress_mbps": 245.71
   },
   {
    "compressor": "native",
@@ -144,8 +144,8 @@
    "level": 4,
    "out_size": 48687,
    "ratio": 0.3889,
-   "compress_mbps": 34.25,
-   "decompress_mbps": 240.73
+   "compress_mbps": 35.82,
+   "decompress_mbps": 250.37
   },
   {
    "compressor": "native",
@@ -154,8 +154,8 @@
    "level": 5,
    "out_size": 48586,
    "ratio": 0.3881,
-   "compress_mbps": 29.47,
-   "decompress_mbps": 239.52
+   "compress_mbps": 30.73,
+   "decompress_mbps": 250.08
   },
   {
    "compressor": "native",
@@ -164,8 +164,8 @@
    "level": 6,
    "out_size": 48373,
    "ratio": 0.3864,
-   "compress_mbps": 27.3,
-   "decompress_mbps": 244.11
+   "compress_mbps": 28.41,
+   "decompress_mbps": 253.69
   },
   {
    "compressor": "native",
@@ -174,8 +174,8 @@
    "level": 7,
    "out_size": 48288,
    "ratio": 0.3858,
-   "compress_mbps": 24.76,
-   "decompress_mbps": 245.11
+   "compress_mbps": 25.7,
+   "decompress_mbps": 255.09
   },
   {
    "compressor": "native",
@@ -184,8 +184,8 @@
    "level": 8,
    "out_size": 48284,
    "ratio": 0.3857,
-   "compress_mbps": 24.52,
-   "decompress_mbps": 245.63
+   "compress_mbps": 25.39,
+   "decompress_mbps": 255.86
   },
   {
    "compressor": "native",
@@ -194,8 +194,8 @@
    "level": 9,
    "out_size": 47430,
    "ratio": 0.3789,
-   "compress_mbps": 4.66,
-   "decompress_mbps": 246.53
+   "compress_mbps": 4.63,
+   "decompress_mbps": 255.63
   },
   {
    "compressor": "native",
@@ -204,7 +204,7 @@
    "level": 10,
    "out_size": 46865,
    "ratio": 0.3744,
-   "compress_mbps": 2.8,
+   "compress_mbps": 2.74,
    "decompress_mbps": null
   },
   {
@@ -214,8 +214,8 @@
    "level": 1,
    "out_size": 8476,
    "ratio": 0.3445,
-   "compress_mbps": 65.01,
-   "decompress_mbps": 262.66
+   "compress_mbps": 64.82,
+   "decompress_mbps": 273.33
   },
   {
    "compressor": "native",
@@ -224,8 +224,8 @@
    "level": 2,
    "out_size": 8271,
    "ratio": 0.3362,
-   "compress_mbps": 54.26,
-   "decompress_mbps": 269.19
+   "compress_mbps": 54.49,
+   "decompress_mbps": 283.56
   },
   {
    "compressor": "native",
@@ -234,8 +234,8 @@
    "level": 3,
    "out_size": 8158,
    "ratio": 0.3316,
-   "compress_mbps": 52.23,
-   "decompress_mbps": 274.29
+   "compress_mbps": 52.61,
+   "decompress_mbps": 287.36
   },
   {
    "compressor": "native",
@@ -244,8 +244,8 @@
    "level": 4,
    "out_size": 7948,
    "ratio": 0.3231,
-   "compress_mbps": 47.16,
-   "decompress_mbps": 280.7
+   "compress_mbps": 49.28,
+   "decompress_mbps": 294.35
   },
   {
    "compressor": "native",
@@ -254,8 +254,8 @@
    "level": 5,
    "out_size": 7899,
    "ratio": 0.3211,
-   "compress_mbps": 40.36,
-   "decompress_mbps": 288.27
+   "compress_mbps": 42.08,
+   "decompress_mbps": 302.22
   },
   {
    "compressor": "native",
@@ -264,8 +264,8 @@
    "level": 6,
    "out_size": 7912,
    "ratio": 0.3216,
-   "compress_mbps": 39.37,
-   "decompress_mbps": 287.29
+   "compress_mbps": 41.19,
+   "decompress_mbps": 301.37
   },
   {
    "compressor": "native",
@@ -274,8 +274,8 @@
    "level": 7,
    "out_size": 7897,
    "ratio": 0.321,
-   "compress_mbps": 35.86,
-   "decompress_mbps": 290.68
+   "compress_mbps": 37.36,
+   "decompress_mbps": 306.22
   },
   {
    "compressor": "native",
@@ -284,8 +284,8 @@
    "level": 8,
    "out_size": 7897,
    "ratio": 0.321,
-   "compress_mbps": 35.82,
-   "decompress_mbps": 291.0
+   "compress_mbps": 37.25,
+   "decompress_mbps": 306.25
   },
   {
    "compressor": "native",
@@ -294,8 +294,8 @@
    "level": 9,
    "out_size": 7803,
    "ratio": 0.3172,
-   "compress_mbps": 4.96,
-   "decompress_mbps": 291.69
+   "compress_mbps": 5.01,
+   "decompress_mbps": 307.54
   },
   {
    "compressor": "native",
@@ -304,7 +304,7 @@
    "level": 10,
    "out_size": 7737,
    "ratio": 0.3145,
-   "compress_mbps": 2.94,
+   "compress_mbps": 2.9,
    "decompress_mbps": null
   },
   {
@@ -314,8 +314,8 @@
    "level": 1,
    "out_size": 3509,
    "ratio": 0.3147,
-   "compress_mbps": 48.67,
-   "decompress_mbps": 181.04
+   "compress_mbps": 48.69,
+   "decompress_mbps": 185.92
   },
   {
    "compressor": "native",
@@ -324,8 +324,8 @@
    "level": 2,
    "out_size": 3269,
    "ratio": 0.2932,
-   "compress_mbps": 42.98,
-   "decompress_mbps": 183.14
+   "compress_mbps": 42.82,
+   "decompress_mbps": 187.06
   },
   {
    "compressor": "native",
@@ -334,8 +334,8 @@
    "level": 3,
    "out_size": 3208,
    "ratio": 0.2877,
-   "compress_mbps": 41.72,
-   "decompress_mbps": 186.75
+   "compress_mbps": 41.59,
+   "decompress_mbps": 191.77
   },
   {
    "compressor": "native",
@@ -344,8 +344,8 @@
    "level": 4,
    "out_size": 3128,
    "ratio": 0.2805,
-   "compress_mbps": 39.0,
-   "decompress_mbps": 190.97
+   "compress_mbps": 41.32,
+   "decompress_mbps": 196.18
   },
   {
    "compressor": "native",
@@ -354,8 +354,8 @@
    "level": 5,
    "out_size": 3111,
    "ratio": 0.279,
-   "compress_mbps": 35.26,
-   "decompress_mbps": 191.17
+   "compress_mbps": 36.84,
+   "decompress_mbps": 196.5
   },
   {
    "compressor": "native",
@@ -364,8 +364,8 @@
    "level": 6,
    "out_size": 3119,
    "ratio": 0.2797,
-   "compress_mbps": 35.57,
-   "decompress_mbps": 190.88
+   "compress_mbps": 37.21,
+   "decompress_mbps": 196.97
   },
   {
    "compressor": "native",
@@ -374,8 +374,8 @@
    "level": 7,
    "out_size": 3111,
    "ratio": 0.279,
-   "compress_mbps": 33.5,
-   "decompress_mbps": 192.77
+   "compress_mbps": 34.63,
+   "decompress_mbps": 196.89
   },
   {
    "compressor": "native",
@@ -384,8 +384,8 @@
    "level": 8,
    "out_size": 3111,
    "ratio": 0.279,
-   "compress_mbps": 33.33,
-   "decompress_mbps": 192.82
+   "compress_mbps": 34.52,
+   "decompress_mbps": 197.17
   },
   {
    "compressor": "native",
@@ -394,8 +394,8 @@
    "level": 9,
    "out_size": 3056,
    "ratio": 0.2741,
-   "compress_mbps": 5.45,
-   "decompress_mbps": 191.81
+   "compress_mbps": 5.48,
+   "decompress_mbps": 196.87
   },
   {
    "compressor": "native",
@@ -404,7 +404,7 @@
    "level": 10,
    "out_size": 3032,
    "ratio": 0.2719,
-   "compress_mbps": 3.06,
+   "compress_mbps": 3.02,
    "decompress_mbps": null
   },
   {
@@ -414,8 +414,8 @@
    "level": 1,
    "out_size": 1282,
    "ratio": 0.3445,
-   "compress_mbps": 25.2,
-   "decompress_mbps": 83.23
+   "compress_mbps": 25.08,
+   "decompress_mbps": 84.57
   },
   {
    "compressor": "native",
@@ -424,8 +424,8 @@
    "level": 2,
    "out_size": 1225,
    "ratio": 0.3292,
-   "compress_mbps": 23.91,
-   "decompress_mbps": 84.42
+   "compress_mbps": 23.87,
+   "decompress_mbps": 85.54
   },
   {
    "compressor": "native",
@@ -434,8 +434,8 @@
    "level": 3,
    "out_size": 1220,
    "ratio": 0.3279,
-   "compress_mbps": 23.66,
-   "decompress_mbps": 84.16
+   "compress_mbps": 23.57,
+   "decompress_mbps": 85.31
   },
   {
    "compressor": "native",
@@ -444,8 +444,8 @@
    "level": 4,
    "out_size": 1213,
    "ratio": 0.326,
-   "compress_mbps": 23.04,
-   "decompress_mbps": 84.73
+   "compress_mbps": 23.63,
+   "decompress_mbps": 85.47
   },
   {
    "compressor": "native",
@@ -454,8 +454,8 @@
    "level": 5,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 22.37,
-   "decompress_mbps": 84.49
+   "compress_mbps": 22.91,
+   "decompress_mbps": 86.05
   },
   {
    "compressor": "native",
@@ -464,8 +464,8 @@
    "level": 6,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 22.0,
-   "decompress_mbps": 85.11
+   "compress_mbps": 22.45,
+   "decompress_mbps": 86.14
   },
   {
    "compressor": "native",
@@ -474,8 +474,8 @@
    "level": 7,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 21.86,
-   "decompress_mbps": 84.79
+   "compress_mbps": 22.23,
+   "decompress_mbps": 86.24
   },
   {
    "compressor": "native",
@@ -484,8 +484,8 @@
    "level": 8,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 21.77,
-   "decompress_mbps": 84.82
+   "compress_mbps": 22.25,
+   "decompress_mbps": 86.16
   },
   {
    "compressor": "native",
@@ -494,8 +494,8 @@
    "level": 9,
    "out_size": 1205,
    "ratio": 0.3238,
-   "compress_mbps": 5.0,
-   "decompress_mbps": 85.59
+   "compress_mbps": 5.03,
+   "decompress_mbps": 86.23
   },
   {
    "compressor": "native",
@@ -504,7 +504,7 @@
    "level": 10,
    "out_size": 1191,
    "ratio": 0.3201,
-   "compress_mbps": 2.98,
+   "compress_mbps": 2.92,
    "decompress_mbps": null
   },
   {
@@ -514,8 +514,8 @@
    "level": 1,
    "out_size": 251793,
    "ratio": 0.2445,
-   "compress_mbps": 141.33,
-   "decompress_mbps": 383.26
+   "compress_mbps": 141.44,
+   "decompress_mbps": 398.28
   },
   {
    "compressor": "native",
@@ -524,8 +524,8 @@
    "level": 2,
    "out_size": 242565,
    "ratio": 0.2356,
-   "compress_mbps": 108.14,
-   "decompress_mbps": 409.03
+   "compress_mbps": 107.23,
+   "decompress_mbps": 427.23
   },
   {
    "compressor": "native",
@@ -534,8 +534,8 @@
    "level": 3,
    "out_size": 242532,
    "ratio": 0.2355,
-   "compress_mbps": 87.67,
-   "decompress_mbps": 435.08
+   "compress_mbps": 87.7,
+   "decompress_mbps": 455.55
   },
   {
    "compressor": "native",
@@ -544,8 +544,8 @@
    "level": 4,
    "out_size": 239953,
    "ratio": 0.233,
-   "compress_mbps": 85.73,
-   "decompress_mbps": 461.17
+   "compress_mbps": 97.86,
+   "decompress_mbps": 483.75
   },
   {
    "compressor": "native",
@@ -554,8 +554,8 @@
    "level": 5,
    "out_size": 218565,
    "ratio": 0.2123,
-   "compress_mbps": 56.22,
-   "decompress_mbps": 448.07
+   "compress_mbps": 59.94,
+   "decompress_mbps": 466.7
   },
   {
    "compressor": "native",
@@ -564,8 +564,8 @@
    "level": 6,
    "out_size": 202676,
    "ratio": 0.1968,
-   "compress_mbps": 41.84,
-   "decompress_mbps": 465.13
+   "compress_mbps": 43.54,
+   "decompress_mbps": 483.6
   },
   {
    "compressor": "native",
@@ -574,8 +574,8 @@
    "level": 7,
    "out_size": 201403,
    "ratio": 0.1956,
-   "compress_mbps": 30.27,
-   "decompress_mbps": 467.49
+   "compress_mbps": 30.97,
+   "decompress_mbps": 488.2
   },
   {
    "compressor": "native",
@@ -584,8 +584,8 @@
    "level": 8,
    "out_size": 200798,
    "ratio": 0.195,
-   "compress_mbps": 22.65,
-   "decompress_mbps": 477.64
+   "compress_mbps": 22.98,
+   "decompress_mbps": 497.39
   },
   {
    "compressor": "native",
@@ -594,8 +594,8 @@
    "level": 9,
    "out_size": 182508,
    "ratio": 0.1772,
-   "compress_mbps": 3.48,
-   "decompress_mbps": 476.59
+   "compress_mbps": 3.51,
+   "decompress_mbps": 497.36
   },
   {
    "compressor": "native",
@@ -604,7 +604,7 @@
    "level": 10,
    "out_size": 178067,
    "ratio": 0.1729,
-   "compress_mbps": 1.45,
+   "compress_mbps": 1.48,
    "decompress_mbps": null
   },
   {
@@ -614,8 +614,8 @@
    "level": 1,
    "out_size": 160674,
    "ratio": 0.3765,
-   "compress_mbps": 79.21,
-   "decompress_mbps": 213.5
+   "compress_mbps": 79.51,
+   "decompress_mbps": 221.95
   },
   {
    "compressor": "native",
@@ -624,8 +624,8 @@
    "level": 2,
    "out_size": 149787,
    "ratio": 0.351,
-   "compress_mbps": 56.61,
-   "decompress_mbps": 231.38
+   "compress_mbps": 56.49,
+   "decompress_mbps": 240.77
   },
   {
    "compressor": "native",
@@ -634,8 +634,8 @@
    "level": 3,
    "out_size": 148055,
    "ratio": 0.3469,
-   "compress_mbps": 49.8,
-   "decompress_mbps": 258.15
+   "compress_mbps": 50.0,
+   "decompress_mbps": 268.9
   },
   {
    "compressor": "native",
@@ -644,8 +644,8 @@
    "level": 4,
    "out_size": 144750,
    "ratio": 0.3392,
-   "compress_mbps": 39.05,
-   "decompress_mbps": 262.19
+   "compress_mbps": 41.24,
+   "decompress_mbps": 272.59
   },
   {
    "compressor": "native",
@@ -654,8 +654,8 @@
    "level": 5,
    "out_size": 144408,
    "ratio": 0.3384,
-   "compress_mbps": 31.43,
-   "decompress_mbps": 262.74
+   "compress_mbps": 33.73,
+   "decompress_mbps": 273.64
   },
   {
    "compressor": "native",
@@ -664,8 +664,8 @@
    "level": 6,
    "out_size": 144070,
    "ratio": 0.3376,
-   "compress_mbps": 30.49,
-   "decompress_mbps": 268.16
+   "compress_mbps": 31.9,
+   "decompress_mbps": 278.38
   },
   {
    "compressor": "native",
@@ -674,8 +674,8 @@
    "level": 7,
    "out_size": 143628,
    "ratio": 0.3366,
-   "compress_mbps": 25.79,
-   "decompress_mbps": 268.79
+   "compress_mbps": 26.64,
+   "decompress_mbps": 279.63
   },
   {
    "compressor": "native",
@@ -684,8 +684,8 @@
    "level": 8,
    "out_size": 143569,
    "ratio": 0.3364,
-   "compress_mbps": 24.87,
-   "decompress_mbps": 268.59
+   "compress_mbps": 25.71,
+   "decompress_mbps": 279.83
   },
   {
    "compressor": "native",
@@ -694,8 +694,8 @@
    "level": 9,
    "out_size": 140322,
    "ratio": 0.3288,
-   "compress_mbps": 4.26,
-   "decompress_mbps": 268.14
+   "compress_mbps": 4.33,
+   "decompress_mbps": 280.56
   },
   {
    "compressor": "native",
@@ -714,8 +714,8 @@
    "level": 1,
    "out_size": 212588,
    "ratio": 0.4412,
-   "compress_mbps": 66.93,
-   "decompress_mbps": 184.85
+   "compress_mbps": 67.07,
+   "decompress_mbps": 192.82
   },
   {
    "compressor": "native",
@@ -724,8 +724,8 @@
    "level": 2,
    "out_size": 199981,
    "ratio": 0.415,
-   "compress_mbps": 48.41,
-   "decompress_mbps": 206.31
+   "compress_mbps": 48.37,
+   "decompress_mbps": 215.15
   },
   {
    "compressor": "native",
@@ -734,8 +734,8 @@
    "level": 3,
    "out_size": 198551,
    "ratio": 0.4121,
-   "compress_mbps": 42.4,
-   "decompress_mbps": 227.54
+   "compress_mbps": 42.67,
+   "decompress_mbps": 237.47
   },
   {
    "compressor": "native",
@@ -744,8 +744,8 @@
    "level": 4,
    "out_size": 193783,
    "ratio": 0.4022,
-   "compress_mbps": 30.89,
-   "decompress_mbps": 230.7
+   "compress_mbps": 32.01,
+   "decompress_mbps": 240.99
   },
   {
    "compressor": "native",
@@ -754,8 +754,8 @@
    "level": 5,
    "out_size": 193223,
    "ratio": 0.401,
-   "compress_mbps": 25.83,
-   "decompress_mbps": 227.47
+   "compress_mbps": 26.67,
+   "decompress_mbps": 237.35
   },
   {
    "compressor": "native",
@@ -764,8 +764,8 @@
    "level": 6,
    "out_size": 193416,
    "ratio": 0.4014,
-   "compress_mbps": 26.17,
-   "decompress_mbps": 230.56
+   "compress_mbps": 27.03,
+   "decompress_mbps": 241.32
   },
   {
    "compressor": "native",
@@ -774,8 +774,8 @@
    "level": 7,
    "out_size": 192664,
    "ratio": 0.3998,
-   "compress_mbps": 21.81,
-   "decompress_mbps": 230.34
+   "compress_mbps": 22.43,
+   "decompress_mbps": 240.76
   },
   {
    "compressor": "native",
@@ -784,8 +784,8 @@
    "level": 8,
    "out_size": 192638,
    "ratio": 0.3998,
-   "compress_mbps": 21.19,
-   "decompress_mbps": 230.31
+   "compress_mbps": 21.78,
+   "decompress_mbps": 241.01
   },
   {
    "compressor": "native",
@@ -794,8 +794,8 @@
    "level": 9,
    "out_size": 189365,
    "ratio": 0.393,
-   "compress_mbps": 4.02,
-   "decompress_mbps": 230.18
+   "compress_mbps": 4.11,
+   "decompress_mbps": 240.66
   },
   {
    "compressor": "native",
@@ -814,8 +814,8 @@
    "level": 1,
    "out_size": 60161,
    "ratio": 0.1172,
-   "compress_mbps": 229.02,
-   "decompress_mbps": 567.71
+   "compress_mbps": 230.43,
+   "decompress_mbps": 585.04
   },
   {
    "compressor": "native",
@@ -824,8 +824,8 @@
    "level": 2,
    "out_size": 58873,
    "ratio": 0.1147,
-   "compress_mbps": 170.18,
-   "decompress_mbps": 593.38
+   "compress_mbps": 171.41,
+   "decompress_mbps": 610.73
   },
   {
    "compressor": "native",
@@ -834,8 +834,8 @@
    "level": 3,
    "out_size": 58327,
    "ratio": 0.1137,
-   "compress_mbps": 148.99,
-   "decompress_mbps": 623.53
+   "compress_mbps": 148.85,
+   "decompress_mbps": 641.52
   },
   {
    "compressor": "native",
@@ -844,8 +844,8 @@
    "level": 4,
    "out_size": 55588,
    "ratio": 0.1083,
-   "compress_mbps": 103.21,
-   "decompress_mbps": 639.25
+   "compress_mbps": 121.66,
+   "decompress_mbps": 663.44
   },
   {
    "compressor": "native",
@@ -854,8 +854,8 @@
    "level": 5,
    "out_size": 55097,
    "ratio": 0.1074,
-   "compress_mbps": 82.14,
-   "decompress_mbps": 663.16
+   "compress_mbps": 93.7,
+   "decompress_mbps": 684.31
   },
   {
    "compressor": "native",
@@ -864,8 +864,8 @@
    "level": 6,
    "out_size": 55195,
    "ratio": 0.1075,
-   "compress_mbps": 63.73,
-   "decompress_mbps": 685.64
+   "compress_mbps": 70.92,
+   "decompress_mbps": 706.88
   },
   {
    "compressor": "native",
@@ -874,8 +874,8 @@
    "level": 7,
    "out_size": 54316,
    "ratio": 0.1058,
-   "compress_mbps": 52.68,
-   "decompress_mbps": 698.6
+   "compress_mbps": 57.75,
+   "decompress_mbps": 719.34
   },
   {
    "compressor": "native",
@@ -884,8 +884,8 @@
    "level": 8,
    "out_size": 53091,
    "ratio": 0.1034,
-   "compress_mbps": 43.7,
-   "decompress_mbps": 725.17
+   "compress_mbps": 47.38,
+   "decompress_mbps": 746.83
   },
   {
    "compressor": "native",
@@ -894,8 +894,8 @@
    "level": 9,
    "out_size": 52605,
    "ratio": 0.1025,
-   "compress_mbps": 5.8,
-   "decompress_mbps": 733.9
+   "compress_mbps": 5.99,
+   "decompress_mbps": 758.93
   },
   {
    "compressor": "native",
@@ -904,7 +904,7 @@
    "level": 10,
    "out_size": 52234,
    "ratio": 0.1018,
-   "compress_mbps": 3.76,
+   "compress_mbps": 3.84,
    "decompress_mbps": null
   },
   {
@@ -914,8 +914,8 @@
    "level": 1,
    "out_size": 14249,
    "ratio": 0.3726,
-   "compress_mbps": 54.32,
-   "decompress_mbps": 234.7
+   "compress_mbps": 53.89,
+   "decompress_mbps": 242.73
   },
   {
    "compressor": "native",
@@ -924,8 +924,8 @@
    "level": 2,
    "out_size": 13825,
    "ratio": 0.3615,
-   "compress_mbps": 47.8,
-   "decompress_mbps": 242.52
+   "compress_mbps": 47.43,
+   "decompress_mbps": 249.22
   },
   {
    "compressor": "native",
@@ -934,8 +934,8 @@
    "level": 3,
    "out_size": 13751,
    "ratio": 0.3596,
-   "compress_mbps": 45.7,
-   "decompress_mbps": 243.24
+   "compress_mbps": 45.58,
+   "decompress_mbps": 247.82
   },
   {
    "compressor": "native",
@@ -944,8 +944,8 @@
    "level": 4,
    "out_size": 13287,
    "ratio": 0.3475,
-   "compress_mbps": 41.43,
-   "decompress_mbps": 249.46
+   "compress_mbps": 43.28,
+   "decompress_mbps": 256.96
   },
   {
    "compressor": "native",
@@ -954,8 +954,8 @@
    "level": 5,
    "out_size": 13240,
    "ratio": 0.3462,
-   "compress_mbps": 36.83,
-   "decompress_mbps": 257.91
+   "compress_mbps": 38.25,
+   "decompress_mbps": 266.4
   },
   {
    "compressor": "native",
@@ -964,8 +964,8 @@
    "level": 6,
    "out_size": 12944,
    "ratio": 0.3385,
-   "compress_mbps": 19.63,
-   "decompress_mbps": 259.87
+   "compress_mbps": 20.2,
+   "decompress_mbps": 271.58
   },
   {
    "compressor": "native",
@@ -974,8 +974,8 @@
    "level": 7,
    "out_size": 12929,
    "ratio": 0.3381,
-   "compress_mbps": 18.04,
-   "decompress_mbps": 264.26
+   "compress_mbps": 18.51,
+   "decompress_mbps": 274.47
   },
   {
    "compressor": "native",
@@ -984,8 +984,8 @@
    "level": 8,
    "out_size": 12921,
    "ratio": 0.3379,
-   "compress_mbps": 16.76,
-   "decompress_mbps": 263.81
+   "compress_mbps": 17.13,
+   "decompress_mbps": 273.99
   },
   {
    "compressor": "native",
@@ -994,8 +994,8 @@
    "level": 9,
    "out_size": 12427,
    "ratio": 0.325,
-   "compress_mbps": 5.42,
-   "decompress_mbps": 268.52
+   "compress_mbps": 5.41,
+   "decompress_mbps": 276.26
   },
   {
    "compressor": "native",
@@ -1004,7 +1004,7 @@
    "level": 10,
    "out_size": 12274,
    "ratio": 0.321,
-   "compress_mbps": 3.08,
+   "compress_mbps": 3.06,
    "decompress_mbps": null
   },
   {
@@ -1014,8 +1014,8 @@
    "level": 1,
    "out_size": 1800,
    "ratio": 0.4258,
-   "compress_mbps": 26.63,
-   "decompress_mbps": 90.4
+   "compress_mbps": 26.59,
+   "decompress_mbps": 92.3
   },
   {
    "compressor": "native",
@@ -1024,8 +1024,8 @@
    "level": 2,
    "out_size": 1750,
    "ratio": 0.414,
-   "compress_mbps": 25.27,
-   "decompress_mbps": 90.36
+   "compress_mbps": 25.23,
+   "decompress_mbps": 92.55
   },
   {
    "compressor": "native",
@@ -1034,8 +1034,8 @@
    "level": 3,
    "out_size": 1742,
    "ratio": 0.4121,
-   "compress_mbps": 25.14,
-   "decompress_mbps": 90.03
+   "compress_mbps": 25.11,
+   "decompress_mbps": 92.26
   },
   {
    "compressor": "native",
@@ -1044,8 +1044,8 @@
    "level": 4,
    "out_size": 1726,
    "ratio": 0.4083,
-   "compress_mbps": 24.76,
-   "decompress_mbps": 91.85
+   "compress_mbps": 25.41,
+   "decompress_mbps": 93.52
   },
   {
    "compressor": "native",
@@ -1054,8 +1054,8 @@
    "level": 5,
    "out_size": 1722,
    "ratio": 0.4074,
-   "compress_mbps": 24.36,
-   "decompress_mbps": 91.95
+   "compress_mbps": 25.04,
+   "decompress_mbps": 93.67
   },
   {
    "compressor": "native",
@@ -1064,8 +1064,8 @@
    "level": 6,
    "out_size": 1722,
    "ratio": 0.4074,
-   "compress_mbps": 23.37,
-   "decompress_mbps": 91.87
+   "compress_mbps": 24.03,
+   "decompress_mbps": 93.59
   },
   {
    "compressor": "native",
@@ -1074,8 +1074,8 @@
    "level": 7,
    "out_size": 1722,
    "ratio": 0.4074,
-   "compress_mbps": 23.36,
-   "decompress_mbps": 91.83
+   "compress_mbps": 24.08,
+   "decompress_mbps": 93.49
   },
   {
    "compressor": "native",
@@ -1084,8 +1084,8 @@
    "level": 8,
    "out_size": 1722,
    "ratio": 0.4074,
-   "compress_mbps": 23.39,
-   "decompress_mbps": 91.96
+   "compress_mbps": 24.06,
+   "decompress_mbps": 93.66
   },
   {
    "compressor": "native",
@@ -1094,8 +1094,8 @@
    "level": 9,
    "out_size": 1708,
    "ratio": 0.4041,
-   "compress_mbps": 5.48,
-   "decompress_mbps": 91.75
+   "compress_mbps": 5.5,
+   "decompress_mbps": 93.34
   },
   {
    "compressor": "native",
@@ -1104,7 +1104,7 @@
    "level": 10,
    "out_size": 1693,
    "ratio": 0.4005,
-   "compress_mbps": 3.31,
+   "compress_mbps": 3.24,
    "decompress_mbps": null
   },
   {
@@ -4414,8 +4414,8 @@
    "level": 1,
    "out_size": 4259644,
    "ratio": 0.4179,
-   "compress_mbps": 69.21,
-   "decompress_mbps": 187.78
+   "compress_mbps": 69.18,
+   "decompress_mbps": 197.96
   },
   {
    "compressor": "native",
@@ -4424,8 +4424,8 @@
    "level": 2,
    "out_size": 3977395,
    "ratio": 0.3902,
-   "compress_mbps": 49.6,
-   "decompress_mbps": 204.25
+   "compress_mbps": 50.3,
+   "decompress_mbps": 215.65
   },
   {
    "compressor": "native",
@@ -4434,8 +4434,8 @@
    "level": 3,
    "out_size": 3945296,
    "ratio": 0.3871,
-   "compress_mbps": 43.92,
-   "decompress_mbps": 226.52
+   "compress_mbps": 44.16,
+   "decompress_mbps": 239.97
   },
   {
    "compressor": "native",
@@ -4444,8 +4444,8 @@
    "level": 4,
    "out_size": 3851998,
    "ratio": 0.3779,
-   "compress_mbps": 33.09,
-   "decompress_mbps": 227.7
+   "compress_mbps": 34.83,
+   "decompress_mbps": 238.6
   },
   {
    "compressor": "native",
@@ -4454,8 +4454,8 @@
    "level": 5,
    "out_size": 3840481,
    "ratio": 0.3768,
-   "compress_mbps": 27.71,
-   "decompress_mbps": 225.33
+   "compress_mbps": 28.8,
+   "decompress_mbps": 237.65
   },
   {
    "compressor": "native",
@@ -4464,8 +4464,8 @@
    "level": 6,
    "out_size": 3847941,
    "ratio": 0.3775,
-   "compress_mbps": 28.1,
-   "decompress_mbps": 230.66
+   "compress_mbps": 29.11,
+   "decompress_mbps": 242.44
   },
   {
    "compressor": "native",
@@ -4474,8 +4474,8 @@
    "level": 7,
    "out_size": 3834802,
    "ratio": 0.3762,
-   "compress_mbps": 23.38,
-   "decompress_mbps": 233.02
+   "compress_mbps": 24.13,
+   "decompress_mbps": 244.62
   },
   {
    "compressor": "native",
@@ -4484,8 +4484,8 @@
    "level": 8,
    "out_size": 3833946,
    "ratio": 0.3762,
-   "compress_mbps": 22.41,
-   "decompress_mbps": 233.3
+   "compress_mbps": 23.24,
+   "decompress_mbps": 243.57
   },
   {
    "compressor": "native",
@@ -4494,8 +4494,8 @@
    "level": 9,
    "out_size": 3766584,
    "ratio": 0.3695,
-   "compress_mbps": 4.11,
-   "decompress_mbps": 241.39
+   "compress_mbps": 4.19,
+   "decompress_mbps": 254.99
   },
   {
    "compressor": "native",
@@ -4514,8 +4514,8 @@
    "level": 1,
    "out_size": 21267086,
    "ratio": 0.4152,
-   "compress_mbps": 84.65,
-   "decompress_mbps": 208.26
+   "compress_mbps": 86.25,
+   "decompress_mbps": 217.88
   },
   {
    "compressor": "native",
@@ -4524,8 +4524,8 @@
    "level": 2,
    "out_size": 20802983,
    "ratio": 0.4061,
-   "compress_mbps": 68.14,
-   "decompress_mbps": 219.0
+   "compress_mbps": 68.76,
+   "decompress_mbps": 228.75
   },
   {
    "compressor": "native",
@@ -4534,8 +4534,8 @@
    "level": 3,
    "out_size": 20665485,
    "ratio": 0.4035,
-   "compress_mbps": 63.4,
-   "decompress_mbps": 226.68
+   "compress_mbps": 64.83,
+   "decompress_mbps": 235.33
   },
   {
    "compressor": "native",
@@ -4544,8 +4544,8 @@
    "level": 4,
    "out_size": 20356893,
    "ratio": 0.3974,
-   "compress_mbps": 51.51,
-   "decompress_mbps": 235.42
+   "compress_mbps": 55.55,
+   "decompress_mbps": 244.39
   },
   {
    "compressor": "native",
@@ -4554,8 +4554,8 @@
    "level": 5,
    "out_size": 20209289,
    "ratio": 0.3946,
-   "compress_mbps": 41.28,
-   "decompress_mbps": 236.68
+   "compress_mbps": 43.33,
+   "decompress_mbps": 246.35
   },
   {
    "compressor": "native",
@@ -4564,8 +4564,8 @@
    "level": 6,
    "out_size": 19174181,
    "ratio": 0.3743,
-   "compress_mbps": 27.59,
-   "decompress_mbps": 247.89
+   "compress_mbps": 28.58,
+   "decompress_mbps": 257.63
   },
   {
    "compressor": "native",
@@ -4574,8 +4574,8 @@
    "level": 7,
    "out_size": 19127630,
    "ratio": 0.3734,
-   "compress_mbps": 22.74,
-   "decompress_mbps": 248.93
+   "compress_mbps": 23.41,
+   "decompress_mbps": 259.25
   },
   {
    "compressor": "native",
@@ -4584,8 +4584,8 @@
    "level": 8,
    "out_size": 19117840,
    "ratio": 0.3732,
-   "compress_mbps": 19.73,
-   "decompress_mbps": 249.45
+   "compress_mbps": 20.04,
+   "decompress_mbps": 259.51
   },
   {
    "compressor": "native",
@@ -4595,7 +4595,7 @@
    "out_size": 18686872,
    "ratio": 0.3648,
    "compress_mbps": 4.37,
-   "decompress_mbps": 238.36
+   "decompress_mbps": 259.51
   },
   {
    "compressor": "native",
@@ -4604,7 +4604,7 @@
    "level": 10,
    "out_size": 18539905,
    "ratio": 0.362,
-   "compress_mbps": 2.33,
+   "compress_mbps": 2.3,
    "decompress_mbps": null
   },
   {
@@ -4614,8 +4614,8 @@
    "level": 1,
    "out_size": 3864163,
    "ratio": 0.3876,
-   "compress_mbps": 86.55,
-   "decompress_mbps": 223.21
+   "compress_mbps": 86.53,
+   "decompress_mbps": 240.99
   },
   {
    "compressor": "native",
@@ -4624,8 +4624,8 @@
    "level": 2,
    "out_size": 3734957,
    "ratio": 0.3746,
-   "compress_mbps": 65.65,
-   "decompress_mbps": 240.6
+   "compress_mbps": 66.28,
+   "decompress_mbps": 251.81
   },
   {
    "compressor": "native",
@@ -4634,8 +4634,8 @@
    "level": 3,
    "out_size": 3708443,
    "ratio": 0.3719,
-   "compress_mbps": 55.68,
-   "decompress_mbps": 249.13
+   "compress_mbps": 56.36,
+   "decompress_mbps": 265.01
   },
   {
    "compressor": "native",
@@ -4644,8 +4644,8 @@
    "level": 4,
    "out_size": 3683603,
    "ratio": 0.3694,
-   "compress_mbps": 39.64,
-   "decompress_mbps": 238.83
+   "compress_mbps": 41.72,
+   "decompress_mbps": 250.74
   },
   {
    "compressor": "native",
@@ -4654,8 +4654,8 @@
    "level": 5,
    "out_size": 3677014,
    "ratio": 0.3688,
-   "compress_mbps": 32.13,
-   "decompress_mbps": 231.57
+   "compress_mbps": 33.55,
+   "decompress_mbps": 242.34
   },
   {
    "compressor": "native",
@@ -4664,8 +4664,8 @@
    "level": 6,
    "out_size": 3588221,
    "ratio": 0.3599,
-   "compress_mbps": 29.33,
-   "decompress_mbps": 237.88
+   "compress_mbps": 30.67,
+   "decompress_mbps": 247.95
   },
   {
    "compressor": "native",
@@ -4674,8 +4674,8 @@
    "level": 7,
    "out_size": 3581006,
    "ratio": 0.3592,
-   "compress_mbps": 24.13,
-   "decompress_mbps": 239.76
+   "compress_mbps": 25.1,
+   "decompress_mbps": 249.9
   },
   {
    "compressor": "native",
@@ -4684,8 +4684,8 @@
    "level": 8,
    "out_size": 3580944,
    "ratio": 0.3592,
-   "compress_mbps": 22.64,
-   "decompress_mbps": 246.53
+   "compress_mbps": 23.63,
+   "decompress_mbps": 257.19
   },
   {
    "compressor": "native",
@@ -4694,8 +4694,8 @@
    "level": 9,
    "out_size": 3581441,
    "ratio": 0.3592,
-   "compress_mbps": 4.73,
-   "decompress_mbps": 262.78
+   "compress_mbps": 4.82,
+   "decompress_mbps": 271.86
   },
   {
    "compressor": "native",
@@ -4714,8 +4714,8 @@
    "level": 1,
    "out_size": 3785443,
    "ratio": 0.1128,
-   "compress_mbps": 263.2,
-   "decompress_mbps": 649.78
+   "compress_mbps": 265.96,
+   "decompress_mbps": 679.18
   },
   {
    "compressor": "native",
@@ -4724,8 +4724,8 @@
    "level": 2,
    "out_size": 3761560,
    "ratio": 0.1121,
-   "compress_mbps": 167.98,
-   "decompress_mbps": 722.0
+   "compress_mbps": 168.47,
+   "decompress_mbps": 753.95
   },
   {
    "compressor": "native",
@@ -4734,8 +4734,8 @@
    "level": 3,
    "out_size": 3606997,
    "ratio": 0.1075,
-   "compress_mbps": 143.99,
-   "decompress_mbps": 800.09
+   "compress_mbps": 143.56,
+   "decompress_mbps": 801.03
   },
   {
    "compressor": "native",
@@ -4744,8 +4744,8 @@
    "level": 4,
    "out_size": 3201209,
    "ratio": 0.0954,
-   "compress_mbps": 111.46,
-   "decompress_mbps": 815.07
+   "compress_mbps": 136.72,
+   "decompress_mbps": 849.49
   },
   {
    "compressor": "native",
@@ -4754,8 +4754,8 @@
    "level": 5,
    "out_size": 3091564,
    "ratio": 0.0921,
-   "compress_mbps": 85.02,
-   "decompress_mbps": 891.91
+   "compress_mbps": 99.09,
+   "decompress_mbps": 925.83
   },
   {
    "compressor": "native",
@@ -4764,8 +4764,8 @@
    "level": 6,
    "out_size": 3112756,
    "ratio": 0.0928,
-   "compress_mbps": 82.25,
-   "decompress_mbps": 940.14
+   "compress_mbps": 95.34,
+   "decompress_mbps": 972.4
   },
   {
    "compressor": "native",
@@ -4774,8 +4774,8 @@
    "level": 7,
    "out_size": 3062314,
    "ratio": 0.0913,
-   "compress_mbps": 63.53,
-   "decompress_mbps": 951.25
+   "compress_mbps": 71.36,
+   "decompress_mbps": 985.66
   },
   {
    "compressor": "native",
@@ -4784,8 +4784,8 @@
    "level": 8,
    "out_size": 3045348,
    "ratio": 0.0908,
-   "compress_mbps": 53.14,
-   "decompress_mbps": 957.69
+   "compress_mbps": 59.09,
+   "decompress_mbps": 989.42
   },
   {
    "compressor": "native",
@@ -4794,8 +4794,8 @@
    "level": 9,
    "out_size": 3031645,
    "ratio": 0.0904,
-   "compress_mbps": 3.54,
-   "decompress_mbps": 978.33
+   "compress_mbps": 3.59,
+   "decompress_mbps": 1018.01
   },
   {
    "compressor": "native",
@@ -4804,7 +4804,7 @@
    "level": 10,
    "out_size": 2902186,
    "ratio": 0.0865,
-   "compress_mbps": 2.0,
+   "compress_mbps": 1.98,
    "decompress_mbps": null
   },
   {
@@ -4814,8 +4814,8 @@
    "level": 1,
    "out_size": 3357083,
    "ratio": 0.5457,
-   "compress_mbps": 59.84,
-   "decompress_mbps": 143.02
+   "compress_mbps": 60.81,
+   "decompress_mbps": 148.72
   },
   {
    "compressor": "native",
@@ -4824,8 +4824,8 @@
    "level": 2,
    "out_size": 3285077,
    "ratio": 0.534,
-   "compress_mbps": 49.45,
-   "decompress_mbps": 143.77
+   "compress_mbps": 50.46,
+   "decompress_mbps": 148.97
   },
   {
    "compressor": "native",
@@ -4834,8 +4834,8 @@
    "level": 3,
    "out_size": 3272746,
    "ratio": 0.532,
-   "compress_mbps": 47.12,
-   "decompress_mbps": 149.09
+   "compress_mbps": 47.91,
+   "decompress_mbps": 154.28
   },
   {
    "compressor": "native",
@@ -4844,8 +4844,8 @@
    "level": 4,
    "out_size": 3228052,
    "ratio": 0.5247,
-   "compress_mbps": 39.84,
-   "decompress_mbps": 159.01
+   "compress_mbps": 41.58,
+   "decompress_mbps": 164.64
   },
   {
    "compressor": "native",
@@ -4854,8 +4854,8 @@
    "level": 5,
    "out_size": 3223415,
    "ratio": 0.5239,
-   "compress_mbps": 35.65,
-   "decompress_mbps": 164.83
+   "compress_mbps": 37.45,
+   "decompress_mbps": 170.62
   },
   {
    "compressor": "native",
@@ -4864,8 +4864,8 @@
    "level": 6,
    "out_size": 3159522,
    "ratio": 0.5136,
-   "compress_mbps": 25.35,
-   "decompress_mbps": 167.8
+   "compress_mbps": 26.13,
+   "decompress_mbps": 172.72
   },
   {
    "compressor": "native",
@@ -4874,8 +4874,8 @@
    "level": 7,
    "out_size": 3156358,
    "ratio": 0.513,
-   "compress_mbps": 23.52,
-   "decompress_mbps": 167.15
+   "compress_mbps": 24.14,
+   "decompress_mbps": 173.84
   },
   {
    "compressor": "native",
@@ -4884,8 +4884,8 @@
    "level": 8,
    "out_size": 3155368,
    "ratio": 0.5129,
-   "compress_mbps": 22.55,
-   "decompress_mbps": 168.98
+   "compress_mbps": 23.1,
+   "decompress_mbps": 174.92
   },
   {
    "compressor": "native",
@@ -4894,8 +4894,8 @@
    "level": 9,
    "out_size": 3048772,
    "ratio": 0.4956,
-   "compress_mbps": 5.06,
-   "decompress_mbps": 174.05
+   "compress_mbps": 5.12,
+   "decompress_mbps": 180.74
   },
   {
    "compressor": "native",
@@ -4904,7 +4904,7 @@
    "level": 10,
    "out_size": 3021986,
    "ratio": 0.4912,
-   "compress_mbps": 3.16,
+   "compress_mbps": 3.13,
    "decompress_mbps": null
   },
   {
@@ -4914,8 +4914,8 @@
    "level": 1,
    "out_size": 3838828,
    "ratio": 0.3806,
-   "compress_mbps": 97.06,
-   "decompress_mbps": 253.1
+   "compress_mbps": 99.1,
+   "decompress_mbps": 265.97
   },
   {
    "compressor": "native",
@@ -4924,8 +4924,8 @@
    "level": 2,
    "out_size": 3792520,
    "ratio": 0.376,
-   "compress_mbps": 70.27,
-   "decompress_mbps": 260.81
+   "compress_mbps": 72.91,
+   "decompress_mbps": 273.81
   },
   {
    "compressor": "native",
@@ -4934,8 +4934,8 @@
    "level": 3,
    "out_size": 3783171,
    "ratio": 0.3751,
-   "compress_mbps": 69.87,
-   "decompress_mbps": 266.7
+   "compress_mbps": 70.12,
+   "decompress_mbps": 280.5
   },
   {
    "compressor": "native",
@@ -4944,8 +4944,8 @@
    "level": 4,
    "out_size": 3648458,
    "ratio": 0.3617,
-   "compress_mbps": 62.63,
-   "decompress_mbps": 281.28
+   "compress_mbps": 68.62,
+   "decompress_mbps": 293.96
   },
   {
    "compressor": "native",
@@ -4954,8 +4954,8 @@
    "level": 5,
    "out_size": 3648472,
    "ratio": 0.3617,
-   "compress_mbps": 58.75,
-   "decompress_mbps": 283.28
+   "compress_mbps": 63.59,
+   "decompress_mbps": 295.08
   },
   {
    "compressor": "native",
@@ -4964,8 +4964,8 @@
    "level": 6,
    "out_size": 3648595,
    "ratio": 0.3618,
-   "compress_mbps": 47.01,
-   "decompress_mbps": 272.34
+   "compress_mbps": 50.51,
+   "decompress_mbps": 286.0
   },
   {
    "compressor": "native",
@@ -4974,8 +4974,8 @@
    "level": 7,
    "out_size": 3648160,
    "ratio": 0.3617,
-   "compress_mbps": 46.38,
-   "decompress_mbps": 279.79
+   "compress_mbps": 49.96,
+   "decompress_mbps": 294.5
   },
   {
    "compressor": "native",
@@ -4984,8 +4984,8 @@
    "level": 8,
    "out_size": 3648156,
    "ratio": 0.3617,
-   "compress_mbps": 46.85,
-   "decompress_mbps": 277.61
+   "compress_mbps": 50.27,
+   "decompress_mbps": 310.93
   },
   {
    "compressor": "native",
@@ -4994,8 +4994,8 @@
    "level": 9,
    "out_size": 3648156,
    "ratio": 0.3617,
-   "compress_mbps": 5.96,
-   "decompress_mbps": 291.88
+   "compress_mbps": 6.04,
+   "decompress_mbps": 306.12
   },
   {
    "compressor": "native",
@@ -5004,7 +5004,7 @@
    "level": 10,
    "out_size": 3647321,
    "ratio": 0.3616,
-   "compress_mbps": 3.41,
+   "compress_mbps": 3.42,
    "decompress_mbps": null
   },
   {
@@ -5014,8 +5014,8 @@
    "level": 1,
    "out_size": 2254442,
    "ratio": 0.3402,
-   "compress_mbps": 90.47,
-   "decompress_mbps": 223.49
+   "compress_mbps": 90.32,
+   "decompress_mbps": 237.49
   },
   {
    "compressor": "native",
@@ -5024,8 +5024,8 @@
    "level": 2,
    "out_size": 2044843,
    "ratio": 0.3086,
-   "compress_mbps": 60.39,
-   "decompress_mbps": 261.13
+   "compress_mbps": 61.08,
+   "decompress_mbps": 275.45
   },
   {
    "compressor": "native",
@@ -5034,8 +5034,8 @@
    "level": 3,
    "out_size": 1992105,
    "ratio": 0.3006,
-   "compress_mbps": 48.9,
-   "decompress_mbps": 275.45
+   "compress_mbps": 49.61,
+   "decompress_mbps": 288.49
   },
   {
    "compressor": "native",
@@ -5044,8 +5044,8 @@
    "level": 4,
    "out_size": 1890729,
    "ratio": 0.2853,
-   "compress_mbps": 34.41,
-   "decompress_mbps": 297.1
+   "compress_mbps": 36.12,
+   "decompress_mbps": 311.13
   },
   {
    "compressor": "native",
@@ -5054,8 +5054,8 @@
    "level": 5,
    "out_size": 1858234,
    "ratio": 0.2804,
-   "compress_mbps": 22.19,
-   "decompress_mbps": 279.98
+   "compress_mbps": 23.16,
+   "decompress_mbps": 292.61
   },
   {
    "compressor": "native",
@@ -5064,8 +5064,8 @@
    "level": 6,
    "out_size": 1856235,
    "ratio": 0.2801,
-   "compress_mbps": 27.02,
-   "decompress_mbps": 307.63
+   "compress_mbps": 28.28,
+   "decompress_mbps": 318.67
   },
   {
    "compressor": "native",
@@ -5074,8 +5074,8 @@
    "level": 7,
    "out_size": 1823963,
    "ratio": 0.2752,
-   "compress_mbps": 17.15,
-   "decompress_mbps": 298.74
+   "compress_mbps": 17.69,
+   "decompress_mbps": 310.64
   },
   {
    "compressor": "native",
@@ -5084,8 +5084,8 @@
    "level": 8,
    "out_size": 1820112,
    "ratio": 0.2746,
-   "compress_mbps": 14.96,
-   "decompress_mbps": 312.43
+   "compress_mbps": 15.32,
+   "decompress_mbps": 326.32
   },
   {
    "compressor": "native",
@@ -5094,8 +5094,8 @@
    "level": 9,
    "out_size": 1773447,
    "ratio": 0.2676,
-   "compress_mbps": 2.95,
-   "decompress_mbps": 311.89
+   "compress_mbps": 2.99,
+   "decompress_mbps": 323.84
   },
   {
    "compressor": "native",
@@ -5114,8 +5114,8 @@
    "level": 1,
    "out_size": 6406301,
    "ratio": 0.2965,
-   "compress_mbps": 119.03,
-   "decompress_mbps": 326.06
+   "compress_mbps": 119.04,
+   "decompress_mbps": 340.16
   },
   {
    "compressor": "native",
@@ -5124,8 +5124,8 @@
    "level": 2,
    "out_size": 6102377,
    "ratio": 0.2824,
-   "compress_mbps": 86.8,
-   "decompress_mbps": 345.97
+   "compress_mbps": 87.91,
+   "decompress_mbps": 359.92
   },
   {
    "compressor": "native",
@@ -5134,8 +5134,8 @@
    "level": 3,
    "out_size": 6022184,
    "ratio": 0.2787,
-   "compress_mbps": 78.85,
-   "decompress_mbps": 361.13
+   "compress_mbps": 80.59,
+   "decompress_mbps": 375.49
   },
   {
    "compressor": "native",
@@ -5144,8 +5144,8 @@
    "level": 4,
    "out_size": 5880892,
    "ratio": 0.2722,
-   "compress_mbps": 62.44,
-   "decompress_mbps": 374.15
+   "compress_mbps": 68.94,
+   "decompress_mbps": 392.75
   },
   {
    "compressor": "native",
@@ -5154,8 +5154,8 @@
    "level": 5,
    "out_size": 5834363,
    "ratio": 0.27,
-   "compress_mbps": 47.84,
-   "decompress_mbps": 374.61
+   "compress_mbps": 53.42,
+   "decompress_mbps": 401.65
   },
   {
    "compressor": "native",
@@ -5164,8 +5164,8 @@
    "level": 6,
    "out_size": 5409792,
    "ratio": 0.2504,
-   "compress_mbps": 40.02,
-   "decompress_mbps": 389.15
+   "compress_mbps": 43.61,
+   "decompress_mbps": 405.65
   },
   {
    "compressor": "native",
@@ -5174,8 +5174,8 @@
    "level": 7,
    "out_size": 5393735,
    "ratio": 0.2496,
-   "compress_mbps": 34.68,
-   "decompress_mbps": 388.18
+   "compress_mbps": 36.85,
+   "decompress_mbps": 406.57
   },
   {
    "compressor": "native",
@@ -5184,8 +5184,8 @@
    "level": 8,
    "out_size": 5389952,
    "ratio": 0.2495,
-   "compress_mbps": 32.86,
-   "decompress_mbps": 389.37
+   "compress_mbps": 34.45,
+   "decompress_mbps": 407.86
   },
   {
    "compressor": "native",
@@ -5194,8 +5194,8 @@
    "level": 9,
    "out_size": 5235865,
    "ratio": 0.2423,
-   "compress_mbps": 4.76,
-   "decompress_mbps": 393.26
+   "compress_mbps": 4.86,
+   "decompress_mbps": 411.64
   },
   {
    "compressor": "native",
@@ -5214,8 +5214,8 @@
    "level": 1,
    "out_size": 5612204,
    "ratio": 0.7739,
-   "compress_mbps": 50.64,
-   "decompress_mbps": 139.65
+   "compress_mbps": 50.26,
+   "decompress_mbps": 147.6
   },
   {
    "compressor": "native",
@@ -5224,8 +5224,8 @@
    "level": 2,
    "out_size": 5533875,
    "ratio": 0.7631,
-   "compress_mbps": 41.71,
-   "decompress_mbps": 147.09
+   "compress_mbps": 41.88,
+   "decompress_mbps": 155.08
   },
   {
    "compressor": "native",
@@ -5234,8 +5234,8 @@
    "level": 3,
    "out_size": 5522436,
    "ratio": 0.7615,
-   "compress_mbps": 39.73,
-   "decompress_mbps": 151.61
+   "compress_mbps": 39.41,
+   "decompress_mbps": 159.9
   },
   {
    "compressor": "native",
@@ -5244,8 +5244,8 @@
    "level": 4,
    "out_size": 5494383,
    "ratio": 0.7576,
-   "compress_mbps": 33.61,
-   "decompress_mbps": 156.72
+   "compress_mbps": 33.9,
+   "decompress_mbps": 166.47
   },
   {
    "compressor": "native",
@@ -5254,8 +5254,8 @@
    "level": 5,
    "out_size": 5489807,
    "ratio": 0.757,
-   "compress_mbps": 31.61,
-   "decompress_mbps": 153.99
+   "compress_mbps": 31.62,
+   "decompress_mbps": 162.57
   },
   {
    "compressor": "native",
@@ -5264,8 +5264,8 @@
    "level": 6,
    "out_size": 5470520,
    "ratio": 0.7544,
-   "compress_mbps": 23.92,
-   "decompress_mbps": 155.87
+   "compress_mbps": 24.23,
+   "decompress_mbps": 164.8
   },
   {
    "compressor": "native",
@@ -5274,8 +5274,8 @@
    "level": 7,
    "out_size": 5463682,
    "ratio": 0.7534,
-   "compress_mbps": 22.64,
-   "decompress_mbps": 154.76
+   "compress_mbps": 22.72,
+   "decompress_mbps": 164.49
   },
   {
    "compressor": "native",
@@ -5284,8 +5284,8 @@
    "level": 8,
    "out_size": 5463761,
    "ratio": 0.7534,
-   "compress_mbps": 22.35,
-   "decompress_mbps": 156.0
+   "compress_mbps": 22.48,
+   "decompress_mbps": 164.87
   },
   {
    "compressor": "native",
@@ -5294,8 +5294,8 @@
    "level": 9,
    "out_size": 5284536,
    "ratio": 0.7287,
-   "compress_mbps": 5.06,
-   "decompress_mbps": 154.54
+   "compress_mbps": 5.12,
+   "decompress_mbps": 163.49
   },
   {
    "compressor": "native",
@@ -5304,7 +5304,7 @@
    "level": 10,
    "out_size": 5262319,
    "ratio": 0.7256,
-   "compress_mbps": 3.6,
+   "compress_mbps": 3.58,
    "decompress_mbps": null
   },
   {
@@ -5314,8 +5314,8 @@
    "level": 1,
    "out_size": 13727247,
    "ratio": 0.3311,
-   "compress_mbps": 88.62,
-   "decompress_mbps": 241.66
+   "compress_mbps": 89.48,
+   "decompress_mbps": 251.03
   },
   {
    "compressor": "native",
@@ -5324,8 +5324,8 @@
    "level": 2,
    "out_size": 12940398,
    "ratio": 0.3121,
-   "compress_mbps": 65.67,
-   "decompress_mbps": 263.82
+   "compress_mbps": 65.78,
+   "decompress_mbps": 272.94
   },
   {
    "compressor": "native",
@@ -5334,8 +5334,8 @@
    "level": 3,
    "out_size": 12703756,
    "ratio": 0.3064,
-   "compress_mbps": 60.41,
-   "decompress_mbps": 283.69
+   "compress_mbps": 60.3,
+   "decompress_mbps": 293.89
   },
   {
    "compressor": "native",
@@ -5344,8 +5344,8 @@
    "level": 4,
    "out_size": 12177338,
    "ratio": 0.2937,
-   "compress_mbps": 46.06,
-   "decompress_mbps": 286.12
+   "compress_mbps": 49.6,
+   "decompress_mbps": 298.12
   },
   {
    "compressor": "native",
@@ -5354,8 +5354,8 @@
    "level": 5,
    "out_size": 12051075,
    "ratio": 0.2907,
-   "compress_mbps": 35.55,
-   "decompress_mbps": 284.18
+   "compress_mbps": 37.75,
+   "decompress_mbps": 301.84
   },
   {
    "compressor": "native",
@@ -5364,8 +5364,8 @@
    "level": 6,
    "out_size": 12103573,
    "ratio": 0.2919,
-   "compress_mbps": 37.13,
-   "decompress_mbps": 298.1
+   "compress_mbps": 39.36,
+   "decompress_mbps": 310.84
   },
   {
    "compressor": "native",
@@ -5374,8 +5374,8 @@
    "level": 7,
    "out_size": 12027976,
    "ratio": 0.2901,
-   "compress_mbps": 29.65,
-   "decompress_mbps": 301.12
+   "compress_mbps": 30.92,
+   "decompress_mbps": 311.74
   },
   {
    "compressor": "native",
@@ -5384,8 +5384,8 @@
    "level": 8,
    "out_size": 12019953,
    "ratio": 0.2899,
-   "compress_mbps": 27.78,
-   "decompress_mbps": 290.9
+   "compress_mbps": 29.11,
+   "decompress_mbps": 313.35
   },
   {
    "compressor": "native",
@@ -5394,8 +5394,8 @@
    "level": 9,
    "out_size": 11806466,
    "ratio": 0.2848,
-   "compress_mbps": 3.89,
-   "decompress_mbps": 301.28
+   "compress_mbps": 3.93,
+   "decompress_mbps": 310.89
   },
   {
    "compressor": "native",
@@ -5404,7 +5404,7 @@
    "level": 10,
    "out_size": 11636727,
    "ratio": 0.2807,
-   "compress_mbps": 2.02,
+   "compress_mbps": 2.01,
    "decompress_mbps": null
   },
   {
@@ -5414,8 +5414,8 @@
    "level": 1,
    "out_size": 6438176,
    "ratio": 0.7597,
-   "compress_mbps": 45.47,
-   "decompress_mbps": 138.99
+   "compress_mbps": 45.25,
+   "decompress_mbps": 145.17
   },
   {
    "compressor": "native",
@@ -5424,8 +5424,8 @@
    "level": 2,
    "out_size": 6392101,
    "ratio": 0.7543,
-   "compress_mbps": 44.08,
-   "decompress_mbps": 140.38
+   "compress_mbps": 43.89,
+   "decompress_mbps": 147.13
   },
   {
    "compressor": "native",
@@ -5434,8 +5434,8 @@
    "level": 3,
    "out_size": 6392124,
    "ratio": 0.7543,
-   "compress_mbps": 43.81,
-   "decompress_mbps": 142.05
+   "compress_mbps": 43.78,
+   "decompress_mbps": 149.21
   },
   {
    "compressor": "native",
@@ -5444,8 +5444,8 @@
    "level": 4,
    "out_size": 6360604,
    "ratio": 0.7506,
-   "compress_mbps": 40.94,
-   "decompress_mbps": 128.74
+   "compress_mbps": 40.87,
+   "decompress_mbps": 133.82
   },
   {
    "compressor": "native",
@@ -5454,8 +5454,8 @@
    "level": 5,
    "out_size": 6360567,
    "ratio": 0.7506,
-   "compress_mbps": 40.99,
-   "decompress_mbps": 128.98
+   "compress_mbps": 41.01,
+   "decompress_mbps": 136.39
   },
   {
    "compressor": "native",
@@ -5464,8 +5464,8 @@
    "level": 6,
    "out_size": 6271453,
    "ratio": 0.7401,
-   "compress_mbps": 17.31,
-   "decompress_mbps": 130.61
+   "compress_mbps": 17.49,
+   "decompress_mbps": 137.34
   },
   {
    "compressor": "native",
@@ -5474,8 +5474,8 @@
    "level": 7,
    "out_size": 6271447,
    "ratio": 0.7401,
-   "compress_mbps": 17.35,
-   "decompress_mbps": 130.75
+   "compress_mbps": 17.43,
+   "decompress_mbps": 137.83
   },
   {
    "compressor": "native",
@@ -5484,8 +5484,8 @@
    "level": 8,
    "out_size": 6271447,
    "ratio": 0.7401,
-   "compress_mbps": 17.16,
-   "decompress_mbps": 131.67
+   "compress_mbps": 17.49,
+   "decompress_mbps": 139.3
   },
   {
    "compressor": "native",
@@ -5494,8 +5494,8 @@
    "level": 9,
    "out_size": 5952505,
    "ratio": 0.7024,
-   "compress_mbps": 5.91,
-   "decompress_mbps": 133.08
+   "compress_mbps": 6.06,
+   "decompress_mbps": 140.88
   },
   {
    "compressor": "native",
@@ -5504,7 +5504,7 @@
    "level": 10,
    "out_size": 5848663,
    "ratio": 0.6902,
-   "compress_mbps": 4.27,
+   "compress_mbps": 4.32,
    "decompress_mbps": null
   },
   {
@@ -5514,8 +5514,8 @@
    "level": 1,
    "out_size": 858525,
    "ratio": 0.1606,
-   "compress_mbps": 194.6,
-   "decompress_mbps": 415.53
+   "compress_mbps": 196.43,
+   "decompress_mbps": 472.63
   },
   {
    "compressor": "native",
@@ -5524,8 +5524,8 @@
    "level": 2,
    "out_size": 846807,
    "ratio": 0.1584,
-   "compress_mbps": 125.97,
-   "decompress_mbps": 500.76
+   "compress_mbps": 126.61,
+   "decompress_mbps": 570.7
   },
   {
    "compressor": "native",
@@ -5534,8 +5534,8 @@
    "level": 3,
    "out_size": 806798,
    "ratio": 0.1509,
-   "compress_mbps": 115.04,
-   "decompress_mbps": 609.02
+   "compress_mbps": 115.81,
+   "decompress_mbps": 633.61
   },
   {
    "compressor": "native",
@@ -5544,8 +5544,8 @@
    "level": 4,
    "out_size": 717301,
    "ratio": 0.1342,
-   "compress_mbps": 85.91,
-   "decompress_mbps": 603.65
+   "compress_mbps": 101.37,
+   "decompress_mbps": 625.62
   },
   {
    "compressor": "native",
@@ -5554,8 +5554,8 @@
    "level": 5,
    "out_size": 701552,
    "ratio": 0.1312,
-   "compress_mbps": 67.73,
-   "decompress_mbps": 653.81
+   "compress_mbps": 76.66,
+   "decompress_mbps": 680.03
   },
   {
    "compressor": "native",
@@ -5564,8 +5564,8 @@
    "level": 6,
    "out_size": 678544,
    "ratio": 0.1269,
-   "compress_mbps": 63.63,
-   "decompress_mbps": 695.8
+   "compress_mbps": 72.43,
+   "decompress_mbps": 728.31
   },
   {
    "compressor": "native",
@@ -5574,8 +5574,8 @@
    "level": 7,
    "out_size": 663716,
    "ratio": 0.1242,
-   "compress_mbps": 51.38,
-   "decompress_mbps": 706.68
+   "compress_mbps": 56.64,
+   "decompress_mbps": 736.78
   },
   {
    "compressor": "native",
@@ -5584,8 +5584,8 @@
    "level": 8,
    "out_size": 660481,
    "ratio": 0.1236,
-   "compress_mbps": 45.44,
-   "decompress_mbps": 718.37
+   "compress_mbps": 49.75,
+   "decompress_mbps": 749.98
   },
   {
    "compressor": "native",
@@ -5594,8 +5594,8 @@
    "level": 9,
    "out_size": 659417,
    "ratio": 0.1234,
-   "compress_mbps": 4.56,
-   "decompress_mbps": 627.97
+   "compress_mbps": 4.63,
+   "decompress_mbps": 664.47
   },
   {
    "compressor": "native",
@@ -5604,7 +5604,7 @@
    "level": 10,
    "out_size": 643093,
    "ratio": 0.1203,
-   "compress_mbps": 3.03,
+   "compress_mbps": 3.02,
    "decompress_mbps": null
   },
   {


### PR DESCRIPTION
This PR de-boxes the lazy matcher's interior-hash insertion loop: `updateHashesMergedFastU` runs the loop counter, insertion cap, data-bound test, bucket index, and chain mask on unboxed `USize` (with the addressability witness and `data.size - pos - 2` bound hoisted to a once-per-match guard), and `hash3U` hoists `hash3`'s per-call `USize` round-trip and position conversion to the caller. Writes and the head read go through proven-bounds `uset`/`uget`. This is the Wave 7 P1b treatment (`chainWalkPackedU`, #2755) applied to the other hot matcher loop, which profiles at 13-25% of L4-L8 compress time (Silesia dickens/xml, perf LBR). Output is byte-identical: `updateHashesMergedFastU_eq` proves the USize walk in lockstep against `updateHashesMerged`, and the rewired `updateHashesMergedGuarded` dispatches to it under a faithfulness guard whose fallback is the existing Nat walk, so `updateHashesMergedGuarded_eq` and every downstream proof are unchanged. No `sorry`.

Measured (chungus2, `bench/pin_core.sh`, `compress-pareto`, interleaved A/B vs master, spread < 1%): xml L4 +17.9% (89.1 to 105.1 MB/s), xml L6 +12.5%, mozilla L6 +4.5%, dickens L6 +4.2%, dickens L8 +3.2%; byte-identical `out=` verified across silesia xml/dickens/reymont/ooffice/mr at L4-L8.

🤖 Prepared with Claude Code