### PR TITLE
perf: seed the lazy lookahead walk with the current match length

### DIFF
--- a/Zip/Native/Deflate.lean
+++ b/Zip/Native/Deflate.lean
@@ -1920,8 +1920,18 @@ def lz77LazyMergedLoop (data : ByteArray)
             let head2 := headProbeGuarded c (prevSize + h2)
             let maxLen2 := min 258 (data.size - (pos + 1))
             have hmaxLen2P : (pos + 1) + maxLen2 ≤ data.size := by omega
+            -- Seed the lookahead walk with the current match length (zlib
+            -- `deflate_slow`'s `prev_length` trick): a candidate shorter than the
+            -- `pos` match cannot improve on it, so pre-loading `matchLen` as the
+            -- probe's best length lets `scan_end` skip those candidates' full
+            -- compares. The seed is only applied below the walk's own cutoff
+            -- (`min niceLen maxLen2`); at or above it a seeded walk would early-stop
+            -- immediately and diverge, so those (rare, long-match) probes stay
+            -- unseeded. Proven byte-identical via `chainWalkGuardedPackedU_seed`.
+            let cutoff2 := min niceLen maxLen2
+            let seed := if matchLen < cutoff2 then matchLen else 0
             let r2 :=
-              chainWalkGuardedPackedU data c windowSize (pos + 1) maxLen2 niceLen hmaxLen2P head2 lazyDepth 0 0
+              chainWalkGuardedPackedU data c windowSize (pos + 1) maxLen2 niceLen hmaxLen2P head2 lazyDepth seed 0
             let matchLen2 := r2 % 512
             let matchPos2 := r2 / 512
             if lazyAcceptCost matchLen (pos - matchPos) matchLen2 (pos + 1 - matchPos2) then

--- a/Zip/Spec/LZ77ChainCorrect.lean
+++ b/Zip/Spec/LZ77ChainCorrect.lean
@@ -47,6 +47,99 @@ theorem chainWalk_spec (data : ByteArray) (prev : Array Nat)
         · exact ih (prev[cand &&& 0x7FFF]!) _ _ hb
     · exact hb
 
+/-! ## Seeding the chain walk's best length (zlib `prev_length` probe seed)
+
+The lazy lookahead probe at `pos+1` starts its chain walk with the current
+`pos`-match length pre-loaded as the best length instead of `0` (zlib's
+`deflate_slow` passes `prev_length`), so a candidate shorter than the current
+match is never extended. `chainWalk_seed` proves this is *output-neutral* when the
+seed is below the walk's own early-stop cutoff (`min niceLen maxLen`): the seeded
+walk either agrees with the unseeded one exactly (when the unseeded walk finds a
+strictly longer match) or returns the seed unchanged (when it does not — in which
+case the unseeded walk's best is `≤` the seed, so the downstream lazy-accept test
+rejects it either way). Proven on the reference pair walk; the packed/`USize`
+twins inherit it through `chainWalkGuardedPacked_eq`. -/
+
+/-- The chain walk's best length only grows: the returned length is at least the
+    seed it started from. -/
+theorem chainWalk_fst_mono (data : ByteArray) (prev : Array Nat)
+    (windowSize pos maxLen niceLen : Nat) (hpm : pos + maxLen ≤ data.size)
+    (cand fuel bestLen bestPos : Nat) :
+    bestLen ≤ (lz77Chain.chainWalk data prev windowSize pos maxLen niceLen hpm cand fuel bestLen bestPos).1 := by
+  induction fuel generalizing cand bestLen bestPos with
+  | zero => rw [lz77Chain.chainWalk]; simp only [↓reduceIte, Nat.le_refl]
+  | succ k ih =>
+    rw [lz77Chain.chainWalk, if_neg (by omega : ¬ (k + 1 = 0))]
+    by_cases hc : cand < pos ∧ pos - cand ≤ windowSize
+    · have hcand : cand + maxLen ≤ data.size := by omega
+      simp only [dif_pos hc, Nat.add_sub_cancel]
+      by_cases hml : lz77Greedy.countMatch data cand pos maxLen hcand hpm > bestLen
+      · simp only [hml, ↓reduceIte]
+        split
+        · omega
+        · exact Nat.le_trans (Nat.le_of_lt hml) (ih (prev[cand &&& 0x7FFF]!) _ _)
+      · simp only [hml, ↓reduceIte]
+        split
+        · exact Nat.le_refl _
+        · exact ih (prev[cand &&& 0x7FFF]!) _ _
+    · simp only [dif_neg hc]
+      exact Nat.le_refl _
+
+/-- Seeding the best length with `m` (below the walk's own cutoff) is
+    output-neutral: from a seed `(m, s)` the walk either equals the walk from a
+    smaller seed `(b, p)` with `b ≤ m` (whenever that walk finds a match strictly
+    longer than `m`) or returns `(m, s)` unchanged (whenever it does not — then the
+    smaller-seed walk's best length is `≤ m`). Generalised over both accumulators
+    for the fuel induction. -/
+theorem chainWalk_seed (data : ByteArray) (prev : Array Nat)
+    (windowSize pos maxLen niceLen : Nat) (hpm : pos + maxLen ≤ data.size)
+    (m : Nat) (hm : m < min niceLen maxLen) (cand fuel b p s : Nat) (hbm : b ≤ m) :
+    (m < (lz77Chain.chainWalk data prev windowSize pos maxLen niceLen hpm cand fuel b p).1 →
+        lz77Chain.chainWalk data prev windowSize pos maxLen niceLen hpm cand fuel m s =
+          lz77Chain.chainWalk data prev windowSize pos maxLen niceLen hpm cand fuel b p) ∧
+      ((lz77Chain.chainWalk data prev windowSize pos maxLen niceLen hpm cand fuel b p).1 ≤ m →
+        lz77Chain.chainWalk data prev windowSize pos maxLen niceLen hpm cand fuel m s = (m, s)) := by
+  induction fuel generalizing cand b p s hbm with
+  | zero =>
+    rw [lz77Chain.chainWalk, lz77Chain.chainWalk]
+    simp only [↓reduceIte]
+    exact ⟨fun h => absurd h (Nat.not_lt.mpr hbm), fun _ => trivial⟩
+  | succ k ih =>
+    rw [lz77Chain.chainWalk, lz77Chain.chainWalk, if_neg (by omega : ¬ (k + 1 = 0)),
+      if_neg (by omega : ¬ (k + 1 = 0))]
+    by_cases hc : cand < pos ∧ pos - cand ≤ windowSize
+    · have hcand : cand + maxLen ≤ data.size := by omega
+      simp only [dif_pos hc, Nat.add_sub_cancel]
+      by_cases hmlm : lz77Greedy.countMatch data cand pos maxLen hcand hpm > m
+      · -- `ml > m ≥ b`: both sides update to `(ml, cand)`, then run in lockstep.
+        have hmlb : lz77Greedy.countMatch data cand pos maxLen hcand hpm > b := by omega
+        simp only [hmlm, hmlb, ↓reduceIte]
+        by_cases hstop : lz77Greedy.countMatch data cand pos maxLen hcand hpm ≥ min niceLen maxLen
+        · simp only [hstop, ↓reduceIte]
+          exact ⟨fun _ => trivial, fun h => absurd h (by omega)⟩
+        · simp only [hstop, ↓reduceIte]
+          -- Both recurse from `(ml, cand)`: literally the same call.
+          refine ⟨fun _ => trivial, fun h => ?_⟩
+          exfalso
+          have hmono := chainWalk_fst_mono data prev windowSize pos maxLen niceLen hpm
+            (prev[cand &&& 0x7FFF]!) k (lz77Greedy.countMatch data cand pos maxLen hcand hpm) cand
+          omega
+      · -- `ml ≤ m`: the seeded side never updates (stays `(m, s)`) and does not
+        -- early-stop (`m < cutoff`); the unseeded side keeps `b' ≤ m`; recurse.
+        have hSeed : ¬ (m ≥ min niceLen maxLen) := by omega
+        simp only [hmlm, ↓reduceIte, hSeed]
+        by_cases hmlb : lz77Greedy.countMatch data cand pos maxLen hcand hpm > b
+        · simp only [hmlb, ↓reduceIte]
+          have hstopU : ¬ (lz77Greedy.countMatch data cand pos maxLen hcand hpm ≥ min niceLen maxLen) := by omega
+          simp only [hstopU, ↓reduceIte]
+          exact ih (prev[cand &&& 0x7FFF]!) _ cand s (by omega)
+        · simp only [hmlb, ↓reduceIte]
+          have hstopU : ¬ (b ≥ min niceLen maxLen) := by omega
+          simp only [hstopU, ↓reduceIte]
+          exact ih (prev[cand &&& 0x7FFF]!) b p s hbm
+    · rw [dif_neg hc, dif_neg hc]
+      exact ⟨fun h => absurd h (Nat.not_lt.mpr hbm), fun _ => rfl⟩
+
 /-! ## Guarded per-position head insertion (Wave 3 Step 0.2, Wave 5 de-boxing)
 
 The mainLoops perform their per-position chain-head insertion (and, in the
@@ -499,6 +592,31 @@ theorem chainWalkGuardedPacked_div (data : ByteArray) (prev : Array Nat)
 /-- Every matcher call site clamps `maxLen` to `min 258 _`; this discharges
     the `maxLen ≤ 511` side condition when `simp` applies the decode lemmas. -/
 theorem min258_le_511 (x : Nat) : min 258 x ≤ 511 := by omega
+
+/-- Seeding lemma transported to the packed `USize` walk the matcher calls
+    (`chainWalkGuardedPackedU`): for a seed `m` below the walk's cutoff, the
+    `m`-seeded walk equals the `0`-seeded one when the latter's best length
+    exceeds `m`, and returns the raw value `m` (best position `0`) otherwise.
+    Proven by decoding both packed results back to `lz77Chain.chainWalk` pairs
+    (`chainWalkGuardedPacked_eq`) and applying `chainWalk_seed`. -/
+theorem chainWalkGuardedPackedU_seed (data : ByteArray) (prev : Array Nat)
+    (windowSize pos maxLen niceLen : Nat) (hpm : pos + maxLen ≤ data.size)
+    (hml511 : maxLen ≤ 511) (m : Nat) (hm : m < min niceLen maxLen) (cand fuel : Nat) :
+    (m < chainWalkGuardedPackedU data prev windowSize pos maxLen niceLen hpm cand fuel 0 0 % 512 →
+        chainWalkGuardedPackedU data prev windowSize pos maxLen niceLen hpm cand fuel m 0 =
+          chainWalkGuardedPackedU data prev windowSize pos maxLen niceLen hpm cand fuel 0 0) ∧
+      (chainWalkGuardedPackedU data prev windowSize pos maxLen niceLen hpm cand fuel 0 0 % 512 ≤ m →
+        chainWalkGuardedPackedU data prev windowSize pos maxLen niceLen hpm cand fuel m 0 = m) := by
+  simp only [chainWalkGuardedPackedU_eq, chainWalkGuardedPacked_eq]
+  have hU1 : (lz77Chain.chainWalk data prev windowSize pos maxLen niceLen hpm cand fuel 0 0).1 ≤ maxLen :=
+    chainWalk_fst_le data prev windowSize pos maxLen niceLen hpm cand fuel
+  obtain ⟨hEq, hLe⟩ := chainWalk_seed data prev windowSize pos maxLen niceLen hpm m hm cand fuel 0 0 0 (Nat.zero_le m)
+  have hmod : ((lz77Chain.chainWalk data prev windowSize pos maxLen niceLen hpm cand fuel 0 0).2 * 512 +
+      (lz77Chain.chainWalk data prev windowSize pos maxLen niceLen hpm cand fuel 0 0).1) % 512 =
+      (lz77Chain.chainWalk data prev windowSize pos maxLen niceLen hpm cand fuel 0 0).1 := by omega
+  refine ⟨fun h => ?_, fun h => ?_⟩
+  · rw [hmod] at h; rw [hEq h]
+  · rw [hmod] at h; rw [hLe h]; simp
 
 /-- The proven-bounds hash-insertion loop computes the same arrays as the
     panic-checked reference: the bodies differ only in how `hashTable[hsh]` is

--- a/Zip/Spec/LZ77MergedCorrect.lean
+++ b/Zip/Spec/LZ77MergedCorrect.lean
@@ -322,6 +322,57 @@ private theorem updateHashesMergedGuarded_eq (data : ByteArray) (hashSize prevSi
         hg.1 hg.2.1 hg.2.2
   · rfl
 
+/-! ## Seeded lookahead probe: byte-identity bridge -/
+
+/-- A lookahead match no longer than the current one is never cost-accepted:
+    `lazyAcceptCost` requires `len1 < len2`. -/
+private theorem lazyAcceptCost_of_le {l1 d1 l2 d2 : Nat} (h : l2 ≤ l1) :
+    lazyAcceptCost l1 d1 l2 d2 = false := by
+  unfold lazyAcceptCost
+  rw [decide_eq_false (show ¬ l1 < l2 by omega), Bool.false_and]
+
+/-- The seeded lookahead probe produces the same lazy decision as the unseeded
+    one, and — whenever that decision is *accept* — the same probe result.
+    `.1`: the cost decision is identical for the seeded and unseeded probe. `.2`:
+    the seeded probe either equals the unseeded one outright, or its decision is
+    *reject* (so the branch it selects never depends on the probe value). Together
+    these make seeding the `pos+1` walk with the `pos` match length
+    byte-identical. The seed is `matchLen` below the walk's cutoff and `0` at or
+    above it; both cases collapse via `chainWalkGuardedPackedU_seed`. -/
+private theorem seeded_probe_bridge (data : ByteArray) (prev : Array Nat)
+    (windowSize pos1 maxLen niceLen : Nat) (hpm : pos1 + maxLen ≤ data.size)
+    (hml511 : maxLen ≤ 511) (cand fuel : Nat) (len1 dist1 base : Nat) :
+    (lazyAcceptCost len1 dist1
+        (chainWalkGuardedPackedU data prev windowSize pos1 maxLen niceLen hpm cand fuel
+          (if len1 < min niceLen maxLen then len1 else 0) 0 % 512)
+        (base - chainWalkGuardedPackedU data prev windowSize pos1 maxLen niceLen hpm cand fuel
+          (if len1 < min niceLen maxLen then len1 else 0) 0 / 512)
+      = lazyAcceptCost len1 dist1
+        (chainWalkGuardedPackedU data prev windowSize pos1 maxLen niceLen hpm cand fuel 0 0 % 512)
+        (base - chainWalkGuardedPackedU data prev windowSize pos1 maxLen niceLen hpm cand fuel 0 0 / 512))
+    ∧ (chainWalkGuardedPackedU data prev windowSize pos1 maxLen niceLen hpm cand fuel
+          (if len1 < min niceLen maxLen then len1 else 0) 0
+        = chainWalkGuardedPackedU data prev windowSize pos1 maxLen niceLen hpm cand fuel 0 0
+       ∨ lazyAcceptCost len1 dist1
+           (chainWalkGuardedPackedU data prev windowSize pos1 maxLen niceLen hpm cand fuel
+             (if len1 < min niceLen maxLen then len1 else 0) 0 % 512)
+           (base - chainWalkGuardedPackedU data prev windowSize pos1 maxLen niceLen hpm cand fuel
+             (if len1 < min niceLen maxLen then len1 else 0) 0 / 512) = false) := by
+  by_cases hc1 : len1 < min niceLen maxLen
+  · rw [if_pos hc1]
+    obtain ⟨hEq, hLe⟩ := chainWalkGuardedPackedU_seed data prev windowSize pos1 maxLen niceLen hpm hml511 len1 hc1 cand fuel
+    by_cases hgt : len1 < chainWalkGuardedPackedU data prev windowSize pos1 maxLen niceLen hpm cand fuel 0 0 % 512
+    · rw [hEq hgt]; exact ⟨rfl, Or.inl rfl⟩
+    · rw [hLe (Nat.le_of_not_lt hgt)]
+      have hfL : lazyAcceptCost len1 dist1 (len1 % 512) (base - len1 / 512) = false :=
+        lazyAcceptCost_of_le (Nat.mod_le len1 512)
+      have hfR : lazyAcceptCost len1 dist1
+          (chainWalkGuardedPackedU data prev windowSize pos1 maxLen niceLen hpm cand fuel 0 0 % 512)
+          (base - chainWalkGuardedPackedU data prev windowSize pos1 maxLen niceLen hpm cand fuel 0 0 / 512) = false :=
+        lazyAcceptCost_of_le (Nat.le_of_not_lt hgt)
+      exact ⟨by rw [hfL, hfR], Or.inr hfL⟩
+  · rw [if_neg hc1]; exact ⟨rfl, Or.inl rfl⟩
+
 /-! ## The lockstep loop equality -/
 
 private theorem mergedLoop_eq (data : ByteArray)
@@ -368,26 +419,45 @@ private theorem mergedLoop_eq (data : ByteArray)
               (lz77Greedy.hash3 data (pos + 1) hashSize (by omega)) hps' hh2]
             rw [chainWalkGuardedPackedU_append data p' t' windowSize (pos + 1)
               (min 258 (data.size - (pos + 1))) niceLen (by omega) hpv'
-              (t'[lz77Greedy.hash3 data (pos + 1) hashSize (by omega)]!) lazyDepth 0 0]
+              (t'[lz77Greedy.hash3 data (pos + 1) hashSize (by omega)]!) lazyDepth]
             split
-            · split
-              · split
-                · rw [updateHashesMergedGuarded_eq,
-                    updateHashesMerged_append data hashSize prevSize t' p' pos 1 _ insertCap hhs hht' hps' hpv',
-                    updateHashesGuarded_eq]
-                  exact ih _ (by omega) _ _ _ _ (by rw [updateHashes_size1]; exact hht')
-                    (by rw [updateHashes_size2]; exact hps') (by rw [updateHashes_size2]; exact hpv') rfl
-                · rw [updateHashesMergedGuarded_eq,
-                    updateHashesMerged_append data hashSize prevSize t' p' pos 1 _ insertCap hhs hht' hps' hpv',
-                    updateHashesGuarded_eq]
-                  exact ih _ (by omega) _ _ _ _ (by rw [updateHashes_size1]; exact hht')
-                    (by rw [updateHashes_size2]; exact hps') (by rw [updateHashes_size2]; exact hpv') rfl
-              · rw [updateHashesMergedGuarded_eq,
+            · -- goodMatch-T: bridge the *seeded* `pos+1` probe to the unseeded one.
+              -- The seeding lemma makes the lazy decision (and, on accept, the probe
+              -- result itself) identical, so the branch tree stays in lockstep.
+              have hbr := seeded_probe_bridge data p' windowSize (pos + 1)
+                (min 258 (data.size - (pos + 1))) niceLen (by omega) (by omega)
+                (t'[lz77Greedy.hash3 data (pos + 1) hashSize (by omega)]!) lazyDepth
+                (chainWalkGuardedPackedU data p' windowSize pos (min 258 (data.size - pos)) niceLen
+                  (by omega) (hashTable[lz77Greedy.hash3 data pos hashSize hlt]!) maxChain 0 0 % 512)
+                (pos - chainWalkGuardedPackedU data p' windowSize pos (min 258 (data.size - pos)) niceLen
+                  (by omega) (hashTable[lz77Greedy.hash3 data pos hashSize hlt]!) maxChain 0 0 / 512)
+                (pos + 1)
+              rw [hbr.1]
+              split
+              · -- accept
+                rename_i hacc
+                rcases hbr.2 with heq | hfalse
+                · rw [heq]
+                  split
+                  · rw [updateHashesMergedGuarded_eq,
+                      updateHashesMerged_append data hashSize prevSize t' p' pos 1 _ insertCap hhs hht' hps' hpv',
+                      updateHashesGuarded_eq]
+                    exact ih _ (by omega) _ _ _ _ (by rw [updateHashes_size1]; exact hht')
+                      (by rw [updateHashes_size2]; exact hps') (by rw [updateHashes_size2]; exact hpv') rfl
+                  · rw [updateHashesMergedGuarded_eq,
+                      updateHashesMerged_append data hashSize prevSize t' p' pos 1 _ insertCap hhs hht' hps' hpv',
+                      updateHashesGuarded_eq]
+                    exact ih _ (by omega) _ _ _ _ (by rw [updateHashes_size1]; exact hht')
+                      (by rw [updateHashes_size2]; exact hps') (by rw [updateHashes_size2]; exact hpv') rfl
+                · rw [← hbr.1, hfalse] at hacc; simp at hacc
+              · -- reject: the emitted token uses only the `pos` match, not the probe.
+                rw [updateHashesMergedGuarded_eq,
                   updateHashesMerged_append data hashSize prevSize t' p' pos 1 _ insertCap hhs hht' hps' hpv',
                   updateHashesGuarded_eq]
                 exact ih _ (by omega) _ _ _ _ (by rw [updateHashes_size1]; exact hht')
                   (by rw [updateHashes_size2]; exact hps') (by rw [updateHashes_size2]; exact hpv') rfl
-            · rw [updateHashesMergedGuarded_eq,
+            · -- goodMatch-F (gated): no probe.
+              rw [updateHashesMergedGuarded_eq,
                 updateHashesMerged_append data hashSize prevSize t' p' pos 1 _ insertCap hhs hht' hps' hpv',
                 updateHashesGuarded_eq]
               exact ih _ (by omega) _ _ _ _ (by rw [updateHashes_size1]; exact hht')

--- a/bench/graphs/canterbury_compress_heatmap.svg
+++ b/bench/graphs/canterbury_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#pc87c342f95)">
+   <g clip-path="url(#pae6807e341)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJF0lEQVR4nO3YzYpl1R2H4Trdp9ROV6SR+EEEiZhhwEHQic4z90K8Aideg3cggnMJZJBxJg5DJgqCNCKGQBur7arq8nw4EHIF7+IfD89zBb/NYu/znrU5/PDp8Yxfl5sfpxes8/Q0n+14ezM9YZnN8y9NT1jj2d9ML1hnc2d6wRo/ne57dqpndnz0zfSEZU7zxAAABgksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAIDY9uHm0fSGJW73N9MTlnnlwR+mJyxzcXhpesISm+vL6QnL/OP6i+kJS/z+mRenJyyzP+ymJyzxeHc1PWGZ3XE/PWGJt3776vSEZdxgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQGx7cf5gesMSh+1hesIyF2fPTU9Y578Ppxcscby+nJ6wzNuvvTM9YYmr3eme2ZMTfbY/XvxpesIyt5vd9IQljl//c3rCMm6wAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAILa9d/diesMSN/ur6QnrbE64i597fnrBEpsTPrPz3W56whKnfGb3t6f5nv379tvpCcvsDrfTE5Z49f6D6QnLnO4XBABgiMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACA2Gb/rw+P0yPgfw6H6QXwizv+f/7q+H7wf8QXBAAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGLb9//zcHrDEpdP99MTlvn828fTE5b563vvTk9Y4uV7r01PWObNjz+ZnrDEX954YXrCMl99fz09YYl727vTE5b57G9fTk9Y4uqjD6YnLOMGCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGKb3eHvx+kRK+wPu+kJy9zZnG4X3725mp6wxt3t9IJ1njyaXrDE/sEr0xOWORwP0xOWON+c7nv20/E0f9POd6f5XGdnbrAAAHICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgtr3d30xvWGJ/3E1PWOb+k6vpCetcfje9YInj06fTE5bZvP7n6QlLnOq38ezs7Ox6/+P0hCVe2P5uesIy59eX0xOWOH731fSEZdxgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQOxnCwGI995LbBIAAAAASUVORK5CYII=" id="image690e8828b8" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJDElEQVR4nO3YvYpdVQCG4ZzMGU3MGIaAMRgIgpaKlTba23shXoGN1+AdiGAvgoW1jaXYKAQkSIgIUSdm/nJ+LASv4F0ss3meK/g2i73Pe9Zq99eX+ys8X87/nr1gnItlPtv+8nz2hGFWN2/PnjDGiy/NXjDO6ursBWM8W+57ttQz2z/+dfaEYZZ5YgAAEwksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAIDY+sHq8ewNQ1xuz2dPGObO8euzJwxztLs9e8IQq7OT2ROG+e7sp9kThnjthVdmTxhmu9vMnjDEk83p7AnDbPbb2ROGePflu7MnDOMGCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGLro8Pj2RuG2K13sycMc3Tl2uwJ4/z5YPaCIfZnJ7MnDPPevfdnTxjidLPcM3u60Gd78+it2ROGuVxtZk8YYv/LD7MnDOMGCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGLr6wdHszcMcb49nT1hnNWCu/jazdkLhlgt+MwON5vZE4ZY8pndWC/zPfvt8uHsCcNsdpezJwxx98bx7AnDLPcLAgAwicACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACA2Gr746f72SPgP7vd7AXwr6v+fz53fD/4H/EFAQCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgNj6498fzN4wxMnFdvaEYb5/+GT2hGG+/uiD2ROGePX6vdkThnnn8y9mTxjiwzduzZ4wzP0/zmZPGOL6+mD2hGG++ubn2ROGOP3sk9kThnGDBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAALHVZvftfvaIEba7zewJw1xdLbeLD85PZ08Y42A9e8E4Tx/PXjDE9vjO7AnD7Pa72ROGOFwt9z17tl/mb9rhZpnPdeWKGywAgJzAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCIrS+357M3DLHdb2ZPGObG09PZE8Y5eTR7wRD7i4vZE4ZZ3Xt79oQhzrfLfc8uFvpstw5uzZ4wzOH5yewJQ+wf3Z89YRg3WAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABD7B3pwiOznHABHAAAAAElFTkSuQmCC" id="image573336cef9" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m050aaef882" d="M 0 0 
+       <path id="m50c57881d9" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m050aaef882" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m50c57881d9" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m050aaef882" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m50c57881d9" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m050aaef882" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m50c57881d9" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m050aaef882" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m50c57881d9" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m050aaef882" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m50c57881d9" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m050aaef882" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m50c57881d9" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m050aaef882" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m50c57881d9" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m050aaef882" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m50c57881d9" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m050aaef882" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m50c57881d9" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m050aaef882" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m50c57881d9" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m050aaef882" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m50c57881d9" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="mdea956b974" d="M 0 0 
+       <path id="m36a26e5866" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mdea956b974" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m36a26e5866" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#mdea956b974" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m36a26e5866" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mdea956b974" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m36a26e5866" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#mdea956b974" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m36a26e5866" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#mdea956b974" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m36a26e5866" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#mdea956b974" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m36a26e5866" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mdea956b974" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m36a26e5866" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#mdea956b974" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m36a26e5866" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1358,8 +1358,37 @@ z
     </g>
    </g>
    <g id="text_21">
-    <!-- +23 -->
+    <!-- +24 -->
     <g transform="translate(147.693424 68.904519) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_22">
+    <!-- -39 -->
+    <g transform="translate(188.495082 68.904519) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
@@ -1394,42 +1423,13 @@ Q 3006 2619 2597 2516
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_22">
-    <!-- -40 -->
-    <g transform="translate(188.495082 68.904519) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-34" d="M 2419 4116 
-L 825 1625 
-L 2419 1625 
-L 2419 4116 
-z
-M 2253 4666 
-L 3047 4666 
-L 3047 1625 
-L 3713 1625 
-L 3713 1100 
-L 3047 1100 
-L 3047 0 
-L 2419 0 
-L 2419 1100 
-L 313 1100 
-L 313 1709 
-L 2253 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_23">
-    <!-- -76 -->
+    <!-- -75 -->
     <g transform="translate(227.74588 68.904519) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-37" d="M 525 4666 
@@ -1445,7 +1445,7 @@ z
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_24">
@@ -1498,18 +1498,19 @@ z
     </g>
    </g>
    <g id="text_25">
-    <!-- -8 -->
-    <g transform="translate(308.31529 68.904519) scale(0.065 -0.065)">
+    <!-- -17 -->
+    <g transform="translate(306.247477 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_26">
-    <!-- +21 -->
+    <!-- +22 -->
     <g transform="translate(343.947416 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_27">
@@ -1521,10 +1522,11 @@ z
     </g>
    </g>
    <g id="text_28">
-    <!-- -8 -->
-    <g transform="translate(426.067685 68.904519) scale(0.065 -0.065)">
+    <!-- -10 -->
+    <g transform="translate(423.999873 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_29">
@@ -2179,18 +2181,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="image4f039db79e" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
+iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="image0bed12608b" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="m0c6635bc2b" d="M 0 0 
+       <path id="m6a1721b66e" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m0c6635bc2b" x="547.779688" y="276.293905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6a1721b66e" x="547.779688" y="276.293905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
@@ -2213,7 +2215,7 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m0c6635bc2b" x="547.779688" y="247.808905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6a1721b66e" x="547.779688" y="247.808905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
@@ -2227,7 +2229,7 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m0c6635bc2b" x="547.779688" y="219.323905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6a1721b66e" x="547.779688" y="219.323905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
@@ -2241,7 +2243,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m0c6635bc2b" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6a1721b66e" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
@@ -2254,7 +2256,7 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m0c6635bc2b" x="547.779688" y="162.353904" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6a1721b66e" x="547.779688" y="162.353904" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_112">
@@ -2267,7 +2269,7 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m0c6635bc2b" x="547.779688" y="133.868904" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6a1721b66e" x="547.779688" y="133.868904" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
@@ -2280,7 +2282,7 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m0c6635bc2b" x="547.779688" y="105.383904" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6a1721b66e" x="547.779688" y="105.383904" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
@@ -2941,8 +2943,8 @@ z
    </g>
   </g>
   <g id="text_117">
-   <!-- 2026-07-08T20:16:47Z  ·  Linux chungus2 x86_64  ·  commit 74c19afa  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(17.841641 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-08T21:41:55Z  ·  Linux chungus2 x86_64  ·  commit b17c222c  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(16.990156 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -3012,13 +3014,13 @@ z
     <use xlink:href="#DejaVuSans-38" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3058,109 +3060,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3254.101562 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3317.724609 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3381.347656 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3442.626953 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3477.832031 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3539.111328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3570.898438 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3602.685547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3634.472656 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3666.259766 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3698.046875 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3725.830078 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3787.353516 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3848.632812 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3912.011719 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3975.488281 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4014.351562 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4075.533203 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4134.712891 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4196.236328 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4237.349609 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4271.041016 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4298.824219 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4360.347656 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4421.626953 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4485.005859 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4548.628906 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4582.320312 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4641.5 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4705.123047 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4736.910156 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4800.533203 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4864.15625 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4895.943359 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4959.566406 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4995.650391 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5034.513672 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5089.494141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5153.117188 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5184.904297 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5216.691406 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5248.478516 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5280.265625 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5312.052734 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5351.261719 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5414.640625 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5453.503906 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5514.685547 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5578.064453 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5641.541016 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5704.919922 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5768.396484 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5831.775391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5870.984375 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5902.771484 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5986.560547 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6018.347656 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6115.759766 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6177.283203 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6240.759766 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6268.542969 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6329.822266 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6393.201172 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6424.988281 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6477.087891 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6540.466797 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6601.746094 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6665.222656 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6717.322266 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6780.701172 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6841.882812 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6881.091797 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6914.783203 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6946.570312 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6987.683594 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7048.962891 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7088.171875 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7115.955078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7177.136719 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7208.923828 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7236.707031 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7288.806641 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7320.59375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7384.070312 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7445.59375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7484.802734 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7546.326172 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7585.689453 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7683.101562 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7710.884766 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7774.263672 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7802.046875 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7854.146484 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7893.355469 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7921.138672 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3135.351562 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3198.974609 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3262.597656 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3317.578125 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3381.201172 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3444.824219 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3508.447266 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3563.427734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3595.214844 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3627.001953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3658.789062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3690.576172 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3722.363281 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3750.146484 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3811.669922 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3872.949219 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3936.328125 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3999.804688 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4038.667969 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4099.849609 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4159.029297 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4220.552734 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4261.666016 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4295.357422 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4323.140625 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4384.664062 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4445.943359 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4509.322266 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4572.945312 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4606.636719 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4665.816406 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4729.439453 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4761.226562 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4824.849609 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4888.472656 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4920.259766 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4983.882812 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5019.966797 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5058.830078 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5113.810547 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5177.433594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5209.220703 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5241.007812 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5272.794922 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5304.582031 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5336.369141 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5375.578125 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5438.957031 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5477.820312 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5539.001953 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5602.380859 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5665.857422 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5729.236328 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5792.712891 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5856.091797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5895.300781 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5927.087891 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6010.876953 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6042.664062 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6140.076172 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6201.599609 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6265.076172 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6292.859375 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6354.138672 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6417.517578 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6449.304688 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6501.404297 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6564.783203 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6626.0625 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6689.539062 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6741.638672 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6805.017578 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6866.199219 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6905.408203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6939.099609 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6970.886719 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7012 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7073.279297 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7112.488281 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7140.271484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7201.453125 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7233.240234 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7261.023438 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7313.123047 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7344.910156 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7408.386719 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7469.910156 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7509.119141 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7570.642578 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7610.005859 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7707.417969 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7735.201172 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7798.580078 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7826.363281 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7878.462891 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7917.671875 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7945.455078 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pc87c342f95">
+  <clipPath id="pae6807e341">
    <rect x="95.67625" y="49.4355" width="431.758783" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_compress_pareto.svg
+++ b/bench/graphs/canterbury_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 79.118387 412.80375 
 L 79.118387 48.323125 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m7798b2a56e" d="M 0 0 
+       <path id="mead52ac3fa" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m7798b2a56e" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mead52ac3fa" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -161,11 +161,11 @@ z
      <g id="line2d_3">
       <path d="M 166.481434 412.80375 
 L 166.481434 48.323125 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m7798b2a56e" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mead52ac3fa" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -216,11 +216,11 @@ z
      <g id="line2d_5">
       <path d="M 253.844481 412.80375 
 L 253.844481 48.323125 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m7798b2a56e" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mead52ac3fa" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -237,11 +237,11 @@ L 253.844481 48.323125
      <g id="line2d_7">
       <path d="M 341.207528 412.80375 
 L 341.207528 48.323125 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m7798b2a56e" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mead52ac3fa" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -279,11 +279,11 @@ z
      <g id="line2d_9">
       <path d="M 428.570575 412.80375 
 L 428.570575 48.323125 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m7798b2a56e" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mead52ac3fa" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -332,11 +332,11 @@ z
      <g id="line2d_11">
       <path d="M 515.933622 412.80375 
 L 515.933622 48.323125 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m7798b2a56e" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mead52ac3fa" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -353,11 +353,11 @@ L 515.933622 48.323125
      <g id="line2d_13">
       <path d="M 603.296669 412.80375 
 L 603.296669 48.323125 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m7798b2a56e" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mead52ac3fa" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -854,16 +854,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 347.786382 
 L 637.2 347.786382 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="m93b0f463f1" d="M 0 0 
+       <path id="me3f5b263a9" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m93b0f463f1" x="49.078125" y="347.786382" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me3f5b263a9" x="49.078125" y="347.786382" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -895,11 +895,11 @@ z
      <g id="line2d_17">
       <path d="M 49.078125 238.646289 
 L 637.2 238.646289 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m93b0f463f1" x="49.078125" y="238.646289" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me3f5b263a9" x="49.078125" y="238.646289" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -915,11 +915,11 @@ L 637.2 238.646289
      <g id="line2d_19">
       <path d="M 49.078125 129.506196 
 L 637.2 129.506196 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m93b0f463f1" x="49.078125" y="129.506196" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me3f5b263a9" x="49.078125" y="129.506196" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -935,16 +935,16 @@ L 637.2 129.506196
      <g id="line2d_21">
       <path d="M 49.078125 404.853417 
 L 637.2 404.853417 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="m54a2238fba" d="M 0 0 
+       <path id="m7d4e1f1ef7" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m54a2238fba" x="49.078125" y="404.853417" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7d4e1f1ef7" x="49.078125" y="404.853417" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -952,11 +952,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 391.217592 
 L 637.2 391.217592 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m54a2238fba" x="49.078125" y="391.217592" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7d4e1f1ef7" x="49.078125" y="391.217592" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -964,11 +964,11 @@ L 637.2 391.217592
      <g id="line2d_25">
       <path d="M 49.078125 380.640824 
 L 637.2 380.640824 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m54a2238fba" x="49.078125" y="380.640824" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7d4e1f1ef7" x="49.078125" y="380.640824" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -976,11 +976,11 @@ L 637.2 380.640824
      <g id="line2d_27">
       <path d="M 49.078125 371.998975 
 L 637.2 371.998975 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m54a2238fba" x="49.078125" y="371.998975" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7d4e1f1ef7" x="49.078125" y="371.998975" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -988,11 +988,11 @@ L 637.2 371.998975
      <g id="line2d_29">
       <path d="M 49.078125 364.692396 
 L 637.2 364.692396 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m54a2238fba" x="49.078125" y="364.692396" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7d4e1f1ef7" x="49.078125" y="364.692396" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1000,11 +1000,11 @@ L 637.2 364.692396
      <g id="line2d_31">
       <path d="M 49.078125 358.36315 
 L 637.2 358.36315 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m54a2238fba" x="49.078125" y="358.36315" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7d4e1f1ef7" x="49.078125" y="358.36315" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1012,11 +1012,11 @@ L 637.2 358.36315
      <g id="line2d_33">
       <path d="M 49.078125 352.780359 
 L 637.2 352.780359 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m54a2238fba" x="49.078125" y="352.780359" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7d4e1f1ef7" x="49.078125" y="352.780359" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1024,11 +1024,11 @@ L 637.2 352.780359
      <g id="line2d_35">
       <path d="M 49.078125 314.93194 
 L 637.2 314.93194 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m54a2238fba" x="49.078125" y="314.93194" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7d4e1f1ef7" x="49.078125" y="314.93194" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1036,11 +1036,11 @@ L 637.2 314.93194
      <g id="line2d_37">
       <path d="M 49.078125 295.713324 
 L 637.2 295.713324 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m54a2238fba" x="49.078125" y="295.713324" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7d4e1f1ef7" x="49.078125" y="295.713324" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1048,11 +1048,11 @@ L 637.2 295.713324
      <g id="line2d_39">
       <path d="M 49.078125 282.077499 
 L 637.2 282.077499 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m54a2238fba" x="49.078125" y="282.077499" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7d4e1f1ef7" x="49.078125" y="282.077499" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1060,11 +1060,11 @@ L 637.2 282.077499
      <g id="line2d_41">
       <path d="M 49.078125 271.500731 
 L 637.2 271.500731 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m54a2238fba" x="49.078125" y="271.500731" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7d4e1f1ef7" x="49.078125" y="271.500731" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1072,11 +1072,11 @@ L 637.2 271.500731
      <g id="line2d_43">
       <path d="M 49.078125 262.858882 
 L 637.2 262.858882 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m54a2238fba" x="49.078125" y="262.858882" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7d4e1f1ef7" x="49.078125" y="262.858882" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1084,11 +1084,11 @@ L 637.2 262.858882
      <g id="line2d_45">
       <path d="M 49.078125 255.552304 
 L 637.2 255.552304 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m54a2238fba" x="49.078125" y="255.552304" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7d4e1f1ef7" x="49.078125" y="255.552304" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1096,11 +1096,11 @@ L 637.2 255.552304
      <g id="line2d_47">
       <path d="M 49.078125 249.223057 
 L 637.2 249.223057 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m54a2238fba" x="49.078125" y="249.223057" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7d4e1f1ef7" x="49.078125" y="249.223057" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1108,11 +1108,11 @@ L 637.2 249.223057
      <g id="line2d_49">
       <path d="M 49.078125 243.640266 
 L 637.2 243.640266 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m54a2238fba" x="49.078125" y="243.640266" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7d4e1f1ef7" x="49.078125" y="243.640266" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1120,11 +1120,11 @@ L 637.2 243.640266
      <g id="line2d_51">
       <path d="M 49.078125 205.791848 
 L 637.2 205.791848 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m54a2238fba" x="49.078125" y="205.791848" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7d4e1f1ef7" x="49.078125" y="205.791848" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1132,11 +1132,11 @@ L 637.2 205.791848
      <g id="line2d_53">
       <path d="M 49.078125 186.573231 
 L 637.2 186.573231 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#m54a2238fba" x="49.078125" y="186.573231" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7d4e1f1ef7" x="49.078125" y="186.573231" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1144,11 +1144,11 @@ L 637.2 186.573231
      <g id="line2d_55">
       <path d="M 49.078125 172.937406 
 L 637.2 172.937406 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#m54a2238fba" x="49.078125" y="172.937406" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7d4e1f1ef7" x="49.078125" y="172.937406" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1156,11 +1156,11 @@ L 637.2 172.937406
      <g id="line2d_57">
       <path d="M 49.078125 162.360638 
 L 637.2 162.360638 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#m54a2238fba" x="49.078125" y="162.360638" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7d4e1f1ef7" x="49.078125" y="162.360638" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1168,11 +1168,11 @@ L 637.2 162.360638
      <g id="line2d_59">
       <path d="M 49.078125 153.71879 
 L 637.2 153.71879 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#m54a2238fba" x="49.078125" y="153.71879" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7d4e1f1ef7" x="49.078125" y="153.71879" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1180,11 +1180,11 @@ L 637.2 153.71879
      <g id="line2d_61">
       <path d="M 49.078125 146.412211 
 L 637.2 146.412211 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#m54a2238fba" x="49.078125" y="146.412211" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7d4e1f1ef7" x="49.078125" y="146.412211" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1192,11 +1192,11 @@ L 637.2 146.412211
      <g id="line2d_63">
       <path d="M 49.078125 140.082964 
 L 637.2 140.082964 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#m54a2238fba" x="49.078125" y="140.082964" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7d4e1f1ef7" x="49.078125" y="140.082964" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1204,11 +1204,11 @@ L 637.2 140.082964
      <g id="line2d_65">
       <path d="M 49.078125 134.500173 
 L 637.2 134.500173 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#m54a2238fba" x="49.078125" y="134.500173" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7d4e1f1ef7" x="49.078125" y="134.500173" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1216,11 +1216,11 @@ L 637.2 134.500173
      <g id="line2d_67">
       <path d="M 49.078125 96.651755 
 L 637.2 96.651755 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_68">
       <g>
-       <use xlink:href="#m54a2238fba" x="49.078125" y="96.651755" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7d4e1f1ef7" x="49.078125" y="96.651755" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1228,11 +1228,11 @@ L 637.2 96.651755
      <g id="line2d_69">
       <path d="M 49.078125 77.433138 
 L 637.2 77.433138 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_70">
       <g>
-       <use xlink:href="#m54a2238fba" x="49.078125" y="77.433138" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7d4e1f1ef7" x="49.078125" y="77.433138" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1240,11 +1240,11 @@ L 637.2 77.433138
      <g id="line2d_71">
       <path d="M 49.078125 63.797313 
 L 637.2 63.797313 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_72">
       <g>
-       <use xlink:href="#m54a2238fba" x="49.078125" y="63.797313" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7d4e1f1ef7" x="49.078125" y="63.797313" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1252,11 +1252,11 @@ L 637.2 63.797313
      <g id="line2d_73">
       <path d="M 49.078125 53.220545 
 L 637.2 53.220545 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_74">
       <g>
-       <use xlink:href="#m54a2238fba" x="49.078125" y="53.220545" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7d4e1f1ef7" x="49.078125" y="53.220545" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1378,7 +1378,7 @@ L 637.2 48.323125
    </g>
    <g id="text_13">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(294.783126 144.15579) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(294.783126 144.17816) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1410,7 +1410,7 @@ z
    </g>
    <g id="text_14">
     <!-- L10 -->
-    <g style="fill: #d62728" transform="translate(104.775489 294.637366) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(104.775489 294.79374) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1732,23 +1732,23 @@ z
    </g>
    <g id="line2d_75">
     <defs>
-     <path id="m50154dfbdd" d="M -2.5 2.5 
+     <path id="m9d33523b74" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p4c7aec78b5)">
-     <use xlink:href="#m50154dfbdd" x="355.479835" y="95.382063" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m50154dfbdd" x="308.273931" y="102.754513" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m50154dfbdd" x="271.230161" y="116.528062" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m50154dfbdd" x="217.83458" y="120.013651" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m50154dfbdd" x="177.077692" y="138.43462" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m50154dfbdd" x="162.880539" y="157.778627" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m50154dfbdd" x="160.741445" y="165.196647" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m50154dfbdd" x="153.966678" y="183.405761" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m50154dfbdd" x="151.589614" y="194.488118" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p9ad19b8953)">
+     <use xlink:href="#m9d33523b74" x="355.479835" y="95.382063" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9d33523b74" x="308.273931" y="102.754513" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9d33523b74" x="271.230161" y="116.528062" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9d33523b74" x="217.83458" y="120.013651" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9d33523b74" x="177.077692" y="138.43462" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9d33523b74" x="162.880539" y="157.778627" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9d33523b74" x="160.741445" y="165.196647" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9d33523b74" x="153.966678" y="183.405761" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9d33523b74" x="151.589614" y="194.488118" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_76">
@@ -1801,7 +1801,7 @@ L 311.2243 102.325849
 L 310.240844 102.469168 
 L 309.257387 102.612055 
 L 308.273931 102.754513 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_77">
     <path d="M 308.273931 102.754513 
@@ -1853,7 +1853,7 @@ L 273.545396 115.775058
 L 272.773651 116.027391 
 L 272.001906 116.278388 
 L 271.230161 116.528062 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_78">
     <path d="M 271.230161 116.528062 
@@ -1905,7 +1905,7 @@ L 221.171803 119.803152
 L 220.059395 119.873422 
 L 218.946988 119.943588 
 L 217.83458 120.013651 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_79">
     <path d="M 217.83458 120.013651 
@@ -1957,7 +1957,7 @@ L 179.624997 137.470928
 L 178.775895 137.79434 
 L 177.926794 138.115561 
 L 177.077692 138.43462 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_80">
     <path d="M 177.077692 138.43462 
@@ -2009,7 +2009,7 @@ L 163.767861 156.775388
 L 163.472087 157.112166 
 L 163.176313 157.446568 
 L 162.880539 157.778627 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_81">
     <path d="M 162.880539 157.778627 
@@ -2061,7 +2061,7 @@ L 160.875139 164.765525
 L 160.830574 164.909668 
 L 160.78601 165.053375 
 L 160.741445 165.196647 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_82">
     <path d="M 160.741445 165.196647 
@@ -2113,7 +2113,7 @@ L 154.390101 182.45125
 L 154.24896 182.771561 
 L 154.107819 183.089721 
 L 153.966678 183.405761 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_83">
     <path d="M 153.966678 183.405761 
@@ -2165,26 +2165,26 @@ L 151.73818 193.866427
 L 151.688658 194.074564 
 L 151.639136 194.281792 
 L 151.589614 194.488118 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_84">
     <defs>
-     <path id="m024edbe29a" d="M 0 -2.5 
+     <path id="mc30565deca" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p4c7aec78b5)">
-     <use xlink:href="#m024edbe29a" x="531.649087" y="75.963093" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m024edbe29a" x="283.721324" y="99.020035" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m024edbe29a" x="218.882044" y="121.069315" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m024edbe29a" x="187.447228" y="127.10685" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m024edbe29a" x="176.342474" y="138.36311" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m024edbe29a" x="163.054314" y="161.312135" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m024edbe29a" x="162.210539" y="168.753955" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m024edbe29a" x="159.303811" y="175.753345" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m024edbe29a" x="157.793928" y="179.494802" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p9ad19b8953)">
+     <use xlink:href="#mc30565deca" x="531.649087" y="75.963093" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc30565deca" x="283.721324" y="99.020035" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc30565deca" x="218.882044" y="121.069315" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc30565deca" x="187.447228" y="127.10685" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc30565deca" x="176.342474" y="138.36311" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc30565deca" x="163.054314" y="161.312135" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc30565deca" x="162.210539" y="168.753955" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc30565deca" x="159.303811" y="175.753345" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc30565deca" x="157.793928" y="179.494802" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_85">
@@ -2237,7 +2237,7 @@ L 299.21681 97.864971
 L 294.051648 98.253128 
 L 288.886486 98.638133 
 L 283.721324 99.020035 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_86">
     <path d="M 283.721324 99.020035 
@@ -2289,7 +2289,7 @@ L 222.934499 119.954333
 L 221.583681 120.328916 
 L 220.232863 120.700561 
 L 218.882044 121.069315 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_87">
     <path d="M 218.882044 121.069315 
@@ -2341,7 +2341,7 @@ L 189.411904 126.751217
 L 188.757012 126.870058 
 L 188.10212 126.988602 
 L 187.447228 127.10685 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_88">
     <path d="M 187.447228 127.10685 
@@ -2393,7 +2393,7 @@ L 177.036521 137.732718
 L 176.805172 137.943781 
 L 176.573823 138.153909 
 L 176.342474 138.36311 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_89">
     <path d="M 176.342474 138.36311 
@@ -2445,7 +2445,7 @@ L 163.884824 160.161325
 L 163.607987 160.548041 
 L 163.33115 160.931628 
 L 163.054314 161.312135 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_90">
     <path d="M 163.054314 161.312135 
@@ -2497,7 +2497,7 @@ L 162.263275 168.321549
 L 162.245696 168.466124 
 L 162.228118 168.610258 
 L 162.210539 168.753955 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_91">
     <path d="M 162.210539 168.753955 
@@ -2549,7 +2549,7 @@ L 159.485481 175.344896
 L 159.424925 175.481437 
 L 159.364368 175.617586 
 L 159.303811 175.753345 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_92">
     <path d="M 159.303811 175.753345 
@@ -2601,30 +2601,30 @@ L 157.888296 179.269417
 L 157.85684 179.344665 
 L 157.825384 179.419793 
 L 157.793928 179.494802 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_93">
     <defs>
-     <path id="m50faf8d58d" d="M -0 3.535534 
+     <path id="mece563f53f" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p4c7aec78b5)">
-     <use xlink:href="#m50faf8d58d" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m50faf8d58d" x="203.775848" y="81.750179" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m50faf8d58d" x="186.982691" y="88.344921" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m50faf8d58d" x="179.779306" y="91.045312" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m50faf8d58d" x="157.610419" y="99.395085" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m50faf8d58d" x="148.722526" y="107.864022" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m50faf8d58d" x="144.388162" y="121.237794" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m50faf8d58d" x="127.071247" y="144.560664" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m50faf8d58d" x="124.491988" y="152.083585" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m50faf8d58d" x="92.613662" y="207.637263" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m50faf8d58d" x="87.348715" y="225.457654" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m50faf8d58d" x="86.053433" y="242.017529" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p9ad19b8953)">
+     <use xlink:href="#mece563f53f" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mece563f53f" x="203.775848" y="81.750179" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mece563f53f" x="186.982691" y="88.344921" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mece563f53f" x="179.779306" y="91.045312" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mece563f53f" x="157.610419" y="99.395085" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mece563f53f" x="148.722526" y="107.864022" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mece563f53f" x="144.388162" y="121.237794" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mece563f53f" x="127.071247" y="144.560664" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mece563f53f" x="124.491988" y="152.083585" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mece563f53f" x="92.613662" y="207.637263" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mece563f53f" x="87.348715" y="225.457654" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mece563f53f" x="86.053433" y="242.017529" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_94">
@@ -2677,7 +2677,7 @@ L 206.762331 80.855075
 L 205.766837 81.155325 
 L 204.771342 81.453685 
 L 203.775848 81.750179 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_95">
     <path d="M 203.775848 81.750179 
@@ -2729,7 +2729,7 @@ L 188.032264 87.958568
 L 187.682406 88.087703 
 L 187.332549 88.216487 
 L 186.982691 88.344921 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_96">
     <path d="M 186.982691 88.344921 
@@ -2781,7 +2781,7 @@ L 180.229518 90.88097
 L 180.079447 90.935814 
 L 179.929376 90.990595 
 L 179.779306 91.045312 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_97">
     <path d="M 179.779306 91.045312 
@@ -2833,7 +2833,7 @@ L 158.995974 98.914174
 L 158.534122 99.075021 
 L 158.07227 99.235323 
 L 157.610419 99.395085 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_98">
     <path d="M 157.610419 99.395085 
@@ -2885,7 +2885,7 @@ L 149.27802 107.37681
 L 149.092855 107.539771 
 L 148.907691 107.702174 
 L 148.722526 107.864022 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_99">
     <path d="M 148.722526 107.864022 
@@ -2937,7 +2937,7 @@ L 144.65906 120.50385
 L 144.568761 120.749763 
 L 144.478462 120.994407 
 L 144.388162 121.237794 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_100">
     <path d="M 144.388162 121.237794 
@@ -2989,7 +2989,7 @@ L 128.153555 143.395158
 L 127.792786 143.786853 
 L 127.432016 144.175338 
 L 127.071247 144.560664 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_101">
     <path d="M 127.071247 144.560664 
@@ -3041,7 +3041,7 @@ L 124.653192 151.646811
 L 124.599457 151.79285 
 L 124.545723 151.93844 
 L 124.491988 152.083585 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_102">
     <path d="M 124.491988 152.083585 
@@ -3093,7 +3093,7 @@ L 94.606058 205.546972
 L 93.941926 206.254028 
 L 93.277794 206.950691 
 L 92.613662 207.637263 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_103">
     <path d="M 92.613662 207.637263 
@@ -3145,7 +3145,7 @@ L 87.677774 224.520091
 L 87.568088 224.834677 
 L 87.458402 225.147189 
 L 87.348715 225.457654 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_104">
     <path d="M 87.348715 225.457654 
@@ -3197,23 +3197,23 @@ L 86.134388 241.135848
 L 86.107403 241.431568 
 L 86.080418 241.725454 
 L 86.053433 242.017529 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_105">
     <defs>
-     <path id="m11c17ea415" d="M -0 2.5 
+     <path id="ma38b41dd73" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p4c7aec78b5)">
-     <use xlink:href="#m11c17ea415" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p9ad19b8953)">
+     <use xlink:href="#ma38b41dd73" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_106">
     <defs>
-     <path id="m0e14a6ff5e" d="M -0.833333 2.5 
+     <path id="m52a127d546" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -3228,16 +3228,16 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p4c7aec78b5)">
-     <use xlink:href="#m0e14a6ff5e" x="362.865999" y="115.428618" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0e14a6ff5e" x="278.798176" y="122.858526" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0e14a6ff5e" x="251.17632" y="128.261574" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0e14a6ff5e" x="200.806828" y="131.522849" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0e14a6ff5e" x="169.803221" y="147.931404" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0e14a6ff5e" x="161.916638" y="160.718659" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0e14a6ff5e" x="158.697104" y="167.705569" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0e14a6ff5e" x="154.26679" y="181.026105" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0e14a6ff5e" x="153.096464" y="191.924265" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p9ad19b8953)">
+     <use xlink:href="#m52a127d546" x="362.865999" y="115.428618" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m52a127d546" x="278.798176" y="122.858526" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m52a127d546" x="251.17632" y="128.261574" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m52a127d546" x="200.806828" y="131.522849" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m52a127d546" x="169.803221" y="147.931404" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m52a127d546" x="161.916638" y="160.718659" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m52a127d546" x="158.697104" y="167.705569" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m52a127d546" x="154.26679" y="181.026105" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m52a127d546" x="153.096464" y="191.924265" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_107">
@@ -3290,7 +3290,7 @@ L 284.052415 122.426763
 L 282.301002 122.571121 
 L 280.549589 122.715042 
 L 278.798176 122.858526 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_108">
     <path d="M 278.798176 122.858526 
@@ -3342,7 +3342,7 @@ L 252.902686 127.94134
 L 252.327231 128.048325 
 L 251.751776 128.155069 
 L 251.17632 128.261574 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_109">
     <path d="M 251.17632 128.261574 
@@ -3394,7 +3394,7 @@ L 203.954921 131.325463
 L 202.905557 131.39135 
 L 201.856192 131.457145 
 L 200.806828 131.522849 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_110">
     <path d="M 200.806828 131.522849 
@@ -3446,7 +3446,7 @@ L 171.740947 147.056528
 L 171.095038 147.349951 
 L 170.44913 147.64157 
 L 169.803221 147.931404 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_111">
     <path d="M 169.803221 147.931404 
@@ -3498,7 +3498,7 @@ L 162.409549 160.012958
 L 162.245246 160.249361 
 L 162.080942 160.484591 
 L 161.916638 160.718659 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_112">
     <path d="M 161.916638 160.718659 
@@ -3550,7 +3550,7 @@ L 158.898325 167.297798
 L 158.831251 167.434112 
 L 158.764178 167.570034 
 L 158.697104 167.705569 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_113">
     <path d="M 158.697104 167.705569 
@@ -3602,7 +3602,7 @@ L 154.543684 180.294711
 L 154.451386 180.539765 
 L 154.359088 180.783558 
 L 154.26679 181.026105 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_114">
     <path d="M 154.26679 181.026105 
@@ -3654,11 +3654,11 @@ L 153.16961 191.311823
 L 153.145228 191.516851 
 L 153.120846 191.720996 
 L 153.096464 191.924265 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_115">
     <defs>
-     <path id="m87ef252b95" d="M -1.25 2.5 
+     <path id="maa6c66c454" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -3673,16 +3673,16 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p4c7aec78b5)">
-     <use xlink:href="#m87ef252b95" x="301.619021" y="150.561849" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m87ef252b95" x="250.236474" y="156.671134" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m87ef252b95" x="225.418659" y="160.842551" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m87ef252b95" x="212.328936" y="161.382211" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m87ef252b95" x="209.030149" y="166.25091" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m87ef252b95" x="197.547749" y="171.432451" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m87ef252b95" x="194.819287" y="175.129495" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m87ef252b95" x="193.12279" y="181.606362" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m87ef252b95" x="192.79794" y="189.451167" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p9ad19b8953)">
+     <use xlink:href="#maa6c66c454" x="301.619021" y="150.561849" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#maa6c66c454" x="250.236474" y="156.671134" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#maa6c66c454" x="225.418659" y="160.842551" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#maa6c66c454" x="212.328936" y="161.382211" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#maa6c66c454" x="209.030149" y="166.25091" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#maa6c66c454" x="197.547749" y="171.432451" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#maa6c66c454" x="194.819287" y="175.129495" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#maa6c66c454" x="193.12279" y="181.606362" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#maa6c66c454" x="192.79794" y="189.451167" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_116">
@@ -3735,7 +3735,7 @@ L 253.447883 156.311526
 L 252.377414 156.431699 
 L 251.306944 156.551567 
 L 250.236474 156.671134 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_117">
     <path d="M 250.236474 156.671134 
@@ -3787,7 +3787,7 @@ L 226.969772 160.592321
 L 226.452735 160.675878 
 L 225.935697 160.759287 
 L 225.418659 160.842551 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_118">
     <path d="M 225.418659 160.842551 
@@ -3839,7 +3839,7 @@ L 213.147044 161.348661
 L 212.874341 161.359847 
 L 212.601639 161.37103 
 L 212.328936 161.382211 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_119">
     <path d="M 212.328936 161.382211 
@@ -3891,7 +3891,7 @@ L 209.236323 165.960837
 L 209.167599 166.057725 
 L 209.098874 166.154416 
 L 209.030149 166.25091 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_120">
     <path d="M 209.030149 166.25091 
@@ -3943,7 +3943,7 @@ L 198.265399 171.124681
 L 198.026182 171.227493 
 L 197.786966 171.330083 
 L 197.547749 171.432451 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_121">
     <path d="M 197.547749 171.432451 
@@ -3995,7 +3995,7 @@ L 194.989815 174.906688
 L 194.932972 174.981074 
 L 194.876129 175.055342 
 L 194.819287 175.129495 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_122">
     <path d="M 194.819287 175.129495 
@@ -4047,7 +4047,7 @@ L 193.228821 181.226479
 L 193.193478 181.353445 
 L 193.158134 181.480072 
 L 193.12279 181.606362 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_123">
     <path d="M 193.12279 181.606362 
@@ -4099,11 +4099,11 @@ L 192.818243 188.997124
 L 192.811475 189.148955 
 L 192.804707 189.300302 
 L 192.79794 189.451167 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_124">
     <defs>
-     <path id="mff3a395b78" d="M 0 -2.5 
+     <path id="m1d8faa8978" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -4116,16 +4116,16 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p4c7aec78b5)">
-     <use xlink:href="#mff3a395b78" x="206.45578" y="118.584066" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mff3a395b78" x="206.45578" y="118.258949" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mff3a395b78" x="206.45578" y="118.759361" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mff3a395b78" x="206.45578" y="118.234957" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mff3a395b78" x="171.767499" y="134.097889" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mff3a395b78" x="163.54283" y="144.663903" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mff3a395b78" x="160.174881" y="151.505345" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mff3a395b78" x="154.179217" y="169.303726" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mff3a395b78" x="152.4406" y="178.584542" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p9ad19b8953)">
+     <use xlink:href="#m1d8faa8978" x="206.45578" y="118.584066" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m1d8faa8978" x="206.45578" y="118.258949" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m1d8faa8978" x="206.45578" y="118.759361" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m1d8faa8978" x="206.45578" y="118.234957" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m1d8faa8978" x="171.767499" y="134.097889" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m1d8faa8978" x="163.54283" y="144.663903" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m1d8faa8978" x="160.174881" y="151.505345" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m1d8faa8978" x="154.179217" y="169.303726" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m1d8faa8978" x="152.4406" y="178.584542" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_125">
@@ -4178,7 +4178,7 @@ L 206.45578 118.279335
 L 206.45578 118.27254 
 L 206.45578 118.265745 
 L 206.45578 118.258949 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_126">
     <path d="M 206.45578 118.258949 
@@ -4230,7 +4230,7 @@ L 206.45578 118.728239
 L 206.45578 118.738615 
 L 206.45578 118.748989 
 L 206.45578 118.759361 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_127">
     <path d="M 206.45578 118.759361 
@@ -4282,7 +4282,7 @@ L 206.45578 118.267903
 L 206.45578 118.256924 
 L 206.45578 118.245942 
 L 206.45578 118.234957 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_128">
     <path d="M 206.45578 118.234957 
@@ -4334,7 +4334,7 @@ L 173.935517 133.247721
 L 173.212844 133.532808 
 L 172.490172 133.816191 
 L 171.767499 134.097889 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_129">
     <path d="M 171.767499 134.097889 
@@ -4386,7 +4386,7 @@ L 164.056872 144.068227
 L 163.885524 144.267619 
 L 163.714177 144.466175 
 L 163.54283 144.663903 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_130">
     <path d="M 163.54283 144.663903 
@@ -4438,7 +4438,7 @@ L 160.385378 151.105499
 L 160.315212 151.239156 
 L 160.245047 151.372438 
 L 160.174881 151.505345 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_131">
     <path d="M 160.174881 151.505345 
@@ -4490,7 +4490,7 @@ L 154.553946 168.367127
 L 154.429036 168.681387 
 L 154.304126 168.993578 
 L 154.179217 169.303726 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_132">
     <path d="M 154.179217 169.303726 
@@ -4542,11 +4542,11 @@ L 152.549264 178.054798
 L 152.513043 178.232038 
 L 152.476822 178.408618 
 L 152.4406 178.584542 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_133">
     <defs>
-     <path id="ma47d225491" d="M 0 -2.5 
+     <path id="m4b98dc399e" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -4555,16 +4555,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p4c7aec78b5)">
-     <use xlink:href="#ma47d225491" x="610.467188" y="172.829682" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma47d225491" x="592.067397" y="173.763838" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma47d225491" x="534.807821" y="180.385179" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma47d225491" x="327.802209" y="176.172104" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma47d225491" x="275.83761" y="186.734601" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma47d225491" x="258.25125" y="198.783148" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma47d225491" x="256.777056" y="203.737732" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma47d225491" x="248.769854" y="217.74136" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma47d225491" x="246.264594" y="227.740017" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p9ad19b8953)">
+     <use xlink:href="#m4b98dc399e" x="610.467188" y="172.829682" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4b98dc399e" x="592.067397" y="173.763838" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4b98dc399e" x="534.807821" y="180.385179" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4b98dc399e" x="327.802209" y="176.172104" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4b98dc399e" x="275.83761" y="186.734601" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4b98dc399e" x="258.25125" y="198.783148" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4b98dc399e" x="256.777056" y="203.737732" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4b98dc399e" x="248.769854" y="217.74136" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4b98dc399e" x="246.264594" y="227.740017" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_134">
@@ -4617,7 +4617,7 @@ L 593.217384 173.705989
 L 592.834055 173.72528 
 L 592.450726 173.744563 
 L 592.067397 173.763838 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_135">
     <path d="M 592.067397 173.763838 
@@ -4669,7 +4669,7 @@ L 538.386544 179.997367
 L 537.193636 180.126991 
 L 536.000728 180.25626 
 L 534.807821 180.385179 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_136">
     <path d="M 534.807821 180.385179 
@@ -4721,7 +4721,7 @@ L 340.74006 176.446681
 L 336.427443 176.355332 
 L 332.114826 176.263806 
 L 327.802209 176.172104 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_137">
     <path d="M 327.802209 176.172104 
@@ -4773,7 +4773,7 @@ L 279.085397 186.139102
 L 278.002801 186.338434 
 L 276.920205 186.536931 
 L 275.83761 186.734601 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_138">
     <path d="M 275.83761 186.734601 
@@ -4825,7 +4825,7 @@ L 259.350398 198.113494
 L 258.984015 198.337765 
 L 258.617633 198.560979 
 L 258.25125 198.783148 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_139">
     <path d="M 258.25125 198.783148 
@@ -4877,7 +4877,7 @@ L 256.869193 203.442789
 L 256.838481 203.541307 
 L 256.807768 203.639621 
 L 256.777056 203.737732 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_140">
     <path d="M 256.777056 203.737732 
@@ -4929,7 +4929,7 @@ L 249.270304 216.977455
 L 249.103487 217.23346 
 L 248.93667 217.48809 
 L 248.769854 217.74136 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_141">
     <path d="M 248.769854 217.74136 
@@ -4981,7 +4981,7 @@ L 246.421172 227.173237
 L 246.368979 227.362918 
 L 246.316786 227.551842 
 L 246.264594 227.740017 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="legend_1">
     <g id="patch_7">
@@ -4999,7 +4999,7 @@ z
     </g>
     <g id="line2d_142">
      <defs>
-      <path id="m0575bb37a3" d="M 0 3.5 
+      <path id="m8cf4c18517" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -5012,7 +5012,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m0575bb37a3" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m8cf4c18517" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -5071,7 +5071,7 @@ z
     </g>
     <g id="line2d_143">
      <g>
-      <use xlink:href="#m50154dfbdd" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m9d33523b74" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -5085,7 +5085,7 @@ z
     </g>
     <g id="line2d_144">
      <g>
-      <use xlink:href="#m024edbe29a" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mc30565deca" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -5130,7 +5130,7 @@ z
     </g>
     <g id="line2d_145">
      <g>
-      <use xlink:href="#m50faf8d58d" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mece563f53f" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -5173,7 +5173,7 @@ z
     </g>
     <g id="line2d_146">
      <g>
-      <use xlink:href="#m11c17ea415" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#ma38b41dd73" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -5189,7 +5189,7 @@ z
     </g>
     <g id="line2d_147">
      <g>
-      <use xlink:href="#m0e14a6ff5e" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m52a127d546" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -5243,7 +5243,7 @@ z
     </g>
     <g id="line2d_148">
      <g>
-      <use xlink:href="#m87ef252b95" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#maa6c66c454" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -5308,7 +5308,7 @@ z
     </g>
     <g id="line2d_149">
      <g>
-      <use xlink:href="#mff3a395b78" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#m1d8faa8978" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -5346,7 +5346,7 @@ z
     </g>
     <g id="line2d_150">
      <g>
-      <use xlink:href="#ma47d225491" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m4b98dc399e" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -5416,486 +5416,486 @@ z
     </g>
    </g>
    <g id="line2d_151">
-    <g clip-path="url(#p4c7aec78b5)">
-     <use xlink:href="#m0575bb37a3" x="289.783126" y="149.15579" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m0575bb37a3" x="223.847406" y="159.367144" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m0575bb37a3" x="212.445767" y="163.330307" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m0575bb37a3" x="181.367844" y="168.276955" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m0575bb37a3" x="165.308999" y="176.883889" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m0575bb37a3" x="153.53933" y="182.740937" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m0575bb37a3" x="148.588101" y="189.048821" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m0575bb37a3" x="145.442461" y="192.09646" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m0575bb37a3" x="115.00257" y="273.409756" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m0575bb37a3" x="99.775489" y="299.637366" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <g clip-path="url(#p9ad19b8953)">
+     <use xlink:href="#m8cf4c18517" x="289.783126" y="149.17816" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m8cf4c18517" x="223.847406" y="159.268604" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m8cf4c18517" x="212.445767" y="163.194674" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m8cf4c18517" x="181.367844" y="168.38581" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m8cf4c18517" x="165.308999" y="177.369888" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m8cf4c18517" x="153.53933" y="182.984995" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m8cf4c18517" x="148.588101" y="189.525409" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m8cf4c18517" x="145.442461" y="192.752932" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m8cf4c18517" x="115.00257" y="273.691065" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m8cf4c18517" x="99.775489" y="299.79374" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
    <g id="line2d_152">
-    <path d="M 289.783126 149.15579 
-L 288.409466 149.392587 
-L 287.035805 149.628208 
-L 285.662144 149.862663 
-L 284.288483 150.095964 
-L 282.914822 150.328122 
-L 281.541161 150.559149 
-L 280.167501 150.789055 
-L 278.79384 151.017851 
-L 277.420179 151.245548 
-L 276.046518 151.472157 
-L 274.672857 151.697687 
-L 273.299196 151.92215 
-L 271.925536 152.145554 
-L 270.551875 152.367911 
-L 269.178214 152.589229 
-L 267.804553 152.809518 
-L 266.430892 153.028789 
-L 265.057231 153.24705 
-L 263.68357 153.46431 
-L 262.30991 153.680579 
-L 260.936249 153.895866 
-L 259.562588 154.110179 
-L 258.188927 154.323528 
-L 256.815266 154.535921 
-L 255.441605 154.747366 
-L 254.067945 154.957872 
-L 252.694284 155.167448 
-L 251.320623 155.3761 
-L 249.946962 155.583839 
-L 248.573301 155.790671 
-L 247.19964 155.996604 
-L 245.82598 156.201646 
-L 244.452319 156.405806 
-L 243.078658 156.609089 
-L 241.704997 156.811505 
-L 240.331336 157.01306 
-L 238.957675 157.213761 
-L 237.584015 157.413616 
-L 236.210354 157.612632 
-L 234.836693 157.810816 
-L 233.463032 158.008174 
-L 232.089371 158.204715 
-L 230.71571 158.400443 
-L 229.34205 158.595367 
-L 227.968389 158.789493 
-L 226.594728 158.982826 
-L 225.221067 159.175374 
-L 223.847406 159.367144 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 289.783126 149.17816 
+L 288.409466 149.411853 
+L 287.035805 149.644399 
+L 285.662144 149.875809 
+L 284.288483 150.106096 
+L 282.914822 150.335269 
+L 281.541161 150.563339 
+L 280.167501 150.790317 
+L 278.79384 151.016213 
+L 277.420179 151.241038 
+L 276.046518 151.464801 
+L 274.672857 151.687513 
+L 273.299196 151.909184 
+L 271.925536 152.129822 
+L 270.551875 152.349439 
+L 269.178214 152.568042 
+L 267.804553 152.785642 
+L 266.430892 153.002248 
+L 265.057231 153.217868 
+L 263.68357 153.432511 
+L 262.30991 153.646187 
+L 260.936249 153.858905 
+L 259.562588 154.070671 
+L 258.188927 154.281496 
+L 256.815266 154.491387 
+L 255.441605 154.700353 
+L 254.067945 154.908402 
+L 252.694284 155.115542 
+L 251.320623 155.32178 
+L 249.946962 155.527125 
+L 248.573301 155.731584 
+L 247.19964 155.935164 
+L 245.82598 156.137875 
+L 244.452319 156.339722 
+L 243.078658 156.540713 
+L 241.704997 156.740855 
+L 240.331336 156.940156 
+L 238.957675 157.138622 
+L 237.584015 157.336261 
+L 236.210354 157.533079 
+L 234.836693 157.729083 
+L 233.463032 157.92428 
+L 232.089371 158.118676 
+L 230.71571 158.312279 
+L 229.34205 158.505094 
+L 227.968389 158.697127 
+L 226.594728 158.888386 
+L 225.221067 159.078876 
+L 223.847406 159.268604 
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_153">
-    <path d="M 223.847406 159.367144 
-L 223.609872 159.453181 
-L 223.372338 159.539063 
-L 223.134804 159.62479 
-L 222.89727 159.710362 
-L 222.659735 159.795779 
-L 222.422201 159.881043 
-L 222.184667 159.966154 
-L 221.947133 160.051113 
-L 221.709599 160.135919 
-L 221.472065 160.220574 
-L 221.23453 160.305078 
-L 220.996996 160.389431 
-L 220.759462 160.473635 
-L 220.521928 160.557689 
-L 220.284394 160.641595 
-L 220.04686 160.725352 
-L 219.809325 160.808962 
-L 219.571791 160.892424 
-L 219.334257 160.975739 
-L 219.096723 161.058909 
-L 218.859189 161.141933 
-L 218.621655 161.224811 
-L 218.38412 161.307545 
-L 218.146586 161.390135 
-L 217.909052 161.472581 
-L 217.671518 161.554884 
-L 217.433984 161.637044 
-L 217.19645 161.719062 
-L 216.958916 161.800939 
-L 216.721381 161.882674 
-L 216.483847 161.964269 
-L 216.246313 162.045723 
-L 216.008779 162.127037 
-L 215.771245 162.208213 
-L 215.533711 162.289249 
-L 215.296176 162.370148 
-L 215.058642 162.450908 
-L 214.821108 162.531531 
-L 214.583574 162.612017 
-L 214.34604 162.692367 
-L 214.108506 162.77258 
-L 213.870971 162.852659 
-L 213.633437 162.932602 
-L 213.395903 163.01241 
-L 213.158369 163.092085 
-L 212.920835 163.171625 
-L 212.683301 163.251033 
-L 212.445767 163.330307 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 223.847406 159.268604 
+L 223.609872 159.353803 
+L 223.372338 159.43885 
+L 223.134804 159.523744 
+L 222.89727 159.608487 
+L 222.659735 159.693078 
+L 222.422201 159.777519 
+L 222.184667 159.861809 
+L 221.947133 159.94595 
+L 221.709599 160.029941 
+L 221.472065 160.113785 
+L 221.23453 160.19748 
+L 220.996996 160.281027 
+L 220.759462 160.364428 
+L 220.521928 160.447682 
+L 220.284394 160.53079 
+L 220.04686 160.613752 
+L 219.809325 160.69657 
+L 219.571791 160.779243 
+L 219.334257 160.861772 
+L 219.096723 160.944158 
+L 218.859189 161.026401 
+L 218.621655 161.108501 
+L 218.38412 161.19046 
+L 218.146586 161.272277 
+L 217.909052 161.353953 
+L 217.671518 161.435488 
+L 217.433984 161.516884 
+L 217.19645 161.59814 
+L 216.958916 161.679257 
+L 216.721381 161.760235 
+L 216.483847 161.841075 
+L 216.246313 161.921778 
+L 216.008779 162.002343 
+L 215.771245 162.082772 
+L 215.533711 162.163064 
+L 215.296176 162.243221 
+L 215.058642 162.323242 
+L 214.821108 162.403128 
+L 214.583574 162.48288 
+L 214.34604 162.562498 
+L 214.108506 162.641983 
+L 213.870971 162.721334 
+L 213.633437 162.800553 
+L 213.395903 162.87964 
+L 213.158369 162.958595 
+L 212.920835 163.037419 
+L 212.683301 163.116111 
+L 212.445767 163.194674 
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_154">
-    <path d="M 212.445767 163.330307 
-L 211.79831 163.438808 
-L 211.150853 163.54706 
-L 210.503396 163.655066 
-L 209.85594 163.762827 
-L 209.208483 163.870343 
-L 208.561026 163.977616 
-L 207.913569 164.084646 
-L 207.266113 164.191435 
-L 206.618656 164.297985 
-L 205.971199 164.404295 
-L 205.323743 164.510367 
-L 204.676286 164.616203 
-L 204.028829 164.721802 
-L 203.381372 164.827167 
-L 202.733916 164.932299 
-L 202.086459 165.037197 
-L 201.439002 165.141864 
-L 200.791546 165.246301 
-L 200.144089 165.350507 
-L 199.496632 165.454486 
-L 198.849175 165.558236 
-L 198.201719 165.66176 
-L 197.554262 165.765059 
-L 196.906805 165.868132 
-L 196.259348 165.970982 
-L 195.611892 166.07361 
-L 194.964435 166.176015 
-L 194.316978 166.2782 
-L 193.669522 166.380165 
-L 193.022065 166.481911 
-L 192.374608 166.58344 
-L 191.727151 166.684751 
-L 191.079695 166.785846 
-L 190.432238 166.886726 
-L 189.784781 166.987392 
-L 189.137324 167.087844 
-L 188.489868 167.188084 
-L 187.842411 167.288113 
-L 187.194954 167.38793 
-L 186.547498 167.487538 
-L 185.900041 167.586937 
-L 185.252584 167.686129 
-L 184.605127 167.785113 
-L 183.957671 167.88389 
-L 183.310214 167.982462 
-L 182.662757 168.08083 
-L 182.015301 168.178994 
-L 181.367844 168.276955 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 212.445767 163.194674 
+L 211.79831 163.308829 
+L 211.150853 163.422711 
+L 210.503396 163.536319 
+L 209.85594 163.649656 
+L 209.208483 163.762722 
+L 208.561026 163.875519 
+L 207.913569 163.988049 
+L 207.266113 164.100312 
+L 206.618656 164.212309 
+L 205.971199 164.324043 
+L 205.323743 164.435514 
+L 204.676286 164.546723 
+L 204.028829 164.657672 
+L 203.381372 164.768362 
+L 202.733916 164.878794 
+L 202.086459 164.98897 
+L 201.439002 165.09889 
+L 200.791546 165.208555 
+L 200.144089 165.317968 
+L 199.496632 165.427128 
+L 198.849175 165.536038 
+L 198.201719 165.644698 
+L 197.554262 165.753109 
+L 196.906805 165.861273 
+L 196.259348 165.969191 
+L 195.611892 166.076863 
+L 194.964435 166.184292 
+L 194.316978 166.291478 
+L 193.669522 166.398421 
+L 193.022065 166.505124 
+L 192.374608 166.611588 
+L 191.727151 166.717813 
+L 191.079695 166.8238 
+L 190.432238 166.929551 
+L 189.784781 167.035066 
+L 189.137324 167.140347 
+L 188.489868 167.245395 
+L 187.842411 167.35021 
+L 187.194954 167.454794 
+L 186.547498 167.559148 
+L 185.900041 167.663273 
+L 185.252584 167.767169 
+L 184.605127 167.870838 
+L 183.957671 167.974281 
+L 183.310214 168.077499 
+L 182.662757 168.180492 
+L 182.015301 168.283262 
+L 181.367844 168.38581 
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_155">
-    <path d="M 181.367844 168.276955 
-L 181.033285 168.473172 
-L 180.698725 168.668579 
-L 180.364166 168.863184 
-L 180.029607 169.056994 
-L 179.695047 169.250014 
-L 179.360488 169.442251 
-L 179.025929 169.633712 
-L 178.69137 169.824402 
-L 178.35681 170.014329 
-L 178.022251 170.203497 
-L 177.687692 170.391914 
-L 177.353133 170.579584 
-L 177.018573 170.766515 
-L 176.684014 170.952711 
-L 176.349455 171.138178 
-L 176.014895 171.322923 
-L 175.680336 171.50695 
-L 175.345777 171.690266 
-L 175.011218 171.872875 
-L 174.676658 172.054784 
-L 174.342099 172.235997 
-L 174.00754 172.41652 
-L 173.672981 172.596358 
-L 173.338421 172.775516 
-L 173.003862 172.953999 
-L 172.669303 173.131813 
-L 172.334743 173.308963 
-L 172.000184 173.485453 
-L 171.665625 173.661288 
-L 171.331066 173.836473 
-L 170.996506 174.011013 
-L 170.661947 174.184913 
-L 170.327388 174.358177 
-L 169.992829 174.53081 
-L 169.658269 174.702816 
-L 169.32371 174.874201 
-L 168.989151 175.044968 
-L 168.654591 175.215122 
-L 168.320032 175.384668 
-L 167.985473 175.553609 
-L 167.650914 175.72195 
-L 167.316354 175.889696 
-L 166.981795 176.05685 
-L 166.647236 176.223416 
-L 166.312676 176.389399 
-L 165.978117 176.554803 
-L 165.643558 176.719632 
-L 165.308999 176.883889 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 181.367844 168.38581 
+L 181.033285 168.591445 
+L 180.698725 168.796193 
+L 180.364166 169.000059 
+L 180.029607 169.203053 
+L 179.695047 169.405181 
+L 179.360488 169.606451 
+L 179.025929 169.806869 
+L 178.69137 170.006444 
+L 178.35681 170.205182 
+L 178.022251 170.40309 
+L 177.687692 170.600175 
+L 177.353133 170.796444 
+L 177.018573 170.991904 
+L 176.684014 171.186561 
+L 176.349455 171.380422 
+L 176.014895 171.573493 
+L 175.680336 171.765781 
+L 175.345777 171.957292 
+L 175.011218 172.148033 
+L 174.676658 172.338009 
+L 174.342099 172.527226 
+L 174.00754 172.715691 
+L 173.672981 172.90341 
+L 173.338421 173.090388 
+L 173.003862 173.276632 
+L 172.669303 173.462147 
+L 172.334743 173.646938 
+L 172.000184 173.831012 
+L 171.665625 174.014373 
+L 171.331066 174.197028 
+L 170.996506 174.378982 
+L 170.661947 174.56024 
+L 170.327388 174.740808 
+L 169.992829 174.92069 
+L 169.658269 175.099893 
+L 169.32371 175.27842 
+L 168.989151 175.456277 
+L 168.654591 175.63347 
+L 168.320032 175.810002 
+L 167.985473 175.98588 
+L 167.650914 176.161107 
+L 167.316354 176.335689 
+L 166.981795 176.50963 
+L 166.647236 176.682935 
+L 166.312676 176.855609 
+L 165.978117 177.027656 
+L 165.643558 177.199081 
+L 165.308999 177.369888 
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_156">
-    <path d="M 165.308999 176.883889 
-L 165.063797 177.013593 
-L 164.818596 177.142943 
-L 164.573394 177.27194 
-L 164.328193 177.400588 
-L 164.082992 177.528887 
-L 163.83779 177.65684 
-L 163.592589 177.784449 
-L 163.347387 177.911714 
-L 163.102186 178.03864 
-L 162.856984 178.165226 
-L 162.611783 178.291475 
-L 162.366582 178.417388 
-L 162.12138 178.542968 
-L 161.876179 178.668216 
-L 161.630977 178.793134 
-L 161.385776 178.917724 
-L 161.140574 179.041987 
-L 160.895373 179.165925 
-L 160.650172 179.28954 
-L 160.40497 179.412833 
-L 160.159769 179.535807 
-L 159.914567 179.658462 
-L 159.669366 179.780801 
-L 159.424164 179.902824 
-L 159.178963 180.024535 
-L 158.933762 180.145933 
-L 158.68856 180.267022 
-L 158.443359 180.387802 
-L 158.198157 180.508275 
-L 157.952956 180.628442 
-L 157.707754 180.748306 
-L 157.462553 180.867867 
-L 157.217352 180.987128 
-L 156.97215 181.106089 
-L 156.726949 181.224752 
-L 156.481747 181.343119 
-L 156.236546 181.461192 
-L 155.991344 181.57897 
-L 155.746143 181.696457 
-L 155.500942 181.813654 
-L 155.25574 181.930561 
-L 155.010539 182.047181 
-L 154.765337 182.163514 
-L 154.520136 182.279563 
-L 154.274934 182.395328 
-L 154.029733 182.510811 
-L 153.784532 182.626013 
-L 153.53933 182.740937 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 165.308999 177.369888 
+L 165.063797 177.493918 
+L 164.818596 177.617625 
+L 164.573394 177.741009 
+L 164.328193 177.864073 
+L 164.082992 177.986818 
+L 163.83779 178.109246 
+L 163.592589 178.231359 
+L 163.347387 178.353158 
+L 163.102186 178.474645 
+L 162.856984 178.595821 
+L 162.611783 178.716688 
+L 162.366582 178.837248 
+L 162.12138 178.957502 
+L 161.876179 179.077451 
+L 161.630977 179.197098 
+L 161.385776 179.316444 
+L 161.140574 179.43549 
+L 160.895373 179.554237 
+L 160.650172 179.672688 
+L 160.40497 179.790844 
+L 160.159769 179.908705 
+L 159.914567 180.026275 
+L 159.669366 180.143553 
+L 159.424164 180.260542 
+L 159.178963 180.377243 
+L 158.933762 180.493658 
+L 158.68856 180.609787 
+L 158.443359 180.725632 
+L 158.198157 180.841195 
+L 157.952956 180.956477 
+L 157.707754 181.071479 
+L 157.462553 181.186203 
+L 157.217352 181.300649 
+L 156.97215 181.41482 
+L 156.726949 181.528717 
+L 156.481747 181.642341 
+L 156.236546 181.755693 
+L 155.991344 181.868774 
+L 155.746143 181.981587 
+L 155.500942 182.094131 
+L 155.25574 182.206409 
+L 155.010539 182.318422 
+L 154.765337 182.43017 
+L 154.520136 182.541656 
+L 154.274934 182.65288 
+L 154.029733 182.763844 
+L 153.784532 182.874548 
+L 153.53933 182.984995 
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_157">
-    <path d="M 153.53933 182.740937 
-L 153.436179 182.881288 
-L 153.333029 183.021226 
-L 153.229878 183.160751 
-L 153.126728 183.299867 
-L 153.023577 183.438576 
-L 152.920426 183.57688 
-L 152.817276 183.714782 
-L 152.714125 183.852284 
-L 152.610975 183.989388 
-L 152.507824 184.126096 
-L 152.404673 184.262411 
-L 152.301523 184.398336 
-L 152.198372 184.533872 
-L 152.095222 184.669021 
-L 151.992071 184.803786 
-L 151.88892 184.938169 
-L 151.78577 185.072172 
-L 151.682619 185.205797 
-L 151.579468 185.339047 
-L 151.476318 185.471923 
-L 151.373167 185.604428 
-L 151.270017 185.736563 
-L 151.166866 185.868331 
-L 151.063715 185.999734 
-L 150.960565 186.130773 
-L 150.857414 186.261451 
-L 150.754264 186.39177 
-L 150.651113 186.521731 
-L 150.547962 186.651337 
-L 150.444812 186.78059 
-L 150.341661 186.909491 
-L 150.238511 187.038043 
-L 150.13536 187.166247 
-L 150.032209 187.294105 
-L 149.929059 187.421619 
-L 149.825908 187.548791 
-L 149.722758 187.675622 
-L 149.619607 187.802116 
-L 149.516456 187.928272 
-L 149.413306 188.054094 
-L 149.310155 188.179582 
-L 149.207004 188.304739 
-L 149.103854 188.429567 
-L 149.000703 188.554067 
-L 148.897553 188.67824 
-L 148.794402 188.802089 
-L 148.691251 188.925616 
-L 148.588101 189.048821 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 153.53933 182.984995 
+L 153.436179 183.130878 
+L 153.333029 183.276313 
+L 153.229878 183.421303 
+L 153.126728 183.565851 
+L 153.023577 183.709959 
+L 152.920426 183.853631 
+L 152.817276 183.996868 
+L 152.714125 184.139674 
+L 152.610975 184.282051 
+L 152.507824 184.424001 
+L 152.404673 184.565528 
+L 152.301523 184.706633 
+L 152.198372 184.84732 
+L 152.095222 184.98759 
+L 151.992071 185.127447 
+L 151.88892 185.266891 
+L 151.78577 185.405927 
+L 151.682619 185.544557 
+L 151.579468 185.682781 
+L 151.476318 185.820604 
+L 151.373167 185.958028 
+L 151.270017 186.095054 
+L 151.166866 186.231685 
+L 151.063715 186.367924 
+L 150.960565 186.503772 
+L 150.857414 186.639231 
+L 150.754264 186.774305 
+L 150.651113 186.908995 
+L 150.547962 187.043303 
+L 150.444812 187.177232 
+L 150.341661 187.310783 
+L 150.238511 187.443959 
+L 150.13536 187.576762 
+L 150.032209 187.709194 
+L 149.929059 187.841257 
+L 149.825908 187.972953 
+L 149.722758 188.104284 
+L 149.619607 188.235253 
+L 149.516456 188.36586 
+L 149.413306 188.496109 
+L 149.310155 188.626 
+L 149.207004 188.755537 
+L 149.103854 188.88472 
+L 149.000703 189.013553 
+L 148.897553 189.142036 
+L 148.794402 189.270172 
+L 148.691251 189.397962 
+L 148.588101 189.525409 
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_158">
-    <path d="M 148.588101 189.048821 
-L 148.522567 189.114354 
-L 148.457032 189.179796 
-L 148.391498 189.245148 
-L 148.325964 189.31041 
-L 148.26043 189.375583 
-L 148.194896 189.440665 
-L 148.129362 189.505659 
-L 148.063827 189.570564 
-L 147.998293 189.63538 
-L 147.932759 189.700107 
-L 147.867225 189.764746 
-L 147.801691 189.829297 
-L 147.736157 189.893761 
-L 147.670622 189.958136 
-L 147.605088 190.022425 
-L 147.539554 190.086626 
-L 147.47402 190.150741 
-L 147.408486 190.214769 
-L 147.342952 190.27871 
-L 147.277418 190.342566 
-L 147.211883 190.406335 
-L 147.146349 190.470019 
-L 147.080815 190.533617 
-L 147.015281 190.59713 
-L 146.949747 190.660559 
-L 146.884213 190.723902 
-L 146.818678 190.787161 
-L 146.753144 190.850335 
-L 146.68761 190.913426 
-L 146.622076 190.976432 
-L 146.556542 191.039355 
-L 146.491008 191.102195 
-L 146.425473 191.164951 
-L 146.359939 191.227624 
-L 146.294405 191.290215 
-L 146.228871 191.352723 
-L 146.163337 191.415149 
-L 146.097803 191.477492 
-L 146.032268 191.539754 
-L 145.966734 191.601934 
-L 145.9012 191.664033 
-L 145.835666 191.72605 
-L 145.770132 191.787986 
-L 145.704598 191.849842 
-L 145.639063 191.911617 
-L 145.573529 191.973311 
-L 145.507995 192.034925 
-L 145.442461 192.09646 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 148.588101 189.525409 
+L 148.522567 189.59494 
+L 148.457032 189.664369 
+L 148.391498 189.733697 
+L 148.325964 189.802924 
+L 148.26043 189.872049 
+L 148.194896 189.941074 
+L 148.129362 190.009999 
+L 148.063827 190.078823 
+L 147.998293 190.147548 
+L 147.932759 190.216173 
+L 147.867225 190.284699 
+L 147.801691 190.353126 
+L 147.736157 190.421454 
+L 147.670622 190.489684 
+L 147.605088 190.557816 
+L 147.539554 190.62585 
+L 147.47402 190.693787 
+L 147.408486 190.761626 
+L 147.342952 190.829369 
+L 147.277418 190.897015 
+L 147.211883 190.964564 
+L 147.146349 191.032017 
+L 147.080815 191.099375 
+L 147.015281 191.166636 
+L 146.949747 191.233803 
+L 146.884213 191.300874 
+L 146.818678 191.367851 
+L 146.753144 191.434733 
+L 146.68761 191.501521 
+L 146.622076 191.568215 
+L 146.556542 191.634815 
+L 146.491008 191.701322 
+L 146.425473 191.767736 
+L 146.359939 191.834056 
+L 146.294405 191.900284 
+L 146.228871 191.96642 
+L 146.163337 192.032463 
+L 146.097803 192.098415 
+L 146.032268 192.164275 
+L 145.966734 192.230043 
+L 145.9012 192.295721 
+L 145.835666 192.361307 
+L 145.770132 192.426803 
+L 145.704598 192.492209 
+L 145.639063 192.557524 
+L 145.573529 192.622749 
+L 145.507995 192.687885 
+L 145.442461 192.752932 
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_159">
-    <path d="M 145.442461 192.09646 
-L 144.808297 196.397672 
-L 144.174132 200.340837 
-L 143.539968 203.981012 
-L 142.905803 207.361454 
-L 142.271639 210.516773 
-L 141.637475 213.475091 
-L 141.00331 216.259567 
-L 140.369146 218.889505 
-L 139.734981 221.381159 
-L 139.100817 223.748348 
-L 138.466652 226.002918 
-L 137.832488 228.155098 
-L 137.198324 230.213788 
-L 136.564159 232.186771 
-L 135.929995 234.0809 
-L 135.29583 235.902237 
-L 134.661666 237.65617 
-L 134.027502 239.34751 
-L 133.393337 240.980571 
-L 132.759173 242.559237 
-L 132.125008 244.087014 
-L 131.490844 245.567081 
-L 130.85668 247.002327 
-L 130.222515 248.395389 
-L 129.588351 249.748675 
-L 128.954186 251.064393 
-L 128.320022 252.344573 
-L 127.685858 253.591084 
-L 127.051693 254.805653 
-L 126.417529 255.989875 
-L 125.783364 257.14523 
-L 125.1492 258.273092 
-L 124.515036 259.374739 
-L 123.880871 260.451362 
-L 123.246707 261.504073 
-L 122.612542 262.53391 
-L 121.978378 263.541847 
-L 121.344214 264.528796 
-L 120.710049 265.495613 
-L 120.075885 266.443103 
-L 119.44172 267.372024 
-L 118.807556 268.283089 
-L 118.173392 269.176972 
-L 117.539227 270.054309 
-L 116.905063 270.915701 
-L 116.270898 271.761718 
-L 115.636734 272.592899 
-L 115.00257 273.409756 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 145.442461 192.752932 
+L 144.808297 197.014602 
+L 144.174132 200.924511 
+L 143.539968 204.536329 
+L 142.905803 207.892304 
+L 142.271639 211.026298 
+L 141.637475 213.965862 
+L 141.00331 216.733719 
+L 140.369146 219.348827 
+L 139.734981 221.827165 
+L 139.100817 224.182333 
+L 138.466652 226.425996 
+L 137.832488 228.568236 
+L 137.198324 230.617828 
+L 136.564159 232.582454 
+L 135.929995 234.468879 
+L 135.29583 236.283091 
+L 134.661666 238.030416 
+L 134.027502 239.715611 
+L 133.393337 241.342943 
+L 132.759173 242.916254 
+L 132.125008 244.439015 
+L 131.490844 245.914374 
+L 130.85668 247.345194 
+L 130.222515 248.734084 
+L 129.588351 250.083433 
+L 128.954186 251.395429 
+L 128.320022 252.672086 
+L 127.685858 253.915257 
+L 127.051693 255.126653 
+L 126.417529 256.30786 
+L 125.783364 257.460344 
+L 125.1492 258.585471 
+L 124.515036 259.684507 
+L 123.880871 260.758637 
+L 123.246707 261.808964 
+L 122.612542 262.83652 
+L 121.978378 263.842272 
+L 121.344214 264.827125 
+L 120.710049 265.791931 
+L 120.075885 266.73749 
+L 119.44172 267.664554 
+L 118.807556 268.573833 
+L 118.173392 269.465997 
+L 117.539227 270.341677 
+L 116.905063 271.201473 
+L 116.270898 272.04595 
+L 115.636734 272.875645 
+L 115.00257 273.691065 
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_160">
-    <path d="M 115.00257 273.409756 
-L 114.685339 274.133988 
-L 114.368108 274.84732 
-L 114.050877 275.550076 
-L 113.733646 276.242564 
-L 113.416415 276.925081 
-L 113.099184 277.59791 
-L 112.781954 278.261321 
-L 112.464723 278.915575 
-L 112.147492 279.56092 
-L 111.830261 280.197598 
-L 111.51303 280.825836 
-L 111.195799 281.445857 
-L 110.878569 282.057871 
-L 110.561338 282.662084 
-L 110.244107 283.258692 
-L 109.926876 283.847883 
-L 109.609645 284.42984 
-L 109.292414 285.004739 
-L 108.975184 285.572748 
-L 108.657953 286.134031 
-L 108.340722 286.688746 
-L 108.023491 287.237043 
-L 107.70626 287.77907 
-L 107.389029 288.314969 
-L 107.071799 288.844877 
-L 106.754568 289.368926 
-L 106.437337 289.887244 
-L 106.120106 290.399955 
-L 105.802875 290.90718 
-L 105.485644 291.409035 
-L 105.168414 291.905631 
-L 104.851183 292.397079 
-L 104.533952 292.883483 
-L 104.216721 293.364947 
-L 103.89949 293.841569 
-L 103.582259 294.313446 
-L 103.265028 294.780671 
-L 102.947798 295.243336 
-L 102.630567 295.701529 
-L 102.313336 296.155334 
-L 101.996105 296.604836 
-L 101.678874 297.050115 
-L 101.361643 297.49125 
-L 101.044413 297.928318 
-L 100.727182 298.361391 
-L 100.409951 298.790544 
-L 100.09272 299.215846 
-L 99.775489 299.637366 
-" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 115.00257 273.691065 
+L 114.685339 274.410845 
+L 114.368108 275.119857 
+L 114.050877 275.818421 
+L 113.733646 276.506838 
+L 113.416415 277.185399 
+L 113.099184 277.854383 
+L 112.781954 278.514057 
+L 112.464723 279.164675 
+L 112.147492 279.806484 
+L 111.830261 280.439718 
+L 111.51303 281.064603 
+L 111.195799 281.681358 
+L 110.878569 282.29019 
+L 110.561338 282.891301 
+L 110.244107 283.484884 
+L 109.926876 284.071125 
+L 109.609645 284.650205 
+L 109.292414 285.222294 
+L 108.975184 285.787561 
+L 108.657953 286.346167 
+L 108.340722 286.898265 
+L 108.023491 287.444007 
+L 107.70626 287.983537 
+L 107.389029 288.516994 
+L 107.071799 289.044514 
+L 106.754568 289.566228 
+L 106.437337 290.082262 
+L 106.120106 290.592738 
+L 105.802875 291.097775 
+L 105.485644 291.597488 
+L 105.168414 292.091987 
+L 104.851183 292.581381 
+L 104.533952 293.065773 
+L 104.216721 293.545264 
+L 103.89949 294.019954 
+L 103.582259 294.489937 
+L 103.265028 294.955306 
+L 102.947798 295.41615 
+L 102.630567 295.872556 
+L 102.313336 296.32461 
+L 101.996105 296.772393 
+L 101.678874 297.215985 
+L 101.361643 297.655464 
+L 101.044413 298.090906 
+L 100.727182 298.522384 
+L 100.409951 298.949969 
+L 100.09272 299.373732 
+L 99.775489 299.79374 
+" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
   </g>
   <g id="text_25">
@@ -6254,8 +6254,8 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-07-08T20:16:47Z  ·  Linux chungus2 x86_64  ·  commit 74c19afa  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(44.841641 465.66) scale(0.07 -0.07)">
+   <!-- 2026-07-08T21:41:55Z  ·  Linux chungus2 x86_64  ·  commit b17c222c  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(43.990156 465.66) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -6289,6 +6289,31 @@ L 1409 3309
 L 1409 2516 
 L 750 2516 
 L 750 3309 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-b7" d="M 684 2619 
@@ -6348,36 +6373,6 @@ Q 2894 3584 3203 3211
 Q 3513 2838 3513 2113 
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-39" d="M 703 97 
-L 703 672 
-Q 941 559 1184 500 
-Q 1428 441 1663 441 
-Q 2288 441 2617 861 
-Q 2947 1281 2994 2138 
-Q 2813 1869 2534 1725 
-Q 2256 1581 1919 1581 
-Q 1219 1581 811 2004 
-Q 403 2428 403 3163 
-Q 403 3881 828 4315 
-Q 1253 4750 1959 4750 
-Q 2769 4750 3195 4129 
-Q 3622 3509 3622 2328 
-Q 3622 1225 3098 567 
-Q 2575 -91 1691 -91 
-Q 1453 -91 1209 -44 
-Q 966 3 703 97 
-z
-M 1959 2075 
-Q 2384 2075 2632 2365 
-Q 2881 2656 2881 3163 
-Q 2881 3666 2632 3958 
-Q 2384 4250 1959 4250 
-Q 1534 4250 1286 3958 
-Q 1038 3666 1038 3163 
-Q 1038 2656 1286 2365 
-Q 1534 2075 1959 2075 
-z
-" transform="scale(0.015625)"/>
      <path id="DejaVuSans-3d" d="M 678 2906 
 L 4684 2906 
 L 4684 2381 
@@ -6419,13 +6414,13 @@ z
     <use xlink:href="#DejaVuSans-38" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -6465,109 +6460,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3254.101562 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3317.724609 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3381.347656 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3442.626953 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3477.832031 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3539.111328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3570.898438 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3602.685547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3634.472656 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3666.259766 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3698.046875 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3725.830078 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3787.353516 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3848.632812 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3912.011719 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3975.488281 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4014.351562 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4075.533203 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4134.712891 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4196.236328 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4237.349609 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4271.041016 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4298.824219 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4360.347656 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4421.626953 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4485.005859 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4548.628906 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4582.320312 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4641.5 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4705.123047 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4736.910156 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4800.533203 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4864.15625 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4895.943359 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4959.566406 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4995.650391 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5034.513672 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5089.494141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5153.117188 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5184.904297 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5216.691406 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5248.478516 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5280.265625 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5312.052734 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5351.261719 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5414.640625 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5453.503906 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5514.685547 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5578.064453 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5641.541016 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5704.919922 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5768.396484 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5831.775391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5870.984375 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5902.771484 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5986.560547 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6018.347656 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6115.759766 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6177.283203 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6240.759766 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6268.542969 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6329.822266 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6393.201172 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6424.988281 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6477.087891 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6540.466797 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6601.746094 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6665.222656 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6717.322266 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6780.701172 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6841.882812 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6881.091797 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6914.783203 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6946.570312 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6987.683594 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7048.962891 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7088.171875 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7115.955078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7177.136719 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7208.923828 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7236.707031 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7288.806641 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7320.59375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7384.070312 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7445.59375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7484.802734 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7546.326172 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7585.689453 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7683.101562 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7710.884766 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7774.263672 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7802.046875 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7854.146484 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7893.355469 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7921.138672 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3135.351562 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3198.974609 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3262.597656 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3317.578125 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3381.201172 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3444.824219 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3508.447266 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3563.427734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3595.214844 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3627.001953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3658.789062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3690.576172 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3722.363281 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3750.146484 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3811.669922 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3872.949219 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3936.328125 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3999.804688 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4038.667969 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4099.849609 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4159.029297 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4220.552734 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4261.666016 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4295.357422 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4323.140625 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4384.664062 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4445.943359 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4509.322266 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4572.945312 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4606.636719 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4665.816406 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4729.439453 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4761.226562 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4824.849609 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4888.472656 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4920.259766 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4983.882812 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5019.966797 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5058.830078 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5113.810547 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5177.433594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5209.220703 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5241.007812 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5272.794922 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5304.582031 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5336.369141 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5375.578125 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5438.957031 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5477.820312 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5539.001953 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5602.380859 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5665.857422 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5729.236328 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5792.712891 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5856.091797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5895.300781 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5927.087891 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6010.876953 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6042.664062 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6140.076172 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6201.599609 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6265.076172 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6292.859375 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6354.138672 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6417.517578 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6449.304688 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6501.404297 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6564.783203 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6626.0625 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6689.539062 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6741.638672 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6805.017578 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6866.199219 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6905.408203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6939.099609 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6970.886719 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7012 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7073.279297 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7112.488281 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7140.271484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7201.453125 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7233.240234 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7261.023438 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7313.123047 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7344.910156 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7408.386719 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7469.910156 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7509.119141 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7570.642578 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7610.005859 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7707.417969 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7735.201172 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7798.580078 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7826.363281 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7878.462891 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7917.671875 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7945.455078 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p4c7aec78b5">
+  <clipPath id="p9ad19b8953">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_ratio_heatmap.svg
+++ b/bench/graphs/canterbury_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p1bc9c5d816)">
+   <g clip-path="url(#p1d8fbc3c25)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAI/ElEQVR4nO3Yv4rkWR2H4aqe7qZnxQFl1GVDwUwWAxMnMfZO9goMxdzrUG9AEBFNRDExETMxE1mW3XEcZ5b+U/37eQmzwpGv1Ps8V/A5FHXqrXPc/vnT/XBu3nw6vWCp/bPzOs/hcDj8/Ye/mJ6w1N/+/HZ6wnLf/9kPpicsd/zOd6cnrHW8mF6w3uuPpxesd/NsesFSP//GT6YnLHeG3yQAgC9ODAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApB3vTr/cp0esth+26QlLHc+wWa8urqcnLHW/3U5PWO7qL3+cnrDc6dsvpicsddrupycs9/b0enrCcs/P7Hp4ePZ8esJy5/crCwDwXxBDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpl1dvX01vWO/u8+kFa+3b9IL1nj6bXrDU9fSA/4H99dvpCctd/fvl9ISlrrbT9ITlnp7jfXf7ZnrBUleX53fjeRkCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBA2vG0/XqfHrHavm/TE5bazuw8h8PhcHVxPT1hqcf9ND1huSdvXk5PWO/LX59esNTDdj89YbnPbv8xPWG59+8upycstX3lg+kJy3kZAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSLv/0ye+nNyx3cThOT1jqa+89n56w3ON2mp6w1PWTm+kJy330299NT1jux9/71vSEpU77Nj1huR/94a/TE5Z78cGXpics9dGHL6YnLOdlCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGnHh8df7dMjVrt/vJ2esNTT4830BN7h/nianrDcv+4+nZ6w3Fdv3p+esNS2b9MTlnt198n0hOVe3n08PWGpbz77cHrCcl6GAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkHbctt/s0yOA/0On++kF611eTy/gHW4fP5+esNzNk/emJ/AOXoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQdnm/3U5vWO5xO01PWOry4np6wnJXZ3amh+1+esJ65/hX6cw+p8f9vO66w+FwePPwanrCctdPbqYnLLXv2/SE5c7xugMA+MLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBA2n8ApwuP+NzbRB0AAAAASUVORK5CYII=" id="imagef0cace4765" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAI/ElEQVR4nO3Yv4rkWR2H4aqe7qZnxQFl1GVDwUwWAxMnMfZO9goMxdzrUG9AEBFNRDExETMxE1mW3XEcZ5b+U/37eQmzwpGv1Ps8V/A5FHXqrXPc/vnT/XBu3nw6vWCp/bPzOs/hcDj8/Ye/mJ6w1N/+/HZ6wnLf/9kPpicsd/zOd6cnrHW8mF6w3uuPpxesd/NsesFSP//GT6YnLHeG3yQAgC9ODAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApB3vTr/cp0esth+26QlLHc+wWa8urqcnLHW/3U5PWO7qL3+cnrDc6dsvpicsddrupycs9/b0enrCcs/P7Hp4ePZ8esJy5/crCwDwXxBDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpl1dvX01vWO/u8+kFa+3b9IL1nj6bXrDU9fSA/4H99dvpCctd/fvl9ISlrrbT9ITlnp7jfXf7ZnrBUleX53fjeRkCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBA2vG0/XqfHrHavm/TE5bazuw8h8PhcHVxPT1hqcf9ND1huSdvXk5PWO/LX59esNTDdj89YbnPbv8xPWG59+8upycstX3lg+kJy3kZAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSLv/0ye+nNyx3cThOT1jqa+89n56w3ON2mp6w1PWTm+kJy330299NT1jux9/71vSEpU77Nj1huR/94a/TE5Z78cGXpics9dGHL6YnLOdlCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGnHh8df7dMjVrt/vJ2esNTT4830BN7h/nianrDcv+4+nZ6w3Fdv3p+esNS2b9MTlnt198n0hOVe3n08PWGpbz77cHrCcl6GAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkHbctt/s0yOA/0On++kF611eTy/gHW4fP5+esNzNk/emJ/AOXoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQdnm/3U5vWO5xO01PWOry4np6wnJXZ3amh+1+esJ65/hX6cw+p8f9vO66w+FwePPwanrCctdPbqYnLLXv2/SE5c7xugMA+MLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBA2n8ApwuP+NzbRB0AAAAASUVORK5CYII=" id="imagedd3bf0a3cc" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m343205af9b" d="M 0 0 
+       <path id="m3bb17d5054" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m343205af9b" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3bb17d5054" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m343205af9b" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3bb17d5054" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m343205af9b" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3bb17d5054" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m343205af9b" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3bb17d5054" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m343205af9b" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3bb17d5054" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m343205af9b" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3bb17d5054" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m343205af9b" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3bb17d5054" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m343205af9b" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3bb17d5054" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m343205af9b" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3bb17d5054" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m343205af9b" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3bb17d5054" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m343205af9b" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3bb17d5054" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="m42a3b6932c" d="M 0 0 
+       <path id="mcef9e6243a" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m42a3b6932c" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcef9e6243a" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m42a3b6932c" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcef9e6243a" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m42a3b6932c" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcef9e6243a" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m42a3b6932c" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcef9e6243a" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m42a3b6932c" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcef9e6243a" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m42a3b6932c" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcef9e6243a" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m42a3b6932c" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcef9e6243a" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m42a3b6932c" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcef9e6243a" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -2092,18 +2092,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="image008064603e" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
+iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="image51a68da8c7" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="mbb03dfc351" d="M 0 0 
+       <path id="m8b04d7bd9b" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mbb03dfc351" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8b04d7bd9b" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
@@ -2129,7 +2129,7 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#mbb03dfc351" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8b04d7bd9b" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
@@ -2146,7 +2146,7 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#mbb03dfc351" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8b04d7bd9b" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
@@ -2163,7 +2163,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#mbb03dfc351" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8b04d7bd9b" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
@@ -2180,7 +2180,7 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mbb03dfc351" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8b04d7bd9b" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_112">
@@ -2196,7 +2196,7 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#mbb03dfc351" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8b04d7bd9b" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
@@ -2212,7 +2212,7 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mbb03dfc351" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8b04d7bd9b" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
@@ -2228,7 +2228,7 @@ z
     <g id="ytick_16">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#mbb03dfc351" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8b04d7bd9b" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_115">
@@ -2244,7 +2244,7 @@ z
     <g id="ytick_17">
      <g id="line2d_28">
       <g>
-       <use xlink:href="#mbb03dfc351" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8b04d7bd9b" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_116">
@@ -2882,8 +2882,8 @@ z
    </g>
   </g>
   <g id="text_119">
-   <!-- 2026-07-08T20:16:47Z  ·  Linux chungus2 x86_64  ·  commit 74c19afa  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(17.841641 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-08T21:41:55Z  ·  Linux chungus2 x86_64  ·  commit b17c222c  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(16.990156 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2953,13 +2953,13 @@ z
     <use xlink:href="#DejaVuSans-38" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2999,109 +2999,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3254.101562 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3317.724609 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3381.347656 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3442.626953 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3477.832031 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3539.111328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3570.898438 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3602.685547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3634.472656 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3666.259766 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3698.046875 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3725.830078 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3787.353516 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3848.632812 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3912.011719 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3975.488281 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4014.351562 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4075.533203 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4134.712891 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4196.236328 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4237.349609 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4271.041016 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4298.824219 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4360.347656 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4421.626953 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4485.005859 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4548.628906 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4582.320312 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4641.5 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4705.123047 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4736.910156 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4800.533203 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4864.15625 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4895.943359 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4959.566406 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4995.650391 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5034.513672 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5089.494141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5153.117188 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5184.904297 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5216.691406 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5248.478516 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5280.265625 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5312.052734 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5351.261719 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5414.640625 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5453.503906 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5514.685547 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5578.064453 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5641.541016 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5704.919922 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5768.396484 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5831.775391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5870.984375 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5902.771484 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5986.560547 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6018.347656 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6115.759766 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6177.283203 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6240.759766 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6268.542969 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6329.822266 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6393.201172 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6424.988281 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6477.087891 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6540.466797 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6601.746094 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6665.222656 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6717.322266 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6780.701172 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6841.882812 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6881.091797 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6914.783203 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6946.570312 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6987.683594 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7048.962891 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7088.171875 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7115.955078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7177.136719 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7208.923828 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7236.707031 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7288.806641 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7320.59375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7384.070312 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7445.59375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7484.802734 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7546.326172 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7585.689453 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7683.101562 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7710.884766 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7774.263672 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7802.046875 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7854.146484 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7893.355469 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7921.138672 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3135.351562 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3198.974609 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3262.597656 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3317.578125 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3381.201172 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3444.824219 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3508.447266 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3563.427734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3595.214844 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3627.001953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3658.789062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3690.576172 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3722.363281 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3750.146484 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3811.669922 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3872.949219 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3936.328125 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3999.804688 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4038.667969 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4099.849609 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4159.029297 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4220.552734 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4261.666016 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4295.357422 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4323.140625 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4384.664062 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4445.943359 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4509.322266 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4572.945312 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4606.636719 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4665.816406 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4729.439453 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4761.226562 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4824.849609 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4888.472656 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4920.259766 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4983.882812 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5019.966797 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5058.830078 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5113.810547 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5177.433594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5209.220703 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5241.007812 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5272.794922 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5304.582031 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5336.369141 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5375.578125 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5438.957031 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5477.820312 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5539.001953 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5602.380859 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5665.857422 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5729.236328 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5792.712891 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5856.091797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5895.300781 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5927.087891 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6010.876953 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6042.664062 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6140.076172 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6201.599609 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6265.076172 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6292.859375 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6354.138672 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6417.517578 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6449.304688 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6501.404297 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6564.783203 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6626.0625 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6689.539062 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6741.638672 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6805.017578 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6866.199219 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6905.408203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6939.099609 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6970.886719 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7012 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7073.279297 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7112.488281 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7140.271484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7201.453125 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7233.240234 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7261.023438 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7313.123047 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7344.910156 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7408.386719 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7469.910156 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7509.119141 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7570.642578 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7610.005859 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7707.417969 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7735.201172 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7798.580078 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7826.363281 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7878.462891 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7917.671875 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7945.455078 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p1bc9c5d816">
+  <clipPath id="p1d8fbc3c25">
    <rect x="95.67625" y="49.4355" width="416.571298" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_summary.svg
+++ b/bench/graphs/canterbury_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="572.716719pt" height="386.202469pt" viewBox="0 0 572.716719 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="574.419688pt" height="386.202469pt" viewBox="0 0 574.419688 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,232 +22,232 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 386.202469 
-L 572.716719 386.202469 
-L 572.716719 0 
+L 574.419688 386.202469 
+L 574.419688 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 188.483359 104.1264 
-L 293.108359 104.1264 
-L 293.108359 74.7432 
-L 188.483359 74.7432 
+    <path d="M 189.334844 104.1264 
+L 293.959844 104.1264 
+L 293.959844 74.7432 
+L 189.334844 74.7432 
 z
-" clip-path="url(#p3d3f3a08b8)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pa6bb1ff674)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 293.108359 104.1264 
-L 397.733359 104.1264 
-L 397.733359 74.7432 
-L 293.108359 74.7432 
+    <path d="M 293.959844 104.1264 
+L 398.584844 104.1264 
+L 398.584844 74.7432 
+L 293.959844 74.7432 
 z
-" clip-path="url(#p3d3f3a08b8)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pa6bb1ff674)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 397.733359 104.1264 
-L 502.358359 104.1264 
-L 502.358359 74.7432 
-L 397.733359 74.7432 
+    <path d="M 398.584844 104.1264 
+L 503.209844 104.1264 
+L 503.209844 74.7432 
+L 398.584844 74.7432 
 z
-" clip-path="url(#p3d3f3a08b8)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pa6bb1ff674)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 188.483359 133.5096 
-L 293.108359 133.5096 
-L 293.108359 104.1264 
-L 188.483359 104.1264 
+    <path d="M 189.334844 133.5096 
+L 293.959844 133.5096 
+L 293.959844 104.1264 
+L 189.334844 104.1264 
 z
-" clip-path="url(#p3d3f3a08b8)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pa6bb1ff674)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 293.108359 133.5096 
-L 397.733359 133.5096 
-L 397.733359 104.1264 
-L 293.108359 104.1264 
+    <path d="M 293.959844 133.5096 
+L 398.584844 133.5096 
+L 398.584844 104.1264 
+L 293.959844 104.1264 
 z
-" clip-path="url(#p3d3f3a08b8)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pa6bb1ff674)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 397.733359 133.5096 
-L 502.358359 133.5096 
-L 502.358359 104.1264 
-L 397.733359 104.1264 
+    <path d="M 398.584844 133.5096 
+L 503.209844 133.5096 
+L 503.209844 104.1264 
+L 398.584844 104.1264 
 z
-" clip-path="url(#p3d3f3a08b8)" style="fill: #fdb768; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pa6bb1ff674)" style="fill: #fdb768; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 188.483359 162.8928 
-L 293.108359 162.8928 
-L 293.108359 133.5096 
-L 188.483359 133.5096 
+    <path d="M 189.334844 162.8928 
+L 293.959844 162.8928 
+L 293.959844 133.5096 
+L 189.334844 133.5096 
 z
-" clip-path="url(#p3d3f3a08b8)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pa6bb1ff674)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 293.108359 162.8928 
-L 397.733359 162.8928 
-L 397.733359 133.5096 
-L 293.108359 133.5096 
+    <path d="M 293.959844 162.8928 
+L 398.584844 162.8928 
+L 398.584844 133.5096 
+L 293.959844 133.5096 
 z
-" clip-path="url(#p3d3f3a08b8)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pa6bb1ff674)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 397.733359 162.8928 
-L 502.358359 162.8928 
-L 502.358359 133.5096 
-L 397.733359 133.5096 
+    <path d="M 398.584844 162.8928 
+L 503.209844 162.8928 
+L 503.209844 133.5096 
+L 398.584844 133.5096 
 z
-" clip-path="url(#p3d3f3a08b8)" style="fill: #bbe278; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pa6bb1ff674)" style="fill: #bbe278; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 188.483359 192.276 
-L 293.108359 192.276 
-L 293.108359 162.8928 
-L 188.483359 162.8928 
+    <path d="M 189.334844 192.276 
+L 293.959844 192.276 
+L 293.959844 162.8928 
+L 189.334844 162.8928 
 z
-" clip-path="url(#p3d3f3a08b8)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pa6bb1ff674)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 293.108359 192.276 
-L 397.733359 192.276 
-L 397.733359 162.8928 
-L 293.108359 162.8928 
+    <path d="M 293.959844 192.276 
+L 398.584844 192.276 
+L 398.584844 162.8928 
+L 293.959844 162.8928 
 z
-" clip-path="url(#p3d3f3a08b8)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pa6bb1ff674)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 397.733359 192.276 
-L 502.358359 192.276 
-L 502.358359 162.8928 
-L 397.733359 162.8928 
+    <path d="M 398.584844 192.276 
+L 503.209844 192.276 
+L 503.209844 162.8928 
+L 398.584844 162.8928 
 z
-" clip-path="url(#p3d3f3a08b8)" style="fill: #fdc776; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pa6bb1ff674)" style="fill: #fdc776; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 188.483359 221.6592 
-L 293.108359 221.6592 
-L 293.108359 192.276 
-L 188.483359 192.276 
+    <path d="M 189.334844 221.6592 
+L 293.959844 221.6592 
+L 293.959844 192.276 
+L 189.334844 192.276 
 z
-" clip-path="url(#p3d3f3a08b8)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pa6bb1ff674)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 293.108359 221.6592 
-L 397.733359 221.6592 
-L 397.733359 192.276 
-L 293.108359 192.276 
+    <path d="M 293.959844 221.6592 
+L 398.584844 221.6592 
+L 398.584844 192.276 
+L 293.959844 192.276 
 z
-" clip-path="url(#p3d3f3a08b8)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pa6bb1ff674)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 397.733359 221.6592 
-L 502.358359 221.6592 
-L 502.358359 192.276 
-L 397.733359 192.276 
+    <path d="M 398.584844 221.6592 
+L 503.209844 221.6592 
+L 503.209844 192.276 
+L 398.584844 192.276 
 z
-" clip-path="url(#p3d3f3a08b8)" style="fill: #addc6f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pa6bb1ff674)" style="fill: #addc6f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 188.483359 251.0424 
-L 293.108359 251.0424 
-L 293.108359 221.6592 
-L 188.483359 221.6592 
+    <path d="M 189.334844 251.0424 
+L 293.959844 251.0424 
+L 293.959844 221.6592 
+L 189.334844 221.6592 
 z
-" clip-path="url(#p3d3f3a08b8)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pa6bb1ff674)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 293.108359 251.0424 
-L 397.733359 251.0424 
-L 397.733359 221.6592 
-L 293.108359 221.6592 
+    <path d="M 293.959844 251.0424 
+L 398.584844 251.0424 
+L 398.584844 221.6592 
+L 293.959844 221.6592 
 z
-" clip-path="url(#p3d3f3a08b8)" style="fill: #fdbd6d; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pa6bb1ff674)" style="fill: #fdbd6d; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 397.733359 251.0424 
-L 502.358359 251.0424 
-L 502.358359 221.6592 
-L 397.733359 221.6592 
+    <path d="M 398.584844 251.0424 
+L 503.209844 251.0424 
+L 503.209844 221.6592 
+L 398.584844 221.6592 
 z
-" clip-path="url(#p3d3f3a08b8)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pa6bb1ff674)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 188.483359 280.4256 
-L 293.108359 280.4256 
-L 293.108359 251.0424 
-L 188.483359 251.0424 
+    <path d="M 189.334844 280.4256 
+L 293.959844 280.4256 
+L 293.959844 251.0424 
+L 189.334844 251.0424 
 z
-" clip-path="url(#p3d3f3a08b8)" style="fill: #ebf7a3; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pa6bb1ff674)" style="fill: #ebf7a3; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 293.108359 280.4256 
-L 397.733359 280.4256 
-L 397.733359 251.0424 
-L 293.108359 251.0424 
+    <path d="M 293.959844 280.4256 
+L 398.584844 280.4256 
+L 398.584844 251.0424 
+L 293.959844 251.0424 
 z
-" clip-path="url(#p3d3f3a08b8)" style="fill: #fca85e; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pa6bb1ff674)" style="fill: #fca85e; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 397.733359 280.4256 
-L 502.358359 280.4256 
-L 502.358359 251.0424 
-L 397.733359 251.0424 
+    <path d="M 398.584844 280.4256 
+L 503.209844 280.4256 
+L 503.209844 251.0424 
+L 398.584844 251.0424 
 z
-" clip-path="url(#p3d3f3a08b8)" style="fill: #fca85e; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pa6bb1ff674)" style="fill: #fca55d; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 188.483359 309.8088 
-L 293.108359 309.8088 
-L 293.108359 280.4256 
-L 188.483359 280.4256 
+    <path d="M 189.334844 309.8088 
+L 293.959844 309.8088 
+L 293.959844 280.4256 
+L 189.334844 280.4256 
 z
-" clip-path="url(#p3d3f3a08b8)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pa6bb1ff674)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 293.108359 309.8088 
-L 397.733359 309.8088 
-L 397.733359 280.4256 
-L 293.108359 280.4256 
+    <path d="M 293.959844 309.8088 
+L 398.584844 309.8088 
+L 398.584844 280.4256 
+L 293.959844 280.4256 
 z
-" clip-path="url(#p3d3f3a08b8)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pa6bb1ff674)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 397.733359 309.8088 
-L 502.358359 309.8088 
-L 502.358359 280.4256 
-L 397.733359 280.4256 
+    <path d="M 398.584844 309.8088 
+L 503.209844 309.8088 
+L 503.209844 280.4256 
+L 398.584844 280.4256 
 z
-" clip-path="url(#p3d3f3a08b8)" style="fill: #ee613e; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pa6bb1ff674)" style="fill: #ee613e; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 188.483359 339.192 
-L 293.108359 339.192 
-L 293.108359 309.8088 
-L 188.483359 309.8088 
+    <path d="M 189.334844 339.192 
+L 293.959844 339.192 
+L 293.959844 309.8088 
+L 189.334844 309.8088 
 z
-" clip-path="url(#p3d3f3a08b8)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pa6bb1ff674)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 293.108359 339.192 
-L 397.733359 339.192 
-L 397.733359 309.8088 
-L 293.108359 309.8088 
+    <path d="M 293.959844 339.192 
+L 398.584844 339.192 
+L 398.584844 309.8088 
+L 293.959844 309.8088 
 z
-" clip-path="url(#p3d3f3a08b8)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pa6bb1ff674)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 397.733359 339.192 
-L 502.358359 339.192 
-L 502.358359 309.8088 
-L 397.733359 309.8088 
+    <path d="M 398.584844 339.192 
+L 503.209844 339.192 
+L 503.209844 309.8088 
+L 398.584844 309.8088 
 z
-" clip-path="url(#p3d3f3a08b8)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pa6bb1ff674)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(121.470625 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(122.322109 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(228.754844 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(229.606328 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(307.326953 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(308.178438 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(405.678672 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(406.530156 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(117.408359 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(118.259844 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.296 -->
-    <g transform="translate(229.344609 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(230.196094 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -946,7 +946,7 @@ z
    </g>
    <g id="text_7">
     <!-- 158 -->
-    <g transform="translate(337.785859 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(338.637344 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -1034,7 +1034,7 @@ z
    </g>
    <g id="text_8">
     <!-- 925 -->
-    <g transform="translate(442.410859 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(443.262344 91.6423) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-39"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
@@ -1042,7 +1042,7 @@ z
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(112.046484 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(112.897969 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1141,7 +1141,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.299 -->
-    <g transform="translate(229.344609 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(230.196094 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1151,7 +1151,7 @@ z
    </g>
    <g id="text_11">
     <!-- 73 -->
-    <g transform="translate(340.330859 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(341.182344 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -1202,7 +1202,7 @@ z
    </g>
    <g id="text_12">
     <!-- 283 -->
-    <g transform="translate(442.410859 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(443.262344 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(127.246094 0)"/>
@@ -1210,7 +1210,7 @@ z
    </g>
    <g id="text_13">
     <!-- zlib -->
-    <g transform="translate(129.309609 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(130.161094 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1234,7 +1234,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.299 -->
-    <g transform="translate(229.344609 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(230.196094 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1244,14 +1244,14 @@ z
    </g>
    <g id="text_15">
     <!-- 55 -->
-    <g transform="translate(340.330859 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(341.182344 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
     <!-- 692 -->
-    <g transform="translate(442.410859 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(443.262344 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-36"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
@@ -1259,7 +1259,7 @@ z
    </g>
    <g id="text_17">
     <!-- Go compress/flate -->
-    <g transform="translate(99.739609 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(100.591094 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -1430,7 +1430,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.299 -->
-    <g transform="translate(229.344609 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(230.196094 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1440,14 +1440,14 @@ z
    </g>
    <g id="text_19">
     <!-- 52 -->
-    <g transform="translate(340.330859 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(341.182344 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
     <!-- 323 -->
-    <g transform="translate(442.410859 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(443.262344 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(127.246094 0)"/>
@@ -1455,7 +1455,7 @@ z
    </g>
    <g id="text_21">
     <!-- miniz_oxide -->
-    <g transform="translate(112.615859 209.06385) scale(0.08 -0.08)">
+    <g transform="translate(113.467344 209.06385) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6e" d="M 3513 2113 
 L 3513 0 
@@ -1514,7 +1514,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.299 -->
-    <g transform="translate(229.344609 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(230.196094 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1524,14 +1524,14 @@ z
    </g>
    <g id="text_23">
     <!-- 51 -->
-    <g transform="translate(340.330859 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(341.182344 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_24">
     <!-- 729 -->
-    <g transform="translate(442.410859 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(443.262344 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-37"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(127.246094 0)"/>
@@ -1539,7 +1539,7 @@ z
    </g>
    <g id="text_25">
     <!-- JS fflate -->
-    <g transform="translate(120.772109 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(121.623594 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1599,7 +1599,7 @@ z
    </g>
    <g id="text_26">
     <!-- 0.307 -->
-    <g transform="translate(229.344609 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(230.196094 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1609,7 +1609,7 @@ z
    </g>
    <g id="text_27">
     <!-- 41 -->
-    <g transform="translate(340.330859 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(341.182344 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1637,14 +1637,14 @@ z
    </g>
    <g id="text_28">
     <!-- 80 -->
-    <g transform="translate(444.955859 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(445.807344 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-38"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_29">
     <!-- lean-zip (native) -->
-    <g transform="translate(99.117734 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(99.969219 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1753,7 +1753,7 @@ z
    </g>
    <g id="text_30">
     <!-- 0.297 -->
-    <g transform="translate(228.143984 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(228.995469 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1854,8 +1854,8 @@ z
     </g>
    </g>
    <g id="text_31">
-    <!-- 33 -->
-    <g transform="translate(339.854609 267.9415) scale(0.08 -0.08)">
+    <!-- 32 -->
+    <g transform="translate(340.706094 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-33" d="M 2981 2516 
 Q 3453 2394 3698 2092 
@@ -1891,12 +1891,12 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-Bold-33"/>
-     <use xlink:href="#DejaVuSans-Bold-33" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-32" transform="translate(69.580078 0)"/>
     </g>
    </g>
    <g id="text_32">
     <!-- 248 -->
-    <g transform="translate(441.696484 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(442.547969 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-34" d="M 2356 3675 
 L 1038 1722 
@@ -1964,7 +1964,7 @@ z
    </g>
    <g id="text_33">
     <!-- OCaml decompress -->
-    <g transform="translate(97.232734 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(98.084219 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -2029,7 +2029,7 @@ z
    </g>
    <g id="text_34">
     <!-- 0.321 -->
-    <g transform="translate(229.344609 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(230.196094 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -2039,14 +2039,14 @@ z
    </g>
    <g id="text_35">
     <!-- 23 -->
-    <g transform="translate(340.330859 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(341.182344 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_36">
     <!-- 117 -->
-    <g transform="translate(442.410859 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(443.262344 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
@@ -2054,7 +2054,7 @@ z
    </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(125.453984 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(126.305469 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -2065,7 +2065,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.279 -->
-    <g transform="translate(229.344609 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(230.196094 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -2075,13 +2075,13 @@ z
    </g>
    <g id="text_39">
     <!-- 0 -->
-    <g transform="translate(342.875859 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(343.727344 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(446.045859 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(446.897344 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2097,7 +2097,7 @@ z
   </g>
   <g id="text_41">
    <!-- canterbury — geomean over files, level 6 -->
-   <g transform="translate(135.867109 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(136.718594 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-62" d="M 2400 722 
 Q 2759 722 2948 984 
@@ -2310,7 +2310,7 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-07-08T20:16:47Z  ·  Linux chungus2 x86_64  ·  commit 74c19afa  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-07-08T21:41:55Z  ·  Linux chungus2 x86_64  ·  commit b17c222c  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2452,13 +2452,13 @@ z
     <use xlink:href="#DejaVuSans-38" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2498,110 +2498,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3254.101562 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3317.724609 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3381.347656 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3442.626953 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3477.832031 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3539.111328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3570.898438 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3602.685547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3634.472656 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3666.259766 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3698.046875 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3725.830078 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3787.353516 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3848.632812 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3912.011719 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3975.488281 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4014.351562 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4075.533203 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4134.712891 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4196.236328 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4237.349609 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4271.041016 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4298.824219 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4360.347656 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4421.626953 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4485.005859 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4548.628906 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4582.320312 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4641.5 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4705.123047 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4736.910156 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4800.533203 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4864.15625 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4895.943359 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4959.566406 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4995.650391 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5034.513672 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5089.494141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5153.117188 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5184.904297 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5216.691406 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5248.478516 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5280.265625 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5312.052734 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5351.261719 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5414.640625 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5453.503906 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5514.685547 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5578.064453 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5641.541016 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5704.919922 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5768.396484 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5831.775391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5870.984375 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5902.771484 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5986.560547 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6018.347656 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6115.759766 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6177.283203 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6240.759766 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6268.542969 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6329.822266 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6393.201172 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6424.988281 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6477.087891 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6540.466797 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6601.746094 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6665.222656 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6717.322266 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6780.701172 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6841.882812 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6881.091797 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6914.783203 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6946.570312 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6987.683594 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7048.962891 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7088.171875 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7115.955078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7177.136719 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7208.923828 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7236.707031 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7288.806641 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7320.59375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7384.070312 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7445.59375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7484.802734 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7546.326172 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7585.689453 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7683.101562 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7710.884766 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7774.263672 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7802.046875 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7854.146484 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7893.355469 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7921.138672 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3135.351562 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3198.974609 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3262.597656 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3317.578125 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3381.201172 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3444.824219 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3508.447266 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3563.427734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3595.214844 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3627.001953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3658.789062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3690.576172 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3722.363281 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3750.146484 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3811.669922 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3872.949219 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3936.328125 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3999.804688 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4038.667969 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4099.849609 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4159.029297 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4220.552734 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4261.666016 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4295.357422 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4323.140625 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4384.664062 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4445.943359 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4509.322266 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4572.945312 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4606.636719 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4665.816406 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4729.439453 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4761.226562 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4824.849609 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4888.472656 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4920.259766 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4983.882812 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5019.966797 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5058.830078 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5113.810547 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5177.433594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5209.220703 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5241.007812 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5272.794922 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5304.582031 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5336.369141 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5375.578125 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5438.957031 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5477.820312 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5539.001953 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5602.380859 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5665.857422 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5729.236328 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5792.712891 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5856.091797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5895.300781 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5927.087891 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6010.876953 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6042.664062 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6140.076172 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6201.599609 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6265.076172 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6292.859375 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6354.138672 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6417.517578 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6449.304688 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6501.404297 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6564.783203 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6626.0625 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6689.539062 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6741.638672 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6805.017578 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6866.199219 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6905.408203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6939.099609 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6970.886719 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7012 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7073.279297 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7112.488281 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7140.271484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7201.453125 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7233.240234 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7261.023438 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7313.123047 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7344.910156 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7408.386719 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7469.910156 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7509.119141 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7570.642578 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7610.005859 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7707.417969 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7735.201172 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7798.580078 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7826.363281 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7878.462891 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7917.671875 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7945.455078 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p3d3f3a08b8">
-   <rect x="83.858359" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="pa6bb1ff674">
+   <rect x="84.709844" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/graphs/silesia_compress_heatmap.svg
+++ b/bench/graphs/silesia_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.34175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#pc20051694a)">
+   <g clip-path="url(#p772d83926e)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAqAAAAGaCAYAAADQNfGTAAAJ9klEQVR4nO3YP45kVx2GYXdXTbunLQ0e2zQMmgQShAiQkSzL22AdRE5ZAxsgI2QBBCQEBEgmcegIS/4DsgweYWsYl7uru1nE6Ly/5up5VvCVTp2q996T269+f/fKll29mF6w1snp9IK1bo/TC9ba+vkdr6YXrHXx+vSCtb57Pr2Al7E7m16w1ta/nw/OpxcstfF/PwAA7hsBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBAav/h8dPpDUudPdhPT1jqcLyanrDUk0c/mp6w1CfffDY9Yanjyc30hKV+9vCN6QlLHV89n56w1D+efz49YanLh5fTE5Y6nB2nJyx18sqL6QlLeQMKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACk9pcXl9Mblnry2k+mJyz15YtPpycs9cPDtp+RHr35i+kJS53tzqcnLHVze5yesNTWz2/zn+90259vf/p0esJS54fD9ISltv3vDgDAvSNAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBI7V/dXUxvWOrZ4YvpCUtt/fxuHr8xPWGpz/7z4fSEpZ5fH6YnLPXO43emJyx1dXecnrDUJ998PD1hqZ+/+cvpCUt98MVfpycs9fb3t31+3oACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApE5u/vL+3fSIpW5vpxfwMrZ+fqeeAWHM1u+f38//b8fj9IKlNn56AADcNwIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAIDU/vKDj6Y3LLU7201PWOrLj/41PWGp3/367ekJS/32b9s+v/eePpqesNQf/vzx9ISlfvOrn05PWOqPf/96esJSP3794fSEpZ59ez09Yal3n1xMT1jKG1AAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACB1cn3zp7vpESvtrq+mJ6y1O5tesNbxML1grf359IK1dvvpBWvd3U4vWOt64/fvZOPvYE63ff+uT7Z9/x4cj9MTltr47QMA4L4RoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApPb/PvxzesNSP9i9NT1hqf/evZiesNRrW39G2u2nF/ASvr5+Nj1hqe9db/v+3Vw8mp6w1O3d7fSEpR589fn0hLUeP51esNS2f10AALh3BCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAAKn/AcIqe9C4En4wAAAAAElFTkSuQmCC" id="image4e0f6f9cfd" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="483.84" height="295.2"/>
+iVBORw0KGgoAAAANSUhEUgAAAqAAAAGaCAYAAADQNfGTAAAJ9UlEQVR4nO3YP27l1R2H4bF9x+MxksWAsBg0TWiiiCIiEoqyjawjVVrWwAboKFkABQ1FikikoaQCiX8SAoEImgyOfX3NItB5v8NPz7OCz9Xx8X3vOTr88N7dvS27fja9YK2j4+kFax320wvW2vr57a+nF6x1/uL0grX+/3R6Ab/Fyen0grW2/vd5/2x6wVIb//YDAOB5I0ABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEjtPtl/Ob1hqdP7u+kJS13tr6cnLPX44rXpCUt98fNX0xOW2h/dTk9Y6k8PX5qesNT+wdn0hKW+efr19ISlLh9eTk9Y6up0Pz1hqaN7z6YnLOUFFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASO0uzy+nNyz1+IXXpycs9d2zL6cnLPXq1bZ/I128/OfpCUudnpxNT1jq9rCfnrDU1s9v85/veNufb3f8ZHrCUmdXV9MTltr2tzsAAM8dAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQGr34OR8esNSP159Oz1hqa2f3+2jl6YnLPXVT59MT1jq6c3V9ISl3nr01vSEpa7v9tMTlvri58+nJyz1xst/mZ6w1Mff/nt6wlJvvrLt8/MCCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJA6uv3XP++mRyx1OEwv4LfY+vkd+w0IY7Z+//z//H3b76cXLLXx0wMA4HkjQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASO0uP/50esNSJ6cn0xOW+u7T76cnLPXuP96cnrDUO//Z9vn97cnF9ISl3v/o8+kJS7399z9OT1jqg8/+Oz1hqT+8+HB6wlI//nIzPWGpvz4+n56wlBdQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgdXRz++Hd9IiVTm6upyesdXI6vWCt/dX0grV2Z9ML1jrZTS9Y6+4wvWCtm43fv6ONv8Ecb/v+3Rxt+/7d3++nJyy18dsHAMDzRoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJDaff/L19Mblnp1dzk9Yan/3T2bnrDUC7eH6QlrPdhNL1jqcG/b5/d0/9P0hKUubqYXrHV7fjE9YanD3bbv3/0ftt0v9x49mV6wlBdQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgNSvp/N/zBRtfskAAAAASUVORK5CYII=" id="image8b03d76803" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="483.84" height="295.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="mf759a82a94" d="M 0 0 
+       <path id="m3981f2f766" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mf759a82a94" x="115.814949" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3981f2f766" x="115.814949" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#mf759a82a94" x="156.092348" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3981f2f766" x="156.092348" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#mf759a82a94" x="196.369746" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3981f2f766" x="196.369746" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mf759a82a94" x="236.647145" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3981f2f766" x="236.647145" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#mf759a82a94" x="276.924544" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3981f2f766" x="276.924544" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#mf759a82a94" x="317.201942" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3981f2f766" x="317.201942" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#mf759a82a94" x="357.479341" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3981f2f766" x="357.479341" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#mf759a82a94" x="397.756739" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3981f2f766" x="397.756739" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#mf759a82a94" x="438.034138" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3981f2f766" x="438.034138" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#mf759a82a94" x="478.311536" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3981f2f766" x="478.311536" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#mf759a82a94" x="518.588935" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3981f2f766" x="518.588935" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#mf759a82a94" x="558.866334" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3981f2f766" x="558.866334" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="m71c38e0436" d="M 0 0 
+       <path id="m62c738e4a4" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m71c38e0436" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m62c738e4a4" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m71c38e0436" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m62c738e4a4" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m71c38e0436" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m62c738e4a4" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m71c38e0436" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m62c738e4a4" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -836,7 +836,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m71c38e0436" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m62c738e4a4" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -899,7 +899,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m71c38e0436" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m62c738e4a4" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -966,7 +966,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m71c38e0436" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m62c738e4a4" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1047,7 +1047,7 @@ z
     <g id="ytick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m71c38e0436" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m62c738e4a4" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -1138,7 +1138,7 @@ L 579.005033 49.34175
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_21">
-    <!-- +37 -->
+    <!-- +38 -->
     <g transform="translate(108.955926 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-2b" d="M 2944 4013 
@@ -1188,74 +1188,6 @@ Q 3450 3153 3228 2886
 Q 3006 2619 2597 2516 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_22">
-    <!-- -12 -->
-    <g transform="translate(150.784184 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-31" d="M 794 531 
-L 1825 531 
-L 1825 4091 
-L 703 3866 
-L 703 4441 
-L 1819 4666 
-L 2450 4666 
-L 2450 531 
-L 3481 531 
-L 3481 0 
-L 794 0 
-L 794 531 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-32" d="M 1228 531 
-L 3431 531 
-L 3431 0 
-L 469 0 
-L 469 531 
-Q 828 903 1448 1529 
-Q 2069 2156 2228 2338 
-Q 2531 2678 2651 2914 
-Q 2772 3150 2772 3378 
-Q 2772 3750 2511 3984 
-Q 2250 4219 1831 4219 
-Q 1534 4219 1204 4116 
-Q 875 4013 500 3803 
-L 500 4441 
-Q 881 4594 1212 4672 
-Q 1544 4750 1819 4750 
-Q 2544 4750 2975 4387 
-Q 3406 4025 3406 3419 
-Q 3406 3131 3298 2873 
-Q 3191 2616 2906 2266 
-Q 2828 2175 2409 1742 
-Q 1991 1309 1228 531 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_23">
-    <!-- +18 -->
-    <g transform="translate(189.510723 69.553235) scale(0.065 -0.065)">
-     <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
 Q 1069 1734 1069 1313 
@@ -1297,13 +1229,142 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
     </g>
    </g>
+   <g id="text_22">
+    <!-- -13 -->
+    <g transform="translate(150.784184 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_23">
+    <!-- +17 -->
+    <g transform="translate(189.510723 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
    <g id="text_24">
-    <!-- -16 -->
+    <!-- -20 -->
     <g transform="translate(231.338981 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_25">
+    <!-- +2 -->
+    <g transform="translate(272.133333 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_26">
+    <!-- +3 -->
+    <g transform="translate(312.410731 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_27">
+    <!-- +21 -->
+    <g transform="translate(350.620317 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_28">
+    <!-- -21 -->
+    <g transform="translate(392.448575 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_29">
+    <!-- +6 -->
+    <g transform="translate(433.242927 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -1336,114 +1397,13 @@ Q 3103 4656 3366 4563
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_25">
-    <!-- +2 -->
-    <g transform="translate(272.133333 69.553235) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_26">
-    <!-- +2 -->
-    <g transform="translate(312.410731 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_27">
-    <!-- +24 -->
-    <g transform="translate(350.620317 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-34" d="M 2419 4116 
-L 825 1625 
-L 2419 1625 
-L 2419 4116 
-z
-M 2253 4666 
-L 3047 4666 
-L 3047 1625 
-L 3713 1625 
-L 3713 1100 
-L 3047 1100 
-L 3047 0 
-L 2419 0 
-L 2419 1100 
-L 313 1100 
-L 313 1709 
-L 2253 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_28">
-    <!-- -22 -->
-    <g transform="translate(392.448575 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_29">
-    <!-- +5 -->
-    <g transform="translate(433.242927 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_30">
-    <!-- +8 -->
+    <!-- +9 -->
     <g transform="translate(473.520325 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_31">
-    <!-- -42 -->
-    <g transform="translate(513.280771 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_32">
-    <!-- -9 -->
-    <g transform="translate(555.625982 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-39" d="M 703 97 
 L 703 672 
@@ -1476,8 +1436,44 @@ Q 1534 2075 1959 2075
 z
 " transform="scale(0.015625)"/>
      </defs>
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_31">
+    <!-- -41 -->
+    <g transform="translate(513.280771 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_32">
+    <!-- -8 -->
+    <g transform="translate(555.625982 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_33">
@@ -1498,6 +1494,33 @@ z
    <g id="text_35">
     <!-- -5 -->
     <g transform="translate(193.129395 106.389018) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
     </g>
@@ -1520,29 +1543,6 @@ z
    <g id="text_38">
     <!-- -0 -->
     <g transform="translate(313.961591 106.389018) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-30" d="M 2034 4250 
-Q 1547 4250 1301 3770 
-Q 1056 3291 1056 2328 
-Q 1056 1369 1301 889 
-Q 1547 409 2034 409 
-Q 2525 409 2770 889 
-Q 3016 1369 3016 2328 
-Q 3016 3291 2770 3770 
-Q 2525 4250 2034 4250 
-z
-M 2034 4750 
-Q 2819 4750 3233 4129 
-Q 3647 3509 3647 2328 
-Q 3647 1150 3233 529 
-Q 2819 -91 2034 -91 
-Q 1250 -91 836 529 
-Q 422 1150 422 2328 
-Q 422 3509 836 4129 
-Q 1250 4750 2034 4750 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(36.083984 0)"/>
     </g>
@@ -2189,18 +2189,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB1ElEQVR4nO2b0a3DMAwD7cSzvM3fmI47gvpxCK6ENABhnkQ5aZH5P/7OAGpdFyEzBiQDnija2qSEghnZhIIZCa3NyWQkmZFOKJhRsDXsOopmJJwjaEPOmxHirE3MWjOqhSBr2EAGMyKtMVpc+ynYwe3viNQVbA0LrZDRFbxGbNbWyM3auG0RGbo1Qp0IZCSMiG2OgtNvbL+Oke6BvddIWaQ1qP3RjGSTLXypwdaIMP2ctWb0olAzKkr4LhLMCPvnOJiRbo6CrTWjF4WCGYHWJtU1TKgZvSZkfNAKZhRsDftFa96MkJCRrf29ausyWrOtWiMjmxDH6FAfDJzzIEKctQc60ToDEqJOBLbfZs04RxQjobWOSFXrjM0IdURqIaG1jkhVPmvGOUqOCPLJMdh+6kRk+zFGMtjKOdK13zbZ2EBGMxLOkSz90YygK9tozSbUa6Qu4RxtRifZ2np0jDY32YiOc44gIQo2aI1ZkB2Rb4SiIyJbtcr0Q0IPdCQyIpCQDnZHpC5uQ27uOtJFBBptH2zlHOnab+uaMSK29htXrW2NKK0hOtlrxLaPjIxys4a99x9dRKgTgUK69gsZ9RxVFWzNyIi6RZIZtbXfE+qI1BU8R5i1D2e5X2tFkZmlAAAAAElFTkSuQmCC" id="image78bc9cc51e" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-69.84" width="12.96" height="253.44"/>
+iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB1ElEQVR4nO2b0a3DMAwD7cSzvM3fmI47gvpxCK6ENABhnkQ5aZH5P/7OAGpdFyEzBiQDnija2qSEghnZhIIZCa3NyWQkmZFOKJhRsDXsOopmJJwjaEPOmxHirE3MWjOqhSBr2EAGMyKtMVpc+ynYwe3viNQVbA0LrZDRFbxGbNbWyM3auG0RGbo1Qp0IZCSMiG2OgtNvbL+Oke6BvddIWaQ1qP3RjGSTLXypwdaIMP2ctWb0olAzKkr4LhLMCPvnOJiRbo6CrTWjF4WCGYHWJtU1TKgZvSZkfNAKZhRsDftFa96MkJCRrf29ausyWrOtWiMjmxDH6FAfDJzzIEKctQc60ToDEqJOBLbfZs04RxQjobWOSFXrjM0IdURqIaG1jkhVPmvGOUqOCPLJMdh+6kRk+zFGMtjKOdK13zbZ2EBGMxLOkSz90YygK9tozSbUa6Qu4RxtRifZ2np0jDY32YiOc44gIQo2aI1ZkB2Rb4SiIyJbtcr0Q0IPdCQyIpCQDnZHpC5uQ27uOtJFBBptH2zlHOnab+uaMSK29htXrW2NKK0hOtlrxLaPjIxys4a99x9dRKgTgUK69gsZ9RxVFWzNyIi6RZIZtbXfE+qI1BU8R5i1D2e5X2tFkZmlAAAAAElFTkSuQmCC" id="imagef0fb3f43fd" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-69.84" width="12.96" height="253.44"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_21">
       <defs>
-       <path id="mfb3ced30c2" d="M 0 0 
+       <path id="m4092f00be7" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mfb3ced30c2" x="601.779688" y="322.507463" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4092f00be7" x="601.779688" y="322.507463" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_117">
@@ -2223,7 +2223,7 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#mfb3ced30c2" x="601.779688" y="280.566603" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4092f00be7" x="601.779688" y="280.566603" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_118">
@@ -2237,7 +2237,7 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#mfb3ced30c2" x="601.779688" y="238.625742" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4092f00be7" x="601.779688" y="238.625742" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_119">
@@ -2251,7 +2251,7 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mfb3ced30c2" x="601.779688" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4092f00be7" x="601.779688" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_120">
@@ -2264,7 +2264,7 @@ z
     <g id="ytick_13">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#mfb3ced30c2" x="601.779688" y="154.74402" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4092f00be7" x="601.779688" y="154.74402" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_121">
@@ -2277,7 +2277,7 @@ z
     <g id="ytick_14">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mfb3ced30c2" x="601.779688" y="112.803159" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4092f00be7" x="601.779688" y="112.803159" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_122">
@@ -2290,7 +2290,7 @@ z
     <g id="ytick_15">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#mfb3ced30c2" x="601.779688" y="70.862298" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4092f00be7" x="601.779688" y="70.862298" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_123">
@@ -2906,8 +2906,8 @@ z
    </g>
   </g>
   <g id="text_126">
-   <!-- 2026-07-08T20:16:47Z  ·  Linux chungus2 x86_64  ·  commit 74c19afa  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(44.841641 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-08T21:41:55Z  ·  Linux chungus2 x86_64  ·  commit b17c222c  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(43.990156 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2999,13 +2999,13 @@ z
     <use xlink:href="#DejaVuSans-38" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3045,109 +3045,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3254.101562 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3317.724609 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3381.347656 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3442.626953 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3477.832031 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3539.111328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3570.898438 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3602.685547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3634.472656 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3666.259766 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3698.046875 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3725.830078 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3787.353516 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3848.632812 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3912.011719 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3975.488281 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4014.351562 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4075.533203 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4134.712891 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4196.236328 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4237.349609 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4271.041016 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4298.824219 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4360.347656 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4421.626953 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4485.005859 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4548.628906 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4582.320312 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4641.5 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4705.123047 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4736.910156 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4800.533203 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4864.15625 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4895.943359 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4959.566406 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4995.650391 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5034.513672 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5089.494141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5153.117188 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5184.904297 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5216.691406 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5248.478516 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5280.265625 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5312.052734 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5351.261719 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5414.640625 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5453.503906 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5514.685547 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5578.064453 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5641.541016 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5704.919922 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5768.396484 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5831.775391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5870.984375 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5902.771484 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5986.560547 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6018.347656 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6115.759766 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6177.283203 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6240.759766 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6268.542969 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6329.822266 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6393.201172 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6424.988281 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6477.087891 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6540.466797 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6601.746094 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6665.222656 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6717.322266 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6780.701172 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6841.882812 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6881.091797 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6914.783203 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6946.570312 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6987.683594 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7048.962891 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7088.171875 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7115.955078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7177.136719 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7208.923828 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7236.707031 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7288.806641 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7320.59375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7384.070312 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7445.59375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7484.802734 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7546.326172 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7585.689453 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7683.101562 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7710.884766 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7774.263672 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7802.046875 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7854.146484 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7893.355469 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7921.138672 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3135.351562 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3198.974609 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3262.597656 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3317.578125 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3381.201172 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3444.824219 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3508.447266 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3563.427734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3595.214844 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3627.001953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3658.789062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3690.576172 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3722.363281 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3750.146484 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3811.669922 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3872.949219 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3936.328125 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3999.804688 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4038.667969 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4099.849609 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4159.029297 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4220.552734 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4261.666016 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4295.357422 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4323.140625 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4384.664062 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4445.943359 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4509.322266 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4572.945312 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4606.636719 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4665.816406 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4729.439453 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4761.226562 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4824.849609 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4888.472656 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4920.259766 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4983.882812 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5019.966797 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5058.830078 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5113.810547 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5177.433594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5209.220703 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5241.007812 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5272.794922 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5304.582031 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5336.369141 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5375.578125 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5438.957031 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5477.820312 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5539.001953 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5602.380859 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5665.857422 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5729.236328 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5792.712891 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5856.091797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5895.300781 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5927.087891 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6010.876953 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6042.664062 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6140.076172 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6201.599609 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6265.076172 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6292.859375 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6354.138672 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6417.517578 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6449.304688 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6501.404297 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6564.783203 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6626.0625 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6689.539062 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6741.638672 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6805.017578 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6866.199219 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6905.408203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6939.099609 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6970.886719 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7012 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7073.279297 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7112.488281 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7140.271484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7201.453125 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7233.240234 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7261.023438 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7313.123047 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7344.910156 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7408.386719 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7469.910156 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7509.119141 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7570.642578 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7610.005859 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7707.417969 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7735.201172 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7798.580078 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7826.363281 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7878.462891 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7917.671875 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7945.455078 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pc20051694a">
+  <clipPath id="p772d83926e">
    <rect x="95.67625" y="49.34175" width="483.328783" height="294.686261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_compress_pareto.svg
+++ b/bench/graphs/silesia_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 61.085542 412.80375 
 L 61.085542 48.323125 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m83617a424c" d="M 0 0 
+       <path id="m67f6590966" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m83617a424c" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m67f6590966" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -130,11 +130,11 @@ z
      <g id="line2d_3">
       <path d="M 145.270284 412.80375 
 L 145.270284 48.323125 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m83617a424c" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m67f6590966" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -177,11 +177,11 @@ z
      <g id="line2d_5">
       <path d="M 229.455026 412.80375 
 L 229.455026 48.323125 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m83617a424c" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m67f6590966" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -219,11 +219,11 @@ z
      <g id="line2d_7">
       <path d="M 313.639768 412.80375 
 L 313.639768 48.323125 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m83617a424c" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m67f6590966" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -272,11 +272,11 @@ z
      <g id="line2d_9">
       <path d="M 397.82451 412.80375 
 L 397.82451 48.323125 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m83617a424c" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m67f6590966" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -334,11 +334,11 @@ z
      <g id="line2d_11">
       <path d="M 482.009253 412.80375 
 L 482.009253 48.323125 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m83617a424c" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m67f6590966" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -355,11 +355,11 @@ L 482.009253 48.323125
      <g id="line2d_13">
       <path d="M 566.193995 412.80375 
 L 566.193995 48.323125 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m83617a424c" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m67f6590966" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -856,16 +856,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 368.08164 
 L 637.2 368.08164 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="m680e5ab90d" d="M 0 0 
+       <path id="m092d619aa8" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m680e5ab90d" x="49.078125" y="368.08164" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m092d619aa8" x="49.078125" y="368.08164" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -897,11 +897,11 @@ z
      <g id="line2d_17">
       <path d="M 49.078125 243.439835 
 L 637.2 243.439835 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m680e5ab90d" x="49.078125" y="243.439835" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m092d619aa8" x="49.078125" y="243.439835" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -917,11 +917,11 @@ L 637.2 243.439835
      <g id="line2d_19">
       <path d="M 49.078125 118.798029 
 L 637.2 118.798029 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m680e5ab90d" x="49.078125" y="118.798029" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m092d619aa8" x="49.078125" y="118.798029" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -937,16 +937,16 @@ L 637.2 118.798029
      <g id="line2d_21">
       <path d="M 49.078125 405.602562 
 L 637.2 405.602562 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="m620317a40c" d="M 0 0 
+       <path id="mad631877e0" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m620317a40c" x="49.078125" y="405.602562" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mad631877e0" x="49.078125" y="405.602562" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -954,11 +954,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 395.733268 
 L 637.2 395.733268 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m620317a40c" x="49.078125" y="395.733268" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mad631877e0" x="49.078125" y="395.733268" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -966,11 +966,11 @@ L 637.2 395.733268
      <g id="line2d_25">
       <path d="M 49.078125 387.3889 
 L 637.2 387.3889 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m620317a40c" x="49.078125" y="387.3889" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mad631877e0" x="49.078125" y="387.3889" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -978,11 +978,11 @@ L 637.2 387.3889
      <g id="line2d_27">
       <path d="M 49.078125 380.160679 
 L 637.2 380.160679 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m620317a40c" x="49.078125" y="380.160679" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mad631877e0" x="49.078125" y="380.160679" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -990,11 +990,11 @@ L 637.2 380.160679
      <g id="line2d_29">
       <path d="M 49.078125 373.784936 
 L 637.2 373.784936 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m620317a40c" x="49.078125" y="373.784936" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mad631877e0" x="49.078125" y="373.784936" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1002,11 +1002,11 @@ L 637.2 373.784936
      <g id="line2d_31">
       <path d="M 49.078125 330.560718 
 L 637.2 330.560718 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m620317a40c" x="49.078125" y="330.560718" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mad631877e0" x="49.078125" y="330.560718" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1014,11 +1014,11 @@ L 637.2 330.560718
      <g id="line2d_33">
       <path d="M 49.078125 308.612385 
 L 637.2 308.612385 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m620317a40c" x="49.078125" y="308.612385" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mad631877e0" x="49.078125" y="308.612385" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1026,11 +1026,11 @@ L 637.2 308.612385
      <g id="line2d_35">
       <path d="M 49.078125 293.039796 
 L 637.2 293.039796 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m620317a40c" x="49.078125" y="293.039796" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mad631877e0" x="49.078125" y="293.039796" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1038,11 +1038,11 @@ L 637.2 293.039796
      <g id="line2d_37">
       <path d="M 49.078125 280.960757 
 L 637.2 280.960757 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m620317a40c" x="49.078125" y="280.960757" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mad631877e0" x="49.078125" y="280.960757" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1050,11 +1050,11 @@ L 637.2 280.960757
      <g id="line2d_39">
       <path d="M 49.078125 271.091463 
 L 637.2 271.091463 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m620317a40c" x="49.078125" y="271.091463" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mad631877e0" x="49.078125" y="271.091463" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1062,11 +1062,11 @@ L 637.2 271.091463
      <g id="line2d_41">
       <path d="M 49.078125 262.747094 
 L 637.2 262.747094 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m620317a40c" x="49.078125" y="262.747094" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mad631877e0" x="49.078125" y="262.747094" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1074,11 +1074,11 @@ L 637.2 262.747094
      <g id="line2d_43">
       <path d="M 49.078125 255.518874 
 L 637.2 255.518874 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m620317a40c" x="49.078125" y="255.518874" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mad631877e0" x="49.078125" y="255.518874" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1086,11 +1086,11 @@ L 637.2 255.518874
      <g id="line2d_45">
       <path d="M 49.078125 249.143131 
 L 637.2 249.143131 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m620317a40c" x="49.078125" y="249.143131" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mad631877e0" x="49.078125" y="249.143131" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1098,11 +1098,11 @@ L 637.2 249.143131
      <g id="line2d_47">
       <path d="M 49.078125 205.918912 
 L 637.2 205.918912 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m620317a40c" x="49.078125" y="205.918912" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mad631877e0" x="49.078125" y="205.918912" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1110,11 +1110,11 @@ L 637.2 205.918912
      <g id="line2d_49">
       <path d="M 49.078125 183.97058 
 L 637.2 183.97058 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m620317a40c" x="49.078125" y="183.97058" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mad631877e0" x="49.078125" y="183.97058" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1122,11 +1122,11 @@ L 637.2 183.97058
      <g id="line2d_51">
       <path d="M 49.078125 168.39799 
 L 637.2 168.39799 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m620317a40c" x="49.078125" y="168.39799" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mad631877e0" x="49.078125" y="168.39799" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1134,11 +1134,11 @@ L 637.2 168.39799
      <g id="line2d_53">
       <path d="M 49.078125 156.318951 
 L 637.2 156.318951 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#m620317a40c" x="49.078125" y="156.318951" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mad631877e0" x="49.078125" y="156.318951" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1146,11 +1146,11 @@ L 637.2 156.318951
      <g id="line2d_55">
       <path d="M 49.078125 146.449658 
 L 637.2 146.449658 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#m620317a40c" x="49.078125" y="146.449658" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mad631877e0" x="49.078125" y="146.449658" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1158,11 +1158,11 @@ L 637.2 146.449658
      <g id="line2d_57">
       <path d="M 49.078125 138.105289 
 L 637.2 138.105289 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#m620317a40c" x="49.078125" y="138.105289" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mad631877e0" x="49.078125" y="138.105289" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1170,11 +1170,11 @@ L 637.2 138.105289
      <g id="line2d_59">
       <path d="M 49.078125 130.877068 
 L 637.2 130.877068 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#m620317a40c" x="49.078125" y="130.877068" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mad631877e0" x="49.078125" y="130.877068" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1182,11 +1182,11 @@ L 637.2 130.877068
      <g id="line2d_61">
       <path d="M 49.078125 124.501326 
 L 637.2 124.501326 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#m620317a40c" x="49.078125" y="124.501326" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mad631877e0" x="49.078125" y="124.501326" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1194,11 +1194,11 @@ L 637.2 124.501326
      <g id="line2d_63">
       <path d="M 49.078125 81.277107 
 L 637.2 81.277107 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#m620317a40c" x="49.078125" y="81.277107" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mad631877e0" x="49.078125" y="81.277107" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1206,11 +1206,11 @@ L 637.2 81.277107
      <g id="line2d_65">
       <path d="M 49.078125 59.328775 
 L 637.2 59.328775 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#m620317a40c" x="49.078125" y="59.328775" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mad631877e0" x="49.078125" y="59.328775" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1332,7 +1332,7 @@ L 637.2 48.323125
    </g>
    <g id="text_13">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(324.643112 118.657817) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(324.643112 118.769985) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1364,7 +1364,7 @@ z
    </g>
    <g id="text_14">
     <!-- L10 -->
-    <g style="fill: #d62728" transform="translate(102.814287 308.642983) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(102.814287 308.662731) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1686,23 +1686,23 @@ z
    </g>
    <g id="line2d_67">
     <defs>
-     <path id="m99c2ebe25d" d="M -2.5 2.5 
+     <path id="m7a66f49d20" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pe54303e94f)">
-     <use xlink:href="#m99c2ebe25d" x="377.110281" y="104.685421" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m99c2ebe25d" x="323.801439" y="110.409833" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m99c2ebe25d" x="272.665744" y="126.308323" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m99c2ebe25d" x="235.168828" y="128.026741" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m99c2ebe25d" x="186.228265" y="149.377587" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m99c2ebe25d" x="158.303164" y="171.457731" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m99c2ebe25d" x="149.489547" y="182.192614" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m99c2ebe25d" x="140.563162" y="202.482797" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m99c2ebe25d" x="138.984853" y="209.328911" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p5ff60b7cdf)">
+     <use xlink:href="#m7a66f49d20" x="377.110281" y="104.685421" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7a66f49d20" x="323.801439" y="110.409833" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7a66f49d20" x="272.665744" y="126.308323" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7a66f49d20" x="235.168828" y="128.026741" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7a66f49d20" x="186.228265" y="149.377587" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7a66f49d20" x="158.303164" y="171.457731" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7a66f49d20" x="149.489547" y="182.192614" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7a66f49d20" x="140.563162" y="202.482797" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7a66f49d20" x="138.984853" y="209.328911" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_68">
@@ -1755,7 +1755,7 @@ L 327.133241 110.069256
 L 326.02264 110.18302 
 L 324.91204 110.296545 
 L 323.801439 110.409833 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_69">
     <path d="M 323.801439 110.409833 
@@ -1807,7 +1807,7 @@ L 275.861725 125.44037
 L 274.796398 125.731236 
 L 273.731071 126.020548 
 L 272.665744 126.308323 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_70">
     <path d="M 272.665744 126.308323 
@@ -1859,7 +1859,7 @@ L 237.512385 127.920923
 L 236.7312 127.956219 
 L 235.950014 127.991491 
 L 235.168828 128.026741 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_71">
     <path d="M 235.168828 128.026741 
@@ -1911,7 +1911,7 @@ L 189.28705 148.263499
 L 188.267455 148.637415 
 L 187.24786 149.008766 
 L 186.228265 149.377587 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_72">
     <path d="M 186.228265 149.377587 
@@ -1963,7 +1963,7 @@ L 160.048483 170.312481
 L 159.46671 170.696929 
 L 158.884937 171.078667 
 L 158.303164 171.457731 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_73">
     <path d="M 158.303164 171.457731 
@@ -2015,7 +2015,7 @@ L 150.040398 181.580576
 L 149.856781 181.785359 
 L 149.673164 181.989369 
 L 149.489547 182.192614 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_74">
     <path d="M 149.489547 182.192614 
@@ -2067,7 +2067,7 @@ L 141.121061 201.414753
 L 140.935095 201.773114 
 L 140.749129 202.129119 
 L 140.563162 202.482797 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_75">
     <path d="M 140.563162 202.482797 
@@ -2119,26 +2119,26 @@ L 139.083497 208.925481
 L 139.050616 209.060292 
 L 139.017734 209.194768 
 L 138.984853 209.328911 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_76">
     <defs>
-     <path id="m42c56d396a" d="M 0 -2.5 
+     <path id="m0d9c3b99f3" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pe54303e94f)">
-     <use xlink:href="#m42c56d396a" x="610.467187" y="71.939349" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m42c56d396a" x="319.880958" y="101.884157" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m42c56d396a" x="210.281253" y="129.778154" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m42c56d396a" x="196.287076" y="133.586625" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m42c56d396a" x="176.054419" y="147.38645" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m42c56d396a" x="152.161413" y="174.753272" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m42c56d396a" x="146.720208" y="186.587648" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m42c56d396a" x="143.994022" y="196.356323" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m42c56d396a" x="142.666037" y="200.180971" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p5ff60b7cdf)">
+     <use xlink:href="#m0d9c3b99f3" x="610.467187" y="71.939349" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0d9c3b99f3" x="319.880958" y="101.884157" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0d9c3b99f3" x="210.281253" y="129.778154" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0d9c3b99f3" x="196.287076" y="133.586625" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0d9c3b99f3" x="176.054419" y="147.38645" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0d9c3b99f3" x="152.161413" y="174.753272" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0d9c3b99f3" x="146.720208" y="186.587648" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0d9c3b99f3" x="143.994022" y="196.356323" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0d9c3b99f3" x="142.666037" y="200.180971" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_77">
@@ -2191,7 +2191,7 @@ L 338.042598 100.427247
 L 331.988718 100.917253 
 L 325.934838 101.402864 
 L 319.880958 101.884157 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_78">
     <path d="M 319.880958 101.884157 
@@ -2243,7 +2243,7 @@ L 217.131235 128.398367
 L 214.847908 128.862215 
 L 212.564581 129.322122 
 L 210.281253 129.778154 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_79">
     <path d="M 210.281253 129.778154 
@@ -2295,7 +2295,7 @@ L 197.161712 133.356286
 L 196.870166 133.433175 
 L 196.578621 133.509954 
 L 196.287076 133.586625 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_80">
     <path d="M 196.287076 133.586625 
@@ -2347,7 +2347,7 @@ L 177.31896 146.619719
 L 176.897447 146.876504 
 L 176.475933 147.132078 
 L 176.054419 147.38645 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_81">
     <path d="M 176.054419 147.38645 
@@ -2399,7 +2399,7 @@ L 153.654726 173.393769
 L 153.156955 173.850741 
 L 152.659184 174.303887 
 L 152.161413 174.753272 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_82">
     <path d="M 152.161413 174.753272 
@@ -2451,7 +2451,7 @@ L 147.060283 185.919158
 L 146.946925 186.142906 
 L 146.833566 186.365734 
 L 146.720208 186.587648 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_83">
     <path d="M 146.720208 186.587648 
@@ -2503,7 +2503,7 @@ L 144.164409 195.794799
 L 144.107613 195.982622 
 L 144.050817 196.169795 
 L 143.994022 196.356323 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_84">
     <path d="M 143.994022 196.356323 
@@ -2555,30 +2555,30 @@ L 142.749036 199.949687
 L 142.72137 200.026891 
 L 142.693704 200.103986 
 L 142.666037 200.180971 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_85">
     <defs>
-     <path id="md65f8c2892" d="M -0 3.535534 
+     <path id="m32086a8271" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pe54303e94f)">
-     <use xlink:href="#md65f8c2892" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md65f8c2892" x="242.839153" y="80.778898" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md65f8c2892" x="218.251194" y="86.377096" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md65f8c2892" x="197.814984" y="90.309617" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md65f8c2892" x="166.378359" y="99.066934" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md65f8c2892" x="145.830392" y="110.431955" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md65f8c2892" x="134.598477" y="126.026287" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md65f8c2892" x="124.077268" y="149.033155" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md65f8c2892" x="122.462976" y="157.476606" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md65f8c2892" x="81.012077" y="220.06889" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md65f8c2892" x="77.44276" y="239.652656" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md65f8c2892" x="76.953425" y="252.706566" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p5ff60b7cdf)">
+     <use xlink:href="#m32086a8271" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m32086a8271" x="242.839153" y="80.778898" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m32086a8271" x="218.251194" y="86.377096" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m32086a8271" x="197.814984" y="90.309617" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m32086a8271" x="166.378359" y="99.066934" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m32086a8271" x="145.830392" y="110.431955" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m32086a8271" x="134.598477" y="126.026287" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m32086a8271" x="124.077268" y="149.033155" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m32086a8271" x="122.462976" y="157.476606" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m32086a8271" x="81.012077" y="220.06889" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m32086a8271" x="77.44276" y="239.652656" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m32086a8271" x="76.953425" y="252.706566" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_86">
@@ -2631,7 +2631,7 @@ L 245.91379 79.91142
 L 244.888911 80.202126 
 L 243.864032 80.49128 
 L 242.839153 80.778898 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_87">
     <path d="M 242.839153 80.778898 
@@ -2683,7 +2683,7 @@ L 219.787941 86.043669
 L 219.275692 86.155039 
 L 218.763443 86.266182 
 L 218.251194 86.377096 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_88">
     <path d="M 218.251194 86.377096 
@@ -2735,7 +2735,7 @@ L 199.092247 90.072029
 L 198.666492 90.151341 
 L 198.240738 90.230537 
 L 197.814984 90.309617 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_89">
     <path d="M 197.814984 90.309617 
@@ -2787,7 +2787,7 @@ L 168.343148 98.559208
 L 167.688219 98.72898 
 L 167.033289 98.898221 
 L 166.378359 99.066934 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_90">
     <path d="M 166.378359 99.066934 
@@ -2839,7 +2839,7 @@ L 147.11464 109.78743
 L 146.686557 110.003126 
 L 146.258475 110.217965 
 L 145.830392 110.431955 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_91">
     <path d="M 145.830392 110.431955 
@@ -2891,7 +2891,7 @@ L 135.300472 125.172774
 L 135.066474 125.458776 
 L 134.832476 125.743276 
 L 134.598477 126.026287 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_92">
     <path d="M 134.598477 126.026287 
@@ -2943,7 +2943,7 @@ L 124.734843 147.848882
 L 124.515652 148.246526 
 L 124.29646 148.641269 
 L 124.077268 149.033155 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_93">
     <path d="M 124.077268 149.033155 
@@ -2995,7 +2995,7 @@ L 122.56387 156.985769
 L 122.530239 157.149876 
 L 122.496607 157.313488 
 L 122.462976 157.476606 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_94">
     <path d="M 122.462976 157.476606 
@@ -3047,7 +3047,7 @@ L 83.602758 217.699074
 L 82.739198 218.500595 
 L 81.875637 219.290422 
 L 81.012077 220.06889 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_95">
     <path d="M 81.012077 220.06889 
@@ -3099,7 +3099,7 @@ L 77.665842 238.615761
 L 77.591481 238.963605 
 L 77.517121 239.309227 
 L 77.44276 239.652656 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_96">
     <path d="M 77.44276 239.652656 
@@ -3151,23 +3151,23 @@ L 76.984008 251.97672
 L 76.973814 252.221097 
 L 76.96362 252.464376 
 L 76.953425 252.706566 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_97">
     <defs>
-     <path id="m1174f5cf53" d="M -0 2.5 
+     <path id="m0acbed5808" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pe54303e94f)">
-     <use xlink:href="#m1174f5cf53" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p5ff60b7cdf)">
+     <use xlink:href="#m0acbed5808" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_98">
     <defs>
-     <path id="md1f43da565" d="M -0.833333 2.5 
+     <path id="mff1feee27e" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -3182,16 +3182,16 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pe54303e94f)">
-     <use xlink:href="#md1f43da565" x="432.495268" y="96.067622" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md1f43da565" x="300.62247" y="112.493412" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md1f43da565" x="266.967623" y="120.8136" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md1f43da565" x="226.040946" y="122.099593" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md1f43da565" x="180.985721" y="141.85872" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md1f43da565" x="164.441833" y="156.106179" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md1f43da565" x="157.761315" y="165.23787" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md1f43da565" x="151.269082" y="178.700983" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md1f43da565" x="150.327087" y="185.23695" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p5ff60b7cdf)">
+     <use xlink:href="#mff1feee27e" x="432.495268" y="96.067622" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mff1feee27e" x="300.62247" y="112.493412" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mff1feee27e" x="266.967623" y="120.8136" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mff1feee27e" x="226.040946" y="122.099593" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mff1feee27e" x="180.985721" y="141.85872" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mff1feee27e" x="164.441833" y="156.106179" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mff1feee27e" x="157.761315" y="165.23787" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mff1feee27e" x="151.269082" y="178.700983" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mff1feee27e" x="150.327087" y="185.23695" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_99">
@@ -3244,7 +3244,7 @@ L 308.86452 111.600609
 L 306.11717 111.899849 
 L 303.36982 112.197444 
 L 300.62247 112.493412 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_100">
     <path d="M 300.62247 112.493412 
@@ -3296,7 +3296,7 @@ L 269.071051 120.329422
 L 268.369908 120.491297 
 L 267.668766 120.652688 
 L 266.967623 120.8136 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_101">
     <path d="M 266.967623 120.8136 
@@ -3348,7 +3348,7 @@ L 228.598863 122.020108
 L 227.746224 122.046616 
 L 226.893585 122.073111 
 L 226.040946 122.099593 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_102">
     <path d="M 226.040946 122.099593 
@@ -3400,7 +3400,7 @@ L 183.801673 140.814056
 L 182.863022 141.164522 
 L 181.924372 141.512734 
 L 180.985721 141.85872 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_103">
     <path d="M 180.985721 141.85872 
@@ -3452,7 +3452,7 @@ L 165.475826 155.317544
 L 165.131161 155.581701 
 L 164.786497 155.844575 
 L 164.441833 156.106179 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_104">
     <path d="M 164.441833 156.106179 
@@ -3504,7 +3504,7 @@ L 158.178848 164.710119
 L 158.03967 164.886608 
 L 157.900493 165.062524 
 L 157.761315 165.23787 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_105">
     <path d="M 157.761315 165.23787 
@@ -3556,7 +3556,7 @@ L 151.674847 177.950842
 L 151.539592 178.202046 
 L 151.404337 178.452089 
 L 151.269082 178.700983 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_106">
     <path d="M 151.269082 178.700983 
@@ -3608,11 +3608,11 @@ L 150.385962 184.850776
 L 150.366337 184.979807 
 L 150.346712 185.108531 
 L 150.327087 185.23695 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_107">
     <defs>
-     <path id="me31bc75c73" d="M -1.25 2.5 
+     <path id="m0c1b2da0ac" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -3627,16 +3627,16 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pe54303e94f)">
-     <use xlink:href="#me31bc75c73" x="345.030867" y="136.859359" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me31bc75c73" x="273.364924" y="143.571257" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me31bc75c73" x="240.719951" y="149.310846" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me31bc75c73" x="221.353978" y="154.160538" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me31bc75c73" x="207.129625" y="156.092215" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me31bc75c73" x="181.064802" y="166.758473" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me31bc75c73" x="179.282169" y="170.289343" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me31bc75c73" x="177.719335" y="175.489948" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me31bc75c73" x="177.643939" y="181.552088" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p5ff60b7cdf)">
+     <use xlink:href="#m0c1b2da0ac" x="345.030867" y="136.859359" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0c1b2da0ac" x="273.364924" y="143.571257" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0c1b2da0ac" x="240.719951" y="149.310846" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0c1b2da0ac" x="221.353978" y="154.160538" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0c1b2da0ac" x="207.129625" y="156.092215" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0c1b2da0ac" x="181.064802" y="166.758473" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0c1b2da0ac" x="179.282169" y="170.289343" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0c1b2da0ac" x="177.719335" y="175.489948" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0c1b2da0ac" x="177.643939" y="181.552088" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_108">
@@ -3689,7 +3689,7 @@ L 277.844045 143.175283
 L 276.351005 143.307597 
 L 274.857964 143.439587 
 L 273.364924 143.571257 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_109">
     <path d="M 273.364924 143.571257 
@@ -3741,7 +3741,7 @@ L 242.760262 148.96941
 L 242.080158 149.083462 
 L 241.400055 149.197273 
 L 240.719951 149.310846 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_110">
     <path d="M 240.719951 149.310846 
@@ -3793,7 +3793,7 @@ L 222.564351 153.869835
 L 222.160893 153.966909 
 L 221.757435 154.06381 
 L 221.353978 154.160538 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_111">
     <path d="M 221.353978 154.160538 
@@ -3845,7 +3845,7 @@ L 208.018647 155.973483
 L 207.722306 156.013089 
 L 207.425965 156.052666 
 L 207.129625 156.092215 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_112">
     <path d="M 207.129625 156.092215 
@@ -3897,7 +3897,7 @@ L 182.693853 166.149994
 L 182.150836 166.353581 
 L 181.607819 166.556405 
 L 181.064802 166.758473 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_113">
     <path d="M 181.064802 166.758473 
@@ -3949,7 +3949,7 @@ L 179.393584 170.075284
 L 179.356445 170.146731 
 L 179.319307 170.218084 
 L 179.282169 170.289343 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_114">
     <path d="M 179.282169 170.289343 
@@ -4001,7 +4001,7 @@ L 177.817012 175.179146
 L 177.784453 175.282945 
 L 177.751894 175.386546 
 L 177.719335 175.489948 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_115">
     <path d="M 177.719335 175.489948 
@@ -4053,11 +4053,11 @@ L 177.648651 181.192458
 L 177.64708 181.3126 
 L 177.645509 181.432477 
 L 177.643939 181.552088 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_116">
     <defs>
-     <path id="m929fd909d6" d="M 0 -2.5 
+     <path id="ma109a78523" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -4070,16 +4070,16 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#pe54303e94f)">
-     <use xlink:href="#m929fd909d6" x="226.871027" y="113.224491" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m929fd909d6" x="226.871027" y="113.066324" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m929fd909d6" x="226.871027" y="113.178221" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m929fd909d6" x="226.871027" y="113.089884" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m929fd909d6" x="177.768423" y="132.327899" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m929fd909d6" x="160.37503" y="145.652356" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m929fd909d6" x="153.995779" y="152.678629" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m929fd909d6" x="147.106887" y="168.143801" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m929fd909d6" x="145.871703" y="175.118358" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p5ff60b7cdf)">
+     <use xlink:href="#ma109a78523" x="226.871027" y="113.224491" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#ma109a78523" x="226.871027" y="113.066324" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#ma109a78523" x="226.871027" y="113.178221" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#ma109a78523" x="226.871027" y="113.089884" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#ma109a78523" x="177.768423" y="132.327899" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#ma109a78523" x="160.37503" y="145.652356" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#ma109a78523" x="153.995779" y="152.678629" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#ma109a78523" x="147.106887" y="168.143801" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#ma109a78523" x="145.871703" y="175.118358" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_117">
@@ -4132,7 +4132,7 @@ L 226.871027 113.076223
 L 226.871027 113.072924 
 L 226.871027 113.069624 
 L 226.871027 113.066324 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_118">
     <path d="M 226.871027 113.066324 
@@ -4184,7 +4184,7 @@ L 226.871027 113.171234
 L 226.871027 113.173563 
 L 226.871027 113.175892 
 L 226.871027 113.178221 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_119">
     <path d="M 226.871027 113.178221 
@@ -4236,7 +4236,7 @@ L 226.871027 113.09541
 L 226.871027 113.093568 
 L 226.871027 113.091726 
 L 226.871027 113.089884 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_120">
     <path d="M 226.871027 113.089884 
@@ -4288,7 +4288,7 @@ L 180.837336 131.306392
 L 179.814365 131.649041 
 L 178.791394 131.989534 
 L 177.768423 132.327899 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_121">
     <path d="M 177.768423 132.327899 
@@ -4340,7 +4340,7 @@ L 161.462117 144.909076
 L 161.099755 145.157972 
 L 160.737393 145.405728 
 L 160.37503 145.652356 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_122">
     <path d="M 160.37503 145.652356 
@@ -4392,7 +4392,7 @@ L 154.394483 152.265218
 L 154.261581 152.403373 
 L 154.12868 152.541176 
 L 153.995779 152.678629 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_123">
     <path d="M 153.995779 152.678629 
@@ -4444,7 +4444,7 @@ L 147.537442 167.296442
 L 147.393924 167.580372 
 L 147.250405 167.862819 
 L 147.106887 168.143801 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_124">
     <path d="M 147.106887 168.143801 
@@ -4496,11 +4496,11 @@ L 145.948902 174.70781
 L 145.923169 174.845005 
 L 145.897436 174.981854 
 L 145.871703 175.118358 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_125">
     <defs>
-     <path id="m318ae91d0c" d="M 0 -2.5 
+     <path id="mbc6e463cf7" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -4509,16 +4509,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pe54303e94f)">
-     <use xlink:href="#m318ae91d0c" x="585.66883" y="173.051371" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m318ae91d0c" x="527.144592" y="175.326465" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m318ae91d0c" x="457.339427" y="183.688849" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m318ae91d0c" x="292.124837" y="178.486631" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m318ae91d0c" x="243.129344" y="190.369032" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m318ae91d0c" x="213.541392" y="204.43395" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m318ae91d0c" x="204.551957" y="212.140784" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m318ae91d0c" x="195.860087" y="228.582256" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m318ae91d0c" x="194.019853" y="234.294862" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p5ff60b7cdf)">
+     <use xlink:href="#mbc6e463cf7" x="585.66883" y="173.051371" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbc6e463cf7" x="527.144592" y="175.326465" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbc6e463cf7" x="457.339427" y="183.688849" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbc6e463cf7" x="292.124837" y="178.486631" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbc6e463cf7" x="243.129344" y="190.369032" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbc6e463cf7" x="213.541392" y="204.43395" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbc6e463cf7" x="204.551957" y="212.140784" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbc6e463cf7" x="195.860087" y="228.582256" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbc6e463cf7" x="194.019853" y="234.294862" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_126">
@@ -4571,7 +4571,7 @@ L 530.802357 175.187039
 L 529.583102 175.233554 
 L 528.363847 175.28003 
 L 527.144592 175.326465 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_127">
     <path d="M 527.144592 175.326465 
@@ -4623,7 +4623,7 @@ L 461.70225 183.20239
 L 460.247976 183.36503 
 L 458.793701 183.527182 
 L 457.339427 183.688849 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_128">
     <path d="M 457.339427 183.688849 
@@ -4675,7 +4675,7 @@ L 302.450749 178.826834
 L 299.008779 178.713671 
 L 295.566808 178.60027 
 L 292.124837 178.486631 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_129">
     <path d="M 292.124837 178.486631 
@@ -4727,7 +4727,7 @@ L 246.191563 189.6981
 L 245.170823 189.922669 
 L 244.150084 190.146311 
 L 243.129344 190.369032 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_130">
     <path d="M 243.129344 190.369032 
@@ -4779,7 +4779,7 @@ L 215.390639 203.654226
 L 214.774224 203.915384 
 L 214.157808 204.175288 
 L 213.541392 204.43395 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_131">
     <path d="M 213.541392 204.43395 
@@ -4831,7 +4831,7 @@ L 205.113797 211.689953
 L 204.926517 211.840648 
 L 204.739237 211.990924 
 L 204.551957 212.140784 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_132">
     <path d="M 204.551957 212.140784 
@@ -4883,7 +4883,7 @@ L 196.403329 227.688717
 L 196.222248 227.988205 
 L 196.041168 228.286045 
 L 195.860087 228.582256 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_133">
     <path d="M 195.860087 228.582256 
@@ -4935,7 +4935,7 @@ L 194.134867 233.954953
 L 194.096529 234.068494 
 L 194.058191 234.181796 
 L 194.019853 234.294862 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="legend_1">
     <g id="patch_7">
@@ -4953,7 +4953,7 @@ z
     </g>
     <g id="line2d_134">
      <defs>
-      <path id="m8b8ff3f75a" d="M 0 3.5 
+      <path id="m19424b704c" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -4966,7 +4966,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m8b8ff3f75a" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m19424b704c" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -5025,7 +5025,7 @@ z
     </g>
     <g id="line2d_135">
      <g>
-      <use xlink:href="#m99c2ebe25d" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m7a66f49d20" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -5039,7 +5039,7 @@ z
     </g>
     <g id="line2d_136">
      <g>
-      <use xlink:href="#m42c56d396a" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m0d9c3b99f3" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -5084,7 +5084,7 @@ z
     </g>
     <g id="line2d_137">
      <g>
-      <use xlink:href="#md65f8c2892" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m32086a8271" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -5127,7 +5127,7 @@ z
     </g>
     <g id="line2d_138">
      <g>
-      <use xlink:href="#m1174f5cf53" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m0acbed5808" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -5143,7 +5143,7 @@ z
     </g>
     <g id="line2d_139">
      <g>
-      <use xlink:href="#md1f43da565" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mff1feee27e" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -5197,7 +5197,7 @@ z
     </g>
     <g id="line2d_140">
      <g>
-      <use xlink:href="#me31bc75c73" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m0c1b2da0ac" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -5262,7 +5262,7 @@ z
     </g>
     <g id="line2d_141">
      <g>
-      <use xlink:href="#m929fd909d6" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#ma109a78523" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -5300,7 +5300,7 @@ z
     </g>
     <g id="line2d_142">
      <g>
-      <use xlink:href="#m318ae91d0c" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mbc6e463cf7" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -5370,486 +5370,486 @@ z
     </g>
    </g>
    <g id="line2d_143">
-    <g clip-path="url(#pe54303e94f)">
-     <use xlink:href="#m8b8ff3f75a" x="319.643112" y="123.657817" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m8b8ff3f75a" x="269.129958" y="139.062532" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m8b8ff3f75a" x="247.452898" y="144.221198" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m8b8ff3f75a" x="192.820547" y="152.969666" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m8b8ff3f75a" x="180.389901" y="164.017653" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m8b8ff3f75a" x="156.380826" y="172.983011" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m8b8ff3f75a" x="147.895047" y="182.69281" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m8b8ff3f75a" x="146.261627" y="186.801762" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m8b8ff3f75a" x="119.666036" y="285.330846" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m8b8ff3f75a" x="97.814287" y="313.642983" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <g clip-path="url(#p5ff60b7cdf)">
+     <use xlink:href="#m19424b704c" x="319.643112" y="123.769985" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m19424b704c" x="269.129958" y="139.061591" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m19424b704c" x="247.452898" y="144.36473" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m19424b704c" x="192.820547" y="153.196067" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m19424b704c" x="180.389901" y="164.537964" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m19424b704c" x="156.380826" y="173.075638" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m19424b704c" x="147.895047" y="182.969617" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m19424b704c" x="146.261627" y="187.228053" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m19424b704c" x="119.666036" y="285.720519" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m19424b704c" x="97.814287" y="313.662731" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
    <g id="line2d_144">
-    <path d="M 319.643112 123.657817 
-L 318.590755 124.027805 
-L 317.538397 124.395282 
-L 316.48604 124.76028 
-L 315.433682 125.122834 
-L 314.381325 125.482976 
-L 313.328968 125.840738 
-L 312.27661 126.19615 
-L 311.224253 126.549244 
-L 310.171896 126.90005 
-L 309.119538 127.248598 
-L 308.067181 127.594915 
-L 307.014823 127.93903 
-L 305.962466 128.280972 
-L 304.910109 128.620768 
-L 303.857751 128.958444 
-L 302.805394 129.294026 
-L 301.753037 129.627541 
-L 300.700679 129.959013 
-L 299.648322 130.288468 
-L 298.595965 130.61593 
-L 297.543607 130.941423 
-L 296.49125 131.264971 
-L 295.438892 131.586596 
-L 294.386535 131.906321 
-L 293.334178 132.224169 
-L 292.28182 132.540162 
-L 291.229463 132.854321 
-L 290.177106 133.166667 
-L 289.124748 133.477221 
-L 288.072391 133.786003 
-L 287.020033 134.093034 
-L 285.967676 134.398333 
-L 284.915319 134.701921 
-L 283.862961 135.003815 
-L 282.810604 135.304034 
-L 281.758247 135.602598 
-L 280.705889 135.899524 
-L 279.653532 136.194831 
-L 278.601175 136.488534 
-L 277.548817 136.780653 
-L 276.49646 137.071205 
-L 275.444102 137.360204 
-L 274.391745 137.647669 
-L 273.339388 137.933616 
-L 272.28703 138.21806 
-L 271.234673 138.501017 
-L 270.182316 138.782503 
-L 269.129958 139.062532 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 319.643112 123.769985 
+L 318.590755 124.136866 
+L 317.538397 124.501276 
+L 316.48604 124.86325 
+L 315.433682 125.22282 
+L 314.381325 125.580016 
+L 313.328968 125.934871 
+L 312.27661 126.287415 
+L 311.224253 126.637678 
+L 310.171896 126.985689 
+L 309.119538 127.331477 
+L 308.067181 127.67507 
+L 307.014823 128.016496 
+L 305.962466 128.355781 
+L 304.910109 128.692954 
+L 303.857751 129.028039 
+L 302.805394 129.361063 
+L 301.753037 129.69205 
+L 300.700679 130.021026 
+L 299.648322 130.348015 
+L 298.595965 130.67304 
+L 297.543607 130.996126 
+L 296.49125 131.317294 
+L 295.438892 131.636568 
+L 294.386535 131.95397 
+L 293.334178 132.269522 
+L 292.28182 132.583245 
+L 291.229463 132.89516 
+L 290.177106 133.205289 
+L 289.124748 133.51365 
+L 288.072391 133.820265 
+L 287.020033 134.125153 
+L 285.967676 134.428333 
+L 284.915319 134.729825 
+L 283.862961 135.029647 
+L 282.810604 135.327817 
+L 281.758247 135.624354 
+L 280.705889 135.919275 
+L 279.653532 136.212598 
+L 278.601175 136.50434 
+L 277.548817 136.794519 
+L 276.49646 137.08315 
+L 275.444102 137.37025 
+L 274.391745 137.655835 
+L 273.339388 137.939922 
+L 272.28703 138.222526 
+L 271.234673 138.503662 
+L 270.182316 138.783345 
+L 269.129958 139.061591 
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_145">
-    <path d="M 269.129958 139.062532 
-L 268.678353 139.175175 
-L 268.226747 139.287584 
-L 267.775142 139.399759 
-L 267.323537 139.511703 
-L 266.871931 139.623416 
-L 266.420326 139.734898 
-L 265.96872 139.846152 
-L 265.517115 139.957177 
-L 265.065509 140.067975 
-L 264.613904 140.178547 
-L 264.162299 140.288893 
-L 263.710693 140.399015 
-L 263.259088 140.508913 
-L 262.807482 140.618589 
-L 262.355877 140.728043 
-L 261.904271 140.837276 
-L 261.452666 140.946289 
-L 261.001061 141.055083 
-L 260.549455 141.163658 
-L 260.09785 141.272017 
-L 259.646244 141.380159 
-L 259.194639 141.488085 
-L 258.743034 141.595796 
-L 258.291428 141.703294 
-L 257.839823 141.810579 
-L 257.388217 141.917651 
-L 256.936612 142.024512 
-L 256.485006 142.131162 
-L 256.033401 142.237603 
-L 255.581796 142.343835 
-L 255.13019 142.449859 
-L 254.678585 142.555675 
-L 254.226979 142.661285 
-L 253.775374 142.76669 
-L 253.323769 142.871889 
-L 252.872163 142.976885 
-L 252.420558 143.081677 
-L 251.968952 143.186267 
-L 251.517347 143.290655 
-L 251.065741 143.394842 
-L 250.614136 143.498829 
-L 250.162531 143.602617 
-L 249.710925 143.706206 
-L 249.25932 143.809597 
-L 248.807714 143.912791 
-L 248.356109 144.015789 
-L 247.904503 144.118591 
-L 247.452898 144.221198 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 269.129958 139.061591 
+L 268.678353 139.177542 
+L 268.226747 139.293245 
+L 267.775142 139.408701 
+L 267.323537 139.523911 
+L 266.871931 139.638877 
+L 266.420326 139.753599 
+L 265.96872 139.868079 
+L 265.517115 139.982316 
+L 265.065509 140.096314 
+L 264.613904 140.210072 
+L 264.162299 140.323591 
+L 263.710693 140.436872 
+L 263.259088 140.549917 
+L 262.807482 140.662727 
+L 262.355877 140.775302 
+L 261.904271 140.887643 
+L 261.452666 140.999751 
+L 261.001061 141.111628 
+L 260.549455 141.223274 
+L 260.09785 141.334691 
+L 259.646244 141.445878 
+L 259.194639 141.556838 
+L 258.743034 141.66757 
+L 258.291428 141.778077 
+L 257.839823 141.888358 
+L 257.388217 141.998415 
+L 256.936612 142.108249 
+L 256.485006 142.217861 
+L 256.033401 142.327251 
+L 255.581796 142.43642 
+L 255.13019 142.54537 
+L 254.678585 142.6541 
+L 254.226979 142.762613 
+L 253.775374 142.870909 
+L 253.323769 142.978988 
+L 252.872163 143.086852 
+L 252.420558 143.194502 
+L 251.968952 143.301938 
+L 251.517347 143.409161 
+L 251.065741 143.516172 
+L 250.614136 143.622972 
+L 250.162531 143.729562 
+L 249.710925 143.835942 
+L 249.25932 143.942114 
+L 248.807714 144.048078 
+L 248.356109 144.153834 
+L 247.904503 144.259385 
+L 247.452898 144.36473 
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_146">
-    <path d="M 247.452898 144.221198 
-L 246.314724 144.418652 
-L 245.17655 144.615388 
-L 244.038376 144.811412 
-L 242.900202 145.006728 
-L 241.762028 145.201342 
-L 240.623854 145.395259 
-L 239.48568 145.588484 
-L 238.347506 145.781022 
-L 237.209332 145.972877 
-L 236.071158 146.164054 
-L 234.932984 146.354559 
-L 233.79481 146.544396 
-L 232.656636 146.733569 
-L 231.518462 146.922083 
-L 230.380288 147.109944 
-L 229.242114 147.297154 
-L 228.10394 147.483719 
-L 226.965766 147.669644 
-L 225.827592 147.854932 
-L 224.689418 148.039588 
-L 223.551244 148.223616 
-L 222.41307 148.407021 
-L 221.274896 148.589806 
-L 220.136722 148.771976 
-L 218.998548 148.953536 
-L 217.860374 149.134488 
-L 216.7222 149.314837 
-L 215.584026 149.494588 
-L 214.445852 149.673744 
-L 213.307678 149.852308 
-L 212.169505 150.030286 
-L 211.031331 150.20768 
-L 209.893157 150.384495 
-L 208.754983 150.560734 
-L 207.616809 150.736401 
-L 206.478635 150.9115 
-L 205.340461 151.086035 
-L 204.202287 151.260008 
-L 203.064113 151.433425 
-L 201.925939 151.606287 
-L 200.787765 151.778599 
-L 199.649591 151.950364 
-L 198.511417 152.121586 
-L 197.373243 152.292269 
-L 196.235069 152.462414 
-L 195.096895 152.632027 
-L 193.958721 152.80111 
-L 192.820547 152.969666 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 247.452898 144.36473 
+L 246.314724 144.564207 
+L 245.17655 144.762952 
+L 244.038376 144.96097 
+L 242.900202 145.158266 
+L 241.762028 145.354845 
+L 240.623854 145.550714 
+L 239.48568 145.745876 
+L 238.347506 145.940337 
+L 237.209332 146.134101 
+L 236.071158 146.327175 
+L 234.932984 146.519563 
+L 233.79481 146.711269 
+L 232.656636 146.902299 
+L 231.518462 147.092657 
+L 230.380288 147.282347 
+L 229.242114 147.471376 
+L 228.10394 147.659746 
+L 226.965766 147.847464 
+L 225.827592 148.034533 
+L 224.689418 148.220957 
+L 223.551244 148.406742 
+L 222.41307 148.591891 
+L 221.274896 148.776409 
+L 220.136722 148.9603 
+L 218.998548 149.143568 
+L 217.860374 149.326219 
+L 216.7222 149.508255 
+L 215.584026 149.689681 
+L 214.445852 149.8705 
+L 213.307678 150.050718 
+L 212.169505 150.230338 
+L 211.031331 150.409364 
+L 209.893157 150.587799 
+L 208.754983 150.765649 
+L 207.616809 150.942916 
+L 206.478635 151.119604 
+L 205.340461 151.295718 
+L 204.202287 151.47126 
+L 203.064113 151.646235 
+L 201.925939 151.820646 
+L 200.787765 151.994497 
+L 199.649591 152.167792 
+L 198.511417 152.340533 
+L 197.373243 152.512725 
+L 196.235069 152.684371 
+L 195.096895 152.855475 
+L 193.958721 153.026039 
+L 192.820547 153.196067 
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_147">
-    <path d="M 192.820547 152.969666 
-L 192.561575 153.224403 
-L 192.302603 153.477947 
-L 192.043631 153.730309 
-L 191.78466 153.981499 
-L 191.525688 154.23153 
-L 191.266716 154.480411 
-L 191.007744 154.728153 
-L 190.748773 154.974766 
-L 190.489801 155.220261 
-L 190.230829 155.464647 
-L 189.971857 155.707936 
-L 189.712885 155.950135 
-L 189.453914 156.191256 
-L 189.194942 156.431307 
-L 188.93597 156.670299 
-L 188.676998 156.90824 
-L 188.418027 157.14514 
-L 188.159055 157.381007 
-L 187.900083 157.615851 
-L 187.641111 157.849681 
-L 187.382139 158.082505 
-L 187.123168 158.314332 
-L 186.864196 158.54517 
-L 186.605224 158.775028 
-L 186.346252 159.003914 
-L 186.087281 159.231837 
-L 185.828309 159.458804 
-L 185.569337 159.684823 
-L 185.310365 159.909902 
-L 185.051393 160.134049 
-L 184.792422 160.357272 
-L 184.53345 160.579578 
-L 184.274478 160.800975 
-L 184.015506 161.021471 
-L 183.756535 161.241071 
-L 183.497563 161.459785 
-L 183.238591 161.677618 
-L 182.979619 161.894578 
-L 182.720647 162.110672 
-L 182.461676 162.325907 
-L 182.202704 162.540289 
-L 181.943732 162.753826 
-L 181.68476 162.966523 
-L 181.425789 163.178389 
-L 181.166817 163.389428 
-L 180.907845 163.599647 
-L 180.648873 163.809054 
-L 180.389901 164.017653 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 192.820547 153.196067 
+L 192.561575 153.458299 
+L 192.302603 153.719265 
+L 192.043631 153.97898 
+L 191.78466 154.237455 
+L 191.525688 154.494701 
+L 191.266716 154.750731 
+L 191.007744 155.005555 
+L 190.748773 155.259185 
+L 190.489801 155.511633 
+L 190.230829 155.762909 
+L 189.971857 156.013023 
+L 189.712885 156.261987 
+L 189.453914 156.509812 
+L 189.194942 156.756507 
+L 188.93597 157.002083 
+L 188.676998 157.24655 
+L 188.418027 157.489917 
+L 188.159055 157.732196 
+L 187.900083 157.973395 
+L 187.641111 158.213523 
+L 187.382139 158.452592 
+L 187.123168 158.690609 
+L 186.864196 158.927584 
+L 186.605224 159.163527 
+L 186.346252 159.398445 
+L 186.087281 159.632348 
+L 185.828309 159.865245 
+L 185.569337 160.097144 
+L 185.310365 160.328054 
+L 185.051393 160.557983 
+L 184.792422 160.78694 
+L 184.53345 161.014932 
+L 184.274478 161.241968 
+L 184.015506 161.468056 
+L 183.756535 161.693204 
+L 183.497563 161.917418 
+L 183.238591 162.140708 
+L 182.979619 162.363081 
+L 182.720647 162.584544 
+L 182.461676 162.805104 
+L 182.202704 163.02477 
+L 181.943732 163.243548 
+L 181.68476 163.461445 
+L 181.425789 163.678468 
+L 181.166817 163.894625 
+L 180.907845 164.109922 
+L 180.648873 164.324366 
+L 180.389901 164.537964 
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_148">
-    <path d="M 180.389901 164.017653 
-L 179.889712 164.220409 
-L 179.389523 164.422408 
-L 178.889334 164.623657 
-L 178.389145 164.824159 
-L 177.888956 165.023922 
-L 177.388767 165.222951 
-L 176.888578 165.42125 
-L 176.388389 165.618826 
-L 175.8882 165.815683 
-L 175.388011 166.011827 
-L 174.887822 166.207262 
-L 174.387633 166.401995 
-L 173.887443 166.596029 
-L 173.387254 166.789371 
-L 172.887065 166.982024 
-L 172.386876 167.173994 
-L 171.886687 167.365286 
-L 171.386498 167.555904 
-L 170.886309 167.745854 
-L 170.38612 167.935139 
-L 169.885931 168.123764 
-L 169.385742 168.311735 
-L 168.885553 168.499055 
-L 168.385364 168.685729 
-L 167.885175 168.871761 
-L 167.384985 169.057156 
-L 166.884796 169.241919 
-L 166.384607 169.426053 
-L 165.884418 169.609563 
-L 165.384229 169.792453 
-L 164.88404 169.974726 
-L 164.383851 170.156389 
-L 163.883662 170.337443 
-L 163.383473 170.517894 
-L 162.883284 170.697746 
-L 162.383095 170.877002 
-L 161.882906 171.055666 
-L 161.382717 171.233743 
-L 160.882527 171.411235 
-L 160.382338 171.588148 
-L 159.882149 171.764484 
-L 159.38196 171.940248 
-L 158.881771 172.115443 
-L 158.381582 172.290072 
-L 157.881393 172.46414 
-L 157.381204 172.637651 
-L 156.881015 172.810606 
-L 156.380826 172.983011 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 180.389901 164.537964 
+L 179.889712 164.730285 
+L 179.389523 164.921924 
+L 178.889334 165.112888 
+L 178.389145 165.30318 
+L 177.888956 165.492806 
+L 177.388767 165.681769 
+L 176.888578 165.870076 
+L 176.388389 166.057729 
+L 175.8882 166.244734 
+L 175.388011 166.431096 
+L 174.887822 166.616818 
+L 174.387633 166.801905 
+L 173.887443 166.986361 
+L 173.387254 167.170191 
+L 172.887065 167.353399 
+L 172.386876 167.535988 
+L 171.886687 167.717964 
+L 171.386498 167.89933 
+L 170.886309 168.080091 
+L 170.38612 168.26025 
+L 169.885931 168.439811 
+L 169.385742 168.618779 
+L 168.885553 168.797157 
+L 168.385364 168.974949 
+L 167.885175 169.152159 
+L 167.384985 169.328791 
+L 166.884796 169.504848 
+L 166.384607 169.680334 
+L 165.884418 169.855254 
+L 165.384229 170.02961 
+L 164.88404 170.203406 
+L 164.383851 170.376646 
+L 163.883662 170.549334 
+L 163.383473 170.721472 
+L 162.883284 170.893064 
+L 162.383095 171.064115 
+L 161.882906 171.234626 
+L 161.382717 171.404602 
+L 160.882527 171.574046 
+L 160.382338 171.742962 
+L 159.882149 171.911352 
+L 159.38196 172.079219 
+L 158.881771 172.246568 
+L 158.381582 172.413401 
+L 157.881393 172.579721 
+L 157.381204 172.745532 
+L 156.881015 172.910836 
+L 156.380826 173.075638 
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_149">
-    <path d="M 156.380826 172.983011 
-L 156.204039 173.204124 
-L 156.027252 173.424338 
-L 155.850465 173.643659 
-L 155.673678 173.862096 
-L 155.496891 174.079654 
-L 155.320103 174.296342 
-L 155.143316 174.512165 
-L 154.966529 174.727132 
-L 154.789742 174.941248 
-L 154.612955 175.154521 
-L 154.436168 175.366956 
-L 154.259381 175.578562 
-L 154.082594 175.789343 
-L 153.905807 175.999307 
-L 153.72902 176.208459 
-L 153.552233 176.416806 
-L 153.375446 176.624355 
-L 153.198659 176.831111 
-L 153.021872 177.03708 
-L 152.845085 177.242268 
-L 152.668298 177.446682 
-L 152.491511 177.650326 
-L 152.314724 177.853208 
-L 152.137937 178.055331 
-L 151.96115 178.256703 
-L 151.784362 178.457329 
-L 151.607575 178.657213 
-L 151.430788 178.856363 
-L 151.254001 179.054782 
-L 151.077214 179.252476 
-L 150.900427 179.449452 
-L 150.72364 179.645713 
-L 150.546853 179.841265 
-L 150.370066 180.036113 
-L 150.193279 180.230262 
-L 150.016492 180.423718 
-L 149.839705 180.616484 
-L 149.662918 180.808567 
-L 149.486131 180.99997 
-L 149.309344 181.190699 
-L 149.132557 181.380758 
-L 148.95577 181.570153 
-L 148.778983 181.758886 
-L 148.602196 181.946965 
-L 148.425408 182.134392 
-L 148.248621 182.321172 
-L 148.071834 182.50731 
-L 147.895047 182.69281 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 156.380826 173.075638 
+L 156.204039 173.301331 
+L 156.027252 173.526087 
+L 155.850465 173.749913 
+L 155.673678 173.972818 
+L 155.496891 174.194809 
+L 155.320103 174.415893 
+L 155.143316 174.636078 
+L 154.966529 174.85537 
+L 154.789742 175.073778 
+L 154.612955 175.291309 
+L 154.436168 175.507968 
+L 154.259381 175.723764 
+L 154.082594 175.938703 
+L 153.905807 176.152792 
+L 153.72902 176.366038 
+L 153.552233 176.578447 
+L 153.375446 176.790025 
+L 153.198659 177.00078 
+L 153.021872 177.210718 
+L 152.845085 177.419844 
+L 152.668298 177.628166 
+L 152.491511 177.835689 
+L 152.314724 178.042419 
+L 152.137937 178.248363 
+L 151.96115 178.453526 
+L 151.784362 178.657915 
+L 151.607575 178.861535 
+L 151.430788 179.064392 
+L 151.254001 179.266491 
+L 151.077214 179.467839 
+L 150.900427 179.66844 
+L 150.72364 179.868301 
+L 150.546853 180.067427 
+L 150.370066 180.265823 
+L 150.193279 180.463494 
+L 150.016492 180.660446 
+L 149.839705 180.856684 
+L 149.662918 181.052214 
+L 149.486131 181.247039 
+L 149.309344 181.441166 
+L 149.132557 181.634599 
+L 148.95577 181.827344 
+L 148.778983 182.019404 
+L 148.602196 182.210786 
+L 148.425408 182.401493 
+L 148.248621 182.591531 
+L 148.071834 182.780904 
+L 147.895047 182.969617 
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_150">
-    <path d="M 147.895047 182.69281 
-L 147.861018 182.781673 
-L 147.826988 182.87039 
-L 147.792959 182.958962 
-L 147.758929 183.04739 
-L 147.724899 183.135673 
-L 147.69087 183.223812 
-L 147.65684 183.311809 
-L 147.622811 183.399662 
-L 147.588781 183.487373 
-L 147.554751 183.574942 
-L 147.520722 183.66237 
-L 147.486692 183.749657 
-L 147.452663 183.836803 
-L 147.418633 183.923809 
-L 147.384604 184.010675 
-L 147.350574 184.097403 
-L 147.316544 184.183991 
-L 147.282515 184.270442 
-L 147.248485 184.356754 
-L 147.214456 184.442929 
-L 147.180426 184.528967 
-L 147.146396 184.614869 
-L 147.112367 184.700634 
-L 147.078337 184.786264 
-L 147.044308 184.871759 
-L 147.010278 184.957118 
-L 146.976249 185.042344 
-L 146.942219 185.127435 
-L 146.908189 185.212393 
-L 146.87416 185.297218 
-L 146.84013 185.38191 
-L 146.806101 185.466469 
-L 146.772071 185.550897 
-L 146.738041 185.635193 
-L 146.704012 185.719359 
-L 146.669982 185.803393 
-L 146.635953 185.887298 
-L 146.601923 185.971072 
-L 146.567893 186.054717 
-L 146.533864 186.138233 
-L 146.499834 186.22162 
-L 146.465805 186.304879 
-L 146.431775 186.388011 
-L 146.397746 186.471014 
-L 146.363716 186.553891 
-L 146.329686 186.636641 
-L 146.295657 186.719265 
-L 146.261627 186.801762 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 147.895047 182.969617 
+L 147.861018 183.061839 
+L 147.826988 183.153904 
+L 147.792959 183.245812 
+L 147.758929 183.337565 
+L 147.724899 183.429163 
+L 147.69087 183.520605 
+L 147.65684 183.611894 
+L 147.622811 183.703029 
+L 147.588781 183.794011 
+L 147.554751 183.88484 
+L 147.520722 183.975517 
+L 147.486692 184.066042 
+L 147.452663 184.156416 
+L 147.418633 184.24664 
+L 147.384604 184.336713 
+L 147.350574 184.426637 
+L 147.316544 184.516412 
+L 147.282515 184.606038 
+L 147.248485 184.695516 
+L 147.214456 184.784846 
+L 147.180426 184.874029 
+L 147.146396 184.963065 
+L 147.112367 185.051955 
+L 147.078337 185.1407 
+L 147.044308 185.229299 
+L 147.010278 185.317753 
+L 146.976249 185.406063 
+L 146.942219 185.49423 
+L 146.908189 185.582253 
+L 146.87416 185.670132 
+L 146.84013 185.75787 
+L 146.806101 185.845466 
+L 146.772071 185.93292 
+L 146.738041 186.020233 
+L 146.704012 186.107405 
+L 146.669982 186.194437 
+L 146.635953 186.28133 
+L 146.601923 186.368083 
+L 146.567893 186.454697 
+L 146.533864 186.541173 
+L 146.499834 186.627511 
+L 146.465805 186.713712 
+L 146.431775 186.799776 
+L 146.397746 186.885703 
+L 146.363716 186.971493 
+L 146.329686 187.057148 
+L 146.295657 187.142668 
+L 146.261627 187.228053 
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_151">
-    <path d="M 146.261627 186.801762 
-L 145.707552 192.342105 
-L 145.153478 197.367672 
-L 144.599403 201.966044 
-L 144.045328 206.204191 
-L 143.491253 210.134476 
-L 142.937178 213.798611 
-L 142.383103 217.230368 
-L 141.829029 220.457472 
-L 141.274954 223.502965 
-L 140.720879 226.386202 
-L 140.166804 229.123602 
-L 139.612729 231.729211 
-L 139.058654 234.215137 
-L 138.50458 236.591895 
-L 137.950505 238.86867 
-L 137.39643 241.053536 
-L 136.842355 243.153627 
-L 136.28828 245.175275 
-L 135.734206 247.124131 
-L 135.180131 249.005255 
-L 134.626056 250.823198 
-L 134.071981 252.582065 
-L 133.517906 254.285576 
-L 132.963831 255.937109 
-L 132.409757 257.539742 
-L 131.855682 259.096288 
-L 131.301607 260.609324 
-L 130.747532 262.081216 
-L 130.193457 263.514143 
-L 129.639382 264.910115 
-L 129.085308 266.270989 
-L 128.531233 267.598488 
-L 127.977158 268.89421 
-L 127.423083 270.15964 
-L 126.869008 271.396162 
-L 126.314933 272.605068 
-L 125.760859 273.787565 
-L 125.206784 274.944781 
-L 124.652709 276.077775 
-L 124.098634 277.187541 
-L 123.544559 278.275011 
-L 122.990485 279.341064 
-L 122.43641 280.386527 
-L 121.882335 281.41218 
-L 121.32826 282.418761 
-L 120.774185 283.406965 
-L 120.22011 284.377452 
-L 119.666036 285.330846 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 146.261627 187.228053 
+L 145.707552 192.764146 
+L 145.153478 197.786216 
+L 144.599403 202.381661 
+L 144.045328 206.617323 
+L 143.491253 210.545469 
+L 142.937178 214.207746 
+L 142.383103 217.637873 
+L 141.829029 220.863535 
+L 141.274954 223.907744 
+L 140.720879 226.789831 
+L 140.166804 229.526193 
+L 139.612729 232.130862 
+L 139.058654 234.615933 
+L 138.50458 236.991909 
+L 137.950505 239.267967 
+L 137.39643 241.452173 
+L 136.842355 243.551653 
+L 136.28828 245.572735 
+L 135.734206 247.521066 
+L 135.180131 249.4017 
+L 134.626056 251.219185 
+L 134.071981 252.977624 
+L 133.517906 254.680733 
+L 132.963831 256.331889 
+L 132.409757 257.934167 
+L 131.855682 259.490378 
+L 131.301607 261.003097 
+L 130.747532 262.474689 
+L 130.193457 263.907331 
+L 129.639382 265.303033 
+L 129.085308 266.663651 
+L 128.531233 267.990906 
+L 127.977158 269.286396 
+L 127.423083 270.551604 
+L 126.869008 271.787915 
+L 126.314933 272.996619 
+L 125.760859 274.178922 
+L 125.206784 275.335953 
+L 124.652709 276.468769 
+L 124.098634 277.578364 
+L 123.544559 278.66567 
+L 122.990485 279.731566 
+L 122.43641 280.776878 
+L 121.882335 281.802385 
+L 121.32826 282.808826 
+L 120.774185 283.796895 
+L 120.22011 284.767251 
+L 119.666036 285.720519 
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_152">
-    <path d="M 119.666036 285.330846 
-L 119.210791 286.100249 
-L 118.755546 286.85887 
-L 118.300301 287.607006 
-L 117.845056 288.344943 
-L 117.389812 289.072955 
-L 116.934567 289.791306 
-L 116.479322 290.500248 
-L 116.024077 291.200026 
-L 115.568833 291.890873 
-L 115.113588 292.573014 
-L 114.658343 293.246665 
-L 114.203098 293.912036 
-L 113.747854 294.569328 
-L 113.292609 295.218734 
-L 112.837364 295.860442 
-L 112.382119 296.494631 
-L 111.926875 297.121477 
-L 111.47163 297.741146 
-L 111.016385 298.353802 
-L 110.56114 298.959602 
-L 110.105895 299.558696 
-L 109.650651 300.151233 
-L 109.195406 300.737354 
-L 108.740161 301.317196 
-L 108.284916 301.890893 
-L 107.829672 302.458574 
-L 107.374427 303.020363 
-L 106.919182 303.576381 
-L 106.463937 304.126747 
-L 106.008693 304.671572 
-L 105.553448 305.210969 
-L 105.098203 305.745044 
-L 104.642958 306.273901 
-L 104.187713 306.797641 
-L 103.732469 307.316362 
-L 103.277224 307.83016 
-L 102.821979 308.339126 
-L 102.366734 308.843352 
-L 101.91149 309.342924 
-L 101.456245 309.837928 
-L 101.001 310.328446 
-L 100.545755 310.814559 
-L 100.090511 311.296346 
-L 99.635266 311.773882 
-L 99.180021 312.247242 
-L 98.724776 312.716499 
-L 98.269531 313.181723 
-L 97.814287 313.642983 
-" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 119.666036 285.720519 
+L 119.210791 286.477146 
+L 118.755546 287.223343 
+L 118.300301 287.959393 
+L 117.845056 288.685569 
+L 117.389812 289.402132 
+L 116.934567 290.109334 
+L 116.479322 290.807415 
+L 116.024077 291.496608 
+L 115.568833 292.177136 
+L 115.113588 292.849215 
+L 114.658343 293.513052 
+L 114.203098 294.168847 
+L 113.747854 294.816792 
+L 113.292609 295.457072 
+L 112.837364 296.089868 
+L 112.382119 296.715351 
+L 111.926875 297.33369 
+L 111.47163 297.945045 
+L 111.016385 298.549572 
+L 110.56114 299.147423 
+L 110.105895 299.738743 
+L 109.650651 300.323673 
+L 109.195406 300.90235 
+L 108.740161 301.474906 
+L 108.284916 302.04147 
+L 107.829672 302.602165 
+L 107.374427 303.157111 
+L 106.919182 303.706426 
+L 106.463937 304.250223 
+L 106.008693 304.788611 
+L 105.553448 305.321697 
+L 105.098203 305.849584 
+L 104.642958 306.372374 
+L 104.187713 306.890162 
+L 103.732469 307.403044 
+L 103.277224 307.911113 
+L 102.821979 308.414457 
+L 102.366734 308.913163 
+L 101.91149 309.407318 
+L 101.456245 309.897001 
+L 101.001 310.382295 
+L 100.545755 310.863277 
+L 100.090511 311.340022 
+L 99.635266 311.812606 
+L 99.180021 312.281099 
+L 98.724776 312.745572 
+L 98.269531 313.206094 
+L 97.814287 313.662731 
+" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
   </g>
   <g id="text_25">
@@ -6166,8 +6166,8 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-07-08T20:16:47Z  ·  Linux chungus2 x86_64  ·  commit 74c19afa  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(44.841641 465.66) scale(0.07 -0.07)">
+   <!-- 2026-07-08T21:41:55Z  ·  Linux chungus2 x86_64  ·  commit b17c222c  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(43.990156 465.66) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -6201,6 +6201,31 @@ L 1409 3309
 L 1409 2516 
 L 750 2516 
 L 750 3309 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-b7" d="M 684 2619 
@@ -6260,36 +6285,6 @@ Q 2894 3584 3203 3211
 Q 3513 2838 3513 2113 
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-39" d="M 703 97 
-L 703 672 
-Q 941 559 1184 500 
-Q 1428 441 1663 441 
-Q 2288 441 2617 861 
-Q 2947 1281 2994 2138 
-Q 2813 1869 2534 1725 
-Q 2256 1581 1919 1581 
-Q 1219 1581 811 2004 
-Q 403 2428 403 3163 
-Q 403 3881 828 4315 
-Q 1253 4750 1959 4750 
-Q 2769 4750 3195 4129 
-Q 3622 3509 3622 2328 
-Q 3622 1225 3098 567 
-Q 2575 -91 1691 -91 
-Q 1453 -91 1209 -44 
-Q 966 3 703 97 
-z
-M 1959 2075 
-Q 2384 2075 2632 2365 
-Q 2881 2656 2881 3163 
-Q 2881 3666 2632 3958 
-Q 2384 4250 1959 4250 
-Q 1534 4250 1286 3958 
-Q 1038 3666 1038 3163 
-Q 1038 2656 1286 2365 
-Q 1534 2075 1959 2075 
-z
-" transform="scale(0.015625)"/>
      <path id="DejaVuSans-3d" d="M 678 2906 
 L 4684 2906 
 L 4684 2381 
@@ -6331,13 +6326,13 @@ z
     <use xlink:href="#DejaVuSans-38" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -6377,109 +6372,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3254.101562 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3317.724609 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3381.347656 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3442.626953 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3477.832031 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3539.111328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3570.898438 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3602.685547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3634.472656 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3666.259766 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3698.046875 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3725.830078 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3787.353516 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3848.632812 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3912.011719 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3975.488281 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4014.351562 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4075.533203 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4134.712891 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4196.236328 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4237.349609 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4271.041016 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4298.824219 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4360.347656 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4421.626953 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4485.005859 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4548.628906 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4582.320312 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4641.5 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4705.123047 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4736.910156 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4800.533203 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4864.15625 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4895.943359 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4959.566406 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4995.650391 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5034.513672 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5089.494141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5153.117188 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5184.904297 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5216.691406 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5248.478516 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5280.265625 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5312.052734 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5351.261719 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5414.640625 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5453.503906 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5514.685547 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5578.064453 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5641.541016 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5704.919922 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5768.396484 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5831.775391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5870.984375 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5902.771484 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5986.560547 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6018.347656 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6115.759766 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6177.283203 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6240.759766 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6268.542969 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6329.822266 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6393.201172 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6424.988281 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6477.087891 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6540.466797 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6601.746094 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6665.222656 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6717.322266 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6780.701172 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6841.882812 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6881.091797 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6914.783203 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6946.570312 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6987.683594 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7048.962891 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7088.171875 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7115.955078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7177.136719 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7208.923828 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7236.707031 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7288.806641 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7320.59375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7384.070312 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7445.59375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7484.802734 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7546.326172 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7585.689453 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7683.101562 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7710.884766 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7774.263672 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7802.046875 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7854.146484 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7893.355469 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7921.138672 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3135.351562 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3198.974609 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3262.597656 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3317.578125 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3381.201172 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3444.824219 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3508.447266 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3563.427734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3595.214844 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3627.001953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3658.789062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3690.576172 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3722.363281 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3750.146484 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3811.669922 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3872.949219 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3936.328125 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3999.804688 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4038.667969 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4099.849609 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4159.029297 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4220.552734 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4261.666016 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4295.357422 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4323.140625 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4384.664062 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4445.943359 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4509.322266 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4572.945312 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4606.636719 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4665.816406 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4729.439453 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4761.226562 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4824.849609 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4888.472656 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4920.259766 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4983.882812 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5019.966797 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5058.830078 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5113.810547 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5177.433594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5209.220703 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5241.007812 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5272.794922 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5304.582031 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5336.369141 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5375.578125 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5438.957031 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5477.820312 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5539.001953 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5602.380859 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5665.857422 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5729.236328 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5792.712891 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5856.091797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5895.300781 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5927.087891 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6010.876953 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6042.664062 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6140.076172 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6201.599609 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6265.076172 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6292.859375 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6354.138672 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6417.517578 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6449.304688 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6501.404297 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6564.783203 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6626.0625 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6689.539062 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6741.638672 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6805.017578 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6866.199219 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6905.408203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6939.099609 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6970.886719 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7012 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7073.279297 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7112.488281 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7140.271484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7201.453125 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7233.240234 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7261.023438 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7313.123047 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7344.910156 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7408.386719 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7469.910156 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7509.119141 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7570.642578 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7610.005859 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7707.417969 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7735.201172 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7798.580078 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7826.363281 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7878.462891 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7917.671875 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7945.455078 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pe54303e94f">
+  <clipPath id="p5ff60b7cdf">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_decode_density.svg
+++ b/bench/graphs/silesia_decode_density.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 82.373685 412.80375 
 L 82.373685 47.3475 
-" clip-path="url(#p482b3a1732)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pf5e1538b81)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="mf9e22cc409" d="M 0 0 
+       <path id="m706dd6b66d" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mf9e22cc409" x="82.373685" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m706dd6b66d" x="82.373685" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -111,11 +111,11 @@ z
      <g id="line2d_3">
       <path d="M 165.44644 412.80375 
 L 165.44644 47.3475 
-" clip-path="url(#p482b3a1732)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pf5e1538b81)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mf9e22cc409" x="165.44644" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m706dd6b66d" x="165.44644" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -157,11 +157,11 @@ z
      <g id="line2d_5">
       <path d="M 248.519195 412.80375 
 L 248.519195 47.3475 
-" clip-path="url(#p482b3a1732)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pf5e1538b81)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#mf9e22cc409" x="248.519195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m706dd6b66d" x="248.519195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -211,11 +211,11 @@ z
      <g id="line2d_7">
       <path d="M 331.59195 412.80375 
 L 331.59195 47.3475 
-" clip-path="url(#p482b3a1732)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pf5e1538b81)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#mf9e22cc409" x="331.59195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m706dd6b66d" x="331.59195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -252,11 +252,11 @@ z
      <g id="line2d_9">
       <path d="M 414.664704 412.80375 
 L 414.664704 47.3475 
-" clip-path="url(#p482b3a1732)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pf5e1538b81)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#mf9e22cc409" x="414.664704" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m706dd6b66d" x="414.664704" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -299,11 +299,11 @@ z
      <g id="line2d_11">
       <path d="M 497.737459 412.80375 
 L 497.737459 47.3475 
-" clip-path="url(#p482b3a1732)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pf5e1538b81)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#mf9e22cc409" x="497.737459" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m706dd6b66d" x="497.737459" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -351,11 +351,11 @@ z
      <g id="line2d_13">
       <path d="M 580.810214 412.80375 
 L 580.810214 47.3475 
-" clip-path="url(#p482b3a1732)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pf5e1538b81)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mf9e22cc409" x="580.810214" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m706dd6b66d" x="580.810214" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -897,16 +897,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 391.33747 
 L 637.2 391.33747 
-" clip-path="url(#p482b3a1732)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pf5e1538b81)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="m5e2a973582" d="M 0 0 
+       <path id="ma50e1efcd9" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m5e2a973582" x="49.078125" y="391.33747" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma50e1efcd9" x="49.078125" y="391.33747" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -922,11 +922,11 @@ L -3.5 0
      <g id="line2d_17">
       <path d="M 49.078125 263.934445 
 L 637.2 263.934445 
-" clip-path="url(#p482b3a1732)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pf5e1538b81)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m5e2a973582" x="49.078125" y="263.934445" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma50e1efcd9" x="49.078125" y="263.934445" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -942,11 +942,11 @@ L 637.2 263.934445
      <g id="line2d_19">
       <path d="M 49.078125 136.53142 
 L 637.2 136.53142 
-" clip-path="url(#p482b3a1732)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pf5e1538b81)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m5e2a973582" x="49.078125" y="136.53142" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma50e1efcd9" x="49.078125" y="136.53142" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -962,16 +962,16 @@ L 637.2 136.53142
      <g id="line2d_21">
       <path d="M 49.078125 411.072449 
 L 637.2 411.072449 
-" clip-path="url(#p482b3a1732)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pf5e1538b81)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="m2b0e05a77b" d="M 0 0 
+       <path id="mf79f956769" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m2b0e05a77b" x="49.078125" y="411.072449" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf79f956769" x="49.078125" y="411.072449" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -979,11 +979,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 403.684099 
 L 637.2 403.684099 
-" clip-path="url(#p482b3a1732)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pf5e1538b81)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m2b0e05a77b" x="49.078125" y="403.684099" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf79f956769" x="49.078125" y="403.684099" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -991,11 +991,11 @@ L 637.2 403.684099
      <g id="line2d_25">
       <path d="M 49.078125 397.167113 
 L 637.2 397.167113 
-" clip-path="url(#p482b3a1732)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pf5e1538b81)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m2b0e05a77b" x="49.078125" y="397.167113" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf79f956769" x="49.078125" y="397.167113" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1003,11 +1003,11 @@ L 637.2 397.167113
      <g id="line2d_27">
       <path d="M 49.078125 352.985338 
 L 637.2 352.985338 
-" clip-path="url(#p482b3a1732)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pf5e1538b81)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m2b0e05a77b" x="49.078125" y="352.985338" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf79f956769" x="49.078125" y="352.985338" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1015,11 +1015,11 @@ L 637.2 352.985338
      <g id="line2d_29">
       <path d="M 49.078125 330.550779 
 L 637.2 330.550779 
-" clip-path="url(#p482b3a1732)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pf5e1538b81)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m2b0e05a77b" x="49.078125" y="330.550779" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf79f956769" x="49.078125" y="330.550779" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1027,11 +1027,11 @@ L 637.2 330.550779
      <g id="line2d_31">
       <path d="M 49.078125 314.633206 
 L 637.2 314.633206 
-" clip-path="url(#p482b3a1732)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pf5e1538b81)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m2b0e05a77b" x="49.078125" y="314.633206" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf79f956769" x="49.078125" y="314.633206" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1039,11 +1039,11 @@ L 637.2 314.633206
      <g id="line2d_33">
       <path d="M 49.078125 302.286577 
 L 637.2 302.286577 
-" clip-path="url(#p482b3a1732)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pf5e1538b81)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m2b0e05a77b" x="49.078125" y="302.286577" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf79f956769" x="49.078125" y="302.286577" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1051,11 +1051,11 @@ L 637.2 302.286577
      <g id="line2d_35">
       <path d="M 49.078125 292.198647 
 L 637.2 292.198647 
-" clip-path="url(#p482b3a1732)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pf5e1538b81)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m2b0e05a77b" x="49.078125" y="292.198647" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf79f956769" x="49.078125" y="292.198647" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1063,11 +1063,11 @@ L 637.2 292.198647
      <g id="line2d_37">
       <path d="M 49.078125 283.669424 
 L 637.2 283.669424 
-" clip-path="url(#p482b3a1732)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pf5e1538b81)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m2b0e05a77b" x="49.078125" y="283.669424" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf79f956769" x="49.078125" y="283.669424" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1075,11 +1075,11 @@ L 637.2 283.669424
      <g id="line2d_39">
       <path d="M 49.078125 276.281074 
 L 637.2 276.281074 
-" clip-path="url(#p482b3a1732)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pf5e1538b81)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m2b0e05a77b" x="49.078125" y="276.281074" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf79f956769" x="49.078125" y="276.281074" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1087,11 +1087,11 @@ L 637.2 276.281074
      <g id="line2d_41">
       <path d="M 49.078125 269.764088 
 L 637.2 269.764088 
-" clip-path="url(#p482b3a1732)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pf5e1538b81)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m2b0e05a77b" x="49.078125" y="269.764088" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf79f956769" x="49.078125" y="269.764088" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1099,11 +1099,11 @@ L 637.2 269.764088
      <g id="line2d_43">
       <path d="M 49.078125 225.582313 
 L 637.2 225.582313 
-" clip-path="url(#p482b3a1732)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pf5e1538b81)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m2b0e05a77b" x="49.078125" y="225.582313" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf79f956769" x="49.078125" y="225.582313" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1111,11 +1111,11 @@ L 637.2 225.582313
      <g id="line2d_45">
       <path d="M 49.078125 203.147754 
 L 637.2 203.147754 
-" clip-path="url(#p482b3a1732)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pf5e1538b81)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m2b0e05a77b" x="49.078125" y="203.147754" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf79f956769" x="49.078125" y="203.147754" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1123,11 +1123,11 @@ L 637.2 203.147754
      <g id="line2d_47">
       <path d="M 49.078125 187.230181 
 L 637.2 187.230181 
-" clip-path="url(#p482b3a1732)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pf5e1538b81)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m2b0e05a77b" x="49.078125" y="187.230181" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf79f956769" x="49.078125" y="187.230181" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1135,11 +1135,11 @@ L 637.2 187.230181
      <g id="line2d_49">
       <path d="M 49.078125 174.883552 
 L 637.2 174.883552 
-" clip-path="url(#p482b3a1732)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pf5e1538b81)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m2b0e05a77b" x="49.078125" y="174.883552" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf79f956769" x="49.078125" y="174.883552" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1147,11 +1147,11 @@ L 637.2 174.883552
      <g id="line2d_51">
       <path d="M 49.078125 164.795622 
 L 637.2 164.795622 
-" clip-path="url(#p482b3a1732)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pf5e1538b81)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m2b0e05a77b" x="49.078125" y="164.795622" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf79f956769" x="49.078125" y="164.795622" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1159,11 +1159,11 @@ L 637.2 164.795622
      <g id="line2d_53">
       <path d="M 49.078125 156.266399 
 L 637.2 156.266399 
-" clip-path="url(#p482b3a1732)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pf5e1538b81)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#m2b0e05a77b" x="49.078125" y="156.266399" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf79f956769" x="49.078125" y="156.266399" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1171,11 +1171,11 @@ L 637.2 156.266399
      <g id="line2d_55">
       <path d="M 49.078125 148.878049 
 L 637.2 148.878049 
-" clip-path="url(#p482b3a1732)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pf5e1538b81)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#m2b0e05a77b" x="49.078125" y="148.878049" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf79f956769" x="49.078125" y="148.878049" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1183,11 +1183,11 @@ L 637.2 148.878049
      <g id="line2d_57">
       <path d="M 49.078125 142.361063 
 L 637.2 142.361063 
-" clip-path="url(#p482b3a1732)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pf5e1538b81)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#m2b0e05a77b" x="49.078125" y="142.361063" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf79f956769" x="49.078125" y="142.361063" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1195,11 +1195,11 @@ L 637.2 142.361063
      <g id="line2d_59">
       <path d="M 49.078125 98.179288 
 L 637.2 98.179288 
-" clip-path="url(#p482b3a1732)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pf5e1538b81)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#m2b0e05a77b" x="49.078125" y="98.179288" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf79f956769" x="49.078125" y="98.179288" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1207,11 +1207,11 @@ L 637.2 98.179288
      <g id="line2d_61">
       <path d="M 49.078125 75.744729 
 L 637.2 75.744729 
-" clip-path="url(#p482b3a1732)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pf5e1538b81)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#m2b0e05a77b" x="49.078125" y="75.744729" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf79f956769" x="49.078125" y="75.744729" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1219,11 +1219,11 @@ L 637.2 75.744729
      <g id="line2d_63">
       <path d="M 49.078125 59.827156 
 L 637.2 59.827156 
-" clip-path="url(#p482b3a1732)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pf5e1538b81)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#m2b0e05a77b" x="49.078125" y="59.827156" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf79f956769" x="49.078125" y="59.827156" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1231,11 +1231,11 @@ L 637.2 59.827156
      <g id="line2d_65">
       <path d="M 49.078125 47.480527 
 L 637.2 47.480527 
-" clip-path="url(#p482b3a1732)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pf5e1538b81)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#m2b0e05a77b" x="49.078125" y="47.480527" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf79f956769" x="49.078125" y="47.480527" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1398,7 +1398,7 @@ z
    <g id="line2d_67">
     <path d="M 49.078125 63.959148 
 L 637.2 63.959148 
-" clip-path="url(#p482b3a1732)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
+" clip-path="url(#pf5e1538b81)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
    </g>
    <g id="patch_3">
     <path d="M 49.078125 412.80375 
@@ -1762,78 +1762,78 @@ z
    </g>
    <g id="line2d_68">
     <defs>
-     <path id="mf018328023" d="M -2.5 2.5 
+     <path id="m3bcb55bba5" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p482b3a1732)">
-     <use xlink:href="#mf018328023" x="75.810937" y="263.190298" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf018328023" x="105.634056" y="267.887378" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf018328023" x="204.490635" y="300.240046" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf018328023" x="234.479899" y="306.367428" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf018328023" x="242.537956" y="316.909198" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf018328023" x="300.771958" y="297.352079" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf018328023" x="303.26414" y="310.698625" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf018328023" x="304.261013" y="317.548512" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf018328023" x="313.897453" y="317.953886" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf018328023" x="414.166268" y="334.149272" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf018328023" x="587.289889" y="327.780982" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf018328023" x="610.467187" y="318.981257" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pf5e1538b81)">
+     <use xlink:href="#m3bcb55bba5" x="75.810937" y="263.190298" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3bcb55bba5" x="105.634056" y="267.887378" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3bcb55bba5" x="204.490635" y="300.240046" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3bcb55bba5" x="234.479899" y="306.367428" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3bcb55bba5" x="242.537956" y="316.909198" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3bcb55bba5" x="300.771958" y="297.352079" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3bcb55bba5" x="303.26414" y="310.698625" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3bcb55bba5" x="304.261013" y="317.548512" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3bcb55bba5" x="313.897453" y="317.953886" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3bcb55bba5" x="414.166268" y="334.149272" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3bcb55bba5" x="587.289889" y="327.780982" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3bcb55bba5" x="610.467187" y="318.981257" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_69">
     <defs>
-     <path id="m49a2c7402b" d="M 0 -2.5 
+     <path id="mf8935de0f8" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p482b3a1732)">
-     <use xlink:href="#m49a2c7402b" x="75.810937" y="260.629553" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m49a2c7402b" x="105.634056" y="253.888028" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m49a2c7402b" x="204.490635" y="301.454063" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m49a2c7402b" x="234.479899" y="296.198152" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m49a2c7402b" x="242.537956" y="306.497434" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m49a2c7402b" x="300.771958" y="285.157082" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m49a2c7402b" x="303.26414" y="299.127298" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m49a2c7402b" x="304.261013" y="312.289143" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m49a2c7402b" x="313.897453" y="305.55147" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m49a2c7402b" x="414.166268" y="323.799851" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m49a2c7402b" x="587.289889" y="327.192921" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m49a2c7402b" x="610.467187" y="316.49707" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pf5e1538b81)">
+     <use xlink:href="#mf8935de0f8" x="75.810937" y="260.629553" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf8935de0f8" x="105.634056" y="253.888028" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf8935de0f8" x="204.490635" y="301.454063" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf8935de0f8" x="234.479899" y="296.198152" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf8935de0f8" x="242.537956" y="306.497434" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf8935de0f8" x="300.771958" y="285.157082" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf8935de0f8" x="303.26414" y="299.127298" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf8935de0f8" x="304.261013" y="312.289143" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf8935de0f8" x="313.897453" y="305.55147" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf8935de0f8" x="414.166268" y="323.799851" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf8935de0f8" x="587.289889" y="327.192921" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf8935de0f8" x="610.467187" y="316.49707" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_70">
     <defs>
-     <path id="m84dab8f19a" d="M -0 3.535534 
+     <path id="ma69b435af8" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p482b3a1732)">
-     <use xlink:href="#m84dab8f19a" x="75.810937" y="229.675972" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m84dab8f19a" x="105.634056" y="230.807252" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m84dab8f19a" x="204.490635" y="262.817606" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m84dab8f19a" x="234.479899" y="260.308889" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m84dab8f19a" x="242.537956" y="274.651617" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m84dab8f19a" x="300.771958" y="258.820574" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m84dab8f19a" x="303.26414" y="270.569757" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m84dab8f19a" x="304.261013" y="279.042037" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m84dab8f19a" x="313.897453" y="275.908162" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m84dab8f19a" x="414.166268" y="294.938772" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m84dab8f19a" x="587.289889" y="301.872049" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m84dab8f19a" x="610.467187" y="298.545064" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pf5e1538b81)">
+     <use xlink:href="#ma69b435af8" x="75.810937" y="229.675972" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma69b435af8" x="105.634056" y="230.807252" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma69b435af8" x="204.490635" y="262.817606" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma69b435af8" x="234.479899" y="260.308889" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma69b435af8" x="242.537956" y="274.651617" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma69b435af8" x="300.771958" y="258.820574" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma69b435af8" x="303.26414" y="270.569757" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma69b435af8" x="304.261013" y="279.042037" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma69b435af8" x="313.897453" y="275.908162" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma69b435af8" x="414.166268" y="294.938772" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma69b435af8" x="587.289889" y="301.872049" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma69b435af8" x="610.467187" y="298.545064" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_71">
     <defs>
-     <path id="m5bfc92ada2" d="M -0.833333 2.5 
+     <path id="m33c2642395" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -1848,24 +1848,24 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p482b3a1732)">
-     <use xlink:href="#m5bfc92ada2" x="75.810937" y="286.028664" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5bfc92ada2" x="105.634056" y="293.887771" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5bfc92ada2" x="204.490635" y="326.335201" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5bfc92ada2" x="234.479899" y="337.903307" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5bfc92ada2" x="242.537956" y="341.092058" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5bfc92ada2" x="300.771958" y="336.485034" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5bfc92ada2" x="303.26414" y="344.754119" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5bfc92ada2" x="304.261013" y="344.606502" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5bfc92ada2" x="313.897453" y="351.527394" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5bfc92ada2" x="414.166268" y="363.295034" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5bfc92ada2" x="587.289889" y="368.159128" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5bfc92ada2" x="610.467187" y="356.976913" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pf5e1538b81)">
+     <use xlink:href="#m33c2642395" x="75.810937" y="286.028664" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m33c2642395" x="105.634056" y="293.887771" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m33c2642395" x="204.490635" y="326.335201" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m33c2642395" x="234.479899" y="337.903307" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m33c2642395" x="242.537956" y="341.092058" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m33c2642395" x="300.771958" y="336.485034" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m33c2642395" x="303.26414" y="344.754119" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m33c2642395" x="304.261013" y="344.606502" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m33c2642395" x="313.897453" y="351.527394" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m33c2642395" x="414.166268" y="363.295034" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m33c2642395" x="587.289889" y="368.159128" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m33c2642395" x="610.467187" y="356.976913" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_72">
     <defs>
-     <path id="m2f7afd1d99" d="M -1.25 2.5 
+     <path id="m5a300280aa" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -1880,24 +1880,24 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p482b3a1732)">
-     <use xlink:href="#m2f7afd1d99" x="75.810937" y="327.723121" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2f7afd1d99" x="105.634056" y="342.646685" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2f7afd1d99" x="204.490635" y="362.850184" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2f7afd1d99" x="234.479899" y="371.338643" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2f7afd1d99" x="242.537956" y="367.245927" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2f7afd1d99" x="300.771958" y="360.026985" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2f7afd1d99" x="303.26414" y="374.683393" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2f7afd1d99" x="304.261013" y="357.457726" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2f7afd1d99" x="313.897453" y="374.58929" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2f7afd1d99" x="414.166268" y="385.027438" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2f7afd1d99" x="587.289889" y="394.333029" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2f7afd1d99" x="610.467187" y="391.249012" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pf5e1538b81)">
+     <use xlink:href="#m5a300280aa" x="75.810937" y="327.723121" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5a300280aa" x="105.634056" y="342.646685" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5a300280aa" x="204.490635" y="362.850184" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5a300280aa" x="234.479899" y="371.338643" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5a300280aa" x="242.537956" y="367.245927" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5a300280aa" x="300.771958" y="360.026985" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5a300280aa" x="303.26414" y="374.683393" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5a300280aa" x="304.261013" y="357.457726" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5a300280aa" x="313.897453" y="374.58929" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5a300280aa" x="414.166268" y="385.027438" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5a300280aa" x="587.289889" y="394.333029" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5a300280aa" x="610.467187" y="391.249012" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_73">
     <defs>
-     <path id="m0167fd575f" d="M 0 -2.5 
+     <path id="m9ea72bf2ee" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -1910,24 +1910,24 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p482b3a1732)">
-     <use xlink:href="#m0167fd575f" x="75.810937" y="273.778134" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m0167fd575f" x="105.634056" y="286.227815" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m0167fd575f" x="204.490635" y="319.608779" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m0167fd575f" x="234.479899" y="321.188418" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m0167fd575f" x="242.537956" y="325.921453" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m0167fd575f" x="300.771958" y="333.05015" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m0167fd575f" x="303.26414" y="336.951003" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m0167fd575f" x="304.261013" y="345.759761" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m0167fd575f" x="313.897453" y="336.754653" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m0167fd575f" x="414.166268" y="357.454726" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m0167fd575f" x="587.289889" y="366.280671" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m0167fd575f" x="610.467187" y="360.878702" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#pf5e1538b81)">
+     <use xlink:href="#m9ea72bf2ee" x="75.810937" y="273.778134" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9ea72bf2ee" x="105.634056" y="286.227815" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9ea72bf2ee" x="204.490635" y="319.608779" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9ea72bf2ee" x="234.479899" y="321.188418" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9ea72bf2ee" x="242.537956" y="325.921453" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9ea72bf2ee" x="300.771958" y="333.05015" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9ea72bf2ee" x="303.26414" y="336.951003" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9ea72bf2ee" x="304.261013" y="345.759761" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9ea72bf2ee" x="313.897453" y="336.754653" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9ea72bf2ee" x="414.166268" y="357.454726" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9ea72bf2ee" x="587.289889" y="366.280671" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9ea72bf2ee" x="610.467187" y="360.878702" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_74">
     <defs>
-     <path id="m0d7e7c68ae" d="M 0 -2.5 
+     <path id="ma69330c2da" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -1936,19 +1936,19 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p482b3a1732)">
-     <use xlink:href="#m0d7e7c68ae" x="75.810937" y="347.176172" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0d7e7c68ae" x="105.634056" y="348.704001" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0d7e7c68ae" x="204.490635" y="367.31757" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0d7e7c68ae" x="234.479899" y="373.033423" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0d7e7c68ae" x="242.537956" y="380.00037" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0d7e7c68ae" x="300.771958" y="370.53122" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0d7e7c68ae" x="303.26414" y="375.375651" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0d7e7c68ae" x="304.261013" y="383.030012" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0d7e7c68ae" x="313.897453" y="385.215351" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0d7e7c68ae" x="414.166268" y="391.648192" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0d7e7c68ae" x="587.289889" y="396.192102" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0d7e7c68ae" x="610.467187" y="383.710333" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pf5e1538b81)">
+     <use xlink:href="#ma69330c2da" x="75.810937" y="347.176172" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma69330c2da" x="105.634056" y="348.704001" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma69330c2da" x="204.490635" y="367.31757" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma69330c2da" x="234.479899" y="373.033423" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma69330c2da" x="242.537956" y="380.00037" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma69330c2da" x="300.771958" y="370.53122" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma69330c2da" x="303.26414" y="375.375651" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma69330c2da" x="304.261013" y="383.030012" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma69330c2da" x="313.897453" y="385.215351" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma69330c2da" x="414.166268" y="391.648192" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma69330c2da" x="587.289889" y="396.192102" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma69330c2da" x="610.467187" y="383.710333" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="legend_1">
@@ -1967,7 +1967,7 @@ z
     </g>
     <g id="line2d_75">
      <defs>
-      <path id="m0b641e34e2" d="M 0 3.5 
+      <path id="m4b17eca917" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -1980,7 +1980,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m0b641e34e2" x="434.04625" y="211.758125" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m4b17eca917" x="434.04625" y="211.758125" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_15">
@@ -2039,7 +2039,7 @@ z
     </g>
     <g id="line2d_76">
      <g>
-      <use xlink:href="#mf018328023" x="434.04625" y="223.500625" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m3bcb55bba5" x="434.04625" y="223.500625" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_16">
@@ -2053,7 +2053,7 @@ z
     </g>
     <g id="line2d_77">
      <g>
-      <use xlink:href="#m49a2c7402b" x="434.04625" y="235.243125" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mf8935de0f8" x="434.04625" y="235.243125" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -2098,7 +2098,7 @@ z
     </g>
     <g id="line2d_78">
      <g>
-      <use xlink:href="#m84dab8f19a" x="434.04625" y="247.208125" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#ma69b435af8" x="434.04625" y="247.208125" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -2118,7 +2118,7 @@ z
     </g>
     <g id="line2d_79">
      <g>
-      <use xlink:href="#m5bfc92ada2" x="537.72375" y="211.758125" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m33c2642395" x="537.72375" y="211.758125" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -2145,7 +2145,7 @@ z
     </g>
     <g id="line2d_80">
      <g>
-      <use xlink:href="#m2f7afd1d99" x="537.72375" y="223.500625" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m5a300280aa" x="537.72375" y="223.500625" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -2210,7 +2210,7 @@ z
     </g>
     <g id="line2d_81">
      <g>
-      <use xlink:href="#m0167fd575f" x="537.72375" y="235.243125" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#m9ea72bf2ee" x="537.72375" y="235.243125" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_21">
@@ -2248,7 +2248,7 @@ z
     </g>
     <g id="line2d_82">
      <g>
-      <use xlink:href="#m0d7e7c68ae" x="537.72375" y="246.985625" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#ma69330c2da" x="537.72375" y="246.985625" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -2318,19 +2318,19 @@ z
     </g>
    </g>
    <g id="line2d_83">
-    <g clip-path="url(#p482b3a1732)">
-     <use xlink:href="#m0b641e34e2" x="75.810937" y="272.143954" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m0b641e34e2" x="105.634056" y="288.399073" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m0b641e34e2" x="204.490635" y="322.103822" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m0b641e34e2" x="234.479899" y="324.29343" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m0b641e34e2" x="242.537956" y="324.418753" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m0b641e34e2" x="300.771958" y="312.453798" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m0b641e34e2" x="303.26414" y="333.249253" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m0b641e34e2" x="304.261013" y="351.748791" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m0b641e34e2" x="313.897453" y="337.048403" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m0b641e34e2" x="414.166268" y="356.441315" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m0b641e34e2" x="587.289889" y="359.296601" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m0b641e34e2" x="610.467187" y="343.193293" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <g clip-path="url(#pf5e1538b81)">
+     <use xlink:href="#m4b17eca917" x="75.810937" y="272.143954" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m4b17eca917" x="105.634056" y="288.399073" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m4b17eca917" x="204.490635" y="322.103822" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m4b17eca917" x="234.479899" y="324.29343" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m4b17eca917" x="242.537956" y="324.418753" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m4b17eca917" x="300.771958" y="312.453798" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m4b17eca917" x="303.26414" y="333.249253" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m4b17eca917" x="304.261013" y="351.748791" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m4b17eca917" x="313.897453" y="337.048403" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m4b17eca917" x="414.166268" y="356.441315" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m4b17eca917" x="587.289889" y="359.296601" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m4b17eca917" x="610.467187" y="343.193293" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
   </g>
@@ -3154,7 +3154,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p482b3a1732">
+  <clipPath id="pf5e1538b81">
    <rect x="49.078125" y="47.3475" width="588.121875" height="365.45625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_decode_ranking.svg
+++ b/bench/graphs/silesia_decode_ranking.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 292.269187 308.04375 
 L 292.269187 56.7075 
-" clip-path="url(#pb2f8164573)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4566bc2936)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="mf9d9e2c816" d="M 0 0 
+       <path id="mabb5f6361d" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mf9d9e2c816" x="292.269187" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mabb5f6361d" x="292.269187" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -136,11 +136,11 @@ z
      <g id="line2d_3">
       <path d="M 449.991563 308.04375 
 L 449.991563 56.7075 
-" clip-path="url(#pb2f8164573)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4566bc2936)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mf9d9e2c816" x="449.991563" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mabb5f6361d" x="449.991563" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -177,16 +177,16 @@ z
      <g id="line2d_5">
       <path d="M 182.025977 308.04375 
 L 182.025977 56.7075 
-" clip-path="url(#pb2f8164573)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4566bc2936)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <defs>
-       <path id="m1df9925dca" d="M 0 0 
+       <path id="maed5668f49" d="M 0 0 
 L 0 2 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m1df9925dca" x="182.025977" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#maed5668f49" x="182.025977" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -194,11 +194,11 @@ L 0 2
      <g id="line2d_7">
       <path d="M 209.799509 308.04375 
 L 209.799509 56.7075 
-" clip-path="url(#pb2f8164573)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4566bc2936)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m1df9925dca" x="209.799509" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#maed5668f49" x="209.799509" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -206,11 +206,11 @@ L 209.799509 56.7075
      <g id="line2d_9">
       <path d="M 229.505143 308.04375 
 L 229.505143 56.7075 
-" clip-path="url(#pb2f8164573)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4566bc2936)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m1df9925dca" x="229.505143" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#maed5668f49" x="229.505143" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -218,11 +218,11 @@ L 229.505143 56.7075
      <g id="line2d_11">
       <path d="M 244.790021 308.04375 
 L 244.790021 56.7075 
-" clip-path="url(#pb2f8164573)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4566bc2936)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m1df9925dca" x="244.790021" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#maed5668f49" x="244.790021" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -230,11 +230,11 @@ L 244.790021 56.7075
      <g id="line2d_13">
       <path d="M 257.278675 308.04375 
 L 257.278675 56.7075 
-" clip-path="url(#pb2f8164573)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4566bc2936)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m1df9925dca" x="257.278675" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#maed5668f49" x="257.278675" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -242,11 +242,11 @@ L 257.278675 56.7075
      <g id="line2d_15">
       <path d="M 267.837682 308.04375 
 L 267.837682 56.7075 
-" clip-path="url(#pb2f8164573)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4566bc2936)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m1df9925dca" x="267.837682" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#maed5668f49" x="267.837682" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -254,11 +254,11 @@ L 267.837682 56.7075
      <g id="line2d_17">
       <path d="M 276.984309 308.04375 
 L 276.984309 56.7075 
-" clip-path="url(#pb2f8164573)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4566bc2936)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m1df9925dca" x="276.984309" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#maed5668f49" x="276.984309" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -266,11 +266,11 @@ L 276.984309 56.7075
      <g id="line2d_19">
       <path d="M 285.052207 308.04375 
 L 285.052207 56.7075 
-" clip-path="url(#pb2f8164573)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4566bc2936)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m1df9925dca" x="285.052207" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#maed5668f49" x="285.052207" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -278,11 +278,11 @@ L 285.052207 56.7075
      <g id="line2d_21">
       <path d="M 339.748353 308.04375 
 L 339.748353 56.7075 
-" clip-path="url(#pb2f8164573)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4566bc2936)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m1df9925dca" x="339.748353" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#maed5668f49" x="339.748353" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -290,11 +290,11 @@ L 339.748353 56.7075
      <g id="line2d_23">
       <path d="M 367.521885 308.04375 
 L 367.521885 56.7075 
-" clip-path="url(#pb2f8164573)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4566bc2936)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m1df9925dca" x="367.521885" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#maed5668f49" x="367.521885" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -302,11 +302,11 @@ L 367.521885 56.7075
      <g id="line2d_25">
       <path d="M 387.227519 308.04375 
 L 387.227519 56.7075 
-" clip-path="url(#pb2f8164573)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4566bc2936)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m1df9925dca" x="387.227519" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#maed5668f49" x="387.227519" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -314,11 +314,11 @@ L 387.227519 56.7075
      <g id="line2d_27">
       <path d="M 402.512397 308.04375 
 L 402.512397 56.7075 
-" clip-path="url(#pb2f8164573)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4566bc2936)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m1df9925dca" x="402.512397" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#maed5668f49" x="402.512397" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -326,11 +326,11 @@ L 402.512397 56.7075
      <g id="line2d_29">
       <path d="M 415.001051 308.04375 
 L 415.001051 56.7075 
-" clip-path="url(#pb2f8164573)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4566bc2936)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m1df9925dca" x="415.001051" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#maed5668f49" x="415.001051" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -338,11 +338,11 @@ L 415.001051 56.7075
      <g id="line2d_31">
       <path d="M 425.560057 308.04375 
 L 425.560057 56.7075 
-" clip-path="url(#pb2f8164573)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4566bc2936)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m1df9925dca" x="425.560057" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#maed5668f49" x="425.560057" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -350,11 +350,11 @@ L 425.560057 56.7075
      <g id="line2d_33">
       <path d="M 434.706685 308.04375 
 L 434.706685 56.7075 
-" clip-path="url(#pb2f8164573)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4566bc2936)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m1df9925dca" x="434.706685" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#maed5668f49" x="434.706685" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -362,11 +362,11 @@ L 434.706685 56.7075
      <g id="line2d_35">
       <path d="M 442.774583 308.04375 
 L 442.774583 56.7075 
-" clip-path="url(#pb2f8164573)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4566bc2936)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m1df9925dca" x="442.774583" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#maed5668f49" x="442.774583" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -374,11 +374,11 @@ L 442.774583 56.7075
      <g id="line2d_37">
       <path d="M 497.470729 308.04375 
 L 497.470729 56.7075 
-" clip-path="url(#pb2f8164573)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4566bc2936)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m1df9925dca" x="497.470729" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#maed5668f49" x="497.470729" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -386,11 +386,11 @@ L 497.470729 56.7075
      <g id="line2d_39">
       <path d="M 525.24426 308.04375 
 L 525.24426 56.7075 
-" clip-path="url(#pb2f8164573)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4566bc2936)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m1df9925dca" x="525.24426" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#maed5668f49" x="525.24426" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -398,11 +398,11 @@ L 525.24426 56.7075
      <g id="line2d_41">
       <path d="M 544.949895 308.04375 
 L 544.949895 56.7075 
-" clip-path="url(#pb2f8164573)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4566bc2936)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m1df9925dca" x="544.949895" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#maed5668f49" x="544.949895" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -410,11 +410,11 @@ L 544.949895 56.7075
      <g id="line2d_43">
       <path d="M 560.234772 308.04375 
 L 560.234772 56.7075 
-" clip-path="url(#pb2f8164573)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4566bc2936)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m1df9925dca" x="560.234772" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#maed5668f49" x="560.234772" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1016,12 +1016,12 @@ z
     <g id="ytick_1">
      <g id="line2d_45">
       <defs>
-       <path id="m459fea81d0" d="M 0 0 
+       <path id="m742b7edf21" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m459fea81d0" x="139.360469" y="296.619375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m742b7edf21" x="139.360469" y="296.619375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -1093,7 +1093,7 @@ z
     <g id="ytick_2">
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m459fea81d0" x="139.360469" y="263.978304" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m742b7edf21" x="139.360469" y="263.978304" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -1160,7 +1160,7 @@ z
     <g id="ytick_3">
      <g id="line2d_47">
       <g>
-       <use xlink:href="#m459fea81d0" x="139.360469" y="231.337232" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m742b7edf21" x="139.360469" y="231.337232" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -1216,7 +1216,7 @@ z
     <g id="ytick_4">
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m459fea81d0" x="139.360469" y="198.696161" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m742b7edf21" x="139.360469" y="198.696161" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -1263,7 +1263,7 @@ z
     <g id="ytick_5">
      <g id="line2d_49">
       <g>
-       <use xlink:href="#m459fea81d0" x="139.360469" y="166.055089" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m742b7edf21" x="139.360469" y="166.055089" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -1376,7 +1376,7 @@ z
     <g id="ytick_6">
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m459fea81d0" x="139.360469" y="133.414018" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m742b7edf21" x="139.360469" y="133.414018" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -1392,7 +1392,7 @@ z
     <g id="ytick_7">
      <g id="line2d_51">
       <g>
-       <use xlink:href="#m459fea81d0" x="139.360469" y="100.772946" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m742b7edf21" x="139.360469" y="100.772946" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -1439,7 +1439,7 @@ z
     <g id="ytick_8">
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m459fea81d0" x="139.360469" y="68.131875" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m742b7edf21" x="139.360469" y="68.131875" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -1462,47 +1462,47 @@ z
    <g id="LineCollection_1">
     <path d="M 139.360469 296.619375 
 L 154.645346 296.619375 
-" clip-path="url(#pb2f8164573)" style="fill: none; stroke: #17becf; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p4566bc2936)" style="fill: none; stroke: #17becf; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_2">
     <path d="M 139.360469 263.978304 
 L 161.142927 263.978304 
-" clip-path="url(#pb2f8164573)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p4566bc2936)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_3">
     <path d="M 139.360469 231.337232 
 L 200.65327 231.337232 
-" clip-path="url(#pb2f8164573)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p4566bc2936)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_4">
     <path d="M 139.360469 198.696161 
 L 208.426981 198.696161 
-" clip-path="url(#pb2f8164573)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p4566bc2936)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_5">
     <path d="M 139.360469 166.055089 
 L 212.673671 166.055089 
-" clip-path="url(#pb2f8164573)" style="fill: none; stroke: #d62728; stroke-opacity: 0.9; stroke-width: 2.4"/>
+" clip-path="url(#p4566bc2936)" style="fill: none; stroke: #d62728; stroke-opacity: 0.9; stroke-width: 2.4"/>
    </g>
    <g id="LineCollection_6">
     <path d="M 139.360469 133.414018 
 L 239.878265 133.414018 
-" clip-path="url(#pb2f8164573)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p4566bc2936)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_7">
     <path d="M 139.360469 100.772946 
 L 248.943982 100.772946 
-" clip-path="url(#pb2f8164573)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p4566bc2936)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_8">
     <path d="M 139.360469 68.131875 
 L 284.774562 68.131875 
-" clip-path="url(#pb2f8164573)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p4566bc2936)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="line2d_53">
     <path d="M 542.152339 308.04375 
 L 542.152339 56.7075 
-" clip-path="url(#pb2f8164573)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
+" clip-path="url(#p4566bc2936)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
    </g>
    <g id="patch_3">
     <path d="M 139.360469 308.04375 
@@ -1888,7 +1888,7 @@ z
    </g>
    <g id="line2d_54">
     <defs>
-     <path id="m65726f3321" d="M 0 3 
+     <path id="mb0400895ba" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1900,13 +1900,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #17becf"/>
     </defs>
-    <g clip-path="url(#pb2f8164573)">
-     <use xlink:href="#m65726f3321" x="154.645346" y="296.619375" style="fill: #17becf; stroke: #17becf"/>
+    <g clip-path="url(#p4566bc2936)">
+     <use xlink:href="#mb0400895ba" x="154.645346" y="296.619375" style="fill: #17becf; stroke: #17becf"/>
     </g>
    </g>
    <g id="line2d_55">
     <defs>
-     <path id="m6e6eff6516" d="M 0 3 
+     <path id="m9fc9284000" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1918,13 +1918,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #e377c2"/>
     </defs>
-    <g clip-path="url(#pb2f8164573)">
-     <use xlink:href="#m6e6eff6516" x="161.142927" y="263.978304" style="fill: #e377c2; stroke: #e377c2"/>
+    <g clip-path="url(#p4566bc2936)">
+     <use xlink:href="#m9fc9284000" x="161.142927" y="263.978304" style="fill: #e377c2; stroke: #e377c2"/>
     </g>
    </g>
    <g id="line2d_56">
     <defs>
-     <path id="m6a004fb50d" d="M 0 3 
+     <path id="m75502bbca1" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1936,13 +1936,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #8c564b"/>
     </defs>
-    <g clip-path="url(#pb2f8164573)">
-     <use xlink:href="#m6a004fb50d" x="200.65327" y="231.337232" style="fill: #8c564b; stroke: #8c564b"/>
+    <g clip-path="url(#p4566bc2936)">
+     <use xlink:href="#m75502bbca1" x="200.65327" y="231.337232" style="fill: #8c564b; stroke: #8c564b"/>
     </g>
    </g>
    <g id="line2d_57">
     <defs>
-     <path id="mcbe8002771" d="M 0 3 
+     <path id="m2be234e50e" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1954,13 +1954,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #bcbd22"/>
     </defs>
-    <g clip-path="url(#pb2f8164573)">
-     <use xlink:href="#mcbe8002771" x="208.426981" y="198.696161" style="fill: #bcbd22; stroke: #bcbd22"/>
+    <g clip-path="url(#p4566bc2936)">
+     <use xlink:href="#m2be234e50e" x="208.426981" y="198.696161" style="fill: #bcbd22; stroke: #bcbd22"/>
     </g>
    </g>
    <g id="line2d_58">
     <defs>
-     <path id="m1d45526457" d="M 0 5 
+     <path id="m8444fc7558" d="M 0 5 
 C 1.326016 5 2.597899 4.473168 3.535534 3.535534 
 C 4.473168 2.597899 5 1.326016 5 0 
 C 5 -1.326016 4.473168 -2.597899 3.535534 -3.535534 
@@ -1972,13 +1972,13 @@ C -2.597899 4.473168 -1.326016 5 0 5
 z
 " style="stroke: #d62728"/>
     </defs>
-    <g clip-path="url(#pb2f8164573)">
-     <use xlink:href="#m1d45526457" x="212.673671" y="166.055089" style="fill: #d62728; stroke: #d62728"/>
+    <g clip-path="url(#p4566bc2936)">
+     <use xlink:href="#m8444fc7558" x="212.673671" y="166.055089" style="fill: #d62728; stroke: #d62728"/>
     </g>
    </g>
    <g id="line2d_59">
     <defs>
-     <path id="mfbdce0101b" d="M 0 3 
+     <path id="maa98235848" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1990,13 +1990,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #1f77b4"/>
     </defs>
-    <g clip-path="url(#pb2f8164573)">
-     <use xlink:href="#mfbdce0101b" x="239.878265" y="133.414018" style="fill: #1f77b4; stroke: #1f77b4"/>
+    <g clip-path="url(#p4566bc2936)">
+     <use xlink:href="#maa98235848" x="239.878265" y="133.414018" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_60">
     <defs>
-     <path id="m6d2152a6d5" d="M 0 3 
+     <path id="m99636e9711" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -2008,13 +2008,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #2ca02c"/>
     </defs>
-    <g clip-path="url(#pb2f8164573)">
-     <use xlink:href="#m6d2152a6d5" x="248.943982" y="100.772946" style="fill: #2ca02c; stroke: #2ca02c"/>
+    <g clip-path="url(#p4566bc2936)">
+     <use xlink:href="#m99636e9711" x="248.943982" y="100.772946" style="fill: #2ca02c; stroke: #2ca02c"/>
     </g>
    </g>
    <g id="line2d_61">
     <defs>
-     <path id="m87fa5e3e39" d="M 0 3 
+     <path id="mb725ac9293" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -2026,8 +2026,8 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #9467bd"/>
     </defs>
-    <g clip-path="url(#pb2f8164573)">
-     <use xlink:href="#m87fa5e3e39" x="284.774562" y="68.131875" style="fill: #9467bd; stroke: #9467bd"/>
+    <g clip-path="url(#p4566bc2936)">
+     <use xlink:href="#mb725ac9293" x="284.774562" y="68.131875" style="fill: #9467bd; stroke: #9467bd"/>
     </g>
    </g>
   </g>
@@ -2967,7 +2967,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="pb2f8164573">
+  <clipPath id="p4566bc2936">
    <rect x="139.360469" y="56.7075" width="425.839531" height="251.33625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_ratio_heatmap.svg
+++ b/bench/graphs/silesia_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.34175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p1091ef30aa)">
+   <g clip-path="url(#p0d2b978fae)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAosAAAGaCAYAAABniAm0AAAJ/UlEQVR4nO3Yu45eVx2H4ZnM+IDHmbEtSCLCQcIRIIVAiUJBlQpBwTVwBTRUVIg7oOIG6FBE6SZlpHAMoQCiJARxkDXE2DGWsccz83EFb4HC0h99ep4r+El7a+13r93z2z/e7Gyhk5/cmp6wxIVXXpqesMzuM5+cnrDE5s3fTk9YYvfLL05PWGLz8P70hGWOv/fq9IQlnvnhN6cnLLF749npCWucPJxesMz5z7fzvH9qegAAAP+/xCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAGn3XyevbqZHrHDwz+PpCUt8cHhlesIy/z59MD1hiU9/eDI9YYkPP/Hc9IQlzjfn0xOWub5/Y3rCGnfen16wxP3r2/m8nv7TH6cnLLP5/FenJyzhZhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgLR/cOf29IY1rlybXrDEZnMyPWGZT732y+kJa7zyjekFSxx98PfpCWucn04vWOdgS8+PS1enFyxx+I/t/D7f/ezN6QnLXP/LW9MTlnCzCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAAKTdJ2e3NtMjVtg7fm96whK3n744PWGZB0/uTU9Y4uaf701PWOL0S1+bnrDEw9P70xOWOdq7Nj1hic27v5iesMSjz700PWGJy2+9MT1hmcdfeXl6whJuFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIC0+7N3v7uZHrHCjcsH0xOWePvenekJy3znR7+enrDEb37wrekJSxxdOpqesMT3X//V9IRlvv785ekJS3z75svTE5Z47a9vTE9Y4uqF7XwPd3Z2dn76zt3pCUu4WQQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAADS7pOzW5vpESvcfXw8PWGJg/3D6QnLvH3vd9MTlnjh2ovTE5bYbM6nJyxx9XR7/6H/dr6d5+LzBy9MT1ji0dnD6QlLbOvZsbOzs7P31P70hCW291QEAOAjE4sAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA2t/b3Z/esMTH925MT1hj7+L0gmWOLh1NT1jiYP9wesISZ5vT6QlLnF/Y3n/o5zZXpifwX9jW7/PJ5tH0hGXuPz6enrDE9p6KAAB8ZGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIC0/+js4fSGJS5vaQe//+AP0xOWOT0/mZ6wxvE70wuWuH90OD1hicOLN6YnLHNy9mh6whIfu/3e9IQlHj/7mekJSxz8/s3pCcs8/sIXpycssZ1FBQDA/4RYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAg/Qdg9JyFmQO2bgAAAABJRU5ErkJggg==" id="imagec02579f729" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="468.72" height="295.2"/>
+iVBORw0KGgoAAAANSUhEUgAAAosAAAGaCAYAAABniAm0AAAJ/UlEQVR4nO3Yu45eVx2H4ZnM+IDHmbEtSCLCQcIRIIVAiUJBlQpBwTVwBTRUVIg7oOIG6FBE6SZlpHAMoQCiJARxkDXE2DGWsccz83EFb4HC0h99ep4r+El7a+13r93z2z/e7Gyhk5/cmp6wxIVXXpqesMzuM5+cnrDE5s3fTk9YYvfLL05PWGLz8P70hGWOv/fq9IQlnvnhN6cnLLF749npCWucPJxesMz5z7fzvH9qegAAAP+/xCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAGn3XyevbqZHrHDwz+PpCUt8cHhlesIy/z59MD1hiU9/eDI9YYkPP/Hc9IQlzjfn0xOWub5/Y3rCGnfen16wxP3r2/m8nv7TH6cnLLP5/FenJyzhZhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgLR/cOf29IY1rlybXrDEZnMyPWGZT732y+kJa7zyjekFSxx98PfpCWucn04vWOdgS8+PS1enFyxx+I/t/D7f/ezN6QnLXP/LW9MTlnCzCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAAKTdJ2e3NtMjVtg7fm96whK3n744PWGZB0/uTU9Y4uaf701PWOL0S1+bnrDEw9P70xOWOdq7Nj1hic27v5iesMSjz700PWGJy2+9MT1hmcdfeXl6whJuFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIC0+7N3v7uZHrHCjcsH0xOWePvenekJy3znR7+enrDEb37wrekJSxxdOpqesMT3X//V9IRlvv785ekJS3z75svTE5Z47a9vTE9Y4uqF7XwPd3Z2dn76zt3pCUu4WQQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAADS7pOzW5vpESvcfXw8PWGJg/3D6QnLvH3vd9MTlnjh2ovTE5bYbM6nJyxx9XR7/6H/dr6d5+LzBy9MT1ji0dnD6QlLbOvZsbOzs7P31P70hCW291QEAOAjE4sAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA2t/b3Z/esMTH925MT1hj7+L0gmWOLh1NT1jiYP9wesISZ5vT6QlLnF/Y3n/o5zZXpifwX9jW7/PJ5tH0hGXuPz6enrDE9p6KAAB8ZGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIC0/+js4fSGJS5vaQe//+AP0xOWOT0/mZ6wxvE70wuWuH90OD1hicOLN6YnLHNy9mh6whIfu/3e9IQlHj/7mekJSxz8/s3pCcs8/sIXpycssZ1FBQDA/4RYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAg/Qdg9JyFmQO2bgAAAABJRU5ErkJggg==" id="image07a5053975" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="468.72" height="295.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="ma0c56d3a59" d="M 0 0 
+       <path id="m5fc6ff1d3c" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#ma0c56d3a59" x="115.182137" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5fc6ff1d3c" x="115.182137" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#ma0c56d3a59" x="154.193912" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5fc6ff1d3c" x="154.193912" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#ma0c56d3a59" x="193.205687" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5fc6ff1d3c" x="193.205687" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#ma0c56d3a59" x="232.217462" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5fc6ff1d3c" x="232.217462" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#ma0c56d3a59" x="271.229237" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5fc6ff1d3c" x="271.229237" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#ma0c56d3a59" x="310.241012" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5fc6ff1d3c" x="310.241012" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#ma0c56d3a59" x="349.252787" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5fc6ff1d3c" x="349.252787" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#ma0c56d3a59" x="388.264562" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5fc6ff1d3c" x="388.264562" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#ma0c56d3a59" x="427.276336" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5fc6ff1d3c" x="427.276336" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#ma0c56d3a59" x="466.288111" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5fc6ff1d3c" x="466.288111" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#ma0c56d3a59" x="505.299886" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5fc6ff1d3c" x="505.299886" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#ma0c56d3a59" x="544.311661" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5fc6ff1d3c" x="544.311661" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="mbbf4e96a03" d="M 0 0 
+       <path id="mc594308882" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mbbf4e96a03" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc594308882" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mbbf4e96a03" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc594308882" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#mbbf4e96a03" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc594308882" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#mbbf4e96a03" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc594308882" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -836,7 +836,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#mbbf4e96a03" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc594308882" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -899,7 +899,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mbbf4e96a03" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc594308882" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -966,7 +966,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#mbbf4e96a03" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc594308882" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1047,7 +1047,7 @@ z
     <g id="ytick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#mbbf4e96a03" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc594308882" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -2060,18 +2060,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABEAAAFUCAYAAADCj9eRAAAB2ElEQVR4nO2aQY7EIAwEIeFP+6X9/33C3MPcKKSS1TygZRftNlLS2//fbJtn9KvvajAi17ZCM7Uzeg+TEyJhsh4TE8D25ZhYRMJkPSYmmZ0zIhfQEMPkJq74JpgQlUBMABkIrOV2KLMRItXMhrQjqcQUSszsbGuomFSbHULEAlblE0klor1zMaG0XwnDBDAsBVY0O4CIBizlE4ntEbCijK3mE8vKUPkEEIF8YslYje2RZFP5BJkdCxOonf1i6jEhRICOyjEBzFaPiWd2iChoYbKKhMkqgmSsh4kkHkU+6UyeACJEJaLZ6QQTzy7WtGPyicX2Kp/c+yKaATTliSWoTXsnPllEEtTLGX37f+7WRpuPQ4RhomlntCdMTohATIDbKceEaGfOD1BJZueIiImJZQBNTCxgw2Q91N7Zf7RBsxMmR0TqMdmvxPRmI0TmDJNVJExWkTBZRcJkFSnFZH6Q5aVhQrQzkYUOVEIxIXxSjAnRDjQ7mndsZud9VEwsPtFcsWjvaNZofHKoEpFPELCPJmORdqblMWxiYjEbw+QJk/dR+SQD+BbROFbEJAP4Q4RgQpiNCupKIhAT4gewakws7YTJIREoY4FPeNWYaNoJk18iQNqXY1LKJ1/07Ct/l+QCQgAAAABJRU5ErkJggg==" id="image3a0ee1fd1d" transform="scale(1 -1) translate(0 -244.8)" x="573.84" y="-74.16" width="12.24" height="244.8"/>
+iVBORw0KGgoAAAANSUhEUgAAABEAAAFUCAYAAADCj9eRAAAB2ElEQVR4nO2aQY7EIAwEIeFP+6X9/33C3MPcKKSS1TygZRftNlLS2//fbJtn9KvvajAi17ZCM7Uzeg+TEyJhsh4TE8D25ZhYRMJkPSYmmZ0zIhfQEMPkJq74JpgQlUBMABkIrOV2KLMRItXMhrQjqcQUSszsbGuomFSbHULEAlblE0klor1zMaG0XwnDBDAsBVY0O4CIBizlE4ntEbCijK3mE8vKUPkEEIF8YslYje2RZFP5BJkdCxOonf1i6jEhRICOyjEBzFaPiWd2iChoYbKKhMkqgmSsh4kkHkU+6UyeACJEJaLZ6QQTzy7WtGPyicX2Kp/c+yKaATTliSWoTXsnPllEEtTLGX37f+7WRpuPQ4RhomlntCdMTohATIDbKceEaGfOD1BJZueIiImJZQBNTCxgw2Q91N7Zf7RBsxMmR0TqMdmvxPRmI0TmDJNVJExWkTBZRcJkFSnFZH6Q5aVhQrQzkYUOVEIxIXxSjAnRDjQ7mndsZud9VEwsPtFcsWjvaNZofHKoEpFPELCPJmORdqblMWxiYjEbw+QJk/dR+SQD+BbROFbEJAP4Q4RgQpiNCupKIhAT4gewakws7YTJIREoY4FPeNWYaNoJk18iQNqXY1LKJ1/07Ct/l+QCQgAAAABJRU5ErkJggg==" id="image35f557e1a5" transform="scale(1 -1) translate(0 -244.8)" x="573.84" y="-74.16" width="12.24" height="244.8"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_21">
       <defs>
-       <path id="m5a7d6d341d" d="M 0 0 
+       <path id="mc3dc5f1adf" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m5a7d6d341d" x="585.876562" y="282.022672" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc3dc5f1adf" x="585.876562" y="282.022672" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_117">
@@ -2097,7 +2097,7 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m5a7d6d341d" x="585.876562" y="239.353777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc3dc5f1adf" x="585.876562" y="239.353777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_118">
@@ -2114,7 +2114,7 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m5a7d6d341d" x="585.876562" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc3dc5f1adf" x="585.876562" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_119">
@@ -2130,7 +2130,7 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m5a7d6d341d" x="585.876562" y="154.015985" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc3dc5f1adf" x="585.876562" y="154.015985" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_120">
@@ -2146,7 +2146,7 @@ z
     <g id="ytick_13">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m5a7d6d341d" x="585.876562" y="111.347089" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc3dc5f1adf" x="585.876562" y="111.347089" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_121">
@@ -2739,8 +2739,8 @@ z
    </g>
   </g>
   <g id="text_124">
-   <!-- 2026-07-08T20:16:47Z  ·  Linux chungus2 x86_64  ·  commit 74c19afa  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(44.841641 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-08T21:41:55Z  ·  Linux chungus2 x86_64  ·  commit b17c222c  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(43.990156 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -2871,13 +2871,13 @@ z
     <use xlink:href="#DejaVuSans-38" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2917,109 +2917,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3254.101562 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3317.724609 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3381.347656 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3442.626953 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3477.832031 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3539.111328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3570.898438 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3602.685547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3634.472656 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3666.259766 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3698.046875 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3725.830078 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3787.353516 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3848.632812 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3912.011719 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3975.488281 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4014.351562 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4075.533203 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4134.712891 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4196.236328 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4237.349609 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4271.041016 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4298.824219 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4360.347656 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4421.626953 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4485.005859 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4548.628906 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4582.320312 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4641.5 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4705.123047 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4736.910156 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4800.533203 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4864.15625 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4895.943359 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4959.566406 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4995.650391 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5034.513672 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5089.494141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5153.117188 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5184.904297 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5216.691406 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5248.478516 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5280.265625 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5312.052734 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5351.261719 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5414.640625 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5453.503906 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5514.685547 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5578.064453 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5641.541016 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5704.919922 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5768.396484 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5831.775391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5870.984375 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5902.771484 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5986.560547 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6018.347656 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6115.759766 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6177.283203 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6240.759766 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6268.542969 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6329.822266 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6393.201172 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6424.988281 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6477.087891 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6540.466797 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6601.746094 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6665.222656 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6717.322266 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6780.701172 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6841.882812 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6881.091797 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6914.783203 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6946.570312 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6987.683594 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7048.962891 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7088.171875 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7115.955078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7177.136719 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7208.923828 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7236.707031 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7288.806641 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7320.59375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7384.070312 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7445.59375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7484.802734 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7546.326172 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7585.689453 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7683.101562 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7710.884766 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7774.263672 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7802.046875 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7854.146484 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7893.355469 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7921.138672 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3135.351562 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3198.974609 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3262.597656 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3317.578125 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3381.201172 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3444.824219 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3508.447266 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3563.427734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3595.214844 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3627.001953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3658.789062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3690.576172 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3722.363281 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3750.146484 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3811.669922 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3872.949219 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3936.328125 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3999.804688 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4038.667969 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4099.849609 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4159.029297 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4220.552734 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4261.666016 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4295.357422 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4323.140625 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4384.664062 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4445.943359 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4509.322266 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4572.945312 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4606.636719 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4665.816406 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4729.439453 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4761.226562 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4824.849609 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4888.472656 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4920.259766 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4983.882812 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5019.966797 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5058.830078 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5113.810547 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5177.433594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5209.220703 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5241.007812 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5272.794922 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5304.582031 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5336.369141 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5375.578125 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5438.957031 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5477.820312 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5539.001953 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5602.380859 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5665.857422 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5729.236328 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5792.712891 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5856.091797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5895.300781 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5927.087891 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6010.876953 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6042.664062 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6140.076172 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6201.599609 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6265.076172 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6292.859375 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6354.138672 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6417.517578 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6449.304688 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6501.404297 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6564.783203 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6626.0625 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6689.539062 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6741.638672 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6805.017578 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6866.199219 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6905.408203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6939.099609 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6970.886719 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7012 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7073.279297 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7112.488281 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7140.271484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7201.453125 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7233.240234 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7261.023438 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7313.123047 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7344.910156 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7408.386719 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7469.910156 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7509.119141 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7570.642578 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7610.005859 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7707.417969 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7735.201172 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7798.580078 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7826.363281 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7878.462891 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7917.671875 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7945.455078 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p1091ef30aa">
+  <clipPath id="p0d2b978fae">
    <rect x="95.67625" y="49.34175" width="468.141298" height="294.686261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_summary.svg
+++ b/bench/graphs/silesia_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="572.716719pt" height="386.202469pt" viewBox="0 0 572.716719 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="574.419688pt" height="386.202469pt" viewBox="0 0 574.419688 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,232 +22,232 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 386.202469 
-L 572.716719 386.202469 
-L 572.716719 0 
+L 574.419688 386.202469 
+L 574.419688 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 188.483359 104.1264 
-L 293.108359 104.1264 
-L 293.108359 74.7432 
-L 188.483359 74.7432 
+    <path d="M 189.334844 104.1264 
+L 293.959844 104.1264 
+L 293.959844 74.7432 
+L 189.334844 74.7432 
 z
-" clip-path="url(#p724545c2c4)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd7bf6d5294)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 293.108359 104.1264 
-L 397.733359 104.1264 
-L 397.733359 74.7432 
-L 293.108359 74.7432 
+    <path d="M 293.959844 104.1264 
+L 398.584844 104.1264 
+L 398.584844 74.7432 
+L 293.959844 74.7432 
 z
-" clip-path="url(#p724545c2c4)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd7bf6d5294)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 397.733359 104.1264 
-L 502.358359 104.1264 
-L 502.358359 74.7432 
-L 397.733359 74.7432 
+    <path d="M 398.584844 104.1264 
+L 503.209844 104.1264 
+L 503.209844 74.7432 
+L 398.584844 74.7432 
 z
-" clip-path="url(#p724545c2c4)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd7bf6d5294)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 188.483359 133.5096 
-L 293.108359 133.5096 
-L 293.108359 104.1264 
-L 188.483359 104.1264 
+    <path d="M 189.334844 133.5096 
+L 293.959844 133.5096 
+L 293.959844 104.1264 
+L 189.334844 104.1264 
 z
-" clip-path="url(#p724545c2c4)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd7bf6d5294)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 293.108359 133.5096 
-L 397.733359 133.5096 
-L 397.733359 104.1264 
-L 293.108359 104.1264 
+    <path d="M 293.959844 133.5096 
+L 398.584844 133.5096 
+L 398.584844 104.1264 
+L 293.959844 104.1264 
 z
-" clip-path="url(#p724545c2c4)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd7bf6d5294)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 397.733359 133.5096 
-L 502.358359 133.5096 
-L 502.358359 104.1264 
-L 397.733359 104.1264 
+    <path d="M 398.584844 133.5096 
+L 503.209844 133.5096 
+L 503.209844 104.1264 
+L 398.584844 104.1264 
 z
-" clip-path="url(#p724545c2c4)" style="fill: #fece7c; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd7bf6d5294)" style="fill: #fece7c; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 188.483359 162.8928 
-L 293.108359 162.8928 
-L 293.108359 133.5096 
-L 188.483359 133.5096 
+    <path d="M 189.334844 162.8928 
+L 293.959844 162.8928 
+L 293.959844 133.5096 
+L 189.334844 133.5096 
 z
-" clip-path="url(#p724545c2c4)" style="fill: #fee08b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd7bf6d5294)" style="fill: #fee08b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 293.108359 162.8928 
-L 397.733359 162.8928 
-L 397.733359 133.5096 
-L 293.108359 133.5096 
+    <path d="M 293.959844 162.8928 
+L 398.584844 162.8928 
+L 398.584844 133.5096 
+L 293.959844 133.5096 
 z
-" clip-path="url(#p724545c2c4)" style="fill: #feefa3; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd7bf6d5294)" style="fill: #feefa3; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 397.733359 162.8928 
-L 502.358359 162.8928 
-L 502.358359 133.5096 
-L 397.733359 133.5096 
+    <path d="M 398.584844 162.8928 
+L 503.209844 162.8928 
+L 503.209844 133.5096 
+L 398.584844 133.5096 
 z
-" clip-path="url(#p724545c2c4)" style="fill: #fdbf6f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd7bf6d5294)" style="fill: #fdbf6f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 188.483359 192.276 
-L 293.108359 192.276 
-L 293.108359 162.8928 
-L 188.483359 162.8928 
+    <path d="M 189.334844 192.276 
+L 293.959844 192.276 
+L 293.959844 162.8928 
+L 189.334844 162.8928 
 z
-" clip-path="url(#p724545c2c4)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd7bf6d5294)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 293.108359 192.276 
-L 397.733359 192.276 
-L 397.733359 162.8928 
-L 293.108359 162.8928 
+    <path d="M 293.959844 192.276 
+L 398.584844 192.276 
+L 398.584844 162.8928 
+L 293.959844 162.8928 
 z
-" clip-path="url(#p724545c2c4)" style="fill: #fede89; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd7bf6d5294)" style="fill: #fede89; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 397.733359 192.276 
-L 502.358359 192.276 
-L 502.358359 162.8928 
-L 397.733359 162.8928 
+    <path d="M 398.584844 192.276 
+L 503.209844 192.276 
+L 503.209844 162.8928 
+L 398.584844 162.8928 
 z
-" clip-path="url(#p724545c2c4)" style="fill: #f7814c; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd7bf6d5294)" style="fill: #f7814c; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 188.483359 221.6592 
-L 293.108359 221.6592 
-L 293.108359 192.276 
-L 188.483359 192.276 
+    <path d="M 189.334844 221.6592 
+L 293.959844 221.6592 
+L 293.959844 192.276 
+L 189.334844 192.276 
 z
-" clip-path="url(#p724545c2c4)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd7bf6d5294)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 293.108359 221.6592 
-L 397.733359 221.6592 
-L 397.733359 192.276 
-L 293.108359 192.276 
+    <path d="M 293.959844 221.6592 
+L 398.584844 221.6592 
+L 398.584844 192.276 
+L 293.959844 192.276 
 z
-" clip-path="url(#p724545c2c4)" style="fill: #fed27f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd7bf6d5294)" style="fill: #fed27f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 397.733359 221.6592 
-L 502.358359 221.6592 
-L 502.358359 192.276 
-L 397.733359 192.276 
+    <path d="M 398.584844 221.6592 
+L 503.209844 221.6592 
+L 503.209844 192.276 
+L 398.584844 192.276 
 z
-" clip-path="url(#p724545c2c4)" style="fill: #fffcba; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd7bf6d5294)" style="fill: #fffcba; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 188.483359 251.0424 
-L 293.108359 251.0424 
-L 293.108359 221.6592 
-L 188.483359 221.6592 
+    <path d="M 189.334844 251.0424 
+L 293.959844 251.0424 
+L 293.959844 221.6592 
+L 189.334844 221.6592 
 z
-" clip-path="url(#p724545c2c4)" style="fill: #feec9f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd7bf6d5294)" style="fill: #feec9f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 293.108359 251.0424 
-L 397.733359 251.0424 
-L 397.733359 221.6592 
-L 293.108359 221.6592 
+    <path d="M 293.959844 251.0424 
+L 398.584844 251.0424 
+L 398.584844 221.6592 
+L 293.959844 221.6592 
 z
-" clip-path="url(#p724545c2c4)" style="fill: #fed07e; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd7bf6d5294)" style="fill: #fed07e; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 397.733359 251.0424 
-L 502.358359 251.0424 
-L 502.358359 221.6592 
-L 397.733359 221.6592 
+    <path d="M 398.584844 251.0424 
+L 503.209844 251.0424 
+L 503.209844 221.6592 
+L 398.584844 221.6592 
 z
-" clip-path="url(#p724545c2c4)" style="fill: #feca79; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd7bf6d5294)" style="fill: #fec877; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 188.483359 280.4256 
-L 293.108359 280.4256 
-L 293.108359 251.0424 
-L 188.483359 251.0424 
+    <path d="M 189.334844 280.4256 
+L 293.959844 280.4256 
+L 293.959844 251.0424 
+L 189.334844 251.0424 
 z
-" clip-path="url(#p724545c2c4)" style="fill: #fff3ac; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd7bf6d5294)" style="fill: #fff3ac; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 293.108359 280.4256 
-L 397.733359 280.4256 
-L 397.733359 251.0424 
-L 293.108359 251.0424 
+    <path d="M 293.959844 280.4256 
+L 398.584844 280.4256 
+L 398.584844 251.0424 
+L 293.959844 251.0424 
 z
-" clip-path="url(#p724545c2c4)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd7bf6d5294)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 397.733359 280.4256 
-L 502.358359 280.4256 
-L 502.358359 251.0424 
-L 397.733359 251.0424 
+    <path d="M 398.584844 280.4256 
+L 503.209844 280.4256 
+L 503.209844 251.0424 
+L 398.584844 251.0424 
 z
-" clip-path="url(#p724545c2c4)" style="fill: #e8f59f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd7bf6d5294)" style="fill: #e8f59f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 188.483359 309.8088 
-L 293.108359 309.8088 
-L 293.108359 280.4256 
-L 188.483359 280.4256 
+    <path d="M 189.334844 309.8088 
+L 293.959844 309.8088 
+L 293.959844 280.4256 
+L 189.334844 280.4256 
 z
-" clip-path="url(#p724545c2c4)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd7bf6d5294)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 293.108359 309.8088 
-L 397.733359 309.8088 
-L 397.733359 280.4256 
-L 293.108359 280.4256 
+    <path d="M 293.959844 309.8088 
+L 398.584844 309.8088 
+L 398.584844 280.4256 
+L 293.959844 280.4256 
 z
-" clip-path="url(#p724545c2c4)" style="fill: #fa9b58; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd7bf6d5294)" style="fill: #fa9b58; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 397.733359 309.8088 
-L 502.358359 309.8088 
-L 502.358359 280.4256 
-L 397.733359 280.4256 
+    <path d="M 398.584844 309.8088 
+L 503.209844 309.8088 
+L 503.209844 280.4256 
+L 398.584844 280.4256 
 z
-" clip-path="url(#p724545c2c4)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd7bf6d5294)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 188.483359 339.192 
-L 293.108359 339.192 
-L 293.108359 309.8088 
-L 188.483359 309.8088 
+    <path d="M 189.334844 339.192 
+L 293.959844 339.192 
+L 293.959844 309.8088 
+L 189.334844 309.8088 
 z
-" clip-path="url(#p724545c2c4)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd7bf6d5294)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 293.108359 339.192 
-L 397.733359 339.192 
-L 397.733359 309.8088 
-L 293.108359 309.8088 
+    <path d="M 293.959844 339.192 
+L 398.584844 339.192 
+L 398.584844 309.8088 
+L 293.959844 309.8088 
 z
-" clip-path="url(#p724545c2c4)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd7bf6d5294)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 397.733359 339.192 
-L 502.358359 339.192 
-L 502.358359 309.8088 
-L 397.733359 309.8088 
+    <path d="M 398.584844 339.192 
+L 503.209844 339.192 
+L 503.209844 309.8088 
+L 398.584844 309.8088 
 z
-" clip-path="url(#p724545c2c4)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd7bf6d5294)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(121.470625 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(122.322109 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(228.754844 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(229.606328 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(307.326953 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(308.178438 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(405.678672 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(406.530156 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(117.408359 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(118.259844 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.320 -->
-    <g transform="translate(229.344609 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(230.196094 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -918,7 +918,7 @@ z
    </g>
    <g id="text_7">
     <!-- 117 -->
-    <g transform="translate(337.785859 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(338.637344 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -952,7 +952,7 @@ z
    </g>
    <g id="text_8">
     <!-- 852 -->
-    <g transform="translate(442.410859 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(443.262344 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -1026,7 +1026,7 @@ z
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(112.046484 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(112.897969 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1125,7 +1125,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.324 -->
-    <g transform="translate(229.344609 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(230.196094 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1156,7 +1156,7 @@ z
    </g>
    <g id="text_11">
     <!-- 61 -->
-    <g transform="translate(340.330859 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(341.182344 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -1195,7 +1195,7 @@ z
    </g>
    <g id="text_12">
     <!-- 312 -->
-    <g transform="translate(442.410859 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(443.262344 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
@@ -1203,7 +1203,7 @@ z
    </g>
    <g id="text_13">
     <!-- Go compress/flate -->
-    <g transform="translate(99.739609 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(100.591094 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -1374,7 +1374,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.325 -->
-    <g transform="translate(229.344609 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(230.196094 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1384,14 +1384,14 @@ z
    </g>
    <g id="text_15">
     <!-- 50 -->
-    <g transform="translate(340.330859 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(341.182344 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
     <!-- 275 -->
-    <g transform="translate(442.410859 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(443.262344 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
@@ -1399,7 +1399,7 @@ z
    </g>
    <g id="text_17">
     <!-- JS fflate -->
-    <g transform="translate(120.772109 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(121.623594 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1459,7 +1459,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.329 -->
-    <g transform="translate(229.344609 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(230.196094 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-39" d="M 703 97 
 L 703 672 
@@ -1501,14 +1501,14 @@ z
    </g>
    <g id="text_19">
     <!-- 41 -->
-    <g transform="translate(340.330859 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(341.182344 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
     <!-- 160 -->
-    <g transform="translate(442.410859 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(443.262344 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -1516,7 +1516,7 @@ z
    </g>
    <g id="text_21">
     <!-- zlib -->
-    <g transform="translate(129.309609 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(130.161094 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1540,7 +1540,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.323 -->
-    <g transform="translate(229.344609 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(230.196094 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1550,14 +1550,14 @@ z
    </g>
    <g id="text_23">
     <!-- 38 -->
-    <g transform="translate(340.330859 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(341.182344 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_24">
     <!-- 448 -->
-    <g transform="translate(442.410859 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(443.262344 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(127.246094 0)"/>
@@ -1565,7 +1565,7 @@ z
    </g>
    <g id="text_25">
     <!-- lean-zip (native) -->
-    <g transform="translate(99.117734 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(99.969219 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1674,7 +1674,7 @@ z
    </g>
    <g id="text_26">
     <!-- 0.323 -->
-    <g transform="translate(228.143984 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(228.995469 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1768,7 +1768,7 @@ z
    </g>
    <g id="text_27">
     <!-- 37 -->
-    <g transform="translate(339.854609 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(340.706094 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-37" d="M 428 4666 
 L 3944 4666 
@@ -1786,16 +1786,73 @@ z
     </g>
    </g>
    <g id="text_28">
-    <!-- 300 -->
-    <g transform="translate(441.696484 238.5583) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-Bold-33"/>
-     <use xlink:href="#DejaVuSans-Bold-30" transform="translate(69.580078 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-30" transform="translate(139.160156 0)"/>
+    <!-- 295 -->
+    <g transform="translate(442.547969 238.5583) scale(0.08 -0.08)">
+     <defs>
+      <path id="DejaVuSans-Bold-39" d="M 641 103 
+L 641 966 
+Q 928 831 1190 764 
+Q 1453 697 1709 697 
+Q 2247 697 2547 995 
+Q 2847 1294 2900 1881 
+Q 2688 1725 2447 1647 
+Q 2206 1569 1925 1569 
+Q 1209 1569 770 1986 
+Q 331 2403 331 3084 
+Q 331 3838 820 4291 
+Q 1309 4744 2131 4744 
+Q 3044 4744 3544 4128 
+Q 4044 3513 4044 2388 
+Q 4044 1231 3459 570 
+Q 2875 -91 1856 -91 
+Q 1528 -91 1228 -42 
+Q 928 6 641 103 
+z
+M 2125 2350 
+Q 2441 2350 2600 2554 
+Q 2759 2759 2759 3169 
+Q 2759 3575 2600 3781 
+Q 2441 3988 2125 3988 
+Q 1809 3988 1650 3781 
+Q 1491 3575 1491 3169 
+Q 1491 2759 1650 2554 
+Q 1809 2350 2125 2350 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-35" d="M 678 4666 
+L 3669 4666 
+L 3669 3781 
+L 1638 3781 
+L 1638 3059 
+Q 1775 3097 1914 3117 
+Q 2053 3138 2203 3138 
+Q 3056 3138 3531 2711 
+Q 4006 2284 4006 1522 
+Q 4006 766 3489 337 
+Q 2972 -91 2053 -91 
+Q 1656 -91 1267 -14 
+Q 878 63 494 219 
+L 494 1166 
+Q 875 947 1217 837 
+Q 1559 728 1863 728 
+Q 2300 728 2551 942 
+Q 2803 1156 2803 1522 
+Q 2803 1891 2551 2103 
+Q 2300 2316 1863 2316 
+Q 1603 2316 1309 2248 
+Q 1016 2181 678 2041 
+L 678 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-Bold-32"/>
+     <use xlink:href="#DejaVuSans-Bold-39" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-35" transform="translate(139.160156 0)"/>
     </g>
    </g>
    <g id="text_29">
     <!-- miniz_oxide -->
-    <g transform="translate(112.615859 267.83025) scale(0.08 -0.08)">
+    <g transform="translate(113.467344 267.83025) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6e" d="M 3513 2113 
 L 3513 0 
@@ -1854,7 +1911,7 @@ z
    </g>
    <g id="text_30">
     <!-- 0.322 -->
-    <g transform="translate(229.344609 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(230.196094 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1864,14 +1921,14 @@ z
    </g>
    <g id="text_31">
     <!-- 36 -->
-    <g transform="translate(340.330859 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(341.182344 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_32">
     <!-- 527 -->
-    <g transform="translate(442.410859 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(443.262344 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
@@ -1879,7 +1936,7 @@ z
    </g>
    <g id="text_33">
     <!-- OCaml decompress -->
-    <g transform="translate(97.232734 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(98.084219 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -1944,7 +2001,7 @@ z
    </g>
    <g id="text_34">
     <!-- 0.336 -->
-    <g transform="translate(229.344609 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(230.196094 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1954,21 +2011,21 @@ z
    </g>
    <g id="text_35">
     <!-- 21 -->
-    <g transform="translate(340.330859 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(341.182344 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_36">
     <!-- 69 -->
-    <g transform="translate(444.955859 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(445.807344 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-36"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(125.453984 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(126.305469 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -1979,7 +2036,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.303 -->
-    <g transform="translate(229.344609 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(230.196094 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1989,13 +2046,13 @@ z
    </g>
    <g id="text_39">
     <!-- 1 -->
-    <g transform="translate(342.875859 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(343.727344 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(446.045859 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(446.897344 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2011,7 +2068,7 @@ z
   </g>
   <g id="text_41">
    <!-- silesia — geomean over files, level 6 -->
-   <g transform="translate(152.960078 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(153.811563 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-2014" d="M 344 2156 
 L 6056 2156 
@@ -2155,7 +2212,7 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-07-08T20:16:47Z  ·  Linux chungus2 x86_64  ·  commit 74c19afa  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-07-08T21:41:55Z  ·  Linux chungus2 x86_64  ·  commit b17c222c  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2297,13 +2354,13 @@ z
     <use xlink:href="#DejaVuSans-38" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2343,110 +2400,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3254.101562 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3317.724609 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3381.347656 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3442.626953 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3477.832031 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3539.111328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3570.898438 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3602.685547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3634.472656 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3666.259766 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3698.046875 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3725.830078 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3787.353516 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3848.632812 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3912.011719 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3975.488281 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4014.351562 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4075.533203 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4134.712891 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4196.236328 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4237.349609 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4271.041016 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4298.824219 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4360.347656 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4421.626953 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4485.005859 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4548.628906 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4582.320312 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4641.5 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4705.123047 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4736.910156 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4800.533203 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4864.15625 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4895.943359 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4959.566406 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4995.650391 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5034.513672 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5089.494141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5153.117188 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5184.904297 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5216.691406 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5248.478516 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5280.265625 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5312.052734 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5351.261719 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5414.640625 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5453.503906 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5514.685547 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5578.064453 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5641.541016 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5704.919922 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5768.396484 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5831.775391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5870.984375 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5902.771484 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5986.560547 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6018.347656 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6115.759766 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6177.283203 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6240.759766 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6268.542969 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6329.822266 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6393.201172 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6424.988281 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6477.087891 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6540.466797 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6601.746094 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6665.222656 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6717.322266 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6780.701172 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6841.882812 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6881.091797 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6914.783203 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6946.570312 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6987.683594 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7048.962891 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7088.171875 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7115.955078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7177.136719 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7208.923828 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7236.707031 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7288.806641 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7320.59375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7384.070312 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7445.59375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7484.802734 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7546.326172 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7585.689453 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7683.101562 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7710.884766 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7774.263672 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7802.046875 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7854.146484 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7893.355469 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7921.138672 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3135.351562 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3198.974609 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3262.597656 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3317.578125 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3381.201172 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3444.824219 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3508.447266 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3563.427734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3595.214844 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3627.001953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3658.789062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3690.576172 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3722.363281 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3750.146484 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3811.669922 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3872.949219 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3936.328125 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3999.804688 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4038.667969 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4099.849609 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4159.029297 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4220.552734 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4261.666016 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4295.357422 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4323.140625 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4384.664062 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4445.943359 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4509.322266 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4572.945312 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4606.636719 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4665.816406 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4729.439453 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4761.226562 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4824.849609 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4888.472656 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4920.259766 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4983.882812 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5019.966797 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5058.830078 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5113.810547 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5177.433594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5209.220703 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5241.007812 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5272.794922 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5304.582031 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5336.369141 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5375.578125 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5438.957031 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5477.820312 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5539.001953 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5602.380859 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5665.857422 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5729.236328 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5792.712891 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5856.091797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5895.300781 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5927.087891 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6010.876953 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6042.664062 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6140.076172 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6201.599609 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6265.076172 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6292.859375 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6354.138672 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6417.517578 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6449.304688 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6501.404297 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6564.783203 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6626.0625 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6689.539062 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6741.638672 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6805.017578 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6866.199219 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6905.408203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6939.099609 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6970.886719 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7012 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7073.279297 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7112.488281 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7140.271484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7201.453125 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7233.240234 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7261.023438 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7313.123047 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7344.910156 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7408.386719 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7469.910156 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7509.119141 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7570.642578 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7610.005859 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7707.417969 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7735.201172 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7798.580078 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7826.363281 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7878.462891 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7917.671875 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7945.455078 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p724545c2c4">
-   <rect x="83.858359" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="pd7bf6d5294">
+   <rect x="84.709844" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/results/latest.json
+++ b/bench/results/latest.json
@@ -1,8 +1,8 @@
 {
  "meta": {
-  "date": "2026-07-08T20:16:47Z",
+  "date": "2026-07-08T21:41:55Z",
   "machine": "Linux chungus2 x86_64",
-  "git_commit": "74c19afa",
+  "git_commit": "b17c222c",
   "toolchain": "leanprover/lean4:v4.30.0-rc2",
   "note": "compress_mbps/decompress_mbps are a median-of-5 snapshot on the machine above; ratio is deterministic"
  },
@@ -14,8 +14,8 @@
    "level": 1,
    "out_size": 60455,
    "ratio": 0.3975,
-   "compress_mbps": 72.47,
-   "decompress_mbps": 215.57
+   "compress_mbps": 73.36,
+   "decompress_mbps": 214.85
   },
   {
    "compressor": "native",
@@ -24,8 +24,8 @@
    "level": 2,
    "out_size": 56316,
    "ratio": 0.3703,
-   "compress_mbps": 52.81,
-   "decompress_mbps": 247.29
+   "compress_mbps": 53.94,
+   "decompress_mbps": 245.86
   },
   {
    "compressor": "native",
@@ -34,8 +34,8 @@
    "level": 3,
    "out_size": 55646,
    "ratio": 0.3659,
-   "compress_mbps": 46.82,
-   "decompress_mbps": 269.96
+   "compress_mbps": 47.79,
+   "decompress_mbps": 269.89
   },
   {
    "compressor": "native",
@@ -44,8 +44,8 @@
    "level": 4,
    "out_size": 54357,
    "ratio": 0.3574,
-   "compress_mbps": 38.12,
-   "decompress_mbps": 271.96
+   "compress_mbps": 37.84,
+   "decompress_mbps": 272.09
   },
   {
    "compressor": "native",
@@ -54,8 +54,8 @@
    "level": 5,
    "out_size": 54078,
    "ratio": 0.3556,
-   "compress_mbps": 30.33,
-   "decompress_mbps": 272.47
+   "compress_mbps": 30.65,
+   "decompress_mbps": 271.89
   },
   {
    "compressor": "native",
@@ -64,8 +64,8 @@
    "level": 6,
    "out_size": 54013,
    "ratio": 0.3551,
-   "compress_mbps": 29.53,
-   "decompress_mbps": 281.05
+   "compress_mbps": 29.55,
+   "decompress_mbps": 279.77
   },
   {
    "compressor": "native",
@@ -74,8 +74,8 @@
    "level": 7,
    "out_size": 53772,
    "ratio": 0.3536,
-   "compress_mbps": 24.59,
-   "decompress_mbps": 281.21
+   "compress_mbps": 24.53,
+   "decompress_mbps": 279.88
   },
   {
    "compressor": "native",
@@ -84,8 +84,8 @@
    "level": 8,
    "out_size": 53753,
    "ratio": 0.3534,
-   "compress_mbps": 23.6,
-   "decompress_mbps": 281.79
+   "compress_mbps": 23.56,
+   "decompress_mbps": 281.47
   },
   {
    "compressor": "native",
@@ -94,8 +94,8 @@
    "level": 9,
    "out_size": 52732,
    "ratio": 0.3467,
-   "compress_mbps": 4.33,
-   "decompress_mbps": 280.83
+   "compress_mbps": 4.31,
+   "decompress_mbps": 281.59
   },
   {
    "compressor": "native",
@@ -114,8 +114,8 @@
    "level": 1,
    "out_size": 53135,
    "ratio": 0.4245,
-   "compress_mbps": 66.03,
-   "decompress_mbps": 208.12
+   "compress_mbps": 65.51,
+   "decompress_mbps": 207.86
   },
   {
    "compressor": "native",
@@ -124,8 +124,8 @@
    "level": 2,
    "out_size": 50187,
    "ratio": 0.4009,
-   "compress_mbps": 49.24,
-   "decompress_mbps": 226.76
+   "compress_mbps": 48.89,
+   "decompress_mbps": 226.61
   },
   {
    "compressor": "native",
@@ -134,8 +134,8 @@
    "level": 3,
    "out_size": 49810,
    "ratio": 0.3979,
-   "compress_mbps": 44.35,
-   "decompress_mbps": 248.22
+   "compress_mbps": 44.13,
+   "decompress_mbps": 247.72
   },
   {
    "compressor": "native",
@@ -144,8 +144,8 @@
    "level": 4,
    "out_size": 48687,
    "ratio": 0.3889,
-   "compress_mbps": 35.44,
-   "decompress_mbps": 251.36
+   "compress_mbps": 35.66,
+   "decompress_mbps": 251.14
   },
   {
    "compressor": "native",
@@ -154,8 +154,8 @@
    "level": 5,
    "out_size": 48586,
    "ratio": 0.3881,
-   "compress_mbps": 30.34,
-   "decompress_mbps": 251.45
+   "compress_mbps": 30.77,
+   "decompress_mbps": 250.39
   },
   {
    "compressor": "native",
@@ -164,8 +164,8 @@
    "level": 6,
    "out_size": 48373,
    "ratio": 0.3864,
-   "compress_mbps": 28.14,
-   "decompress_mbps": 254.54
+   "compress_mbps": 28.34,
+   "decompress_mbps": 254.23
   },
   {
    "compressor": "native",
@@ -174,8 +174,8 @@
    "level": 7,
    "out_size": 48287,
    "ratio": 0.3857,
-   "compress_mbps": 25.44,
-   "decompress_mbps": 256.44
+   "compress_mbps": 25.66,
+   "decompress_mbps": 255.41
   },
   {
    "compressor": "native",
@@ -184,8 +184,8 @@
    "level": 8,
    "out_size": 48284,
    "ratio": 0.3857,
-   "compress_mbps": 25.17,
-   "decompress_mbps": 256.31
+   "compress_mbps": 25.34,
+   "decompress_mbps": 256.14
   },
   {
    "compressor": "native",
@@ -194,8 +194,8 @@
    "level": 9,
    "out_size": 47433,
    "ratio": 0.3789,
-   "compress_mbps": 4.65,
-   "decompress_mbps": 256.34
+   "compress_mbps": 4.69,
+   "decompress_mbps": 253.99
   },
   {
    "compressor": "native",
@@ -204,7 +204,7 @@
    "level": 10,
    "out_size": 46866,
    "ratio": 0.3744,
-   "compress_mbps": 2.82,
+   "compress_mbps": 2.84,
    "decompress_mbps": null
   },
   {
@@ -214,8 +214,8 @@
    "level": 1,
    "out_size": 8476,
    "ratio": 0.3445,
-   "compress_mbps": 65.24,
-   "decompress_mbps": 274.06
+   "compress_mbps": 65.35,
+   "decompress_mbps": 272.1
   },
   {
    "compressor": "native",
@@ -224,8 +224,8 @@
    "level": 2,
    "out_size": 8271,
    "ratio": 0.3362,
-   "compress_mbps": 54.72,
-   "decompress_mbps": 282.9
+   "compress_mbps": 55.0,
+   "decompress_mbps": 282.32
   },
   {
    "compressor": "native",
@@ -234,8 +234,8 @@
    "level": 3,
    "out_size": 8159,
    "ratio": 0.3316,
-   "compress_mbps": 52.89,
-   "decompress_mbps": 287.68
+   "compress_mbps": 53.27,
+   "decompress_mbps": 287.59
   },
   {
    "compressor": "native",
@@ -244,8 +244,8 @@
    "level": 4,
    "out_size": 7948,
    "ratio": 0.3231,
-   "compress_mbps": 49.98,
-   "decompress_mbps": 291.77
+   "compress_mbps": 50.05,
+   "decompress_mbps": 295.37
   },
   {
    "compressor": "native",
@@ -254,8 +254,8 @@
    "level": 5,
    "out_size": 7899,
    "ratio": 0.3211,
-   "compress_mbps": 42.09,
-   "decompress_mbps": 302.4
+   "compress_mbps": 42.6,
+   "decompress_mbps": 303.12
   },
   {
    "compressor": "native",
@@ -264,8 +264,8 @@
    "level": 6,
    "out_size": 7912,
    "ratio": 0.3216,
-   "compress_mbps": 41.35,
-   "decompress_mbps": 301.69
+   "compress_mbps": 41.97,
+   "decompress_mbps": 301.6
   },
   {
    "compressor": "native",
@@ -274,8 +274,8 @@
    "level": 7,
    "out_size": 7897,
    "ratio": 0.321,
-   "compress_mbps": 37.38,
-   "decompress_mbps": 307.39
+   "compress_mbps": 37.73,
+   "decompress_mbps": 306.48
   },
   {
    "compressor": "native",
@@ -284,8 +284,8 @@
    "level": 8,
    "out_size": 7897,
    "ratio": 0.321,
-   "compress_mbps": 37.38,
-   "decompress_mbps": 306.91
+   "compress_mbps": 37.79,
+   "decompress_mbps": 307.17
   },
   {
    "compressor": "native",
@@ -294,8 +294,8 @@
    "level": 9,
    "out_size": 7803,
    "ratio": 0.3172,
-   "compress_mbps": 4.96,
-   "decompress_mbps": 306.94
+   "compress_mbps": 5.02,
+   "decompress_mbps": 305.88
   },
   {
    "compressor": "native",
@@ -304,7 +304,7 @@
    "level": 10,
    "out_size": 7737,
    "ratio": 0.3145,
-   "compress_mbps": 2.95,
+   "compress_mbps": 2.99,
    "decompress_mbps": null
   },
   {
@@ -314,8 +314,8 @@
    "level": 1,
    "out_size": 3509,
    "ratio": 0.3147,
-   "compress_mbps": 49.58,
-   "decompress_mbps": 185.62
+   "compress_mbps": 48.96,
+   "decompress_mbps": 186.64
   },
   {
    "compressor": "native",
@@ -324,8 +324,8 @@
    "level": 2,
    "out_size": 3269,
    "ratio": 0.2932,
-   "compress_mbps": 43.31,
-   "decompress_mbps": 187.57
+   "compress_mbps": 43.94,
+   "decompress_mbps": 188.52
   },
   {
    "compressor": "native",
@@ -334,8 +334,8 @@
    "level": 3,
    "out_size": 3209,
    "ratio": 0.2878,
-   "compress_mbps": 42.43,
-   "decompress_mbps": 191.57
+   "compress_mbps": 42.78,
+   "decompress_mbps": 192.66
   },
   {
    "compressor": "native",
@@ -344,8 +344,8 @@
    "level": 4,
    "out_size": 3128,
    "ratio": 0.2805,
-   "compress_mbps": 41.83,
-   "decompress_mbps": 195.9
+   "compress_mbps": 42.45,
+   "decompress_mbps": 196.82
   },
   {
    "compressor": "native",
@@ -354,8 +354,8 @@
    "level": 5,
    "out_size": 3112,
    "ratio": 0.2791,
-   "compress_mbps": 37.35,
-   "decompress_mbps": 196.51
+   "compress_mbps": 37.95,
+   "decompress_mbps": 197.2
   },
   {
    "compressor": "native",
@@ -364,8 +364,8 @@
    "level": 6,
    "out_size": 3120,
    "ratio": 0.2798,
-   "compress_mbps": 37.6,
-   "decompress_mbps": 197.43
+   "compress_mbps": 38.34,
+   "decompress_mbps": 198.37
   },
   {
    "compressor": "native",
@@ -374,8 +374,8 @@
    "level": 7,
    "out_size": 3112,
    "ratio": 0.2791,
-   "compress_mbps": 35.17,
-   "decompress_mbps": 197.41
+   "compress_mbps": 35.6,
+   "decompress_mbps": 198.26
   },
   {
    "compressor": "native",
@@ -384,8 +384,8 @@
    "level": 8,
    "out_size": 3112,
    "ratio": 0.2791,
-   "compress_mbps": 34.97,
-   "decompress_mbps": 197.3
+   "compress_mbps": 35.57,
+   "decompress_mbps": 198.67
   },
   {
    "compressor": "native",
@@ -394,8 +394,8 @@
    "level": 9,
    "out_size": 3056,
    "ratio": 0.2741,
-   "compress_mbps": 5.55,
-   "decompress_mbps": 197.99
+   "compress_mbps": 5.54,
+   "decompress_mbps": 198.66
   },
   {
    "compressor": "native",
@@ -414,8 +414,8 @@
    "level": 1,
    "out_size": 1283,
    "ratio": 0.3448,
-   "compress_mbps": 24.8,
-   "decompress_mbps": 84.67
+   "compress_mbps": 24.96,
+   "decompress_mbps": 84.91
   },
   {
    "compressor": "native",
@@ -424,8 +424,8 @@
    "level": 2,
    "out_size": 1225,
    "ratio": 0.3292,
-   "compress_mbps": 23.64,
-   "decompress_mbps": 85.98
+   "compress_mbps": 23.99,
+   "decompress_mbps": 86.0
   },
   {
    "compressor": "native",
@@ -434,8 +434,8 @@
    "level": 3,
    "out_size": 1222,
    "ratio": 0.3284,
-   "compress_mbps": 23.28,
-   "decompress_mbps": 85.74
+   "compress_mbps": 23.67,
+   "decompress_mbps": 85.96
   },
   {
    "compressor": "native",
@@ -444,8 +444,8 @@
    "level": 4,
    "out_size": 1213,
    "ratio": 0.326,
-   "compress_mbps": 23.55,
-   "decompress_mbps": 85.94
+   "compress_mbps": 23.9,
+   "decompress_mbps": 86.17
   },
   {
    "compressor": "native",
@@ -454,8 +454,8 @@
    "level": 5,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 22.86,
-   "decompress_mbps": 86.44
+   "compress_mbps": 23.23,
+   "decompress_mbps": 86.56
   },
   {
    "compressor": "native",
@@ -464,8 +464,8 @@
    "level": 6,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 22.38,
-   "decompress_mbps": 86.61
+   "compress_mbps": 22.84,
+   "decompress_mbps": 86.62
   },
   {
    "compressor": "native",
@@ -474,8 +474,8 @@
    "level": 7,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 22.23,
-   "decompress_mbps": 86.67
+   "compress_mbps": 22.67,
+   "decompress_mbps": 86.75
   },
   {
    "compressor": "native",
@@ -484,8 +484,8 @@
    "level": 8,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 22.19,
-   "decompress_mbps": 86.69
+   "compress_mbps": 22.62,
+   "decompress_mbps": 86.7
   },
   {
    "compressor": "native",
@@ -494,8 +494,8 @@
    "level": 9,
    "out_size": 1205,
    "ratio": 0.3238,
-   "compress_mbps": 5.01,
-   "decompress_mbps": 86.82
+   "compress_mbps": 5.05,
+   "decompress_mbps": 86.49
   },
   {
    "compressor": "native",
@@ -504,7 +504,7 @@
    "level": 10,
    "out_size": 1191,
    "ratio": 0.3201,
-   "compress_mbps": 3.0,
+   "compress_mbps": 3.02,
    "decompress_mbps": null
   },
   {
@@ -514,8 +514,8 @@
    "level": 1,
    "out_size": 251793,
    "ratio": 0.2445,
-   "compress_mbps": 142.7,
-   "decompress_mbps": 398.89
+   "compress_mbps": 143.62,
+   "decompress_mbps": 396.59
   },
   {
    "compressor": "native",
@@ -524,8 +524,8 @@
    "level": 2,
    "out_size": 242565,
    "ratio": 0.2356,
-   "compress_mbps": 108.81,
-   "decompress_mbps": 429.1
+   "compress_mbps": 108.65,
+   "decompress_mbps": 428.96
   },
   {
    "compressor": "native",
@@ -534,8 +534,8 @@
    "level": 3,
    "out_size": 242532,
    "ratio": 0.2355,
-   "compress_mbps": 90.12,
-   "decompress_mbps": 456.94
+   "compress_mbps": 90.94,
+   "decompress_mbps": 454.73
   },
   {
    "compressor": "native",
@@ -544,8 +544,8 @@
    "level": 4,
    "out_size": 239953,
    "ratio": 0.233,
-   "compress_mbps": 98.05,
-   "decompress_mbps": 485.1
+   "compress_mbps": 95.98,
+   "decompress_mbps": 482.68
   },
   {
    "compressor": "native",
@@ -554,8 +554,8 @@
    "level": 5,
    "out_size": 218565,
    "ratio": 0.2123,
-   "compress_mbps": 60.82,
-   "decompress_mbps": 467.89
+   "compress_mbps": 53.29,
+   "decompress_mbps": 466.02
   },
   {
    "compressor": "native",
@@ -564,8 +564,8 @@
    "level": 6,
    "out_size": 202718,
    "ratio": 0.1969,
-   "compress_mbps": 46.08,
-   "decompress_mbps": 485.57
+   "compress_mbps": 41.62,
+   "decompress_mbps": 484.78
   },
   {
    "compressor": "native",
@@ -574,8 +574,8 @@
    "level": 7,
    "out_size": 201435,
    "ratio": 0.1956,
-   "compress_mbps": 32.75,
-   "decompress_mbps": 489.68
+   "compress_mbps": 30.31,
+   "decompress_mbps": 490.42
   },
   {
    "compressor": "native",
@@ -584,8 +584,8 @@
    "level": 8,
    "out_size": 200825,
    "ratio": 0.195,
-   "compress_mbps": 24.03,
-   "decompress_mbps": 498.49
+   "compress_mbps": 22.38,
+   "decompress_mbps": 496.91
   },
   {
    "compressor": "native",
@@ -594,8 +594,8 @@
    "level": 9,
    "out_size": 182511,
    "ratio": 0.1772,
-   "compress_mbps": 3.54,
-   "decompress_mbps": 498.32
+   "compress_mbps": 3.45,
+   "decompress_mbps": 497.51
   },
   {
    "compressor": "native",
@@ -604,7 +604,7 @@
    "level": 10,
    "out_size": 178069,
    "ratio": 0.1729,
-   "compress_mbps": 1.48,
+   "compress_mbps": 1.47,
    "decompress_mbps": null
   },
   {
@@ -614,8 +614,8 @@
    "level": 1,
    "out_size": 160674,
    "ratio": 0.3765,
-   "compress_mbps": 78.72,
-   "decompress_mbps": 224.31
+   "compress_mbps": 79.06,
+   "decompress_mbps": 224.13
   },
   {
    "compressor": "native",
@@ -624,8 +624,8 @@
    "level": 2,
    "out_size": 149787,
    "ratio": 0.351,
-   "compress_mbps": 56.67,
-   "decompress_mbps": 243.23
+   "compress_mbps": 56.61,
+   "decompress_mbps": 242.59
   },
   {
    "compressor": "native",
@@ -634,8 +634,8 @@
    "level": 3,
    "out_size": 148055,
    "ratio": 0.3469,
-   "compress_mbps": 50.06,
-   "decompress_mbps": 271.04
+   "compress_mbps": 49.74,
+   "decompress_mbps": 270.37
   },
   {
    "compressor": "native",
@@ -644,8 +644,8 @@
    "level": 4,
    "out_size": 144750,
    "ratio": 0.3392,
-   "compress_mbps": 41.38,
-   "decompress_mbps": 273.9
+   "compress_mbps": 41.12,
+   "decompress_mbps": 273.1
   },
   {
    "compressor": "native",
@@ -654,8 +654,8 @@
    "level": 5,
    "out_size": 144408,
    "ratio": 0.3384,
-   "compress_mbps": 32.9,
-   "decompress_mbps": 274.81
+   "compress_mbps": 33.32,
+   "decompress_mbps": 273.04
   },
   {
    "compressor": "native",
@@ -664,8 +664,8 @@
    "level": 6,
    "out_size": 144071,
    "ratio": 0.3376,
-   "compress_mbps": 31.92,
-   "decompress_mbps": 280.37
+   "compress_mbps": 32.07,
+   "decompress_mbps": 278.79
   },
   {
    "compressor": "native",
@@ -674,8 +674,8 @@
    "level": 7,
    "out_size": 143631,
    "ratio": 0.3366,
-   "compress_mbps": 26.69,
-   "decompress_mbps": 280.71
+   "compress_mbps": 26.74,
+   "decompress_mbps": 278.62
   },
   {
    "compressor": "native",
@@ -684,8 +684,8 @@
    "level": 8,
    "out_size": 143573,
    "ratio": 0.3364,
-   "compress_mbps": 25.78,
-   "decompress_mbps": 280.7
+   "compress_mbps": 25.4,
+   "decompress_mbps": 279.84
   },
   {
    "compressor": "native",
@@ -694,8 +694,8 @@
    "level": 9,
    "out_size": 140323,
    "ratio": 0.3288,
-   "compress_mbps": 4.24,
-   "decompress_mbps": 280.13
+   "compress_mbps": 4.27,
+   "decompress_mbps": 280.11
   },
   {
    "compressor": "native",
@@ -704,7 +704,7 @@
    "level": 10,
    "out_size": 138833,
    "ratio": 0.3253,
-   "compress_mbps": 2.52,
+   "compress_mbps": 2.53,
    "decompress_mbps": null
   },
   {
@@ -714,8 +714,8 @@
    "level": 1,
    "out_size": 212588,
    "ratio": 0.4412,
-   "compress_mbps": 66.37,
-   "decompress_mbps": 193.08
+   "compress_mbps": 66.44,
+   "decompress_mbps": 192.88
   },
   {
    "compressor": "native",
@@ -724,8 +724,8 @@
    "level": 2,
    "out_size": 199981,
    "ratio": 0.415,
-   "compress_mbps": 48.31,
-   "decompress_mbps": 216.67
+   "compress_mbps": 47.91,
+   "decompress_mbps": 216.35
   },
   {
    "compressor": "native",
@@ -734,8 +734,8 @@
    "level": 3,
    "out_size": 198551,
    "ratio": 0.4121,
-   "compress_mbps": 42.51,
-   "decompress_mbps": 239.54
+   "compress_mbps": 42.28,
+   "decompress_mbps": 237.61
   },
   {
    "compressor": "native",
@@ -744,8 +744,8 @@
    "level": 4,
    "out_size": 193783,
    "ratio": 0.4022,
-   "compress_mbps": 31.9,
-   "decompress_mbps": 242.06
+   "compress_mbps": 31.92,
+   "decompress_mbps": 241.87
   },
   {
    "compressor": "native",
@@ -754,8 +754,8 @@
    "level": 5,
    "out_size": 193223,
    "ratio": 0.401,
-   "compress_mbps": 26.63,
-   "decompress_mbps": 238.55
+   "compress_mbps": 26.79,
+   "decompress_mbps": 238.11
   },
   {
    "compressor": "native",
@@ -764,8 +764,8 @@
    "level": 6,
    "out_size": 193415,
    "ratio": 0.4014,
-   "compress_mbps": 26.97,
-   "decompress_mbps": 242.61
+   "compress_mbps": 27.04,
+   "decompress_mbps": 241.93
   },
   {
    "compressor": "native",
@@ -774,8 +774,8 @@
    "level": 7,
    "out_size": 192664,
    "ratio": 0.3998,
-   "compress_mbps": 22.48,
-   "decompress_mbps": 243.09
+   "compress_mbps": 22.31,
+   "decompress_mbps": 242.64
   },
   {
    "compressor": "native",
@@ -784,8 +784,8 @@
    "level": 8,
    "out_size": 192638,
    "ratio": 0.3998,
-   "compress_mbps": 21.79,
-   "decompress_mbps": 242.66
+   "compress_mbps": 21.62,
+   "decompress_mbps": 242.37
   },
   {
    "compressor": "native",
@@ -794,8 +794,8 @@
    "level": 9,
    "out_size": 189368,
    "ratio": 0.393,
-   "compress_mbps": 4.03,
-   "decompress_mbps": 242.67
+   "compress_mbps": 4.04,
+   "decompress_mbps": 242.09
   },
   {
    "compressor": "native",
@@ -814,8 +814,8 @@
    "level": 1,
    "out_size": 60161,
    "ratio": 0.1172,
-   "compress_mbps": 229.23,
-   "decompress_mbps": 590.21
+   "compress_mbps": 230.09,
+   "decompress_mbps": 589.85
   },
   {
    "compressor": "native",
@@ -824,8 +824,8 @@
    "level": 2,
    "out_size": 58873,
    "ratio": 0.1147,
-   "compress_mbps": 171.45,
-   "decompress_mbps": 618.89
+   "compress_mbps": 171.55,
+   "decompress_mbps": 614.48
   },
   {
    "compressor": "native",
@@ -834,8 +834,8 @@
    "level": 3,
    "out_size": 58327,
    "ratio": 0.1137,
-   "compress_mbps": 148.97,
-   "decompress_mbps": 649.2
+   "compress_mbps": 149.2,
+   "decompress_mbps": 645.07
   },
   {
    "compressor": "native",
@@ -844,8 +844,8 @@
    "level": 4,
    "out_size": 55586,
    "ratio": 0.1083,
-   "compress_mbps": 121.3,
-   "decompress_mbps": 665.09
+   "compress_mbps": 120.91,
+   "decompress_mbps": 664.38
   },
   {
    "compressor": "native",
@@ -854,8 +854,8 @@
    "level": 5,
    "out_size": 55097,
    "ratio": 0.1074,
-   "compress_mbps": 93.21,
-   "decompress_mbps": 693.48
+   "compress_mbps": 89.96,
+   "decompress_mbps": 687.13
   },
   {
    "compressor": "native",
@@ -864,8 +864,8 @@
    "level": 6,
    "out_size": 55199,
    "ratio": 0.1076,
-   "compress_mbps": 70.84,
-   "decompress_mbps": 712.22
+   "compress_mbps": 69.56,
+   "decompress_mbps": 708.05
   },
   {
    "compressor": "native",
@@ -874,8 +874,8 @@
    "level": 7,
    "out_size": 54313,
    "ratio": 0.1058,
-   "compress_mbps": 57.62,
-   "decompress_mbps": 728.31
+   "compress_mbps": 54.67,
+   "decompress_mbps": 723.5
   },
   {
    "compressor": "native",
@@ -884,8 +884,8 @@
    "level": 8,
    "out_size": 53095,
    "ratio": 0.1035,
-   "compress_mbps": 47.32,
-   "decompress_mbps": 748.77
+   "compress_mbps": 43.97,
+   "decompress_mbps": 748.02
   },
   {
    "compressor": "native",
@@ -894,8 +894,8 @@
    "level": 9,
    "out_size": 52603,
    "ratio": 0.1025,
-   "compress_mbps": 6.06,
-   "decompress_mbps": 764.87
+   "compress_mbps": 5.81,
+   "decompress_mbps": 761.53
   },
   {
    "compressor": "native",
@@ -904,7 +904,7 @@
    "level": 10,
    "out_size": 52236,
    "ratio": 0.1018,
-   "compress_mbps": 3.89,
+   "compress_mbps": 3.8,
    "decompress_mbps": null
   },
   {
@@ -914,8 +914,8 @@
    "level": 1,
    "out_size": 14249,
    "ratio": 0.3726,
-   "compress_mbps": 59.9,
-   "decompress_mbps": 240.94
+   "compress_mbps": 59.35,
+   "decompress_mbps": 241.26
   },
   {
    "compressor": "native",
@@ -924,8 +924,8 @@
    "level": 2,
    "out_size": 13825,
    "ratio": 0.3615,
-   "compress_mbps": 52.06,
-   "decompress_mbps": 248.13
+   "compress_mbps": 51.79,
+   "decompress_mbps": 248.29
   },
   {
    "compressor": "native",
@@ -934,8 +934,8 @@
    "level": 3,
    "out_size": 13751,
    "ratio": 0.3596,
-   "compress_mbps": 50.04,
-   "decompress_mbps": 250.37
+   "compress_mbps": 49.9,
+   "decompress_mbps": 248.96
   },
   {
    "compressor": "native",
@@ -944,8 +944,8 @@
    "level": 4,
    "out_size": 13290,
    "ratio": 0.3475,
-   "compress_mbps": 46.84,
-   "decompress_mbps": 258.22
+   "compress_mbps": 45.86,
+   "decompress_mbps": 256.7
   },
   {
    "compressor": "native",
@@ -954,8 +954,8 @@
    "level": 5,
    "out_size": 13244,
    "ratio": 0.3463,
-   "compress_mbps": 40.94,
-   "decompress_mbps": 268.68
+   "compress_mbps": 39.73,
+   "decompress_mbps": 268.75
   },
   {
    "compressor": "native",
@@ -964,8 +964,8 @@
    "level": 6,
    "out_size": 12946,
    "ratio": 0.3385,
-   "compress_mbps": 22.19,
-   "decompress_mbps": 270.86
+   "compress_mbps": 22.04,
+   "decompress_mbps": 271.96
   },
   {
    "compressor": "native",
@@ -974,8 +974,8 @@
    "level": 7,
    "out_size": 12930,
    "ratio": 0.3381,
-   "compress_mbps": 20.05,
-   "decompress_mbps": 274.19
+   "compress_mbps": 19.66,
+   "decompress_mbps": 274.29
   },
   {
    "compressor": "native",
@@ -984,8 +984,8 @@
    "level": 8,
    "out_size": 12922,
    "ratio": 0.3379,
-   "compress_mbps": 18.59,
-   "decompress_mbps": 273.31
+   "compress_mbps": 17.97,
+   "decompress_mbps": 274.98
   },
   {
    "compressor": "native",
@@ -994,8 +994,8 @@
    "level": 9,
    "out_size": 12427,
    "ratio": 0.325,
-   "compress_mbps": 5.59,
-   "decompress_mbps": 277.74
+   "compress_mbps": 5.43,
+   "decompress_mbps": 275.89
   },
   {
    "compressor": "native",
@@ -1004,7 +1004,7 @@
    "level": 10,
    "out_size": 12273,
    "ratio": 0.3209,
-   "compress_mbps": 3.16,
+   "compress_mbps": 3.1,
    "decompress_mbps": null
   },
   {
@@ -1014,8 +1014,8 @@
    "level": 1,
    "out_size": 1800,
    "ratio": 0.4258,
-   "compress_mbps": 26.62,
-   "decompress_mbps": 92.75
+   "compress_mbps": 26.32,
+   "decompress_mbps": 91.8
   },
   {
    "compressor": "native",
@@ -1024,8 +1024,8 @@
    "level": 2,
    "out_size": 1750,
    "ratio": 0.414,
-   "compress_mbps": 25.25,
-   "decompress_mbps": 92.81
+   "compress_mbps": 25.0,
+   "decompress_mbps": 92.0
   },
   {
    "compressor": "native",
@@ -1034,8 +1034,8 @@
    "level": 3,
    "out_size": 1742,
    "ratio": 0.4121,
-   "compress_mbps": 25.14,
-   "decompress_mbps": 92.66
+   "compress_mbps": 24.84,
+   "decompress_mbps": 91.98
   },
   {
    "compressor": "native",
@@ -1044,8 +1044,8 @@
    "level": 4,
    "out_size": 1726,
    "ratio": 0.4083,
-   "compress_mbps": 25.29,
-   "decompress_mbps": 93.91
+   "compress_mbps": 25.2,
+   "decompress_mbps": 93.12
   },
   {
    "compressor": "native",
@@ -1054,8 +1054,8 @@
    "level": 5,
    "out_size": 1722,
    "ratio": 0.4074,
-   "compress_mbps": 24.96,
-   "decompress_mbps": 94.03
+   "compress_mbps": 24.9,
+   "decompress_mbps": 93.28
   },
   {
    "compressor": "native",
@@ -1064,8 +1064,8 @@
    "level": 6,
    "out_size": 1722,
    "ratio": 0.4074,
-   "compress_mbps": 23.91,
-   "decompress_mbps": 94.07
+   "compress_mbps": 23.92,
+   "decompress_mbps": 93.35
   },
   {
    "compressor": "native",
@@ -1074,8 +1074,8 @@
    "level": 7,
    "out_size": 1722,
    "ratio": 0.4074,
-   "compress_mbps": 24.03,
-   "decompress_mbps": 94.03
+   "compress_mbps": 23.97,
+   "decompress_mbps": 93.41
   },
   {
    "compressor": "native",
@@ -1084,8 +1084,8 @@
    "level": 8,
    "out_size": 1722,
    "ratio": 0.4074,
-   "compress_mbps": 24.03,
-   "decompress_mbps": 93.96
+   "compress_mbps": 23.95,
+   "decompress_mbps": 93.42
   },
   {
    "compressor": "native",
@@ -1095,7 +1095,7 @@
    "out_size": 1708,
    "ratio": 0.4041,
    "compress_mbps": 5.51,
-   "decompress_mbps": 94.08
+   "decompress_mbps": 93.57
   },
   {
    "compressor": "native",
@@ -1104,7 +1104,7 @@
    "level": 10,
    "out_size": 1693,
    "ratio": 0.4005,
-   "compress_mbps": 3.35,
+   "compress_mbps": 3.29,
    "decompress_mbps": null
   },
   {
@@ -4414,8 +4414,8 @@
    "level": 1,
    "out_size": 4259644,
    "ratio": 0.4179,
-   "compress_mbps": 69.24,
-   "decompress_mbps": 197.55
+   "compress_mbps": 69.75,
+   "decompress_mbps": 196.01
   },
   {
    "compressor": "native",
@@ -4424,8 +4424,8 @@
    "level": 2,
    "out_size": 3977395,
    "ratio": 0.3902,
-   "compress_mbps": 49.92,
-   "decompress_mbps": 217.69
+   "compress_mbps": 49.97,
+   "decompress_mbps": 216.73
   },
   {
    "compressor": "native",
@@ -4434,8 +4434,8 @@
    "level": 3,
    "out_size": 3945296,
    "ratio": 0.3871,
-   "compress_mbps": 44.12,
-   "decompress_mbps": 241.04
+   "compress_mbps": 44.14,
+   "decompress_mbps": 240.23
   },
   {
    "compressor": "native",
@@ -4444,8 +4444,8 @@
    "level": 4,
    "out_size": 3851998,
    "ratio": 0.3779,
-   "compress_mbps": 34.47,
-   "decompress_mbps": 240.67
+   "compress_mbps": 34.57,
+   "decompress_mbps": 240.46
   },
   {
    "compressor": "native",
@@ -4454,8 +4454,8 @@
    "level": 5,
    "out_size": 3840481,
    "ratio": 0.3768,
-   "compress_mbps": 28.66,
-   "decompress_mbps": 238.47
+   "compress_mbps": 28.99,
+   "decompress_mbps": 239.27
   },
   {
    "compressor": "native",
@@ -4464,8 +4464,8 @@
    "level": 6,
    "out_size": 3847942,
    "ratio": 0.3775,
-   "compress_mbps": 28.97,
-   "decompress_mbps": 243.15
+   "compress_mbps": 29.2,
+   "decompress_mbps": 242.87
   },
   {
    "compressor": "native",
@@ -4474,8 +4474,8 @@
    "level": 7,
    "out_size": 3834801,
    "ratio": 0.3762,
-   "compress_mbps": 23.94,
-   "decompress_mbps": 244.05
+   "compress_mbps": 24.17,
+   "decompress_mbps": 243.5
   },
   {
    "compressor": "native",
@@ -4484,8 +4484,8 @@
    "level": 8,
    "out_size": 3833946,
    "ratio": 0.3762,
-   "compress_mbps": 23.14,
-   "decompress_mbps": 241.5
+   "compress_mbps": 23.34,
+   "decompress_mbps": 244.88
   },
   {
    "compressor": "native",
@@ -4494,8 +4494,8 @@
    "level": 9,
    "out_size": 3766619,
    "ratio": 0.3696,
-   "compress_mbps": 4.17,
-   "decompress_mbps": 255.07
+   "compress_mbps": 4.16,
+   "decompress_mbps": 254.77
   },
   {
    "compressor": "native",
@@ -4504,7 +4504,7 @@
    "level": 10,
    "out_size": 3711208,
    "ratio": 0.3641,
-   "compress_mbps": 2.47,
+   "compress_mbps": 2.48,
    "decompress_mbps": null
   },
   {
@@ -4514,8 +4514,8 @@
    "level": 1,
    "out_size": 21267086,
    "ratio": 0.4152,
-   "compress_mbps": 86.07,
-   "decompress_mbps": 212.26
+   "compress_mbps": 85.71,
+   "decompress_mbps": 213.41
   },
   {
    "compressor": "native",
@@ -4524,8 +4524,8 @@
    "level": 2,
    "out_size": 20802983,
    "ratio": 0.4061,
-   "compress_mbps": 68.26,
-   "decompress_mbps": 226.86
+   "compress_mbps": 68.35,
+   "decompress_mbps": 226.45
   },
   {
    "compressor": "native",
@@ -4534,8 +4534,8 @@
    "level": 3,
    "out_size": 20665485,
    "ratio": 0.4035,
-   "compress_mbps": 63.82,
-   "decompress_mbps": 236.42
+   "compress_mbps": 63.53,
+   "decompress_mbps": 235.02
   },
   {
    "compressor": "native",
@@ -4544,8 +4544,8 @@
    "level": 4,
    "out_size": 20356893,
    "ratio": 0.3974,
-   "compress_mbps": 55.1,
-   "decompress_mbps": 244.36
+   "compress_mbps": 54.43,
+   "decompress_mbps": 245.49
   },
   {
    "compressor": "native",
@@ -4554,8 +4554,8 @@
    "level": 5,
    "out_size": 20209289,
    "ratio": 0.3946,
-   "compress_mbps": 43.17,
-   "decompress_mbps": 245.96
+   "compress_mbps": 41.23,
+   "decompress_mbps": 247.69
   },
   {
    "compressor": "native",
@@ -4564,8 +4564,8 @@
    "level": 6,
    "out_size": 19175370,
    "ratio": 0.3744,
-   "compress_mbps": 30.07,
-   "decompress_mbps": 257.02
+   "compress_mbps": 29.74,
+   "decompress_mbps": 256.92
   },
   {
    "compressor": "native",
@@ -4574,8 +4574,8 @@
    "level": 7,
    "out_size": 19128614,
    "ratio": 0.3735,
-   "compress_mbps": 24.46,
-   "decompress_mbps": 258.05
+   "compress_mbps": 23.68,
+   "decompress_mbps": 258.69
   },
   {
    "compressor": "native",
@@ -4584,8 +4584,8 @@
    "level": 8,
    "out_size": 19118971,
    "ratio": 0.3733,
-   "compress_mbps": 20.82,
-   "decompress_mbps": 259.25
+   "compress_mbps": 20.36,
+   "decompress_mbps": 258.52
   },
   {
    "compressor": "native",
@@ -4594,8 +4594,8 @@
    "level": 9,
    "out_size": 18688252,
    "ratio": 0.3649,
-   "compress_mbps": 4.49,
-   "decompress_mbps": 260.43
+   "compress_mbps": 4.41,
+   "decompress_mbps": 260.56
   },
   {
    "compressor": "native",
@@ -4604,7 +4604,7 @@
    "level": 10,
    "out_size": 18541040,
    "ratio": 0.362,
-   "compress_mbps": 2.37,
+   "compress_mbps": 2.36,
    "decompress_mbps": null
   },
   {
@@ -4614,8 +4614,8 @@
    "level": 1,
    "out_size": 3864163,
    "ratio": 0.3876,
-   "compress_mbps": 86.26,
-   "decompress_mbps": 239.94
+   "compress_mbps": 86.1,
+   "decompress_mbps": 242.61
   },
   {
    "compressor": "native",
@@ -4624,8 +4624,8 @@
    "level": 2,
    "out_size": 3734957,
    "ratio": 0.3746,
-   "compress_mbps": 66.18,
-   "decompress_mbps": 252.25
+   "compress_mbps": 66.02,
+   "decompress_mbps": 248.15
   },
   {
    "compressor": "native",
@@ -4634,8 +4634,8 @@
    "level": 3,
    "out_size": 3708443,
    "ratio": 0.3719,
-   "compress_mbps": 56.24,
-   "decompress_mbps": 262.93
+   "compress_mbps": 56.28,
+   "decompress_mbps": 264.0
   },
   {
    "compressor": "native",
@@ -4644,8 +4644,8 @@
    "level": 4,
    "out_size": 3683603,
    "ratio": 0.3694,
-   "compress_mbps": 41.73,
-   "decompress_mbps": 250.34
+   "compress_mbps": 41.15,
+   "decompress_mbps": 249.92
   },
   {
    "compressor": "native",
@@ -4654,8 +4654,8 @@
    "level": 5,
    "out_size": 3677014,
    "ratio": 0.3688,
-   "compress_mbps": 33.77,
-   "decompress_mbps": 241.46
+   "compress_mbps": 33.15,
+   "decompress_mbps": 241.95
   },
   {
    "compressor": "native",
@@ -4664,8 +4664,8 @@
    "level": 6,
    "out_size": 3588296,
    "ratio": 0.3599,
-   "compress_mbps": 31.09,
-   "decompress_mbps": 248.69
+   "compress_mbps": 30.77,
+   "decompress_mbps": 249.94
   },
   {
    "compressor": "native",
@@ -4674,8 +4674,8 @@
    "level": 7,
    "out_size": 3581081,
    "ratio": 0.3592,
-   "compress_mbps": 25.37,
-   "decompress_mbps": 252.07
+   "compress_mbps": 25.19,
+   "decompress_mbps": 251.64
   },
   {
    "compressor": "native",
@@ -4684,8 +4684,8 @@
    "level": 8,
    "out_size": 3581042,
    "ratio": 0.3592,
-   "compress_mbps": 23.88,
-   "decompress_mbps": 257.27
+   "compress_mbps": 23.54,
+   "decompress_mbps": 258.41
   },
   {
    "compressor": "native",
@@ -4694,8 +4694,8 @@
    "level": 9,
    "out_size": 3581643,
    "ratio": 0.3592,
-   "compress_mbps": 4.89,
-   "decompress_mbps": 268.11
+   "compress_mbps": 4.83,
+   "decompress_mbps": 268.25
   },
   {
    "compressor": "native",
@@ -4704,7 +4704,7 @@
    "level": 10,
    "out_size": 3513006,
    "ratio": 0.3523,
-   "compress_mbps": 2.97,
+   "compress_mbps": 2.96,
    "decompress_mbps": null
   },
   {
@@ -4714,8 +4714,8 @@
    "level": 1,
    "out_size": 3785443,
    "ratio": 0.1128,
-   "compress_mbps": 263.43,
-   "decompress_mbps": 656.39
+   "compress_mbps": 262.19,
+   "decompress_mbps": 676.78
   },
   {
    "compressor": "native",
@@ -4724,8 +4724,8 @@
    "level": 2,
    "out_size": 3761560,
    "ratio": 0.1121,
-   "compress_mbps": 168.66,
-   "decompress_mbps": 752.81
+   "compress_mbps": 166.31,
+   "decompress_mbps": 752.3
   },
   {
    "compressor": "native",
@@ -4734,8 +4734,8 @@
    "level": 3,
    "out_size": 3606997,
    "ratio": 0.1075,
-   "compress_mbps": 144.92,
-   "decompress_mbps": 836.45
+   "compress_mbps": 142.89,
+   "decompress_mbps": 833.8
   },
   {
    "compressor": "native",
@@ -4744,8 +4744,8 @@
    "level": 4,
    "out_size": 3201209,
    "ratio": 0.0954,
-   "compress_mbps": 136.66,
-   "decompress_mbps": 846.94
+   "compress_mbps": 135.92,
+   "decompress_mbps": 849.82
   },
   {
    "compressor": "native",
@@ -4754,8 +4754,8 @@
    "level": 5,
    "out_size": 3091564,
    "ratio": 0.0921,
-   "compress_mbps": 98.66,
-   "decompress_mbps": 924.16
+   "compress_mbps": 94.19,
+   "decompress_mbps": 923.95
   },
   {
    "compressor": "native",
@@ -4764,8 +4764,8 @@
    "level": 6,
    "out_size": 3112786,
    "ratio": 0.0928,
-   "compress_mbps": 95.42,
-   "decompress_mbps": 977.35
+   "compress_mbps": 91.9,
+   "decompress_mbps": 907.05
   },
   {
    "compressor": "native",
@@ -4774,8 +4774,8 @@
    "level": 7,
    "out_size": 3062338,
    "ratio": 0.0913,
-   "compress_mbps": 70.88,
-   "decompress_mbps": 995.74
+   "compress_mbps": 67.77,
+   "decompress_mbps": 991.7
   },
   {
    "compressor": "native",
@@ -4784,8 +4784,8 @@
    "level": 8,
    "out_size": 3045373,
    "ratio": 0.0908,
-   "compress_mbps": 58.87,
-   "decompress_mbps": 1001.72
+   "compress_mbps": 55.62,
+   "decompress_mbps": 995.47
   },
   {
    "compressor": "native",
@@ -4794,8 +4794,8 @@
    "level": 9,
    "out_size": 3031645,
    "ratio": 0.0904,
-   "compress_mbps": 3.57,
-   "decompress_mbps": 1018.25
+   "compress_mbps": 3.56,
+   "decompress_mbps": 1014.58
   },
   {
    "compressor": "native",
@@ -4814,8 +4814,8 @@
    "level": 1,
    "out_size": 3357083,
    "ratio": 0.5457,
-   "compress_mbps": 60.27,
-   "decompress_mbps": 148.3
+   "compress_mbps": 60.55,
+   "decompress_mbps": 148.57
   },
   {
    "compressor": "native",
@@ -4824,8 +4824,8 @@
    "level": 2,
    "out_size": 3285077,
    "ratio": 0.534,
-   "compress_mbps": 49.56,
-   "decompress_mbps": 148.97
+   "compress_mbps": 49.75,
+   "decompress_mbps": 148.58
   },
   {
    "compressor": "native",
@@ -4834,8 +4834,8 @@
    "level": 3,
    "out_size": 3272746,
    "ratio": 0.532,
-   "compress_mbps": 47.5,
-   "decompress_mbps": 157.94
+   "compress_mbps": 47.34,
+   "decompress_mbps": 158.19
   },
   {
    "compressor": "native",
@@ -4844,8 +4844,8 @@
    "level": 4,
    "out_size": 3228052,
    "ratio": 0.5247,
-   "compress_mbps": 41.16,
-   "decompress_mbps": 168.7
+   "compress_mbps": 40.8,
+   "decompress_mbps": 165.48
   },
   {
    "compressor": "native",
@@ -4854,8 +4854,8 @@
    "level": 5,
    "out_size": 3223415,
    "ratio": 0.5239,
-   "compress_mbps": 37.18,
-   "decompress_mbps": 171.48
+   "compress_mbps": 36.76,
+   "decompress_mbps": 171.47
   },
   {
    "compressor": "native",
@@ -4864,8 +4864,8 @@
    "level": 6,
    "out_size": 3159592,
    "ratio": 0.5136,
-   "compress_mbps": 27.0,
-   "decompress_mbps": 173.76
+   "compress_mbps": 26.91,
+   "decompress_mbps": 173.78
   },
   {
    "compressor": "native",
@@ -4874,8 +4874,8 @@
    "level": 7,
    "out_size": 3156403,
    "ratio": 0.5131,
-   "compress_mbps": 24.73,
-   "decompress_mbps": 173.77
+   "compress_mbps": 24.68,
+   "decompress_mbps": 173.93
   },
   {
    "compressor": "native",
@@ -4884,8 +4884,8 @@
    "level": 8,
    "out_size": 3155458,
    "ratio": 0.5129,
-   "compress_mbps": 23.65,
-   "decompress_mbps": 174.72
+   "compress_mbps": 23.54,
+   "decompress_mbps": 174.11
   },
   {
    "compressor": "native",
@@ -4894,8 +4894,8 @@
    "level": 9,
    "out_size": 3049028,
    "ratio": 0.4956,
-   "compress_mbps": 5.17,
-   "decompress_mbps": 178.03
+   "compress_mbps": 5.21,
+   "decompress_mbps": 178.34
   },
   {
    "compressor": "native",
@@ -4914,8 +4914,8 @@
    "level": 1,
    "out_size": 3838828,
    "ratio": 0.3806,
-   "compress_mbps": 98.8,
-   "decompress_mbps": 265.98
+   "compress_mbps": 98.0,
+   "decompress_mbps": 265.65
   },
   {
    "compressor": "native",
@@ -4924,8 +4924,8 @@
    "level": 2,
    "out_size": 3792520,
    "ratio": 0.376,
-   "compress_mbps": 73.1,
-   "decompress_mbps": 274.52
+   "compress_mbps": 72.91,
+   "decompress_mbps": 274.45
   },
   {
    "compressor": "native",
@@ -4934,8 +4934,8 @@
    "level": 3,
    "out_size": 3783171,
    "ratio": 0.3751,
-   "compress_mbps": 69.97,
-   "decompress_mbps": 278.45
+   "compress_mbps": 70.01,
+   "decompress_mbps": 251.81
   },
   {
    "compressor": "native",
@@ -4944,8 +4944,8 @@
    "level": 4,
    "out_size": 3648458,
    "ratio": 0.3617,
-   "compress_mbps": 68.55,
-   "decompress_mbps": 294.61
+   "compress_mbps": 68.22,
+   "decompress_mbps": 277.36
   },
   {
    "compressor": "native",
@@ -4954,8 +4954,8 @@
    "level": 5,
    "out_size": 3648472,
    "ratio": 0.3617,
-   "compress_mbps": 63.36,
-   "decompress_mbps": 297.24
+   "compress_mbps": 63.07,
+   "decompress_mbps": 279.29
   },
   {
    "compressor": "native",
@@ -4964,8 +4964,8 @@
    "level": 6,
    "out_size": 3648595,
    "ratio": 0.3618,
-   "compress_mbps": 50.41,
-   "decompress_mbps": 307.62
+   "compress_mbps": 50.83,
+   "decompress_mbps": 287.32
   },
   {
    "compressor": "native",
@@ -4974,8 +4974,8 @@
    "level": 7,
    "out_size": 3648160,
    "ratio": 0.3617,
-   "compress_mbps": 50.25,
-   "decompress_mbps": 313.33
+   "compress_mbps": 50.63,
+   "decompress_mbps": 293.09
   },
   {
    "compressor": "native",
@@ -4984,8 +4984,8 @@
    "level": 8,
    "out_size": 3648156,
    "ratio": 0.3617,
-   "compress_mbps": 50.09,
-   "decompress_mbps": 313.9
+   "compress_mbps": 50.41,
+   "decompress_mbps": 293.06
   },
   {
    "compressor": "native",
@@ -4994,8 +4994,8 @@
    "level": 9,
    "out_size": 3648156,
    "ratio": 0.3617,
-   "compress_mbps": 6.14,
-   "decompress_mbps": 305.18
+   "compress_mbps": 6.12,
+   "decompress_mbps": 307.78
   },
   {
    "compressor": "native",
@@ -5004,7 +5004,7 @@
    "level": 10,
    "out_size": 3647385,
    "ratio": 0.3616,
-   "compress_mbps": 3.47,
+   "compress_mbps": 3.49,
    "decompress_mbps": null
   },
   {
@@ -5014,8 +5014,8 @@
    "level": 1,
    "out_size": 2254442,
    "ratio": 0.3402,
-   "compress_mbps": 89.9,
-   "decompress_mbps": 246.93
+   "compress_mbps": 89.19,
+   "decompress_mbps": 248.19
   },
   {
    "compressor": "native",
@@ -5024,8 +5024,8 @@
    "level": 2,
    "out_size": 2044843,
    "ratio": 0.3086,
-   "compress_mbps": 60.9,
-   "decompress_mbps": 267.33
+   "compress_mbps": 60.87,
+   "decompress_mbps": 268.11
   },
   {
    "compressor": "native",
@@ -5034,8 +5034,8 @@
    "level": 3,
    "out_size": 1992105,
    "ratio": 0.3006,
-   "compress_mbps": 49.51,
-   "decompress_mbps": 305.12
+   "compress_mbps": 48.01,
+   "decompress_mbps": 297.87
   },
   {
    "compressor": "native",
@@ -5044,8 +5044,8 @@
    "level": 4,
    "out_size": 1890729,
    "ratio": 0.2853,
-   "compress_mbps": 36.2,
-   "decompress_mbps": 298.88
+   "compress_mbps": 35.31,
+   "decompress_mbps": 293.59
   },
   {
    "compressor": "native",
@@ -5054,8 +5054,8 @@
    "level": 5,
    "out_size": 1858234,
    "ratio": 0.2804,
-   "compress_mbps": 23.17,
-   "decompress_mbps": 293.86
+   "compress_mbps": 22.63,
+   "decompress_mbps": 291.8
   },
   {
    "compressor": "native",
@@ -5064,8 +5064,8 @@
    "level": 6,
    "out_size": 1856238,
    "ratio": 0.2801,
-   "compress_mbps": 28.39,
-   "decompress_mbps": 308.81
+   "compress_mbps": 27.71,
+   "decompress_mbps": 299.45
   },
   {
    "compressor": "native",
@@ -5074,8 +5074,8 @@
    "level": 7,
    "out_size": 1823963,
    "ratio": 0.2752,
-   "compress_mbps": 17.76,
-   "decompress_mbps": 313.15
+   "compress_mbps": 17.25,
+   "decompress_mbps": 306.1
   },
   {
    "compressor": "native",
@@ -5084,8 +5084,8 @@
    "level": 8,
    "out_size": 1820116,
    "ratio": 0.2746,
-   "compress_mbps": 15.34,
-   "decompress_mbps": 314.57
+   "compress_mbps": 14.86,
+   "decompress_mbps": 312.52
   },
   {
    "compressor": "native",
@@ -5094,8 +5094,8 @@
    "level": 9,
    "out_size": 1773469,
    "ratio": 0.2676,
-   "compress_mbps": 2.97,
-   "decompress_mbps": 326.68
+   "compress_mbps": 2.96,
+   "decompress_mbps": 327.64
   },
   {
    "compressor": "native",
@@ -5104,7 +5104,7 @@
    "level": 10,
    "out_size": 1718509,
    "ratio": 0.2593,
-   "compress_mbps": 1.6,
+   "compress_mbps": 1.59,
    "decompress_mbps": null
   },
   {
@@ -5114,8 +5114,8 @@
    "level": 1,
    "out_size": 6406301,
    "ratio": 0.2965,
-   "compress_mbps": 118.24,
-   "decompress_mbps": 341.81
+   "compress_mbps": 118.66,
+   "decompress_mbps": 339.02
   },
   {
    "compressor": "native",
@@ -5124,8 +5124,8 @@
    "level": 2,
    "out_size": 6102377,
    "ratio": 0.2824,
-   "compress_mbps": 89.22,
-   "decompress_mbps": 360.22
+   "compress_mbps": 89.14,
+   "decompress_mbps": 360.08
   },
   {
    "compressor": "native",
@@ -5134,8 +5134,8 @@
    "level": 3,
    "out_size": 6022184,
    "ratio": 0.2787,
-   "compress_mbps": 81.04,
-   "decompress_mbps": 375.26
+   "compress_mbps": 80.78,
+   "decompress_mbps": 375.15
   },
   {
    "compressor": "native",
@@ -5144,8 +5144,8 @@
    "level": 4,
    "out_size": 5880892,
    "ratio": 0.2722,
-   "compress_mbps": 68.77,
-   "decompress_mbps": 392.38
+   "compress_mbps": 68.29,
+   "decompress_mbps": 392.07
   },
   {
    "compressor": "native",
@@ -5154,8 +5154,8 @@
    "level": 5,
    "out_size": 5834363,
    "ratio": 0.27,
-   "compress_mbps": 52.86,
-   "decompress_mbps": 401.54
+   "compress_mbps": 53.5,
+   "decompress_mbps": 400.85
   },
   {
    "compressor": "native",
@@ -5164,8 +5164,8 @@
    "level": 6,
    "out_size": 5409868,
    "ratio": 0.2504,
-   "compress_mbps": 43.97,
-   "decompress_mbps": 408.38
+   "compress_mbps": 44.53,
+   "decompress_mbps": 405.84
   },
   {
    "compressor": "native",
@@ -5174,8 +5174,8 @@
    "level": 7,
    "out_size": 5393825,
    "ratio": 0.2496,
-   "compress_mbps": 37.41,
-   "decompress_mbps": 407.56
+   "compress_mbps": 37.8,
+   "decompress_mbps": 405.24
   },
   {
    "compressor": "native",
@@ -5184,8 +5184,8 @@
    "level": 8,
    "out_size": 5390050,
    "ratio": 0.2495,
-   "compress_mbps": 34.84,
-   "decompress_mbps": 407.43
+   "compress_mbps": 35.06,
+   "decompress_mbps": 408.52
   },
   {
    "compressor": "native",
@@ -5194,8 +5194,8 @@
    "level": 9,
    "out_size": 5236015,
    "ratio": 0.2423,
-   "compress_mbps": 4.9,
-   "decompress_mbps": 411.82
+   "compress_mbps": 4.78,
+   "decompress_mbps": 410.47
   },
   {
    "compressor": "native",
@@ -5214,8 +5214,8 @@
    "level": 1,
    "out_size": 5612204,
    "ratio": 0.7739,
-   "compress_mbps": 50.44,
-   "decompress_mbps": 147.42
+   "compress_mbps": 50.36,
+   "decompress_mbps": 147.51
   },
   {
    "compressor": "native",
@@ -5224,8 +5224,8 @@
    "level": 2,
    "out_size": 5533875,
    "ratio": 0.7631,
-   "compress_mbps": 41.44,
-   "decompress_mbps": 155.03
+   "compress_mbps": 41.78,
+   "decompress_mbps": 152.66
   },
   {
    "compressor": "native",
@@ -5234,8 +5234,8 @@
    "level": 3,
    "out_size": 5522436,
    "ratio": 0.7615,
-   "compress_mbps": 39.15,
-   "decompress_mbps": 158.04
+   "compress_mbps": 39.32,
+   "decompress_mbps": 156.5
   },
   {
    "compressor": "native",
@@ -5244,8 +5244,8 @@
    "level": 4,
    "out_size": 5494383,
    "ratio": 0.7576,
-   "compress_mbps": 33.71,
-   "decompress_mbps": 164.08
+   "compress_mbps": 34.03,
+   "decompress_mbps": 163.09
   },
   {
    "compressor": "native",
@@ -5254,8 +5254,8 @@
    "level": 5,
    "out_size": 5489807,
    "ratio": 0.757,
-   "compress_mbps": 31.94,
-   "decompress_mbps": 160.54
+   "compress_mbps": 31.91,
+   "decompress_mbps": 160.41
   },
   {
    "compressor": "native",
@@ -5264,8 +5264,8 @@
    "level": 6,
    "out_size": 5470520,
    "ratio": 0.7544,
-   "compress_mbps": 24.15,
-   "decompress_mbps": 165.01
+   "compress_mbps": 24.42,
+   "decompress_mbps": 164.06
   },
   {
    "compressor": "native",
@@ -5274,8 +5274,8 @@
    "level": 7,
    "out_size": 5463682,
    "ratio": 0.7534,
-   "compress_mbps": 23.0,
-   "decompress_mbps": 162.7
+   "compress_mbps": 23.17,
+   "decompress_mbps": 161.72
   },
   {
    "compressor": "native",
@@ -5284,8 +5284,8 @@
    "level": 8,
    "out_size": 5463761,
    "ratio": 0.7534,
-   "compress_mbps": 22.78,
-   "decompress_mbps": 162.42
+   "compress_mbps": 22.87,
+   "decompress_mbps": 161.78
   },
   {
    "compressor": "native",
@@ -5294,8 +5294,8 @@
    "level": 9,
    "out_size": 5284606,
    "ratio": 0.7287,
-   "compress_mbps": 5.33,
-   "decompress_mbps": 163.38
+   "compress_mbps": 5.3,
+   "decompress_mbps": 162.8
   },
   {
    "compressor": "native",
@@ -5304,7 +5304,7 @@
    "level": 10,
    "out_size": 5262387,
    "ratio": 0.7257,
-   "compress_mbps": 3.68,
+   "compress_mbps": 3.71,
    "decompress_mbps": null
   },
   {
@@ -5314,8 +5314,8 @@
    "level": 1,
    "out_size": 13727247,
    "ratio": 0.3311,
-   "compress_mbps": 88.83,
-   "decompress_mbps": 252.78
+   "compress_mbps": 88.29,
+   "decompress_mbps": 252.25
   },
   {
    "compressor": "native",
@@ -5324,8 +5324,8 @@
    "level": 2,
    "out_size": 12940398,
    "ratio": 0.3121,
-   "compress_mbps": 66.01,
-   "decompress_mbps": 274.88
+   "compress_mbps": 65.85,
+   "decompress_mbps": 274.23
   },
   {
    "compressor": "native",
@@ -5334,8 +5334,8 @@
    "level": 3,
    "out_size": 12703756,
    "ratio": 0.3064,
-   "compress_mbps": 60.04,
-   "decompress_mbps": 295.44
+   "compress_mbps": 60.34,
+   "decompress_mbps": 293.83
   },
   {
    "compressor": "native",
@@ -5344,8 +5344,8 @@
    "level": 4,
    "out_size": 12177338,
    "ratio": 0.2937,
-   "compress_mbps": 49.55,
-   "decompress_mbps": 298.99
+   "compress_mbps": 49.33,
+   "decompress_mbps": 298.42
   },
   {
    "compressor": "native",
@@ -5354,8 +5354,8 @@
    "level": 5,
    "out_size": 12051075,
    "ratio": 0.2907,
-   "compress_mbps": 37.84,
-   "decompress_mbps": 303.44
+   "compress_mbps": 38.05,
+   "decompress_mbps": 302.5
   },
   {
    "compressor": "native",
@@ -5364,8 +5364,8 @@
    "level": 6,
    "out_size": 12103573,
    "ratio": 0.2919,
-   "compress_mbps": 39.23,
-   "decompress_mbps": 310.64
+   "compress_mbps": 39.53,
+   "decompress_mbps": 310.05
   },
   {
    "compressor": "native",
@@ -5374,8 +5374,8 @@
    "level": 7,
    "out_size": 12027976,
    "ratio": 0.2901,
-   "compress_mbps": 30.85,
-   "decompress_mbps": 312.53
+   "compress_mbps": 31.22,
+   "decompress_mbps": 298.48
   },
   {
    "compressor": "native",
@@ -5384,8 +5384,8 @@
    "level": 8,
    "out_size": 12019953,
    "ratio": 0.2899,
-   "compress_mbps": 28.95,
-   "decompress_mbps": 302.33
+   "compress_mbps": 29.09,
+   "decompress_mbps": 307.73
   },
   {
    "compressor": "native",
@@ -5394,8 +5394,8 @@
    "level": 9,
    "out_size": 11806641,
    "ratio": 0.2848,
-   "compress_mbps": 3.92,
-   "decompress_mbps": 313.72
+   "compress_mbps": 3.95,
+   "decompress_mbps": 313.49
   },
   {
    "compressor": "native",
@@ -5404,7 +5404,7 @@
    "level": 10,
    "out_size": 11636945,
    "ratio": 0.2807,
-   "compress_mbps": 2.04,
+   "compress_mbps": 2.05,
    "decompress_mbps": null
   },
   {
@@ -5414,8 +5414,8 @@
    "level": 1,
    "out_size": 6438176,
    "ratio": 0.7597,
-   "compress_mbps": 45.28,
-   "decompress_mbps": 143.99
+   "compress_mbps": 45.07,
+   "decompress_mbps": 144.31
   },
   {
    "compressor": "native",
@@ -5424,8 +5424,8 @@
    "level": 2,
    "out_size": 6392101,
    "ratio": 0.7543,
-   "compress_mbps": 43.19,
-   "decompress_mbps": 147.38
+   "compress_mbps": 43.45,
+   "decompress_mbps": 147.17
   },
   {
    "compressor": "native",
@@ -5434,8 +5434,8 @@
    "level": 3,
    "out_size": 6392124,
    "ratio": 0.7543,
-   "compress_mbps": 42.79,
-   "decompress_mbps": 149.34
+   "compress_mbps": 43.51,
+   "decompress_mbps": 149.1
   },
   {
    "compressor": "native",
@@ -5444,8 +5444,8 @@
    "level": 4,
    "out_size": 6360604,
    "ratio": 0.7506,
-   "compress_mbps": 40.05,
-   "decompress_mbps": 134.1
+   "compress_mbps": 40.85,
+   "decompress_mbps": 133.57
   },
   {
    "compressor": "native",
@@ -5454,8 +5454,8 @@
    "level": 5,
    "out_size": 6360567,
    "ratio": 0.7506,
-   "compress_mbps": 40.49,
-   "decompress_mbps": 136.23
+   "compress_mbps": 40.55,
+   "decompress_mbps": 135.72
   },
   {
    "compressor": "native",
@@ -5464,8 +5464,8 @@
    "level": 6,
    "out_size": 6271790,
    "ratio": 0.7401,
-   "compress_mbps": 20.26,
-   "decompress_mbps": 136.25
+   "compress_mbps": 20.41,
+   "decompress_mbps": 137.13
   },
   {
    "compressor": "native",
@@ -5474,8 +5474,8 @@
    "level": 7,
    "out_size": 6271785,
    "ratio": 0.7401,
-   "compress_mbps": 20.23,
-   "decompress_mbps": 136.46
+   "compress_mbps": 20.32,
+   "decompress_mbps": 137.49
   },
   {
    "compressor": "native",
@@ -5484,8 +5484,8 @@
    "level": 8,
    "out_size": 6271785,
    "ratio": 0.7401,
-   "compress_mbps": 20.26,
-   "decompress_mbps": 136.69
+   "compress_mbps": 20.39,
+   "decompress_mbps": 136.98
   },
   {
    "compressor": "native",
@@ -5494,8 +5494,8 @@
    "level": 9,
    "out_size": 5952975,
    "ratio": 0.7025,
-   "compress_mbps": 6.33,
-   "decompress_mbps": 140.23
+   "compress_mbps": 6.27,
+   "decompress_mbps": 140.45
   },
   {
    "compressor": "native",
@@ -5504,7 +5504,7 @@
    "level": 10,
    "out_size": 5849157,
    "ratio": 0.6902,
-   "compress_mbps": 4.54,
+   "compress_mbps": 4.48,
    "decompress_mbps": null
   },
   {
@@ -5514,8 +5514,8 @@
    "level": 1,
    "out_size": 858525,
    "ratio": 0.1606,
-   "compress_mbps": 195.8,
-   "decompress_mbps": 440.96
+   "compress_mbps": 195.56,
+   "decompress_mbps": 470.47
   },
   {
    "compressor": "native",
@@ -5524,8 +5524,8 @@
    "level": 2,
    "out_size": 846807,
    "ratio": 0.1584,
-   "compress_mbps": 126.56,
-   "decompress_mbps": 516.9
+   "compress_mbps": 126.91,
+   "decompress_mbps": 574.86
   },
   {
    "compressor": "native",
@@ -5534,8 +5534,8 @@
    "level": 3,
    "out_size": 806798,
    "ratio": 0.1509,
-   "compress_mbps": 115.9,
-   "decompress_mbps": 632.06
+   "compress_mbps": 115.49,
+   "decompress_mbps": 636.64
   },
   {
    "compressor": "native",
@@ -5544,8 +5544,8 @@
    "level": 4,
    "out_size": 717301,
    "ratio": 0.1342,
-   "compress_mbps": 100.79,
-   "decompress_mbps": 625.98
+   "compress_mbps": 100.72,
+   "decompress_mbps": 627.76
   },
   {
    "compressor": "native",
@@ -5554,8 +5554,8 @@
    "level": 5,
    "out_size": 701552,
    "ratio": 0.1312,
-   "compress_mbps": 76.12,
-   "decompress_mbps": 678.8
+   "compress_mbps": 76.54,
+   "decompress_mbps": 681.08
   },
   {
    "compressor": "native",
@@ -5564,8 +5564,8 @@
    "level": 6,
    "out_size": 678560,
    "ratio": 0.1269,
-   "compress_mbps": 72.04,
-   "decompress_mbps": 731.52
+   "compress_mbps": 72.84,
+   "decompress_mbps": 732.69
   },
   {
    "compressor": "native",
@@ -5574,8 +5574,8 @@
    "level": 7,
    "out_size": 663724,
    "ratio": 0.1242,
-   "compress_mbps": 56.53,
-   "decompress_mbps": 740.46
+   "compress_mbps": 56.7,
+   "decompress_mbps": 740.83
   },
   {
    "compressor": "native",
@@ -5584,8 +5584,8 @@
    "level": 8,
    "out_size": 660492,
    "ratio": 0.1236,
-   "compress_mbps": 49.52,
-   "decompress_mbps": 745.2
+   "compress_mbps": 49.47,
+   "decompress_mbps": 746.99
   },
   {
    "compressor": "native",
@@ -5594,8 +5594,8 @@
    "level": 9,
    "out_size": 659422,
    "ratio": 0.1234,
-   "compress_mbps": 4.64,
-   "decompress_mbps": 657.51
+   "compress_mbps": 4.55,
+   "decompress_mbps": 650.17
   },
   {
    "compressor": "native",


### PR DESCRIPTION
This PR passes the current match length as the initial best length of the lazy `pos+1` lookahead walk (zlib's `prev_length` seeding): below the walk's `niceLen` cutoff, the `scan_end` prefilter can then reject any candidate that cannot beat the pending match with a single byte compare, instead of paying a full `countMatch` extension; at or above the cutoff the walk stays unseeded (a seeded walk would early-stop and diverge). The output is proven byte-identical: `chainWalk_seed` (fuel induction on the reference walk) shows the seeded walk either reproduces the unseeded result or returns the seed itself, `lazyAcceptCost_of_le` shows a probe no longer than the current match is never accepted, and `seeded_probe_bridge` transports both through the packed USize walk into `mergedLoop_eq`, leaving every downstream theorem untouched. No `sorry`.

Measured (chungus2, pinned, interleaved A/B vs master): xml L6 +0.9%, dickens L6 +0.8%, wash at L4 (the `good_match` gate already skips most probes there) and on match-sparse binaries; byte-identical `out=` verified for {xml, dickens, mozilla, samba} × L4-L8. A modest but strictly free speed win; the seeding lemmas are also the proof machinery the planned hash3-singleton walk seeding reuses.

🤖 Prepared with Claude Code