### PR TITLE
perf: array-native two-queue Huffman tree build

### DIFF
--- a/Zip/Native/HuffmanEncode.lean
+++ b/Zip/Native/HuffmanEncode.lean
@@ -12,15 +12,33 @@ members) no longer pays the `O(n²)` `List.set`/`List.length` churn that
 `assignLengths` incurs, nor the allocator/reference-count traffic of the
 `List Nat` result the emitters immediately `toArray` anyway.
 
-The correspondence theorems (`computeCodeLengthsN_toList`,
-`computeCodeLengthsN_toArray`) prove the array pipeline yields exactly the spec
-`List`, so every downstream property of `computeCodeLengths` (length,
-`ValidLengths`, completeness, nonzero) transfers verbatim and the compressed
-output is byte-identical.
+The array pipeline uses an array-native **two-queue (van Leeuwen) Huffman tree
+build** (`huffTreeDepthsN`) in place of the spec's `List.mergeSort` +
+`insertByWeight` construction. The spec built the tree with `O(n²)` boxed list
+insertion and a `BuildTree` allocation per merge; on stat-shifting corpora the
+observation-divergence splitter cuts each member into hundreds of blocks, each
+paying two tree builds (~286-symbol lit + 30-symbol dist), so `insertByWeight`
+was the top compress profile entry. The two-queue build is `O(n)` over a sorted
+leaf array with no tree allocation: merged nodes are produced in non-decreasing
+weight order, so a second array + two head indices suffice, and leaf depths are
+recovered by a single reverse pass over parent pointers.
 
-The tree build (`limitedPairs`) is reused unchanged: only the leaf-depth
-histogram it feeds and the symbol→length assignment are array-native here. The
-`O(n²)` cost lived in `assignLengths`, not the merge.
+This is a **heuristic replacement** (route (b)): on weight ties the two-queue
+tree can differ from the insertion tree, so the emitted code lengths — and hence
+the compressed bytes — differ slightly from the spec pipeline, but only among
+equally optimal codes. The spec `computeCodeLengths`/`limitedPairs` stay untouched
+as the reference. What downstream consumers actually need — result size, every
+length in `[1, maxBits]` (`bounded`), the Kraft inequality (`ValidLengths`), and
+a nonzero length for every used symbol (`nonzero`) — depends only on the *shape*
+of the output (`symsByFreq.zip (expandBl bl ++ padding)` wrapped in
+`fixKraftList`), not on which histogram `bl` the build produces. So those
+properties are re-proved here for the list twin `computeCodeLengthsListN` by
+copying the spec proofs with `limitedPairs` swapped for `limitedPairsN`; the
+`fixKraftList`/`expandBl`/`assignLengths` infrastructure is shared verbatim.
+
+The capped-histogram Kraft repair (`cappedBlCount`/`repairBl`/`expandBl`) and the
+array symbol→length assignment (`assignLengthsN`) and Kraft fixup
+(`fixKraftListN`) are reused unchanged; only the tree build itself is new.
 -/
 
 namespace Huffman.Spec
@@ -75,12 +93,133 @@ theorem fixKraftListN_toList (lengths : Array Nat) (maxBits : Nat) :
   · rfl
   · simp only [Array.toList_map]
 
+/-! ## Array-native two-queue Huffman tree build
+
+`huffTreeDepthsN` replaces the spec's `mergeSort` + `insertByWeight` +
+`BuildTree.depths` with the van Leeuwen two-queue method over flat arrays. Nodes
+live in a single index space: leaves `0 .. n-1` (sorted ascending by weight),
+internal nodes `n .. 2n-2` created in non-decreasing weight order. A merge always
+combines the two smallest available among the leaf-queue front and the
+merged-queue front, so two head indices suffice — no per-merge allocation. Parent
+pointers always point to a *higher* index (the parent is created later), so a
+single reverse pass computes every node's depth. Only the leaf depths feed the
+shared `cappedBlCount`/`repairBl`/`expandBl` histogram pipeline.
+
+No property of this build is proved: the downstream proofs need only the *shape*
+of `limitedPairsN`'s output, which holds for any histogram (see the module
+docstring). Correctness here is a *ratio* concern (the build must be an optimal
+Huffman construction), validated by the corpus benchmark, not a *validity*
+concern (guaranteed by `fixKraftList`). -/
+
+/-- Select the smaller-weight node between the leaf-queue front (`leafHead`, valid
+    while `< n`) and the merged-queue front (`intHead`, valid while `< next`),
+    returning the chosen node index and the advanced head indices. Ties go to the
+    merged node (mirrors `insertByWeight` placing a merged node before equal-weight
+    leaves). The caller guarantees at least one queue is non-empty. -/
+def popMinNode (weight : Array Nat) (n leafHead intHead next : Nat) : Nat × Nat × Nat :=
+  if leafHead < n then
+    if intHead < next then
+      if weight[intHead]! ≤ weight[leafHead]! then (intHead, leafHead, intHead + 1)
+      else (leafHead, leafHead + 1, intHead)
+    else (leafHead, leafHead + 1, intHead)
+  else (intHead, leafHead, intHead + 1)
+
+/-- The merge loop: create internal node `next` (`n ≤ next ≤ 2n-2`) from the two
+    smallest available nodes, record their parent, and recurse. Threads `weight`
+    (destructively updated in place at RC 1) and `parent`; returns the completed
+    parent array once every internal node exists. -/
+def mergeLoopN (n : Nat) (weight parent : Array Nat) (leafHead intHead next : Nat) : Array Nat :=
+  if _h : next < 2 * n - 1 then
+    let (a, leafHead₁, intHead₁) := popMinNode weight n leafHead intHead next
+    let (b, leafHead₂, intHead₂) := popMinNode weight n leafHead₁ intHead₁ next
+    let weight := weight.set! next (weight[a]! + weight[b]!)
+    let parent := (parent.set! a next).set! b next
+    mergeLoopN n weight parent leafHead₂ intHead₂ (next + 1)
+  else
+    parent
+termination_by 2 * n - 1 - next
+decreasing_by omega
+
+/-- Fill leaf/internal depths bottom-up: process indices `i` down from the node
+    below the root, setting `depth[i] = depth[parent[i]] + 1`. Every non-root node
+    has `parent[i] > i` and the root (index `2n-2`, depth 0) is left as the array's
+    initial `0`, so each parent's depth is already set when its child is reached. -/
+def depthLoopN (parent depth : Array Nat) (i : Nat) : Array Nat :=
+  match i with
+  | 0 => depth.set! 0 (depth[parent[0]!]! + 1)
+  | i + 1 =>
+    depthLoopN parent (depth.set! (i + 1) (depth[parent[i + 1]!]! + 1)) i
+
+/-- Leaf depths of the two-queue Huffman tree over the nonzero `(symbol, freq)`
+    pairs, as `(0, depth)` pairs (the symbol slot is a placeholder — only the depth
+    multiset feeds `cappedBlCount`). Degenerate `≤ 1`-leaf inputs never reach here
+    on the multi-symbol path; they return a harmless empty/zero list. -/
+def huffTreeDepthsN (nz : List (Nat × Nat)) : List (Nat × Nat) :=
+  let leafW := (nz.map (·.2)).toArray.qsort (· < ·)
+  let n := leafW.size
+  if n ≤ 1 then []
+  else
+    let weight := leafW ++ Array.replicate (n - 1) 0
+    let parent := mergeLoopN n weight (Array.replicate (2 * n - 1) 0) 0 n n
+    let depth := depthLoopN parent (Array.replicate (2 * n - 1) 0) (2 * n - 3)
+    (List.range n).map (fun i => ((0 : Nat), depth[i]!))
+
+/-! ## Array-native `limitedPairs` twin
+
+`limitedPairsN` has the exact output shape of the spec `limitedPairs`
+(`symsByFreq.zip (expandBl bl ++ padding)`); only the histogram `bl` comes from
+the two-queue build instead of `buildHuffmanTree`. The shared `cappedBlCount` +
+`repairBl` cap-and-repair keeps the code length-limited and complete. -/
+
+/-- Array-native twin of `limitedPairs`: same frequency-sorted symbol list and
+    same `expandBl`-plus-padding shape, but the depth histogram comes from the
+    two-queue build (`huffTreeDepthsN`) rather than `buildHuffmanTree`. -/
+def limitedPairsN (nz : List (Nat × Nat)) (maxBits : Nat) : List (Nat × Nat) :=
+  let capped := cappedBlCount (huffTreeDepthsN nz) maxBits
+  let bl := repairBl capped (blKraft capped maxBits - 2 ^ maxBits) maxBits
+  let symsByFreq := (nz.mergeSort (fun a b => b.2 ≤ a.2)).map (·.1)
+  symsByFreq.zip (expandBl bl maxBits ++ List.replicate symsByFreq.length maxBits)
+
+/-- Every length in a `limitedPairsN` pair is in `[1, maxBits]` (shape fact, from
+    the padded `expandBl`). Copy of `limitedPairs_mem_range` — the histogram is
+    irrelevant. -/
+theorem limitedPairsN_mem_range (nz : List (Nat × Nat)) (maxBits : Nat) (hmb : maxBits ≥ 1) :
+    ∀ p ∈ limitedPairsN nz maxBits, 1 ≤ p.2 ∧ p.2 ≤ maxBits := by
+  intro p hp
+  simp only [limitedPairsN] at hp
+  obtain ⟨_, h2⟩ := List.of_mem_zip hp
+  rw [List.mem_append] at h2
+  cases h2 with
+  | inl h => exact expandBl_mem_range _ _ p.2 h
+  | inr h => rw [List.mem_replicate] at h; omega
+
+/-- The first components of `limitedPairsN` are exactly the frequency-sorted
+    symbols. Copy of `limitedPairs_map_fst`. -/
+theorem limitedPairsN_map_fst (nz : List (Nat × Nat)) (maxBits : Nat) :
+    (limitedPairsN nz maxBits).map Prod.fst
+      = (nz.mergeSort (fun a b => b.2 ≤ a.2)).map (·.1) := by
+  simp only [limitedPairsN]
+  apply List.map_fst_zip
+  rw [List.length_append, List.length_replicate]
+  omega
+
+/-- Every symbol with a nonzero frequency receives a pair in `limitedPairsN`.
+    Copy of `limitedPairs_covers`. -/
+theorem limitedPairsN_covers (nz : List (Nat × Nat)) (maxBits s : Nat)
+    (hs : s ∈ nz.map (·.1)) : ∃ p ∈ limitedPairsN nz maxBits, p.1 = s := by
+  have hs' : s ∈ (limitedPairsN nz maxBits).map Prod.fst := by
+    rw [limitedPairsN_map_fst]
+    exact ((List.mergeSort_perm nz _).map (·.1)).mem_iff.mpr hs
+  rw [List.mem_map] at hs'
+  obtain ⟨p, hp, hps⟩ := hs'
+  exact ⟨p, hp, hps⟩
+
 /-! ## Array-based code-length pipeline -/
 
-/-- Array twin of `computeCodeLengths`: same branch structure and same tree
-    build (`limitedPairs`), but the symbol→length assignment and Kraft fixup are
-    array-native. Returns the code lengths as an `Array Nat` directly, saving the
-    emitters the `List Nat → Array` round-trip. -/
+/-- Array twin of `computeCodeLengths`: same branch structure, but the tree build
+    is the array-native two-queue (`limitedPairsN`) and the symbol→length
+    assignment and Kraft fixup are array-native. Returns an `Array Nat` directly,
+    saving the emitters the `List Nat → Array` round-trip. -/
 def computeCodeLengthsN (freqs : List (Nat × Nat)) (numSymbols : Nat)
     (maxBits : Nat := 15) : Array Nat :=
   let nonzero := freqs.filter (fun (_, f) => f > 0)
@@ -89,30 +228,185 @@ def computeCodeLengthsN (freqs : List (Nat × Nat)) (numSymbols : Nat)
     let (sym, _) := nonzero.head!
     assignLengthsN [(sym, 1)] numSymbols
   else
-    fixKraftListN (assignLengthsN (limitedPairs nonzero maxBits) numSymbols) maxBits
+    fixKraftListN (assignLengthsN (limitedPairsN nonzero maxBits) numSymbols) maxBits
 
-/-- **Correspondence.** The array pipeline read back as a list is exactly the
-    spec `List` pipeline, so every property of `computeCodeLengths` transfers. -/
+/-- List twin of `computeCodeLengthsN`: identical to the spec `computeCodeLengths`
+    except the multi-symbol branch uses `limitedPairsN` (two-queue build). This is
+    the value `(computeCodeLengthsN …).toList` reduces to; its properties are the
+    spec ones with `limitedPairs` swapped for `limitedPairsN`. -/
+def computeCodeLengthsListN (freqs : List (Nat × Nat)) (numSymbols : Nat)
+    (maxBits : Nat := 15) : List Nat :=
+  let nonzero := freqs.filter (fun (_, f) => f > 0)
+  if nonzero.isEmpty then List.replicate numSymbols 0
+  else if nonzero.length == 1 then
+    let (sym, _) := nonzero.head!
+    assignLengths [(sym, 1)] numSymbols
+  else
+    fixKraftList (assignLengths (limitedPairsN nonzero maxBits) numSymbols) maxBits
+
+/-- **Correspondence.** The array pipeline read back as a list is the list twin
+    `computeCodeLengthsListN` (the array-native assignment/fixup are `toList`-equal
+    to the spec `List` ones; the two-queue build is shared verbatim). -/
 theorem computeCodeLengthsN_toList (freqs : List (Nat × Nat)) (numSymbols maxBits : Nat) :
     (computeCodeLengthsN freqs numSymbols maxBits).toList
-      = computeCodeLengths freqs numSymbols maxBits := by
-  simp only [computeCodeLengthsN, computeCodeLengths]
+      = computeCodeLengthsListN freqs numSymbols maxBits := by
+  simp only [computeCodeLengthsN, computeCodeLengthsListN]
   split
   · exact Array.toList_replicate ..
   · split
     · exact assignLengthsN_toList ..
     · rw [fixKraftListN_toList, assignLengthsN_toList]
 
-/-- The array pipeline is the `toArray` of the spec `List` pipeline: the form
-    the emitters (which immediately `toArray`) consume. -/
+/-- The array pipeline is the `toArray` of the list twin. -/
 theorem computeCodeLengthsN_toArray (freqs : List (Nat × Nat)) (numSymbols maxBits : Nat) :
     computeCodeLengthsN freqs numSymbols maxBits
-      = (computeCodeLengths freqs numSymbols maxBits).toArray := by
+      = (computeCodeLengthsListN freqs numSymbols maxBits).toArray := by
   rw [← computeCodeLengthsN_toList, Array.toArray_toList]
+
+/-- `computeCodeLengthsListN` produces a list of length `numSymbols`. Copy of
+    `computeCodeLengths_length` (histogram-independent). -/
+theorem computeCodeLengthsListN_length (freqs : List (Nat × Nat)) (n maxBits : Nat) :
+    (computeCodeLengthsListN freqs n maxBits).length = n := by
+  simp only [computeCodeLengthsListN]
+  split
+  · exact List.length_replicate ..
+  · split
+    · exact assignLengths_length ..
+    · simp only [fixKraftList]
+      split
+      · exact assignLengths_length ..
+      · simp only [List.length_map]; exact assignLengths_length ..
 
 /-- `computeCodeLengthsN` produces an array of size `numSymbols`. -/
 theorem computeCodeLengthsN_size (freqs : List (Nat × Nat)) (numSymbols maxBits : Nat) :
     (computeCodeLengthsN freqs numSymbols maxBits).size = numSymbols := by
-  rw [← Array.length_toList, computeCodeLengthsN_toList, computeCodeLengths_length]
+  rw [← Array.length_toList, computeCodeLengthsN_toList, computeCodeLengthsListN_length]
+
+/-! ## Properties of the list twin
+
+The two-queue build only changes the *multi-symbol* branch (`limitedPairsN` vs
+`limitedPairs`); the empty and single-symbol branches are byte-for-byte identical
+to the spec `computeCodeLengths`. So each property is proved by delegating the
+non-multi branches to the (public) spec lemma via `..._eq_of_small`, and proving
+only the multi branch directly from the `limitedPairsN` shape facts
+(`_mem_range`, `_covers`) — the same facts the spec proof uses. The tree-dependent
+completeness (`computeCodeLengths_complete`) is *not* reproved: it is not consumed
+downstream, and a heuristic build need not produce the same complete code. -/
+
+/-- On non-multi inputs (`< 2` nonzero-frequency symbols) the two-queue twin is
+    exactly the spec `computeCodeLengths`: the differing `limitedPairsN`/`limitedPairs`
+    branch is unreachable, and the empty/single branches are identical. Used to
+    delegate the empty/single-symbol `ValidLengths` to the spec (whose proof needs
+    the file-private single-symbol Kraft lemmas). -/
+theorem computeCodeLengthsListN_eq_of_small (freqs : List (Nat × Nat)) (n maxBits : Nat)
+    (h : (freqs.filter (fun (_, f) => f > 0)).length < 2) :
+    computeCodeLengthsListN freqs n maxBits = computeCodeLengths freqs n maxBits := by
+  have h' : (freqs.filter (fun x => decide (x.2 > 0))).length < 2 := h
+  simp only [computeCodeLengthsListN, computeCodeLengths]
+  split
+  · rfl
+  · split
+    · rfl
+    · rename_i h1 h2
+      simp only [List.isEmpty_iff_length_eq_zero] at h1
+      simp only [beq_iff_eq] at h2
+      omega
+
+/-- On multi-symbol inputs (`≥ 2` nonzero-frequency symbols) the two-queue twin
+    reduces to its `fixKraftList ∘ assignLengths ∘ limitedPairsN` form: the
+    empty/single branches are excluded. Lets the shape-based property proofs work
+    on the concrete `limitedPairsN` term. -/
+theorem computeCodeLengthsListN_multi (freqs : List (Nat × Nat)) (n maxBits : Nat)
+    (h : 2 ≤ (freqs.filter (fun (_, f) => f > 0)).length) :
+    computeCodeLengthsListN freqs n maxBits
+      = fixKraftList (assignLengths
+          (limitedPairsN (freqs.filter (fun x => decide (x.2 > 0))) maxBits) n) maxBits := by
+  have h' : 2 ≤ (freqs.filter (fun x => decide (x.2 > 0))).length := h
+  simp only [computeCodeLengthsListN]
+  split
+  · rename_i he; simp only [List.isEmpty_iff_length_eq_zero] at he; omega
+  · split
+    · rename_i hs1; simp only [beq_iff_eq] at hs1; omega
+    · rfl
+
+/-- All lengths are `≤ maxBits`. Copy of `computeCodeLengths_bounded` with
+    `limitedPairs → limitedPairsN` (uses only the shared shape lemma
+    `limitedPairsN_mem_range`). -/
+theorem computeCodeLengthsListN_bounded (freqs : List (Nat × Nat)) (n maxBits : Nat)
+    (hmb : maxBits > 0) :
+    ∀ l ∈ computeCodeLengthsListN freqs n maxBits, l ≤ maxBits := by
+  simp only [computeCodeLengthsListN]
+  split
+  · intro l hl; have := List.eq_of_mem_replicate hl; omega
+  · split
+    · apply assignLengths_bounded
+      intro p hp
+      cases hp with
+      | head => omega
+      | tail _ h => contradiction
+    · apply fixKraftList_bounded
+      apply assignLengths_bounded
+      intro p hp
+      exact (limitedPairsN_mem_range _ maxBits hmb p hp).2
+
+/-- The lengths satisfy `ValidLengths`. The multi-symbol branch is proved directly
+    from the shape (`fixKraftList_kraft` needs only `length ≤ 2^maxBits`); the
+    empty/single branches delegate to `computeCodeLengths_valid` via
+    `computeCodeLengthsListN_eq_of_small`. -/
+theorem computeCodeLengthsListN_valid (freqs : List (Nat × Nat)) (n : Nat)
+    (maxBits : Nat) (hmb : maxBits > 0) (hn : n ≤ 2 ^ maxBits) :
+    ValidLengths (computeCodeLengthsListN freqs n maxBits) maxBits := by
+  by_cases hmulti : 2 ≤ (freqs.filter (fun (_, f) => f > 0)).length
+  · refine ⟨computeCodeLengthsListN_bounded freqs n maxBits hmb, ?_⟩
+    rw [computeCodeLengthsListN_multi freqs n maxBits hmulti]
+    apply fixKraftList_kraft
+    rw [assignLengths_length]
+    exact hn
+  · rw [computeCodeLengthsListN_eq_of_small freqs n maxBits (by omega)]
+    exact computeCodeLengths_valid freqs n maxBits hmb hn
+
+/-- Every nonzero-frequency symbol `< numSymbols` gets a nonzero length. Copy of
+    `computeCodeLengths_nonzero` with `limitedPairs → limitedPairsN` (uses only the
+    shared shape lemmas `limitedPairsN_mem_range`/`limitedPairsN_covers`). -/
+theorem computeCodeLengthsListN_nonzero (freqs : List (Nat × Nat)) (numSymbols maxBits : Nat)
+    (hmb : maxBits > 0) (s : Nat) (hs : s < numSymbols)
+    (hfreq : ∃ p ∈ freqs, p.1 = s ∧ p.2 > 0) :
+    (computeCodeLengthsListN freqs numSymbols maxBits)[s]! ≠ 0 := by
+  simp only [computeCodeLengthsListN]
+  obtain ⟨p, hp, hps, hpf⟩ := hfreq
+  have hs_nz : p ∈ freqs.filter (fun x => decide (x.2 > 0)) := by
+    simp only [List.mem_filter, decide_eq_true_eq]; exact ⟨hp, hpf⟩
+  have hne : ¬(freqs.filter (fun x => decide (x.2 > 0))).isEmpty := by
+    intro h; rw [List.isEmpty_iff_length_eq_zero] at h
+    exact absurd (List.length_pos_of_mem hs_nz) (by omega)
+  rw [if_neg hne]
+  let nz := freqs.filter (fun x => decide (x.2 > 0))
+  split
+  · rename_i hlen1
+    have hs_nz' : p ∈ nz := hs_nz
+    have hlen1' : nz.length = 1 := by rw [beq_iff_eq] at hlen1; exact hlen1
+    have hhead : nz.head! = p := by
+      have ⟨hd, tl, htl⟩ : ∃ hd tl, nz = hd :: tl := by
+        cases hc : nz with
+        | nil => rw [hc] at hs_nz'; exact nomatch hs_nz'
+        | cons x xs => exact ⟨x, xs, rfl⟩
+      have htl_nil : tl = [] := by
+        rw [htl] at hlen1'; simp only [List.length_cons] at hlen1'
+        exact List.eq_nil_of_length_eq_zero (by omega)
+      rw [htl, htl_nil] at hs_nz'
+      simp only [List.mem_cons, List.mem_nil_iff, or_false] at hs_nz'
+      rw [htl, htl_nil]; simp only [List.head!]; exact hs_nz'.symm
+    have hhead_fst : nz.head!.fst = s := by rw [hhead, hps]
+    rw [show (nz.head!.fst, 1) = (s, 1) from by rw [hhead_fst]]
+    have := assignLengths_pos [(s, 1)] numSymbols s hs
+      (fun q hq _ => by simp only [List.mem_cons, List.mem_nil_iff, or_false] at hq; subst hq; omega)
+      ⟨(s, 1), List.Mem.head _, rfl⟩
+    omega
+  · apply fixKraftList_nonzero _ _ hmb s
+    · rw [assignLengths_length]; exact hs
+    · have hpos := assignLengths_pos (limitedPairsN nz maxBits) numSymbols s hs
+        (fun q hq _ => by have := (limitedPairsN_mem_range nz maxBits hmb q hq).1; omega)
+        (limitedPairsN_covers nz maxBits s (List.mem_map.mpr ⟨p, hs_nz, hps⟩))
+      exact Nat.pos_iff_ne_zero.mp hpos
 
 end Huffman.Spec

--- a/Zip/Spec/DeflateDynamicCorrect.lean
+++ b/Zip/Spec/DeflateDynamicCorrect.lean
@@ -65,28 +65,30 @@ theorem emitDynBlock_spec (bw : BitWriter) (hbw : bw.wf)
   let distFreqPairs := freqsToPairs distFreqs
   -- `litLens`/`distLens` are defined through the array twin `computeCodeLengthsN`
   -- exactly as `dynamicCodeLengths` does, so they are *definitionally* `(dynLens
-  -- tokens).1`/`.2`; `computeCodeLengthsN_toList` bridges to the spec
-  -- `computeCodeLengths` for the property lemmas below.
+  -- tokens).1`/`.2`; `computeCodeLengthsN_toList` bridges to the list twin
+  -- `computeCodeLengthsListN` (the two-queue heuristic build) for the property
+  -- lemmas below. Those properties (length, ValidLengths, bounded, nonzero) hold
+  -- for the heuristic build too, since they depend only on the output shape.
   let litLens := (Huffman.Spec.computeCodeLengthsN litFreqPairs 286 15).toList
   let distLens₀ := (Huffman.Spec.computeCodeLengthsN distFreqPairs 30 15).toList
   let distLens := if distLens₀.all (fun x => x == 0) then distLens₀.set 0 1 else distLens₀
-  have hlit_bridge : litLens = Huffman.Spec.computeCodeLengths litFreqPairs 286 15 :=
+  have hlit_bridge : litLens = Huffman.Spec.computeCodeLengthsListN litFreqPairs 286 15 :=
     Huffman.Spec.computeCodeLengthsN_toList litFreqPairs 286 15
-  have hdist₀_bridge : distLens₀ = Huffman.Spec.computeCodeLengths distFreqPairs 30 15 :=
+  have hdist₀_bridge : distLens₀ = Huffman.Spec.computeCodeLengthsListN distFreqPairs 30 15 :=
     Huffman.Spec.computeCodeLengthsN_toList distFreqPairs 30 15
-  -- Properties of computeCodeLengths
+  -- Properties of computeCodeLengthsListN
   have hlit_len : litLens.length = 286 := by
-    rw [hlit_bridge]; exact Huffman.Spec.computeCodeLengths_length litFreqPairs 286 15
+    rw [hlit_bridge]; exact Huffman.Spec.computeCodeLengthsListN_length litFreqPairs 286 15
   have hdist₀_len : distLens₀.length = 30 := by
-    rw [hdist₀_bridge]; exact Huffman.Spec.computeCodeLengths_length distFreqPairs 30 15
+    rw [hdist₀_bridge]; exact Huffman.Spec.computeCodeLengthsListN_length distFreqPairs 30 15
   have hlit_valid : Huffman.Spec.ValidLengths litLens 15 := by
-    rw [hlit_bridge]; exact Huffman.Spec.computeCodeLengths_valid litFreqPairs 286 15 (by omega) (by omega)
+    rw [hlit_bridge]; exact Huffman.Spec.computeCodeLengthsListN_valid litFreqPairs 286 15 (by omega) (by omega)
   have hlit_bound : ∀ x ∈ litLens, x ≤ 15 := by
-    rw [hlit_bridge]; exact Huffman.Spec.computeCodeLengths_bounded litFreqPairs 286 15 (by omega)
+    rw [hlit_bridge]; exact Huffman.Spec.computeCodeLengthsListN_bounded litFreqPairs 286 15 (by omega)
   have hdist₀_valid : Huffman.Spec.ValidLengths distLens₀ 15 := by
-    rw [hdist₀_bridge]; exact Huffman.Spec.computeCodeLengths_valid distFreqPairs 30 15 (by omega) (by omega)
+    rw [hdist₀_bridge]; exact Huffman.Spec.computeCodeLengthsListN_valid distFreqPairs 30 15 (by omega) (by omega)
   have hdist₀_bound : ∀ x ∈ distLens₀, x ≤ 15 := by
-    rw [hdist₀_bridge]; exact Huffman.Spec.computeCodeLengths_bounded distFreqPairs 30 15 (by omega)
+    rw [hdist₀_bridge]; exact Huffman.Spec.computeCodeLengthsListN_bounded distFreqPairs 30 15 (by omega)
   -- distLens properties (with the fixup)
   have hdist_len : distLens.length = 30 := by
     simp only [distLens]; split
@@ -203,7 +205,7 @@ theorem emitDynBlock_spec (bw : BitWriter) (hbw : bw.wf)
         have hfreq := Deflate.tokenFreqs_literal_pos tokens b ht_mem
         have hlen_nz : litLens[b.toNat]! ≠ 0 := by
           rw [hlit_bridge]
-          exact Huffman.Spec.computeCodeLengths_nonzero litFreqPairs 286 15
+          exact Huffman.Spec.computeCodeLengthsListN_nonzero litFreqPairs 286 15
             (by omega) b.toNat (by have := UInt8.toNat_lt b; omega)
             (Deflate.freqPairs_witness litFreqs b.toNat (by have := UInt8.toNat_lt b; omega) hfreq)
         have hlen_le := getElem!_le_of_forall_mem_le litLens b.toNat 15 hb_lt hlit_bound
@@ -227,7 +229,7 @@ theorem emitDynBlock_spec (bw : BitWriter) (hbw : bw.wf)
             extraV.toUInt32 ht_mem hflc_native
           have hlen_nz : litLens[257 + idx]! ≠ 0 := by
             rw [hlit_bridge]
-            exact Huffman.Spec.computeCodeLengths_nonzero litFreqPairs 286 15
+            exact Huffman.Spec.computeCodeLengthsListN_nonzero litFreqPairs 286 15
               (by omega) (257 + idx) (by omega)
               (Deflate.freqPairs_witness litFreqs (257 + idx) (by omega) hfreq)
           have hlen_le' := getElem!_le_of_forall_mem_le litLens (257 + idx) 15 hsym hlit_bound
@@ -254,7 +256,7 @@ theorem emitDynBlock_spec (bw : BitWriter) (hbw : bw.wf)
                   dExtraV.toUInt32 ht_mem hfdc_native
                 have hdlen_nz : distLens₀[dCode]! ≠ 0 := by
                   rw [hdist₀_bridge]
-                  exact Huffman.Spec.computeCodeLengths_nonzero distFreqPairs 30 15
+                  exact Huffman.Spec.computeCodeLengthsListN_nonzero distFreqPairs 30 15
                     (by omega) dCode (by omega)
                     (Deflate.freqPairs_witness distFreqs dCode (by omega) hdfreq)
                 -- If all were zero, distLens₀[dCode]! would be 0, contradiction
@@ -275,7 +277,7 @@ theorem emitDynBlock_spec (bw : BitWriter) (hbw : bw.wf)
                 dExtraV.toUInt32 ht_mem hfdc_native
               have hdlen_nz : distLens[dCode]! ≠ 0 := by
                 rw [hdl_eq, hdist₀_bridge]
-                exact Huffman.Spec.computeCodeLengths_nonzero distFreqPairs 30 15
+                exact Huffman.Spec.computeCodeLengthsListN_nonzero distFreqPairs 30 15
                   (by omega) dCode (by omega)
                   (Deflate.freqPairs_witness distFreqs dCode (by omega) hdfreq)
               have hdlen_le' := getElem!_le_of_forall_mem_le distLens dCode 15 hdsym hdist_bound
@@ -297,7 +299,7 @@ theorem emitDynBlock_spec (bw : BitWriter) (hbw : bw.wf)
       have hfreq := Deflate.tokenFreqs_eob_pos tokens
       have hlen_nz : litLens[256]! ≠ 0 := by
         rw [hlit_bridge]
-        exact Huffman.Spec.computeCodeLengths_nonzero litFreqPairs 286 15
+        exact Huffman.Spec.computeCodeLengthsListN_nonzero litFreqPairs 286 15
           (by omega) 256 (by omega)
           (Deflate.freqPairs_witness litFreqs 256 (by omega) hfreq)
       have hlen_le := getElem!_le_of_forall_mem_le litLens 256 15 hsym hlit_bound

--- a/bench/graphs/canterbury_compress_heatmap.svg
+++ b/bench/graphs/canterbury_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#pf459e75f72)">
+   <g clip-path="url(#pc87c342f95)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJGElEQVR4nO3YzaqdZx2H4b2StbUx2xJCrcVAKuiwkJGd6Nx5D8QjcOIxeAal4LwUHDh24rA4URA0lFAJpDYfe+/sro8OhB7B/fBvFtd1BL+Xh/dd93o2h6//dDzjzXL9cnrBOq9P89mON9fTE5bZvP3u9IQ1fvij6QXrbG5NL1jjm9N9z071zI7PvpiesMxpnhgAwCCBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQ2z7ePJvesMTN/np6wjLv3fv59IRlLg7vTk9YYnP1fHrCMn+9+sf0hCV+9oOfTE9YZn/YTU9Y4sXucnrCMrvjfnrCEr/68YPpCcu4wQIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAIDY9uL83vSGJQ7bw/SEZS7O3pqesM7/Hk8vWOJ49Xx6wjIfPvz19IQlLnene2avTvTZfnnxwfSEZW42u+kJSxz//fn0hGXcYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBse+f2xfSGJa73l9MT1tmccBe/9fb0giU2J3xm57vd9IQlTvnM7m5P8z37782T6QnL7A430xOWeHD33vSEZU73CwIAMERgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQGyz//sfjtMj4DuHw/QC+L9b/n++cXw/+B7xBQEAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAIDY9ndPH09vWOL56/30hGX+9uTF9IRlPvvoN9MTlvjpnYfTE5Z59PEn0xOW+O0v7k9PWOZfX11NT1jizvb29IRlPv3zP6cnLHH5x99PT1jGDRYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDENrvDX47TI1bYH3bTE5a5tTndLr59fTk9YY3b2+kF67x6Nr1gif2996YnLHM4HqYnLHG+Od337Jvjaf6mne9O87nOztxgAQDkBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQGx7s7+e3rDE/ribnrDM3VeX0xPWef7l9IIljq9fT09YZvP+o+kJS5zqt/Hs7Ozsav9yesIS97fvTE9Y5vzls+kJSxyf/md6wjJusAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACD2LVi2iPFSXrVuAAAAAElFTkSuQmCC" id="image00d620f1aa" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJF0lEQVR4nO3YzYpl1R2H4Trdp9ROV6SR+EEEiZhhwEHQic4z90K8Aideg3cggnMJZJBxJg5DJgqCNCKGQBur7arq8nw4EHIF7+IfD89zBb/NYu/znrU5/PDp8Yxfl5sfpxes8/Q0n+14ezM9YZnN8y9NT1jj2d9ML1hnc2d6wRo/ne57dqpndnz0zfSEZU7zxAAABgksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAIDY9uHm0fSGJW73N9MTlnnlwR+mJyxzcXhpesISm+vL6QnL/OP6i+kJS/z+mRenJyyzP+ymJyzxeHc1PWGZ3XE/PWGJt3776vSEZdxgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQGx7cf5gesMSh+1hesIyF2fPTU9Y578Ppxcscby+nJ6wzNuvvTM9YYmr3eme2ZMTfbY/XvxpesIyt5vd9IQljl//c3rCMm6wAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAILa9d/diesMSN/ur6QnrbE64i597fnrBEpsTPrPz3W56whKnfGb3t6f5nv379tvpCcvsDrfTE5Z49f6D6QnLnO4XBABgiMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACA2Gb/rw+P0yPgfw6H6QXwizv+f/7q+H7wf8QXBAAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGLb9//zcHrDEpdP99MTlvn828fTE5b563vvTk9Y4uV7r01PWObNjz+ZnrDEX954YXrCMl99fz09YYl727vTE5b57G9fTk9Y4uqjD6YnLOMGCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGKb3eHvx+kRK+wPu+kJy9zZnG4X3725mp6wxt3t9IJ1njyaXrDE/sEr0xOWORwP0xOWON+c7nv20/E0f9POd6f5XGdnbrAAAHICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgtr3d30xvWGJ/3E1PWOb+k6vpCetcfje9YInj06fTE5bZvP7n6QlLnOq38ezs7Ox6/+P0hCVe2P5uesIy59eX0xOWOH731fSEZdxgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQOxnCwGI995LbBIAAAAASUVORK5CYII=" id="image690e8828b8" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m7ff2d43ade" d="M 0 0 
+       <path id="m050aaef882" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m7ff2d43ade" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m050aaef882" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m7ff2d43ade" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m050aaef882" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m7ff2d43ade" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m050aaef882" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m7ff2d43ade" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m050aaef882" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m7ff2d43ade" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m050aaef882" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m7ff2d43ade" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m050aaef882" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m7ff2d43ade" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m050aaef882" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m7ff2d43ade" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m050aaef882" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m7ff2d43ade" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m050aaef882" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m7ff2d43ade" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m050aaef882" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m7ff2d43ade" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m050aaef882" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="m1da4e89dec" d="M 0 0 
+       <path id="mdea956b974" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m1da4e89dec" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdea956b974" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m1da4e89dec" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdea956b974" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m1da4e89dec" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdea956b974" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m1da4e89dec" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdea956b974" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m1da4e89dec" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdea956b974" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m1da4e89dec" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdea956b974" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m1da4e89dec" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdea956b974" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m1da4e89dec" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdea956b974" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1303,7 +1303,7 @@ L 527.435033 49.4355
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_20">
-    <!-- +17 -->
+    <!-- +16 -->
     <g transform="translate(108.442626 68.904519) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-2b" d="M 2944 4013 
@@ -1321,28 +1321,82 @@ L 2419 4013
 L 2944 4013 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
+      <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_21">
-    <!-- +25 -->
+    <!-- +23 -->
     <g transform="translate(147.693424 68.904519) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_22">
@@ -1378,34 +1432,14 @@ z
     <!-- -76 -->
     <g transform="translate(227.74588 68.904519) scale(0.065 -0.065)">
      <defs>
-      <path id="DejaVuSans-36" d="M 2113 2584 
-Q 1688 2584 1439 2293 
-Q 1191 2003 1191 1497 
-Q 1191 994 1439 701 
-Q 1688 409 2113 409 
-Q 2538 409 2786 701 
-Q 3034 994 3034 1497 
-Q 3034 2003 2786 2293 
-Q 2538 2584 2113 2584 
-z
-M 3366 4563 
-L 3366 3988 
-Q 3128 4100 2886 4159 
-Q 2644 4219 2406 4219 
-Q 1781 4219 1451 3797 
-Q 1122 3375 1075 2522 
-Q 1259 2794 1537 2939 
-Q 1816 3084 2150 3084 
-Q 2853 3084 3261 2657 
-Q 3669 2231 3669 1497 
-Q 3669 778 3244 343 
-Q 2819 -91 2113 -91 
-Q 1303 -91 875 529 
-Q 447 1150 447 2328 
-Q 447 3434 972 4092 
-Q 1497 4750 2381 4750 
-Q 2619 4750 2861 4703 
-Q 3103 4656 3366 4563 
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
 z
 " transform="scale(0.015625)"/>
      </defs>
@@ -1464,45 +1498,10 @@ z
     </g>
    </g>
    <g id="text_25">
-    <!-- -13 -->
-    <g transform="translate(306.247477 68.904519) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-33" d="M 2597 2516 
-Q 3050 2419 3304 2112 
-Q 3559 1806 3559 1356 
-Q 3559 666 3084 287 
-Q 2609 -91 1734 -91 
-Q 1441 -91 1130 -33 
-Q 819 25 488 141 
-L 488 750 
-Q 750 597 1062 519 
-Q 1375 441 1716 441 
-Q 2309 441 2620 675 
-Q 2931 909 2931 1356 
-Q 2931 1769 2642 2001 
-Q 2353 2234 1838 2234 
-L 1294 2234 
-L 1294 2753 
-L 1863 2753 
-Q 2328 2753 2575 2939 
-Q 2822 3125 2822 3475 
-Q 2822 3834 2567 4026 
-Q 2313 4219 1838 4219 
-Q 1578 4219 1281 4162 
-Q 984 4106 628 3988 
-L 628 4550 
-Q 988 4650 1302 4700 
-Q 1616 4750 1894 4750 
-Q 2613 4750 3031 4423 
-Q 3450 4097 3450 3541 
-Q 3450 3153 3228 2886 
-Q 3006 2619 2597 2516 
-z
-" transform="scale(0.015625)"/>
-     </defs>
+    <!-- -8 -->
+    <g transform="translate(308.31529 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_26">
@@ -1529,11 +1528,11 @@ z
     </g>
    </g>
    <g id="text_29">
-    <!-- -39 -->
+    <!-- -33 -->
     <g transform="translate(463.250671 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_30">
@@ -2180,18 +2179,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="image5375827f94" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
+iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="image4f039db79e" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="m868698eca0" d="M 0 0 
+       <path id="m0c6635bc2b" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m868698eca0" x="547.779688" y="276.293905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0c6635bc2b" x="547.779688" y="276.293905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
@@ -2214,7 +2213,7 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m868698eca0" x="547.779688" y="247.808905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0c6635bc2b" x="547.779688" y="247.808905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
@@ -2228,7 +2227,7 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m868698eca0" x="547.779688" y="219.323905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0c6635bc2b" x="547.779688" y="219.323905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
@@ -2242,7 +2241,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m868698eca0" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0c6635bc2b" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
@@ -2255,7 +2254,7 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m868698eca0" x="547.779688" y="162.353904" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0c6635bc2b" x="547.779688" y="162.353904" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_112">
@@ -2268,7 +2267,7 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m868698eca0" x="547.779688" y="133.868904" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0c6635bc2b" x="547.779688" y="133.868904" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
@@ -2281,7 +2280,7 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m868698eca0" x="547.779688" y="105.383904" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0c6635bc2b" x="547.779688" y="105.383904" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
@@ -2942,8 +2941,8 @@ z
    </g>
   </g>
   <g id="text_117">
-   <!-- 2026-07-08T20:00:36Z  ·  Linux chungus2 x86_64  ·  commit 29539fd5  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(17.380078 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-08T20:16:47Z  ·  Linux chungus2 x86_64  ·  commit 74c19afa  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(17.841641 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -3015,11 +3014,11 @@ z
     <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3059,109 +3058,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3262.744141 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3326.367188 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3389.990234 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3425.195312 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3488.671875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3552.294922 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3584.082031 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3615.869141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3647.65625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3679.443359 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3711.230469 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3739.013672 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3800.537109 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3861.816406 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3925.195312 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3988.671875 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4027.535156 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4088.716797 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4147.896484 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4209.419922 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4250.533203 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4284.224609 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4312.007812 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4373.53125 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4434.810547 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4498.189453 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4561.8125 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4595.503906 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4654.683594 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4718.306641 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4750.09375 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4813.716797 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4877.339844 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4909.126953 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4972.75 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5008.833984 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5047.697266 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5102.677734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5166.300781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5198.087891 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5229.875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5261.662109 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5293.449219 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5325.236328 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5364.445312 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5427.824219 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5466.6875 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5527.869141 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5591.248047 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5654.724609 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5718.103516 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5781.580078 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5844.958984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5884.167969 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5915.955078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5999.744141 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6031.53125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6128.943359 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6190.466797 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6253.943359 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6281.726562 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6343.005859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6406.384766 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6438.171875 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6490.271484 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6553.650391 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6614.929688 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6678.40625 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6730.505859 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6793.884766 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6855.066406 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6894.275391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6927.966797 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6959.753906 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7000.867188 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7062.146484 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7101.355469 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7129.138672 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7190.320312 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7222.107422 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7249.890625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7301.990234 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7333.777344 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7397.253906 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7458.777344 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7497.986328 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7559.509766 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7598.873047 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7696.285156 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7724.068359 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7787.447266 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7815.230469 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7867.330078 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7906.539062 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7934.322266 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3254.101562 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3317.724609 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3381.347656 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3442.626953 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3477.832031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3539.111328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3570.898438 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3602.685547 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3634.472656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3666.259766 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3698.046875 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3725.830078 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3787.353516 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3848.632812 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3912.011719 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3975.488281 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4014.351562 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4075.533203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4134.712891 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4196.236328 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4237.349609 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4271.041016 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4298.824219 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4360.347656 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4421.626953 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4485.005859 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4548.628906 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4582.320312 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4641.5 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4705.123047 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4736.910156 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4800.533203 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4864.15625 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4895.943359 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4959.566406 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4995.650391 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5034.513672 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5089.494141 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5153.117188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5184.904297 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5216.691406 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5248.478516 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5280.265625 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5312.052734 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5351.261719 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5414.640625 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5453.503906 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5514.685547 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5578.064453 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5641.541016 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5704.919922 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5768.396484 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5831.775391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5870.984375 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5902.771484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5986.560547 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6018.347656 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6115.759766 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6177.283203 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6240.759766 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6268.542969 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6329.822266 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6393.201172 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6424.988281 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6477.087891 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6540.466797 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6601.746094 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6665.222656 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6717.322266 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6780.701172 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6841.882812 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6881.091797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6914.783203 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6946.570312 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6987.683594 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7048.962891 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7088.171875 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7115.955078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7177.136719 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7208.923828 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7236.707031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7288.806641 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7320.59375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7384.070312 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7445.59375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7484.802734 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7546.326172 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7585.689453 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7683.101562 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7710.884766 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7774.263672 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7802.046875 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7854.146484 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7893.355469 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7921.138672 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pf459e75f72">
+  <clipPath id="pc87c342f95">
    <rect x="95.67625" y="49.4355" width="431.758783" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_compress_pareto.svg
+++ b/bench/graphs/canterbury_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 79.118387 412.80375 
 L 79.118387 48.323125 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m1547b4d489" d="M 0 0 
+       <path id="m7798b2a56e" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m1547b4d489" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7798b2a56e" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -161,11 +161,11 @@ z
      <g id="line2d_3">
       <path d="M 166.481434 412.80375 
 L 166.481434 48.323125 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m1547b4d489" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7798b2a56e" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -216,11 +216,11 @@ z
      <g id="line2d_5">
       <path d="M 253.844481 412.80375 
 L 253.844481 48.323125 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m1547b4d489" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7798b2a56e" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -237,11 +237,11 @@ L 253.844481 48.323125
      <g id="line2d_7">
       <path d="M 341.207528 412.80375 
 L 341.207528 48.323125 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m1547b4d489" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7798b2a56e" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -279,11 +279,11 @@ z
      <g id="line2d_9">
       <path d="M 428.570575 412.80375 
 L 428.570575 48.323125 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m1547b4d489" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7798b2a56e" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -332,11 +332,11 @@ z
      <g id="line2d_11">
       <path d="M 515.933622 412.80375 
 L 515.933622 48.323125 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m1547b4d489" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7798b2a56e" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -353,11 +353,11 @@ L 515.933622 48.323125
      <g id="line2d_13">
       <path d="M 603.296669 412.80375 
 L 603.296669 48.323125 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m1547b4d489" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7798b2a56e" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -854,16 +854,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 347.786382 
 L 637.2 347.786382 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="m6e8f10cda5" d="M 0 0 
+       <path id="m93b0f463f1" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m6e8f10cda5" x="49.078125" y="347.786382" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m93b0f463f1" x="49.078125" y="347.786382" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -895,11 +895,11 @@ z
      <g id="line2d_17">
       <path d="M 49.078125 238.646289 
 L 637.2 238.646289 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m6e8f10cda5" x="49.078125" y="238.646289" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m93b0f463f1" x="49.078125" y="238.646289" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -915,11 +915,11 @@ L 637.2 238.646289
      <g id="line2d_19">
       <path d="M 49.078125 129.506196 
 L 637.2 129.506196 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m6e8f10cda5" x="49.078125" y="129.506196" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m93b0f463f1" x="49.078125" y="129.506196" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -935,16 +935,16 @@ L 637.2 129.506196
      <g id="line2d_21">
       <path d="M 49.078125 404.853417 
 L 637.2 404.853417 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="m1899d02072" d="M 0 0 
+       <path id="m54a2238fba" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m1899d02072" x="49.078125" y="404.853417" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m54a2238fba" x="49.078125" y="404.853417" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -952,11 +952,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 391.217592 
 L 637.2 391.217592 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m1899d02072" x="49.078125" y="391.217592" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m54a2238fba" x="49.078125" y="391.217592" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -964,11 +964,11 @@ L 637.2 391.217592
      <g id="line2d_25">
       <path d="M 49.078125 380.640824 
 L 637.2 380.640824 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m1899d02072" x="49.078125" y="380.640824" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m54a2238fba" x="49.078125" y="380.640824" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -976,11 +976,11 @@ L 637.2 380.640824
      <g id="line2d_27">
       <path d="M 49.078125 371.998975 
 L 637.2 371.998975 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m1899d02072" x="49.078125" y="371.998975" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m54a2238fba" x="49.078125" y="371.998975" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -988,11 +988,11 @@ L 637.2 371.998975
      <g id="line2d_29">
       <path d="M 49.078125 364.692396 
 L 637.2 364.692396 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m1899d02072" x="49.078125" y="364.692396" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m54a2238fba" x="49.078125" y="364.692396" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1000,11 +1000,11 @@ L 637.2 364.692396
      <g id="line2d_31">
       <path d="M 49.078125 358.36315 
 L 637.2 358.36315 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m1899d02072" x="49.078125" y="358.36315" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m54a2238fba" x="49.078125" y="358.36315" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1012,11 +1012,11 @@ L 637.2 358.36315
      <g id="line2d_33">
       <path d="M 49.078125 352.780359 
 L 637.2 352.780359 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m1899d02072" x="49.078125" y="352.780359" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m54a2238fba" x="49.078125" y="352.780359" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1024,11 +1024,11 @@ L 637.2 352.780359
      <g id="line2d_35">
       <path d="M 49.078125 314.93194 
 L 637.2 314.93194 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m1899d02072" x="49.078125" y="314.93194" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m54a2238fba" x="49.078125" y="314.93194" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1036,11 +1036,11 @@ L 637.2 314.93194
      <g id="line2d_37">
       <path d="M 49.078125 295.713324 
 L 637.2 295.713324 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m1899d02072" x="49.078125" y="295.713324" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m54a2238fba" x="49.078125" y="295.713324" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1048,11 +1048,11 @@ L 637.2 295.713324
      <g id="line2d_39">
       <path d="M 49.078125 282.077499 
 L 637.2 282.077499 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m1899d02072" x="49.078125" y="282.077499" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m54a2238fba" x="49.078125" y="282.077499" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1060,11 +1060,11 @@ L 637.2 282.077499
      <g id="line2d_41">
       <path d="M 49.078125 271.500731 
 L 637.2 271.500731 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m1899d02072" x="49.078125" y="271.500731" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m54a2238fba" x="49.078125" y="271.500731" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1072,11 +1072,11 @@ L 637.2 271.500731
      <g id="line2d_43">
       <path d="M 49.078125 262.858882 
 L 637.2 262.858882 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m1899d02072" x="49.078125" y="262.858882" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m54a2238fba" x="49.078125" y="262.858882" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1084,11 +1084,11 @@ L 637.2 262.858882
      <g id="line2d_45">
       <path d="M 49.078125 255.552304 
 L 637.2 255.552304 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m1899d02072" x="49.078125" y="255.552304" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m54a2238fba" x="49.078125" y="255.552304" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1096,11 +1096,11 @@ L 637.2 255.552304
      <g id="line2d_47">
       <path d="M 49.078125 249.223057 
 L 637.2 249.223057 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m1899d02072" x="49.078125" y="249.223057" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m54a2238fba" x="49.078125" y="249.223057" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1108,11 +1108,11 @@ L 637.2 249.223057
      <g id="line2d_49">
       <path d="M 49.078125 243.640266 
 L 637.2 243.640266 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m1899d02072" x="49.078125" y="243.640266" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m54a2238fba" x="49.078125" y="243.640266" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1120,11 +1120,11 @@ L 637.2 243.640266
      <g id="line2d_51">
       <path d="M 49.078125 205.791848 
 L 637.2 205.791848 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m1899d02072" x="49.078125" y="205.791848" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m54a2238fba" x="49.078125" y="205.791848" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1132,11 +1132,11 @@ L 637.2 205.791848
      <g id="line2d_53">
       <path d="M 49.078125 186.573231 
 L 637.2 186.573231 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#m1899d02072" x="49.078125" y="186.573231" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m54a2238fba" x="49.078125" y="186.573231" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1144,11 +1144,11 @@ L 637.2 186.573231
      <g id="line2d_55">
       <path d="M 49.078125 172.937406 
 L 637.2 172.937406 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#m1899d02072" x="49.078125" y="172.937406" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m54a2238fba" x="49.078125" y="172.937406" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1156,11 +1156,11 @@ L 637.2 172.937406
      <g id="line2d_57">
       <path d="M 49.078125 162.360638 
 L 637.2 162.360638 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#m1899d02072" x="49.078125" y="162.360638" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m54a2238fba" x="49.078125" y="162.360638" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1168,11 +1168,11 @@ L 637.2 162.360638
      <g id="line2d_59">
       <path d="M 49.078125 153.71879 
 L 637.2 153.71879 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#m1899d02072" x="49.078125" y="153.71879" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m54a2238fba" x="49.078125" y="153.71879" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1180,11 +1180,11 @@ L 637.2 153.71879
      <g id="line2d_61">
       <path d="M 49.078125 146.412211 
 L 637.2 146.412211 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#m1899d02072" x="49.078125" y="146.412211" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m54a2238fba" x="49.078125" y="146.412211" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1192,11 +1192,11 @@ L 637.2 146.412211
      <g id="line2d_63">
       <path d="M 49.078125 140.082964 
 L 637.2 140.082964 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#m1899d02072" x="49.078125" y="140.082964" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m54a2238fba" x="49.078125" y="140.082964" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1204,11 +1204,11 @@ L 637.2 140.082964
      <g id="line2d_65">
       <path d="M 49.078125 134.500173 
 L 637.2 134.500173 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#m1899d02072" x="49.078125" y="134.500173" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m54a2238fba" x="49.078125" y="134.500173" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1216,11 +1216,11 @@ L 637.2 134.500173
      <g id="line2d_67">
       <path d="M 49.078125 96.651755 
 L 637.2 96.651755 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_68">
       <g>
-       <use xlink:href="#m1899d02072" x="49.078125" y="96.651755" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m54a2238fba" x="49.078125" y="96.651755" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1228,11 +1228,11 @@ L 637.2 96.651755
      <g id="line2d_69">
       <path d="M 49.078125 77.433138 
 L 637.2 77.433138 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_70">
       <g>
-       <use xlink:href="#m1899d02072" x="49.078125" y="77.433138" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m54a2238fba" x="49.078125" y="77.433138" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1240,11 +1240,11 @@ L 637.2 77.433138
      <g id="line2d_71">
       <path d="M 49.078125 63.797313 
 L 637.2 63.797313 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_72">
       <g>
-       <use xlink:href="#m1899d02072" x="49.078125" y="63.797313" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m54a2238fba" x="49.078125" y="63.797313" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1252,11 +1252,11 @@ L 637.2 63.797313
      <g id="line2d_73">
       <path d="M 49.078125 53.220545 
 L 637.2 53.220545 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_74">
       <g>
-       <use xlink:href="#m1899d02072" x="49.078125" y="53.220545" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m54a2238fba" x="49.078125" y="53.220545" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1378,7 +1378,7 @@ L 637.2 48.323125
    </g>
    <g id="text_13">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(294.669676 144.450565) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(294.783126 144.15579) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1410,7 +1410,7 @@ z
    </g>
    <g id="text_14">
     <!-- L10 -->
-    <g style="fill: #d62728" transform="translate(104.852312 295.665435) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(104.775489 294.637366) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1732,23 +1732,23 @@ z
    </g>
    <g id="line2d_75">
     <defs>
-     <path id="mcc7f57953a" d="M -2.5 2.5 
+     <path id="m50154dfbdd" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p27197ae956)">
-     <use xlink:href="#mcc7f57953a" x="355.479835" y="95.382063" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcc7f57953a" x="308.273931" y="102.754513" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcc7f57953a" x="271.230161" y="116.528062" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcc7f57953a" x="217.83458" y="120.013651" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcc7f57953a" x="177.077692" y="138.43462" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcc7f57953a" x="162.880539" y="157.778627" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcc7f57953a" x="160.741445" y="165.196647" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcc7f57953a" x="153.966678" y="183.405761" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcc7f57953a" x="151.589614" y="194.488118" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p4c7aec78b5)">
+     <use xlink:href="#m50154dfbdd" x="355.479835" y="95.382063" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m50154dfbdd" x="308.273931" y="102.754513" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m50154dfbdd" x="271.230161" y="116.528062" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m50154dfbdd" x="217.83458" y="120.013651" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m50154dfbdd" x="177.077692" y="138.43462" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m50154dfbdd" x="162.880539" y="157.778627" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m50154dfbdd" x="160.741445" y="165.196647" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m50154dfbdd" x="153.966678" y="183.405761" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m50154dfbdd" x="151.589614" y="194.488118" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_76">
@@ -1801,7 +1801,7 @@ L 311.2243 102.325849
 L 310.240844 102.469168 
 L 309.257387 102.612055 
 L 308.273931 102.754513 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_77">
     <path d="M 308.273931 102.754513 
@@ -1853,7 +1853,7 @@ L 273.545396 115.775058
 L 272.773651 116.027391 
 L 272.001906 116.278388 
 L 271.230161 116.528062 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_78">
     <path d="M 271.230161 116.528062 
@@ -1905,7 +1905,7 @@ L 221.171803 119.803152
 L 220.059395 119.873422 
 L 218.946988 119.943588 
 L 217.83458 120.013651 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_79">
     <path d="M 217.83458 120.013651 
@@ -1957,7 +1957,7 @@ L 179.624997 137.470928
 L 178.775895 137.79434 
 L 177.926794 138.115561 
 L 177.077692 138.43462 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_80">
     <path d="M 177.077692 138.43462 
@@ -2009,7 +2009,7 @@ L 163.767861 156.775388
 L 163.472087 157.112166 
 L 163.176313 157.446568 
 L 162.880539 157.778627 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_81">
     <path d="M 162.880539 157.778627 
@@ -2061,7 +2061,7 @@ L 160.875139 164.765525
 L 160.830574 164.909668 
 L 160.78601 165.053375 
 L 160.741445 165.196647 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_82">
     <path d="M 160.741445 165.196647 
@@ -2113,7 +2113,7 @@ L 154.390101 182.45125
 L 154.24896 182.771561 
 L 154.107819 183.089721 
 L 153.966678 183.405761 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_83">
     <path d="M 153.966678 183.405761 
@@ -2165,26 +2165,26 @@ L 151.73818 193.866427
 L 151.688658 194.074564 
 L 151.639136 194.281792 
 L 151.589614 194.488118 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_84">
     <defs>
-     <path id="md17940d300" d="M 0 -2.5 
+     <path id="m024edbe29a" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p27197ae956)">
-     <use xlink:href="#md17940d300" x="531.649087" y="75.963093" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md17940d300" x="283.721324" y="99.020035" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md17940d300" x="218.882044" y="121.069315" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md17940d300" x="187.447228" y="127.10685" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md17940d300" x="176.342474" y="138.36311" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md17940d300" x="163.054314" y="161.312135" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md17940d300" x="162.210539" y="168.753955" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md17940d300" x="159.303811" y="175.753345" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md17940d300" x="157.793928" y="179.494802" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p4c7aec78b5)">
+     <use xlink:href="#m024edbe29a" x="531.649087" y="75.963093" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m024edbe29a" x="283.721324" y="99.020035" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m024edbe29a" x="218.882044" y="121.069315" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m024edbe29a" x="187.447228" y="127.10685" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m024edbe29a" x="176.342474" y="138.36311" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m024edbe29a" x="163.054314" y="161.312135" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m024edbe29a" x="162.210539" y="168.753955" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m024edbe29a" x="159.303811" y="175.753345" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m024edbe29a" x="157.793928" y="179.494802" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_85">
@@ -2237,7 +2237,7 @@ L 299.21681 97.864971
 L 294.051648 98.253128 
 L 288.886486 98.638133 
 L 283.721324 99.020035 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_86">
     <path d="M 283.721324 99.020035 
@@ -2289,7 +2289,7 @@ L 222.934499 119.954333
 L 221.583681 120.328916 
 L 220.232863 120.700561 
 L 218.882044 121.069315 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_87">
     <path d="M 218.882044 121.069315 
@@ -2341,7 +2341,7 @@ L 189.411904 126.751217
 L 188.757012 126.870058 
 L 188.10212 126.988602 
 L 187.447228 127.10685 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_88">
     <path d="M 187.447228 127.10685 
@@ -2393,7 +2393,7 @@ L 177.036521 137.732718
 L 176.805172 137.943781 
 L 176.573823 138.153909 
 L 176.342474 138.36311 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_89">
     <path d="M 176.342474 138.36311 
@@ -2445,7 +2445,7 @@ L 163.884824 160.161325
 L 163.607987 160.548041 
 L 163.33115 160.931628 
 L 163.054314 161.312135 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_90">
     <path d="M 163.054314 161.312135 
@@ -2497,7 +2497,7 @@ L 162.263275 168.321549
 L 162.245696 168.466124 
 L 162.228118 168.610258 
 L 162.210539 168.753955 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_91">
     <path d="M 162.210539 168.753955 
@@ -2549,7 +2549,7 @@ L 159.485481 175.344896
 L 159.424925 175.481437 
 L 159.364368 175.617586 
 L 159.303811 175.753345 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_92">
     <path d="M 159.303811 175.753345 
@@ -2601,30 +2601,30 @@ L 157.888296 179.269417
 L 157.85684 179.344665 
 L 157.825384 179.419793 
 L 157.793928 179.494802 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_93">
     <defs>
-     <path id="m1781017fe3" d="M -0 3.535534 
+     <path id="m50faf8d58d" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p27197ae956)">
-     <use xlink:href="#m1781017fe3" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1781017fe3" x="203.775848" y="81.750179" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1781017fe3" x="186.982691" y="88.344921" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1781017fe3" x="179.779306" y="91.045312" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1781017fe3" x="157.610419" y="99.395085" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1781017fe3" x="148.722526" y="107.864022" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1781017fe3" x="144.388162" y="121.237794" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1781017fe3" x="127.071247" y="144.560664" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1781017fe3" x="124.491988" y="152.083585" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1781017fe3" x="92.613662" y="207.637263" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1781017fe3" x="87.348715" y="225.457654" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1781017fe3" x="86.053433" y="242.017529" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p4c7aec78b5)">
+     <use xlink:href="#m50faf8d58d" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m50faf8d58d" x="203.775848" y="81.750179" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m50faf8d58d" x="186.982691" y="88.344921" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m50faf8d58d" x="179.779306" y="91.045312" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m50faf8d58d" x="157.610419" y="99.395085" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m50faf8d58d" x="148.722526" y="107.864022" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m50faf8d58d" x="144.388162" y="121.237794" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m50faf8d58d" x="127.071247" y="144.560664" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m50faf8d58d" x="124.491988" y="152.083585" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m50faf8d58d" x="92.613662" y="207.637263" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m50faf8d58d" x="87.348715" y="225.457654" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m50faf8d58d" x="86.053433" y="242.017529" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_94">
@@ -2677,7 +2677,7 @@ L 206.762331 80.855075
 L 205.766837 81.155325 
 L 204.771342 81.453685 
 L 203.775848 81.750179 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_95">
     <path d="M 203.775848 81.750179 
@@ -2729,7 +2729,7 @@ L 188.032264 87.958568
 L 187.682406 88.087703 
 L 187.332549 88.216487 
 L 186.982691 88.344921 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_96">
     <path d="M 186.982691 88.344921 
@@ -2781,7 +2781,7 @@ L 180.229518 90.88097
 L 180.079447 90.935814 
 L 179.929376 90.990595 
 L 179.779306 91.045312 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_97">
     <path d="M 179.779306 91.045312 
@@ -2833,7 +2833,7 @@ L 158.995974 98.914174
 L 158.534122 99.075021 
 L 158.07227 99.235323 
 L 157.610419 99.395085 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_98">
     <path d="M 157.610419 99.395085 
@@ -2885,7 +2885,7 @@ L 149.27802 107.37681
 L 149.092855 107.539771 
 L 148.907691 107.702174 
 L 148.722526 107.864022 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_99">
     <path d="M 148.722526 107.864022 
@@ -2937,7 +2937,7 @@ L 144.65906 120.50385
 L 144.568761 120.749763 
 L 144.478462 120.994407 
 L 144.388162 121.237794 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_100">
     <path d="M 144.388162 121.237794 
@@ -2989,7 +2989,7 @@ L 128.153555 143.395158
 L 127.792786 143.786853 
 L 127.432016 144.175338 
 L 127.071247 144.560664 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_101">
     <path d="M 127.071247 144.560664 
@@ -3041,7 +3041,7 @@ L 124.653192 151.646811
 L 124.599457 151.79285 
 L 124.545723 151.93844 
 L 124.491988 152.083585 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_102">
     <path d="M 124.491988 152.083585 
@@ -3093,7 +3093,7 @@ L 94.606058 205.546972
 L 93.941926 206.254028 
 L 93.277794 206.950691 
 L 92.613662 207.637263 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_103">
     <path d="M 92.613662 207.637263 
@@ -3145,7 +3145,7 @@ L 87.677774 224.520091
 L 87.568088 224.834677 
 L 87.458402 225.147189 
 L 87.348715 225.457654 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_104">
     <path d="M 87.348715 225.457654 
@@ -3197,23 +3197,23 @@ L 86.134388 241.135848
 L 86.107403 241.431568 
 L 86.080418 241.725454 
 L 86.053433 242.017529 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_105">
     <defs>
-     <path id="ma5cf3353e4" d="M -0 2.5 
+     <path id="m11c17ea415" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p27197ae956)">
-     <use xlink:href="#ma5cf3353e4" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p4c7aec78b5)">
+     <use xlink:href="#m11c17ea415" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_106">
     <defs>
-     <path id="mf27cb95702" d="M -0.833333 2.5 
+     <path id="m0e14a6ff5e" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -3228,16 +3228,16 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p27197ae956)">
-     <use xlink:href="#mf27cb95702" x="362.865999" y="115.428618" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf27cb95702" x="278.798176" y="122.858526" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf27cb95702" x="251.17632" y="128.261574" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf27cb95702" x="200.806828" y="131.522849" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf27cb95702" x="169.803221" y="147.931404" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf27cb95702" x="161.916638" y="160.718659" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf27cb95702" x="158.697104" y="167.705569" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf27cb95702" x="154.26679" y="181.026105" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf27cb95702" x="153.096464" y="191.924265" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p4c7aec78b5)">
+     <use xlink:href="#m0e14a6ff5e" x="362.865999" y="115.428618" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0e14a6ff5e" x="278.798176" y="122.858526" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0e14a6ff5e" x="251.17632" y="128.261574" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0e14a6ff5e" x="200.806828" y="131.522849" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0e14a6ff5e" x="169.803221" y="147.931404" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0e14a6ff5e" x="161.916638" y="160.718659" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0e14a6ff5e" x="158.697104" y="167.705569" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0e14a6ff5e" x="154.26679" y="181.026105" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0e14a6ff5e" x="153.096464" y="191.924265" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_107">
@@ -3290,7 +3290,7 @@ L 284.052415 122.426763
 L 282.301002 122.571121 
 L 280.549589 122.715042 
 L 278.798176 122.858526 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_108">
     <path d="M 278.798176 122.858526 
@@ -3342,7 +3342,7 @@ L 252.902686 127.94134
 L 252.327231 128.048325 
 L 251.751776 128.155069 
 L 251.17632 128.261574 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_109">
     <path d="M 251.17632 128.261574 
@@ -3394,7 +3394,7 @@ L 203.954921 131.325463
 L 202.905557 131.39135 
 L 201.856192 131.457145 
 L 200.806828 131.522849 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_110">
     <path d="M 200.806828 131.522849 
@@ -3446,7 +3446,7 @@ L 171.740947 147.056528
 L 171.095038 147.349951 
 L 170.44913 147.64157 
 L 169.803221 147.931404 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_111">
     <path d="M 169.803221 147.931404 
@@ -3498,7 +3498,7 @@ L 162.409549 160.012958
 L 162.245246 160.249361 
 L 162.080942 160.484591 
 L 161.916638 160.718659 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_112">
     <path d="M 161.916638 160.718659 
@@ -3550,7 +3550,7 @@ L 158.898325 167.297798
 L 158.831251 167.434112 
 L 158.764178 167.570034 
 L 158.697104 167.705569 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_113">
     <path d="M 158.697104 167.705569 
@@ -3602,7 +3602,7 @@ L 154.543684 180.294711
 L 154.451386 180.539765 
 L 154.359088 180.783558 
 L 154.26679 181.026105 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_114">
     <path d="M 154.26679 181.026105 
@@ -3654,11 +3654,11 @@ L 153.16961 191.311823
 L 153.145228 191.516851 
 L 153.120846 191.720996 
 L 153.096464 191.924265 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_115">
     <defs>
-     <path id="me94916b7c5" d="M -1.25 2.5 
+     <path id="m87ef252b95" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -3673,16 +3673,16 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p27197ae956)">
-     <use xlink:href="#me94916b7c5" x="301.619021" y="150.561849" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me94916b7c5" x="250.236474" y="156.671134" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me94916b7c5" x="225.418659" y="160.842551" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me94916b7c5" x="212.328936" y="161.382211" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me94916b7c5" x="209.030149" y="166.25091" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me94916b7c5" x="197.547749" y="171.432451" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me94916b7c5" x="194.819287" y="175.129495" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me94916b7c5" x="193.12279" y="181.606362" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me94916b7c5" x="192.79794" y="189.451167" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p4c7aec78b5)">
+     <use xlink:href="#m87ef252b95" x="301.619021" y="150.561849" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m87ef252b95" x="250.236474" y="156.671134" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m87ef252b95" x="225.418659" y="160.842551" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m87ef252b95" x="212.328936" y="161.382211" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m87ef252b95" x="209.030149" y="166.25091" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m87ef252b95" x="197.547749" y="171.432451" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m87ef252b95" x="194.819287" y="175.129495" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m87ef252b95" x="193.12279" y="181.606362" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m87ef252b95" x="192.79794" y="189.451167" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_116">
@@ -3735,7 +3735,7 @@ L 253.447883 156.311526
 L 252.377414 156.431699 
 L 251.306944 156.551567 
 L 250.236474 156.671134 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_117">
     <path d="M 250.236474 156.671134 
@@ -3787,7 +3787,7 @@ L 226.969772 160.592321
 L 226.452735 160.675878 
 L 225.935697 160.759287 
 L 225.418659 160.842551 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_118">
     <path d="M 225.418659 160.842551 
@@ -3839,7 +3839,7 @@ L 213.147044 161.348661
 L 212.874341 161.359847 
 L 212.601639 161.37103 
 L 212.328936 161.382211 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_119">
     <path d="M 212.328936 161.382211 
@@ -3891,7 +3891,7 @@ L 209.236323 165.960837
 L 209.167599 166.057725 
 L 209.098874 166.154416 
 L 209.030149 166.25091 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_120">
     <path d="M 209.030149 166.25091 
@@ -3943,7 +3943,7 @@ L 198.265399 171.124681
 L 198.026182 171.227493 
 L 197.786966 171.330083 
 L 197.547749 171.432451 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_121">
     <path d="M 197.547749 171.432451 
@@ -3995,7 +3995,7 @@ L 194.989815 174.906688
 L 194.932972 174.981074 
 L 194.876129 175.055342 
 L 194.819287 175.129495 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_122">
     <path d="M 194.819287 175.129495 
@@ -4047,7 +4047,7 @@ L 193.228821 181.226479
 L 193.193478 181.353445 
 L 193.158134 181.480072 
 L 193.12279 181.606362 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_123">
     <path d="M 193.12279 181.606362 
@@ -4099,11 +4099,11 @@ L 192.818243 188.997124
 L 192.811475 189.148955 
 L 192.804707 189.300302 
 L 192.79794 189.451167 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_124">
     <defs>
-     <path id="mebc971e2c8" d="M 0 -2.5 
+     <path id="mff3a395b78" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -4116,16 +4116,16 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p27197ae956)">
-     <use xlink:href="#mebc971e2c8" x="206.45578" y="118.584066" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mebc971e2c8" x="206.45578" y="118.258949" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mebc971e2c8" x="206.45578" y="118.759361" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mebc971e2c8" x="206.45578" y="118.234957" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mebc971e2c8" x="171.767499" y="134.097889" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mebc971e2c8" x="163.54283" y="144.663903" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mebc971e2c8" x="160.174881" y="151.505345" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mebc971e2c8" x="154.179217" y="169.303726" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mebc971e2c8" x="152.4406" y="178.584542" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p4c7aec78b5)">
+     <use xlink:href="#mff3a395b78" x="206.45578" y="118.584066" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mff3a395b78" x="206.45578" y="118.258949" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mff3a395b78" x="206.45578" y="118.759361" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mff3a395b78" x="206.45578" y="118.234957" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mff3a395b78" x="171.767499" y="134.097889" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mff3a395b78" x="163.54283" y="144.663903" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mff3a395b78" x="160.174881" y="151.505345" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mff3a395b78" x="154.179217" y="169.303726" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mff3a395b78" x="152.4406" y="178.584542" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_125">
@@ -4178,7 +4178,7 @@ L 206.45578 118.279335
 L 206.45578 118.27254 
 L 206.45578 118.265745 
 L 206.45578 118.258949 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_126">
     <path d="M 206.45578 118.258949 
@@ -4230,7 +4230,7 @@ L 206.45578 118.728239
 L 206.45578 118.738615 
 L 206.45578 118.748989 
 L 206.45578 118.759361 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_127">
     <path d="M 206.45578 118.759361 
@@ -4282,7 +4282,7 @@ L 206.45578 118.267903
 L 206.45578 118.256924 
 L 206.45578 118.245942 
 L 206.45578 118.234957 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_128">
     <path d="M 206.45578 118.234957 
@@ -4334,7 +4334,7 @@ L 173.935517 133.247721
 L 173.212844 133.532808 
 L 172.490172 133.816191 
 L 171.767499 134.097889 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_129">
     <path d="M 171.767499 134.097889 
@@ -4386,7 +4386,7 @@ L 164.056872 144.068227
 L 163.885524 144.267619 
 L 163.714177 144.466175 
 L 163.54283 144.663903 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_130">
     <path d="M 163.54283 144.663903 
@@ -4438,7 +4438,7 @@ L 160.385378 151.105499
 L 160.315212 151.239156 
 L 160.245047 151.372438 
 L 160.174881 151.505345 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_131">
     <path d="M 160.174881 151.505345 
@@ -4490,7 +4490,7 @@ L 154.553946 168.367127
 L 154.429036 168.681387 
 L 154.304126 168.993578 
 L 154.179217 169.303726 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_132">
     <path d="M 154.179217 169.303726 
@@ -4542,11 +4542,11 @@ L 152.549264 178.054798
 L 152.513043 178.232038 
 L 152.476822 178.408618 
 L 152.4406 178.584542 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_133">
     <defs>
-     <path id="mfe2e0b1a84" d="M 0 -2.5 
+     <path id="ma47d225491" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -4555,16 +4555,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p27197ae956)">
-     <use xlink:href="#mfe2e0b1a84" x="610.467188" y="172.829682" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfe2e0b1a84" x="592.067397" y="173.763838" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfe2e0b1a84" x="534.807821" y="180.385179" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfe2e0b1a84" x="327.802209" y="176.172104" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfe2e0b1a84" x="275.83761" y="186.734601" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfe2e0b1a84" x="258.25125" y="198.783148" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfe2e0b1a84" x="256.777056" y="203.737732" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfe2e0b1a84" x="248.769854" y="217.74136" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfe2e0b1a84" x="246.264594" y="227.740017" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p4c7aec78b5)">
+     <use xlink:href="#ma47d225491" x="610.467188" y="172.829682" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma47d225491" x="592.067397" y="173.763838" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma47d225491" x="534.807821" y="180.385179" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma47d225491" x="327.802209" y="176.172104" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma47d225491" x="275.83761" y="186.734601" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma47d225491" x="258.25125" y="198.783148" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma47d225491" x="256.777056" y="203.737732" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma47d225491" x="248.769854" y="217.74136" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma47d225491" x="246.264594" y="227.740017" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_134">
@@ -4617,7 +4617,7 @@ L 593.217384 173.705989
 L 592.834055 173.72528 
 L 592.450726 173.744563 
 L 592.067397 173.763838 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_135">
     <path d="M 592.067397 173.763838 
@@ -4669,7 +4669,7 @@ L 538.386544 179.997367
 L 537.193636 180.126991 
 L 536.000728 180.25626 
 L 534.807821 180.385179 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_136">
     <path d="M 534.807821 180.385179 
@@ -4721,7 +4721,7 @@ L 340.74006 176.446681
 L 336.427443 176.355332 
 L 332.114826 176.263806 
 L 327.802209 176.172104 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_137">
     <path d="M 327.802209 176.172104 
@@ -4773,7 +4773,7 @@ L 279.085397 186.139102
 L 278.002801 186.338434 
 L 276.920205 186.536931 
 L 275.83761 186.734601 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_138">
     <path d="M 275.83761 186.734601 
@@ -4825,7 +4825,7 @@ L 259.350398 198.113494
 L 258.984015 198.337765 
 L 258.617633 198.560979 
 L 258.25125 198.783148 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_139">
     <path d="M 258.25125 198.783148 
@@ -4877,7 +4877,7 @@ L 256.869193 203.442789
 L 256.838481 203.541307 
 L 256.807768 203.639621 
 L 256.777056 203.737732 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_140">
     <path d="M 256.777056 203.737732 
@@ -4929,7 +4929,7 @@ L 249.270304 216.977455
 L 249.103487 217.23346 
 L 248.93667 217.48809 
 L 248.769854 217.74136 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_141">
     <path d="M 248.769854 217.74136 
@@ -4981,7 +4981,7 @@ L 246.421172 227.173237
 L 246.368979 227.362918 
 L 246.316786 227.551842 
 L 246.264594 227.740017 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="legend_1">
     <g id="patch_7">
@@ -4999,7 +4999,7 @@ z
     </g>
     <g id="line2d_142">
      <defs>
-      <path id="m1b020c8409" d="M 0 3.5 
+      <path id="m0575bb37a3" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -5012,7 +5012,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m1b020c8409" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m0575bb37a3" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -5071,7 +5071,7 @@ z
     </g>
     <g id="line2d_143">
      <g>
-      <use xlink:href="#mcc7f57953a" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m50154dfbdd" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -5085,7 +5085,7 @@ z
     </g>
     <g id="line2d_144">
      <g>
-      <use xlink:href="#md17940d300" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m024edbe29a" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -5130,7 +5130,7 @@ z
     </g>
     <g id="line2d_145">
      <g>
-      <use xlink:href="#m1781017fe3" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m50faf8d58d" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -5173,7 +5173,7 @@ z
     </g>
     <g id="line2d_146">
      <g>
-      <use xlink:href="#ma5cf3353e4" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m11c17ea415" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -5189,7 +5189,7 @@ z
     </g>
     <g id="line2d_147">
      <g>
-      <use xlink:href="#mf27cb95702" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m0e14a6ff5e" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -5243,7 +5243,7 @@ z
     </g>
     <g id="line2d_148">
      <g>
-      <use xlink:href="#me94916b7c5" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m87ef252b95" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -5308,7 +5308,7 @@ z
     </g>
     <g id="line2d_149">
      <g>
-      <use xlink:href="#mebc971e2c8" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#mff3a395b78" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -5346,7 +5346,7 @@ z
     </g>
     <g id="line2d_150">
      <g>
-      <use xlink:href="#mfe2e0b1a84" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#ma47d225491" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -5416,486 +5416,486 @@ z
     </g>
    </g>
    <g id="line2d_151">
-    <g clip-path="url(#p27197ae956)">
-     <use xlink:href="#m1b020c8409" x="289.669676" y="149.450565" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m1b020c8409" x="223.847406" y="159.848498" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m1b020c8409" x="212.215046" y="163.815848" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m1b020c8409" x="181.367844" y="168.643335" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m1b020c8409" x="165.231972" y="177.092266" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m1b020c8409" x="153.327587" y="183.323176" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m1b020c8409" x="148.576453" y="189.616311" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m1b020c8409" x="145.287154" y="192.635039" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m1b020c8409" x="115.00257" y="273.533072" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m1b020c8409" x="99.852312" y="300.665435" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <g clip-path="url(#p4c7aec78b5)">
+     <use xlink:href="#m0575bb37a3" x="289.783126" y="149.15579" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m0575bb37a3" x="223.847406" y="159.367144" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m0575bb37a3" x="212.445767" y="163.330307" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m0575bb37a3" x="181.367844" y="168.276955" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m0575bb37a3" x="165.308999" y="176.883889" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m0575bb37a3" x="153.53933" y="182.740937" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m0575bb37a3" x="148.588101" y="189.048821" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m0575bb37a3" x="145.442461" y="192.09646" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m0575bb37a3" x="115.00257" y="273.409756" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m0575bb37a3" x="99.775489" y="299.637366" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
    <g id="line2d_152">
-    <path d="M 289.669676 149.450565 
-L 288.298379 149.692169 
-L 286.927082 149.932548 
-L 285.555784 150.171715 
-L 284.184487 150.40968 
-L 282.81319 150.646457 
-L 281.441892 150.882056 
-L 280.070595 151.116491 
-L 278.699298 151.349771 
-L 277.328 151.58191 
-L 275.956703 151.812916 
-L 274.585406 152.042803 
-L 273.214109 152.271579 
-L 271.842811 152.499257 
-L 270.471514 152.725847 
-L 269.100217 152.951358 
-L 267.728919 153.175802 
-L 266.357622 153.399188 
-L 264.986325 153.621526 
-L 263.615028 153.842825 
-L 262.24373 154.063097 
-L 260.872433 154.282349 
-L 259.501136 154.500592 
-L 258.129838 154.717835 
-L 256.758541 154.934087 
-L 255.387244 155.149356 
-L 254.015947 155.363652 
-L 252.644649 155.576984 
-L 251.273352 155.78936 
-L 249.902055 156.000788 
-L 248.530757 156.211278 
-L 247.15946 156.420837 
-L 245.788163 156.629474 
-L 244.416866 156.837196 
-L 243.045568 157.044012 
-L 241.674271 157.249929 
-L 240.302974 157.454956 
-L 238.931676 157.659099 
-L 237.560379 157.862368 
-L 236.189082 158.064768 
-L 234.817784 158.266307 
-L 233.446487 158.466994 
-L 232.07519 158.666834 
-L 230.703893 158.865835 
-L 229.332595 159.064004 
-L 227.961298 159.261348 
-L 226.590001 159.457874 
-L 225.218703 159.653588 
-L 223.847406 159.848498 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 289.783126 149.15579 
+L 288.409466 149.392587 
+L 287.035805 149.628208 
+L 285.662144 149.862663 
+L 284.288483 150.095964 
+L 282.914822 150.328122 
+L 281.541161 150.559149 
+L 280.167501 150.789055 
+L 278.79384 151.017851 
+L 277.420179 151.245548 
+L 276.046518 151.472157 
+L 274.672857 151.697687 
+L 273.299196 151.92215 
+L 271.925536 152.145554 
+L 270.551875 152.367911 
+L 269.178214 152.589229 
+L 267.804553 152.809518 
+L 266.430892 153.028789 
+L 265.057231 153.24705 
+L 263.68357 153.46431 
+L 262.30991 153.680579 
+L 260.936249 153.895866 
+L 259.562588 154.110179 
+L 258.188927 154.323528 
+L 256.815266 154.535921 
+L 255.441605 154.747366 
+L 254.067945 154.957872 
+L 252.694284 155.167448 
+L 251.320623 155.3761 
+L 249.946962 155.583839 
+L 248.573301 155.790671 
+L 247.19964 155.996604 
+L 245.82598 156.201646 
+L 244.452319 156.405806 
+L 243.078658 156.609089 
+L 241.704997 156.811505 
+L 240.331336 157.01306 
+L 238.957675 157.213761 
+L 237.584015 157.413616 
+L 236.210354 157.612632 
+L 234.836693 157.810816 
+L 233.463032 158.008174 
+L 232.089371 158.204715 
+L 230.71571 158.400443 
+L 229.34205 158.595367 
+L 227.968389 158.789493 
+L 226.594728 158.982826 
+L 225.221067 159.175374 
+L 223.847406 159.367144 
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_153">
-    <path d="M 223.847406 159.848498 
-L 223.605065 159.93463 
-L 223.362724 160.020607 
-L 223.120384 160.106427 
-L 222.878043 160.192093 
-L 222.635702 160.277604 
-L 222.393361 160.362961 
-L 222.15102 160.448164 
-L 221.908679 160.533215 
-L 221.666339 160.618113 
-L 221.423998 160.702859 
-L 221.181657 160.787455 
-L 220.939316 160.871899 
-L 220.696975 160.956193 
-L 220.454635 161.040338 
-L 220.212294 161.124334 
-L 219.969953 161.208181 
-L 219.727612 161.29188 
-L 219.485271 161.375431 
-L 219.24293 161.458835 
-L 219.00059 161.542093 
-L 218.758249 161.625205 
-L 218.515908 161.708171 
-L 218.273567 161.790993 
-L 218.031226 161.87367 
-L 217.788885 161.956203 
-L 217.546545 162.038592 
-L 217.304204 162.120839 
-L 217.061863 162.202943 
-L 216.819522 162.284905 
-L 216.577181 162.366726 
-L 216.33484 162.448406 
-L 216.0925 162.529945 
-L 215.850159 162.611344 
-L 215.607818 162.692603 
-L 215.365477 162.773724 
-L 215.123136 162.854706 
-L 214.880795 162.93555 
-L 214.638455 163.016256 
-L 214.396114 163.096825 
-L 214.153773 163.177257 
-L 213.911432 163.257553 
-L 213.669091 163.337713 
-L 213.42675 163.417738 
-L 213.18441 163.497628 
-L 212.942069 163.577383 
-L 212.699728 163.657005 
-L 212.457387 163.736493 
-L 212.215046 163.815848 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 223.847406 159.367144 
+L 223.609872 159.453181 
+L 223.372338 159.539063 
+L 223.134804 159.62479 
+L 222.89727 159.710362 
+L 222.659735 159.795779 
+L 222.422201 159.881043 
+L 222.184667 159.966154 
+L 221.947133 160.051113 
+L 221.709599 160.135919 
+L 221.472065 160.220574 
+L 221.23453 160.305078 
+L 220.996996 160.389431 
+L 220.759462 160.473635 
+L 220.521928 160.557689 
+L 220.284394 160.641595 
+L 220.04686 160.725352 
+L 219.809325 160.808962 
+L 219.571791 160.892424 
+L 219.334257 160.975739 
+L 219.096723 161.058909 
+L 218.859189 161.141933 
+L 218.621655 161.224811 
+L 218.38412 161.307545 
+L 218.146586 161.390135 
+L 217.909052 161.472581 
+L 217.671518 161.554884 
+L 217.433984 161.637044 
+L 217.19645 161.719062 
+L 216.958916 161.800939 
+L 216.721381 161.882674 
+L 216.483847 161.964269 
+L 216.246313 162.045723 
+L 216.008779 162.127037 
+L 215.771245 162.208213 
+L 215.533711 162.289249 
+L 215.296176 162.370148 
+L 215.058642 162.450908 
+L 214.821108 162.531531 
+L 214.583574 162.612017 
+L 214.34604 162.692367 
+L 214.108506 162.77258 
+L 213.870971 162.852659 
+L 213.633437 162.932602 
+L 213.395903 163.01241 
+L 213.158369 163.092085 
+L 212.920835 163.171625 
+L 212.683301 163.251033 
+L 212.445767 163.330307 
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_154">
-    <path d="M 212.215046 163.815848 
-L 211.572396 163.921602 
-L 210.929746 164.027122 
-L 210.287096 164.132406 
-L 209.644446 164.237458 
-L 209.001796 164.342277 
-L 208.359146 164.446865 
-L 207.716496 164.551222 
-L 207.073846 164.65535 
-L 206.431196 164.75925 
-L 205.788546 164.862923 
-L 205.145896 164.966369 
-L 204.503246 165.069591 
-L 203.860596 165.172588 
-L 203.217946 165.275361 
-L 202.575296 165.377912 
-L 201.932645 165.480242 
-L 201.289995 165.582352 
-L 200.647345 165.684241 
-L 200.004695 165.785913 
-L 199.362045 165.887367 
-L 198.719395 165.988604 
-L 198.076745 166.089625 
-L 197.434095 166.190431 
-L 196.791445 166.291024 
-L 196.148795 166.391403 
-L 195.506145 166.49157 
-L 194.863495 166.591526 
-L 194.220845 166.691272 
-L 193.578195 166.790808 
-L 192.935545 166.890136 
-L 192.292895 166.989256 
-L 191.650245 167.088169 
-L 191.007595 167.186876 
-L 190.364945 167.285378 
-L 189.722294 167.383676 
-L 189.079644 167.48177 
-L 188.436994 167.579662 
-L 187.794344 167.677352 
-L 187.151694 167.774841 
-L 186.509044 167.87213 
-L 185.866394 167.96922 
-L 185.223744 168.066111 
-L 184.581094 168.162804 
-L 183.938444 168.259301 
-L 183.295794 168.355602 
-L 182.653144 168.451707 
-L 182.010494 168.547618 
-L 181.367844 168.643335 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 212.445767 163.330307 
+L 211.79831 163.438808 
+L 211.150853 163.54706 
+L 210.503396 163.655066 
+L 209.85594 163.762827 
+L 209.208483 163.870343 
+L 208.561026 163.977616 
+L 207.913569 164.084646 
+L 207.266113 164.191435 
+L 206.618656 164.297985 
+L 205.971199 164.404295 
+L 205.323743 164.510367 
+L 204.676286 164.616203 
+L 204.028829 164.721802 
+L 203.381372 164.827167 
+L 202.733916 164.932299 
+L 202.086459 165.037197 
+L 201.439002 165.141864 
+L 200.791546 165.246301 
+L 200.144089 165.350507 
+L 199.496632 165.454486 
+L 198.849175 165.558236 
+L 198.201719 165.66176 
+L 197.554262 165.765059 
+L 196.906805 165.868132 
+L 196.259348 165.970982 
+L 195.611892 166.07361 
+L 194.964435 166.176015 
+L 194.316978 166.2782 
+L 193.669522 166.380165 
+L 193.022065 166.481911 
+L 192.374608 166.58344 
+L 191.727151 166.684751 
+L 191.079695 166.785846 
+L 190.432238 166.886726 
+L 189.784781 166.987392 
+L 189.137324 167.087844 
+L 188.489868 167.188084 
+L 187.842411 167.288113 
+L 187.194954 167.38793 
+L 186.547498 167.487538 
+L 185.900041 167.586937 
+L 185.252584 167.686129 
+L 184.605127 167.785113 
+L 183.957671 167.88389 
+L 183.310214 167.982462 
+L 182.662757 168.08083 
+L 182.015301 168.178994 
+L 181.367844 168.276955 
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_155">
-    <path d="M 181.367844 168.643335 
-L 181.03168 168.835627 
-L 180.695516 169.027142 
-L 180.359352 169.217886 
-L 180.023188 169.407866 
-L 179.687024 169.597087 
-L 179.35086 169.785556 
-L 179.014696 169.973278 
-L 178.678532 170.16026 
-L 178.342368 170.346507 
-L 178.006204 170.532026 
-L 177.67004 170.716821 
-L 177.333876 170.900898 
-L 176.997712 171.084263 
-L 176.661548 171.266921 
-L 176.325384 171.448879 
-L 175.98922 171.63014 
-L 175.653056 171.810711 
-L 175.316892 171.990597 
-L 174.980728 172.169803 
-L 174.644564 172.348333 
-L 174.3084 172.526194 
-L 173.972236 172.70339 
-L 173.636072 172.879925 
-L 173.299908 173.055806 
-L 172.963744 173.231037 
-L 172.62758 173.405622 
-L 172.291416 173.579566 
-L 171.955252 173.752874 
-L 171.619088 173.925551 
-L 171.282924 174.097602 
-L 170.94676 174.26903 
-L 170.610596 174.43984 
-L 170.274432 174.610037 
-L 169.938268 174.779624 
-L 169.602104 174.948608 
-L 169.26594 175.116991 
-L 168.929776 175.284778 
-L 168.593612 175.451973 
-L 168.257448 175.61858 
-L 167.921284 175.784604 
-L 167.58512 175.950048 
-L 167.248956 176.114917 
-L 166.912792 176.279215 
-L 166.576628 176.442944 
-L 166.240464 176.606111 
-L 165.9043 176.768717 
-L 165.568136 176.930768 
-L 165.231972 177.092266 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 181.367844 168.276955 
+L 181.033285 168.473172 
+L 180.698725 168.668579 
+L 180.364166 168.863184 
+L 180.029607 169.056994 
+L 179.695047 169.250014 
+L 179.360488 169.442251 
+L 179.025929 169.633712 
+L 178.69137 169.824402 
+L 178.35681 170.014329 
+L 178.022251 170.203497 
+L 177.687692 170.391914 
+L 177.353133 170.579584 
+L 177.018573 170.766515 
+L 176.684014 170.952711 
+L 176.349455 171.138178 
+L 176.014895 171.322923 
+L 175.680336 171.50695 
+L 175.345777 171.690266 
+L 175.011218 171.872875 
+L 174.676658 172.054784 
+L 174.342099 172.235997 
+L 174.00754 172.41652 
+L 173.672981 172.596358 
+L 173.338421 172.775516 
+L 173.003862 172.953999 
+L 172.669303 173.131813 
+L 172.334743 173.308963 
+L 172.000184 173.485453 
+L 171.665625 173.661288 
+L 171.331066 173.836473 
+L 170.996506 174.011013 
+L 170.661947 174.184913 
+L 170.327388 174.358177 
+L 169.992829 174.53081 
+L 169.658269 174.702816 
+L 169.32371 174.874201 
+L 168.989151 175.044968 
+L 168.654591 175.215122 
+L 168.320032 175.384668 
+L 167.985473 175.553609 
+L 167.650914 175.72195 
+L 167.316354 175.889696 
+L 166.981795 176.05685 
+L 166.647236 176.223416 
+L 166.312676 176.389399 
+L 165.978117 176.554803 
+L 165.643558 176.719632 
+L 165.308999 176.883889 
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_156">
-    <path d="M 165.231972 177.092266 
-L 164.983964 177.230793 
-L 164.735956 177.368916 
-L 164.487948 177.506637 
-L 164.23994 177.64396 
-L 163.991932 177.780886 
-L 163.743924 177.917418 
-L 163.495916 178.053557 
-L 163.247908 178.189307 
-L 162.9999 178.324669 
-L 162.751892 178.459645 
-L 162.503884 178.594238 
-L 162.255876 178.72845 
-L 162.007868 178.862283 
-L 161.75986 178.99574 
-L 161.511852 179.128821 
-L 161.263844 179.26153 
-L 161.015836 179.393869 
-L 160.767828 179.525839 
-L 160.51982 179.657442 
-L 160.271812 179.788681 
-L 160.023804 179.919558 
-L 159.775796 180.050075 
-L 159.527788 180.180233 
-L 159.27978 180.310034 
-L 159.031772 180.439481 
-L 158.783764 180.568576 
-L 158.535756 180.69732 
-L 158.287748 180.825715 
-L 158.03974 180.953763 
-L 157.791732 181.081466 
-L 157.543724 181.208827 
-L 157.295716 181.335845 
-L 157.047708 181.462525 
-L 156.7997 181.588866 
-L 156.551691 181.714872 
-L 156.303683 181.840544 
-L 156.055675 181.965884 
-L 155.807667 182.090892 
-L 155.559659 182.215572 
-L 155.311651 182.339925 
-L 155.063643 182.463953 
-L 154.815635 182.587657 
-L 154.567627 182.711039 
-L 154.319619 182.8341 
-L 154.071611 182.956843 
-L 153.823603 183.079269 
-L 153.575595 183.201379 
-L 153.327587 183.323176 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 165.308999 176.883889 
+L 165.063797 177.013593 
+L 164.818596 177.142943 
+L 164.573394 177.27194 
+L 164.328193 177.400588 
+L 164.082992 177.528887 
+L 163.83779 177.65684 
+L 163.592589 177.784449 
+L 163.347387 177.911714 
+L 163.102186 178.03864 
+L 162.856984 178.165226 
+L 162.611783 178.291475 
+L 162.366582 178.417388 
+L 162.12138 178.542968 
+L 161.876179 178.668216 
+L 161.630977 178.793134 
+L 161.385776 178.917724 
+L 161.140574 179.041987 
+L 160.895373 179.165925 
+L 160.650172 179.28954 
+L 160.40497 179.412833 
+L 160.159769 179.535807 
+L 159.914567 179.658462 
+L 159.669366 179.780801 
+L 159.424164 179.902824 
+L 159.178963 180.024535 
+L 158.933762 180.145933 
+L 158.68856 180.267022 
+L 158.443359 180.387802 
+L 158.198157 180.508275 
+L 157.952956 180.628442 
+L 157.707754 180.748306 
+L 157.462553 180.867867 
+L 157.217352 180.987128 
+L 156.97215 181.106089 
+L 156.726949 181.224752 
+L 156.481747 181.343119 
+L 156.236546 181.461192 
+L 155.991344 181.57897 
+L 155.746143 181.696457 
+L 155.500942 181.813654 
+L 155.25574 181.930561 
+L 155.010539 182.047181 
+L 154.765337 182.163514 
+L 154.520136 182.279563 
+L 154.274934 182.395328 
+L 154.029733 182.510811 
+L 153.784532 182.626013 
+L 153.53933 182.740937 
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_157">
-    <path d="M 153.327587 183.323176 
-L 153.228605 183.463178 
-L 153.129623 183.602767 
-L 153.030641 183.741947 
-L 152.931659 183.880719 
-L 152.832678 184.019086 
-L 152.733696 184.15705 
-L 152.634714 184.294614 
-L 152.535732 184.43178 
-L 152.43675 184.56855 
-L 152.337768 184.704927 
-L 152.238786 184.840912 
-L 152.139804 184.976508 
-L 152.040822 185.111718 
-L 151.94184 185.246542 
-L 151.842858 185.380985 
-L 151.743876 185.515047 
-L 151.644894 185.648731 
-L 151.545912 185.782039 
-L 151.44693 185.914973 
-L 151.347948 186.047536 
-L 151.248966 186.179728 
-L 151.149984 186.311553 
-L 151.051002 186.443013 
-L 150.95202 186.574109 
-L 150.853038 186.704843 
-L 150.754056 186.835218 
-L 150.655074 186.965235 
-L 150.556093 187.094896 
-L 150.457111 187.224204 
-L 150.358129 187.353159 
-L 150.259147 187.481765 
-L 150.160165 187.610023 
-L 150.061183 187.737935 
-L 149.962201 187.865503 
-L 149.863219 187.992728 
-L 149.764237 188.119613 
-L 149.665255 188.246158 
-L 149.566273 188.372367 
-L 149.467291 188.498241 
-L 149.368309 188.623781 
-L 149.269327 188.74899 
-L 149.170345 188.873869 
-L 149.071363 188.99842 
-L 148.972381 189.122644 
-L 148.873399 189.246543 
-L 148.774417 189.37012 
-L 148.675435 189.493375 
-L 148.576453 189.616311 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 153.53933 182.740937 
+L 153.436179 182.881288 
+L 153.333029 183.021226 
+L 153.229878 183.160751 
+L 153.126728 183.299867 
+L 153.023577 183.438576 
+L 152.920426 183.57688 
+L 152.817276 183.714782 
+L 152.714125 183.852284 
+L 152.610975 183.989388 
+L 152.507824 184.126096 
+L 152.404673 184.262411 
+L 152.301523 184.398336 
+L 152.198372 184.533872 
+L 152.095222 184.669021 
+L 151.992071 184.803786 
+L 151.88892 184.938169 
+L 151.78577 185.072172 
+L 151.682619 185.205797 
+L 151.579468 185.339047 
+L 151.476318 185.471923 
+L 151.373167 185.604428 
+L 151.270017 185.736563 
+L 151.166866 185.868331 
+L 151.063715 185.999734 
+L 150.960565 186.130773 
+L 150.857414 186.261451 
+L 150.754264 186.39177 
+L 150.651113 186.521731 
+L 150.547962 186.651337 
+L 150.444812 186.78059 
+L 150.341661 186.909491 
+L 150.238511 187.038043 
+L 150.13536 187.166247 
+L 150.032209 187.294105 
+L 149.929059 187.421619 
+L 149.825908 187.548791 
+L 149.722758 187.675622 
+L 149.619607 187.802116 
+L 149.516456 187.928272 
+L 149.413306 188.054094 
+L 149.310155 188.179582 
+L 149.207004 188.304739 
+L 149.103854 188.429567 
+L 149.000703 188.554067 
+L 148.897553 188.67824 
+L 148.794402 188.802089 
+L 148.691251 188.925616 
+L 148.588101 189.048821 
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_158">
-    <path d="M 148.576453 189.616311 
-L 148.507926 189.681202 
-L 148.439399 189.746005 
-L 148.370872 189.810719 
-L 148.302345 189.875346 
-L 148.233818 189.939884 
-L 148.165291 190.004334 
-L 148.096764 190.068697 
-L 148.028237 190.132973 
-L 147.95971 190.197161 
-L 147.891183 190.261263 
-L 147.822656 190.325278 
-L 147.754129 190.389207 
-L 147.685602 190.45305 
-L 147.617074 190.516807 
-L 147.548547 190.580478 
-L 147.48002 190.644064 
-L 147.411493 190.707564 
-L 147.342966 190.77098 
-L 147.274439 190.834311 
-L 147.205912 190.897557 
-L 147.137385 190.96072 
-L 147.068858 191.023798 
-L 147.000331 191.086792 
-L 146.931804 191.149703 
-L 146.863277 191.21253 
-L 146.79475 191.275274 
-L 146.726223 191.337935 
-L 146.657696 191.400514 
-L 146.589169 191.46301 
-L 146.520641 191.525423 
-L 146.452114 191.587755 
-L 146.383587 191.650004 
-L 146.31506 191.712172 
-L 146.246533 191.774259 
-L 146.178006 191.836264 
-L 146.109479 191.898189 
-L 146.040952 191.960032 
-L 145.972425 192.021795 
-L 145.903898 192.083478 
-L 145.835371 192.14508 
-L 145.766844 192.206603 
-L 145.698317 192.268046 
-L 145.62979 192.329409 
-L 145.561263 192.390693 
-L 145.492735 192.451897 
-L 145.424208 192.513023 
-L 145.355681 192.57407 
-L 145.287154 192.635039 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 148.588101 189.048821 
+L 148.522567 189.114354 
+L 148.457032 189.179796 
+L 148.391498 189.245148 
+L 148.325964 189.31041 
+L 148.26043 189.375583 
+L 148.194896 189.440665 
+L 148.129362 189.505659 
+L 148.063827 189.570564 
+L 147.998293 189.63538 
+L 147.932759 189.700107 
+L 147.867225 189.764746 
+L 147.801691 189.829297 
+L 147.736157 189.893761 
+L 147.670622 189.958136 
+L 147.605088 190.022425 
+L 147.539554 190.086626 
+L 147.47402 190.150741 
+L 147.408486 190.214769 
+L 147.342952 190.27871 
+L 147.277418 190.342566 
+L 147.211883 190.406335 
+L 147.146349 190.470019 
+L 147.080815 190.533617 
+L 147.015281 190.59713 
+L 146.949747 190.660559 
+L 146.884213 190.723902 
+L 146.818678 190.787161 
+L 146.753144 190.850335 
+L 146.68761 190.913426 
+L 146.622076 190.976432 
+L 146.556542 191.039355 
+L 146.491008 191.102195 
+L 146.425473 191.164951 
+L 146.359939 191.227624 
+L 146.294405 191.290215 
+L 146.228871 191.352723 
+L 146.163337 191.415149 
+L 146.097803 191.477492 
+L 146.032268 191.539754 
+L 145.966734 191.601934 
+L 145.9012 191.664033 
+L 145.835666 191.72605 
+L 145.770132 191.787986 
+L 145.704598 191.849842 
+L 145.639063 191.911617 
+L 145.573529 191.973311 
+L 145.507995 192.034925 
+L 145.442461 192.09646 
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_159">
-    <path d="M 145.287154 192.635039 
-L 144.656225 196.892499 
-L 144.025297 200.798865 
-L 143.394368 204.407658 
-L 142.763439 207.761023 
-L 142.13251 210.89274 
-L 141.501581 213.830301 
-L 140.870652 216.596383 
-L 140.239723 219.209905 
-L 139.608795 221.68682 
-L 138.977866 224.040702 
-L 138.346937 226.283198 
-L 137.716008 228.424374 
-L 137.085079 230.472992 
-L 136.45415 232.436723 
-L 135.823222 234.322323 
-L 135.192293 236.135773 
-L 134.561364 237.88239 
-L 133.930435 239.566927 
-L 133.299506 241.193645 
-L 132.668577 242.766382 
-L 132.037648 244.288605 
-L 131.40672 245.76346 
-L 130.775791 247.193805 
-L 130.144862 248.582248 
-L 129.513933 249.931175 
-L 128.883004 251.242772 
-L 128.252075 252.519051 
-L 127.621147 253.761863 
-L 126.990218 254.97292 
-L 126.359289 256.153803 
-L 125.72836 257.305979 
-L 125.097431 258.430812 
-L 124.466502 259.529569 
-L 123.835573 260.603431 
-L 123.204645 261.653502 
-L 122.573716 262.680813 
-L 121.942787 263.686331 
-L 121.311858 264.670959 
-L 120.680929 265.635549 
-L 120.05 266.580901 
-L 119.419071 267.507765 
-L 118.788143 268.416853 
-L 118.157214 269.308832 
-L 117.526285 270.184335 
-L 116.895356 271.043959 
-L 116.264427 271.888271 
-L 115.633498 272.717806 
-L 115.00257 273.533072 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 145.442461 192.09646 
+L 144.808297 196.397672 
+L 144.174132 200.340837 
+L 143.539968 203.981012 
+L 142.905803 207.361454 
+L 142.271639 210.516773 
+L 141.637475 213.475091 
+L 141.00331 216.259567 
+L 140.369146 218.889505 
+L 139.734981 221.381159 
+L 139.100817 223.748348 
+L 138.466652 226.002918 
+L 137.832488 228.155098 
+L 137.198324 230.213788 
+L 136.564159 232.186771 
+L 135.929995 234.0809 
+L 135.29583 235.902237 
+L 134.661666 237.65617 
+L 134.027502 239.34751 
+L 133.393337 240.980571 
+L 132.759173 242.559237 
+L 132.125008 244.087014 
+L 131.490844 245.567081 
+L 130.85668 247.002327 
+L 130.222515 248.395389 
+L 129.588351 249.748675 
+L 128.954186 251.064393 
+L 128.320022 252.344573 
+L 127.685858 253.591084 
+L 127.051693 254.805653 
+L 126.417529 255.989875 
+L 125.783364 257.14523 
+L 125.1492 258.273092 
+L 124.515036 259.374739 
+L 123.880871 260.451362 
+L 123.246707 261.504073 
+L 122.612542 262.53391 
+L 121.978378 263.541847 
+L 121.344214 264.528796 
+L 120.710049 265.495613 
+L 120.075885 266.443103 
+L 119.44172 267.372024 
+L 118.807556 268.283089 
+L 118.173392 269.176972 
+L 117.539227 270.054309 
+L 116.905063 270.915701 
+L 116.270898 271.761718 
+L 115.636734 272.592899 
+L 115.00257 273.409756 
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_160">
-    <path d="M 115.00257 273.533072 
-L 114.686939 274.289885 
-L 114.371309 275.034804 
-L 114.055678 275.768196 
-L 113.740048 276.490414 
-L 113.424418 277.201792 
-L 113.108787 277.902651 
-L 112.793157 278.593298 
-L 112.477527 279.274026 
-L 112.161896 279.945115 
-L 111.846266 280.606836 
-L 111.530636 281.259445 
-L 111.215005 281.903192 
-L 110.899375 282.538312 
-L 110.583745 283.165034 
-L 110.268114 283.783578 
-L 109.952484 284.394153 
-L 109.636853 284.996963 
-L 109.321223 285.592204 
-L 109.005593 286.180061 
-L 108.689962 286.760717 
-L 108.374332 287.334346 
-L 108.058702 287.901116 
-L 107.743071 288.461188 
-L 107.427441 289.01472 
-L 107.111811 289.561862 
-L 106.79618 290.10276 
-L 106.48055 290.637555 
-L 106.16492 291.166384 
-L 105.849289 291.689378 
-L 105.533659 292.206663 
-L 105.218028 292.718365 
-L 104.902398 293.224601 
-L 104.586768 293.725487 
-L 104.271137 294.221136 
-L 103.955507 294.711655 
-L 103.639877 295.19715 
-L 103.324246 295.677722 
-L 103.008616 296.153471 
-L 102.692986 296.624492 
-L 102.377355 297.090879 
-L 102.061725 297.552721 
-L 101.746095 298.010106 
-L 101.430464 298.46312 
-L 101.114834 298.911846 
-L 100.799203 299.356362 
-L 100.483573 299.796749 
-L 100.167943 300.233082 
-L 99.852312 300.665435 
-" clip-path="url(#p27197ae956)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 115.00257 273.409756 
+L 114.685339 274.133988 
+L 114.368108 274.84732 
+L 114.050877 275.550076 
+L 113.733646 276.242564 
+L 113.416415 276.925081 
+L 113.099184 277.59791 
+L 112.781954 278.261321 
+L 112.464723 278.915575 
+L 112.147492 279.56092 
+L 111.830261 280.197598 
+L 111.51303 280.825836 
+L 111.195799 281.445857 
+L 110.878569 282.057871 
+L 110.561338 282.662084 
+L 110.244107 283.258692 
+L 109.926876 283.847883 
+L 109.609645 284.42984 
+L 109.292414 285.004739 
+L 108.975184 285.572748 
+L 108.657953 286.134031 
+L 108.340722 286.688746 
+L 108.023491 287.237043 
+L 107.70626 287.77907 
+L 107.389029 288.314969 
+L 107.071799 288.844877 
+L 106.754568 289.368926 
+L 106.437337 289.887244 
+L 106.120106 290.399955 
+L 105.802875 290.90718 
+L 105.485644 291.409035 
+L 105.168414 291.905631 
+L 104.851183 292.397079 
+L 104.533952 292.883483 
+L 104.216721 293.364947 
+L 103.89949 293.841569 
+L 103.582259 294.313446 
+L 103.265028 294.780671 
+L 102.947798 295.243336 
+L 102.630567 295.701529 
+L 102.313336 296.155334 
+L 101.996105 296.604836 
+L 101.678874 297.050115 
+L 101.361643 297.49125 
+L 101.044413 297.928318 
+L 100.727182 298.361391 
+L 100.409951 298.790544 
+L 100.09272 299.215846 
+L 99.775489 299.637366 
+" clip-path="url(#p4c7aec78b5)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
   </g>
   <g id="text_25">
@@ -6254,8 +6254,8 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-07-08T20:00:36Z  ·  Linux chungus2 x86_64  ·  commit 29539fd5  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(44.380078 465.66) scale(0.07 -0.07)">
+   <!-- 2026-07-08T20:16:47Z  ·  Linux chungus2 x86_64  ·  commit 74c19afa  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(44.841641 465.66) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -6378,31 +6378,6 @@ Q 1038 2656 1286 2365
 Q 1534 2075 1959 2075 
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
-z
-" transform="scale(0.015625)"/>
      <path id="DejaVuSans-3d" d="M 678 2906 
 L 4684 2906 
 L 4684 2381 
@@ -6446,11 +6421,11 @@ z
     <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -6490,109 +6465,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3262.744141 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3326.367188 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3389.990234 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3425.195312 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3488.671875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3552.294922 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3584.082031 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3615.869141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3647.65625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3679.443359 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3711.230469 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3739.013672 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3800.537109 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3861.816406 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3925.195312 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3988.671875 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4027.535156 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4088.716797 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4147.896484 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4209.419922 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4250.533203 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4284.224609 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4312.007812 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4373.53125 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4434.810547 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4498.189453 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4561.8125 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4595.503906 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4654.683594 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4718.306641 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4750.09375 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4813.716797 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4877.339844 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4909.126953 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4972.75 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5008.833984 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5047.697266 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5102.677734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5166.300781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5198.087891 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5229.875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5261.662109 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5293.449219 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5325.236328 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5364.445312 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5427.824219 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5466.6875 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5527.869141 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5591.248047 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5654.724609 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5718.103516 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5781.580078 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5844.958984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5884.167969 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5915.955078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5999.744141 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6031.53125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6128.943359 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6190.466797 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6253.943359 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6281.726562 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6343.005859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6406.384766 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6438.171875 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6490.271484 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6553.650391 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6614.929688 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6678.40625 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6730.505859 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6793.884766 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6855.066406 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6894.275391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6927.966797 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6959.753906 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7000.867188 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7062.146484 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7101.355469 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7129.138672 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7190.320312 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7222.107422 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7249.890625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7301.990234 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7333.777344 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7397.253906 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7458.777344 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7497.986328 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7559.509766 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7598.873047 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7696.285156 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7724.068359 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7787.447266 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7815.230469 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7867.330078 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7906.539062 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7934.322266 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3254.101562 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3317.724609 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3381.347656 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3442.626953 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3477.832031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3539.111328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3570.898438 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3602.685547 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3634.472656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3666.259766 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3698.046875 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3725.830078 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3787.353516 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3848.632812 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3912.011719 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3975.488281 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4014.351562 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4075.533203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4134.712891 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4196.236328 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4237.349609 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4271.041016 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4298.824219 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4360.347656 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4421.626953 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4485.005859 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4548.628906 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4582.320312 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4641.5 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4705.123047 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4736.910156 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4800.533203 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4864.15625 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4895.943359 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4959.566406 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4995.650391 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5034.513672 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5089.494141 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5153.117188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5184.904297 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5216.691406 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5248.478516 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5280.265625 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5312.052734 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5351.261719 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5414.640625 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5453.503906 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5514.685547 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5578.064453 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5641.541016 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5704.919922 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5768.396484 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5831.775391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5870.984375 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5902.771484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5986.560547 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6018.347656 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6115.759766 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6177.283203 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6240.759766 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6268.542969 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6329.822266 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6393.201172 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6424.988281 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6477.087891 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6540.466797 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6601.746094 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6665.222656 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6717.322266 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6780.701172 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6841.882812 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6881.091797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6914.783203 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6946.570312 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6987.683594 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7048.962891 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7088.171875 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7115.955078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7177.136719 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7208.923828 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7236.707031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7288.806641 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7320.59375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7384.070312 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7445.59375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7484.802734 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7546.326172 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7585.689453 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7683.101562 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7710.884766 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7774.263672 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7802.046875 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7854.146484 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7893.355469 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7921.138672 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p27197ae956">
+  <clipPath id="p4c7aec78b5">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_ratio_heatmap.svg
+++ b/bench/graphs/canterbury_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#pff9aea0db8)">
+   <g clip-path="url(#p1bc9c5d816)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAI/UlEQVR4nO3YwYqkVx2H4aqe7qYn4oAyashScCfBhRtn49o7yRW4DNl7HcYbEEQk2Yjixo24E3ciISRjnMyE7p7q78sljMKRv9T7PFfwO3zUqZdz3P71y/1wbl5+Nr1gqf3z8zrP4XA4/OPnv56esNTf//JqesJyP/3wZ9MTljv+6MfTE9Y6XkwvWO/FJ9ML1rt5Mr1gqV997xfTE5Y7w18SAMB/TgwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKQd706/2adHrLYftukJSx3PsFmvLq6nJyx1v91OT1ju6q9/mp6w3OmHz6YnLHXa7qcnLPfq9GJ6wnJPz+x6eP3k6fSE5c7vXxYA4L8ghgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0i6vXn0xvWG9u6+mF6y1b9ML1nv8ZHrBUtfTA/4H9hevpicsd/Xl8+kJS11tp+kJyz0+x/vu9uX0gqWuLs/vxvMyBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgLTjafvdPj1itX3fpicstZ3ZeQ6Hw+Hq4np6wlIP+2l6wnKPXj6fnrDeN787vWCp19v99ITlPr/95/SE5d6+u5yesNT2rXemJyznZQgASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASLv886d/mN6w3MXhOD1hqe+89XR6wnIP22l6wlLXj26mJyz33se/n56w3Ac/+cH0hKVO+zY9Ybn3//i36QnLPXvnG9MTlnrv3WfTE5bzMgQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIC04+uH3+7TI1a7f7idnrDU4+PN9ATe4P54mp6w3L/vPpuesNy3b96enrDUtm/TE5b74u7T6QnLPb/7ZHrCUt9/8u70hOW8DAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACDtuG0f7dMjgP9Dp/vpBetdXk8v4A1uH76anrDczaO3pifwBl6GAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkHZ5v91Ob1juYTtNT1jq8uJ6esJyV2d2ptfb/fSE5faLbXrCcscz+04P+3nddYfD4fDl/fPpCctdP76ZnrDUvp/f3eBlCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGlfA43TkfjdNPLgAAAAAElFTkSuQmCC" id="imageeb7b243aeb" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAI/ElEQVR4nO3Yv4rkWR2H4aqe7qZnxQFl1GVDwUwWAxMnMfZO9goMxdzrUG9AEBFNRDExETMxE1mW3XEcZ5b+U/37eQmzwpGv1Ps8V/A5FHXqrXPc/vnT/XBu3nw6vWCp/bPzOs/hcDj8/Ye/mJ6w1N/+/HZ6wnLf/9kPpicsd/zOd6cnrHW8mF6w3uuPpxesd/NsesFSP//GT6YnLHeG3yQAgC9ODAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApB3vTr/cp0esth+26QlLHc+wWa8urqcnLHW/3U5PWO7qL3+cnrDc6dsvpicsddrupycs9/b0enrCcs/P7Hp4ePZ8esJy5/crCwDwXxBDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpl1dvX01vWO/u8+kFa+3b9IL1nj6bXrDU9fSA/4H99dvpCctd/fvl9ISlrrbT9ITlnp7jfXf7ZnrBUleX53fjeRkCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBA2vG0/XqfHrHavm/TE5bazuw8h8PhcHVxPT1hqcf9ND1huSdvXk5PWO/LX59esNTDdj89YbnPbv8xPWG59+8upycstX3lg+kJy3kZAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSLv/0ye+nNyx3cThOT1jqa+89n56w3ON2mp6w1PWTm+kJy330299NT1jux9/71vSEpU77Nj1huR/94a/TE5Z78cGXpics9dGHL6YnLOdlCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGnHh8df7dMjVrt/vJ2esNTT4830BN7h/nianrDcv+4+nZ6w3Fdv3p+esNS2b9MTlnt198n0hOVe3n08PWGpbz77cHrCcl6GAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkHbctt/s0yOA/0On++kF611eTy/gHW4fP5+esNzNk/emJ/AOXoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQdnm/3U5vWO5xO01PWOry4np6wnJXZ3amh+1+esJ65/hX6cw+p8f9vO66w+FwePPwanrCctdPbqYnLLXv2/SE5c7xugMA+MLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBA2n8ApwuP+NzbRB0AAAAASUVORK5CYII=" id="imagef0cace4765" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m7abf2286b3" d="M 0 0 
+       <path id="m343205af9b" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m7abf2286b3" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m343205af9b" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m7abf2286b3" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m343205af9b" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m7abf2286b3" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m343205af9b" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m7abf2286b3" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m343205af9b" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m7abf2286b3" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m343205af9b" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m7abf2286b3" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m343205af9b" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m7abf2286b3" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m343205af9b" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m7abf2286b3" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m343205af9b" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m7abf2286b3" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m343205af9b" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m7abf2286b3" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m343205af9b" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m7abf2286b3" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m343205af9b" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="m41efdef2e3" d="M 0 0 
+       <path id="m42a3b6932c" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m41efdef2e3" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m42a3b6932c" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m41efdef2e3" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m42a3b6932c" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m41efdef2e3" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m42a3b6932c" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m41efdef2e3" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m42a3b6932c" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m41efdef2e3" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m42a3b6932c" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m41efdef2e3" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m42a3b6932c" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m41efdef2e3" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m42a3b6932c" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m41efdef2e3" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m42a3b6932c" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -2092,18 +2092,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="image55ecd70f3c" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
+iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="image008064603e" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="m7eed2e0b61" d="M 0 0 
+       <path id="mbb03dfc351" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m7eed2e0b61" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbb03dfc351" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
@@ -2129,7 +2129,7 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m7eed2e0b61" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbb03dfc351" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
@@ -2146,7 +2146,7 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m7eed2e0b61" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbb03dfc351" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
@@ -2163,7 +2163,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m7eed2e0b61" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbb03dfc351" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
@@ -2180,7 +2180,7 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m7eed2e0b61" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbb03dfc351" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_112">
@@ -2196,7 +2196,7 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m7eed2e0b61" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbb03dfc351" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
@@ -2212,7 +2212,7 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m7eed2e0b61" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbb03dfc351" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
@@ -2228,7 +2228,7 @@ z
     <g id="ytick_16">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#m7eed2e0b61" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbb03dfc351" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_115">
@@ -2244,7 +2244,7 @@ z
     <g id="ytick_17">
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m7eed2e0b61" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbb03dfc351" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_116">
@@ -2882,8 +2882,8 @@ z
    </g>
   </g>
   <g id="text_119">
-   <!-- 2026-07-08T20:00:36Z  ·  Linux chungus2 x86_64  ·  commit 29539fd5  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(17.380078 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-08T20:16:47Z  ·  Linux chungus2 x86_64  ·  commit 74c19afa  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(17.841641 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2955,11 +2955,11 @@ z
     <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2999,109 +2999,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3262.744141 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3326.367188 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3389.990234 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3425.195312 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3488.671875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3552.294922 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3584.082031 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3615.869141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3647.65625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3679.443359 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3711.230469 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3739.013672 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3800.537109 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3861.816406 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3925.195312 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3988.671875 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4027.535156 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4088.716797 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4147.896484 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4209.419922 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4250.533203 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4284.224609 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4312.007812 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4373.53125 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4434.810547 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4498.189453 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4561.8125 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4595.503906 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4654.683594 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4718.306641 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4750.09375 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4813.716797 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4877.339844 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4909.126953 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4972.75 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5008.833984 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5047.697266 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5102.677734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5166.300781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5198.087891 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5229.875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5261.662109 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5293.449219 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5325.236328 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5364.445312 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5427.824219 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5466.6875 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5527.869141 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5591.248047 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5654.724609 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5718.103516 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5781.580078 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5844.958984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5884.167969 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5915.955078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5999.744141 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6031.53125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6128.943359 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6190.466797 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6253.943359 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6281.726562 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6343.005859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6406.384766 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6438.171875 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6490.271484 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6553.650391 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6614.929688 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6678.40625 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6730.505859 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6793.884766 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6855.066406 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6894.275391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6927.966797 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6959.753906 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7000.867188 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7062.146484 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7101.355469 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7129.138672 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7190.320312 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7222.107422 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7249.890625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7301.990234 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7333.777344 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7397.253906 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7458.777344 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7497.986328 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7559.509766 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7598.873047 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7696.285156 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7724.068359 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7787.447266 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7815.230469 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7867.330078 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7906.539062 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7934.322266 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3254.101562 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3317.724609 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3381.347656 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3442.626953 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3477.832031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3539.111328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3570.898438 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3602.685547 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3634.472656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3666.259766 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3698.046875 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3725.830078 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3787.353516 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3848.632812 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3912.011719 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3975.488281 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4014.351562 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4075.533203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4134.712891 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4196.236328 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4237.349609 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4271.041016 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4298.824219 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4360.347656 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4421.626953 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4485.005859 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4548.628906 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4582.320312 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4641.5 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4705.123047 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4736.910156 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4800.533203 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4864.15625 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4895.943359 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4959.566406 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4995.650391 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5034.513672 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5089.494141 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5153.117188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5184.904297 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5216.691406 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5248.478516 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5280.265625 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5312.052734 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5351.261719 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5414.640625 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5453.503906 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5514.685547 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5578.064453 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5641.541016 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5704.919922 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5768.396484 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5831.775391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5870.984375 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5902.771484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5986.560547 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6018.347656 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6115.759766 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6177.283203 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6240.759766 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6268.542969 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6329.822266 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6393.201172 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6424.988281 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6477.087891 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6540.466797 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6601.746094 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6665.222656 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6717.322266 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6780.701172 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6841.882812 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6881.091797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6914.783203 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6946.570312 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6987.683594 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7048.962891 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7088.171875 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7115.955078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7177.136719 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7208.923828 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7236.707031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7288.806641 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7320.59375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7384.070312 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7445.59375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7484.802734 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7546.326172 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7585.689453 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7683.101562 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7710.884766 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7774.263672 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7802.046875 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7854.146484 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7893.355469 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7921.138672 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pff9aea0db8">
+  <clipPath id="p1bc9c5d816">
    <rect x="95.67625" y="49.4355" width="416.571298" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_summary.svg
+++ b/bench/graphs/canterbury_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="573.639844pt" height="386.202469pt" viewBox="0 0 573.639844 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="572.716719pt" height="386.202469pt" viewBox="0 0 572.716719 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,232 +22,232 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 386.202469 
-L 573.639844 386.202469 
-L 573.639844 0 
+L 572.716719 386.202469 
+L 572.716719 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 188.944922 104.1264 
-L 293.569922 104.1264 
-L 293.569922 74.7432 
-L 188.944922 74.7432 
+    <path d="M 188.483359 104.1264 
+L 293.108359 104.1264 
+L 293.108359 74.7432 
+L 188.483359 74.7432 
 z
-" clip-path="url(#pc3c08d5fa9)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p3d3f3a08b8)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 293.569922 104.1264 
-L 398.194922 104.1264 
-L 398.194922 74.7432 
-L 293.569922 74.7432 
+    <path d="M 293.108359 104.1264 
+L 397.733359 104.1264 
+L 397.733359 74.7432 
+L 293.108359 74.7432 
 z
-" clip-path="url(#pc3c08d5fa9)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p3d3f3a08b8)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 398.194922 104.1264 
-L 502.819922 104.1264 
-L 502.819922 74.7432 
-L 398.194922 74.7432 
+    <path d="M 397.733359 104.1264 
+L 502.358359 104.1264 
+L 502.358359 74.7432 
+L 397.733359 74.7432 
 z
-" clip-path="url(#pc3c08d5fa9)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p3d3f3a08b8)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 188.944922 133.5096 
-L 293.569922 133.5096 
-L 293.569922 104.1264 
-L 188.944922 104.1264 
+    <path d="M 188.483359 133.5096 
+L 293.108359 133.5096 
+L 293.108359 104.1264 
+L 188.483359 104.1264 
 z
-" clip-path="url(#pc3c08d5fa9)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p3d3f3a08b8)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 293.569922 133.5096 
-L 398.194922 133.5096 
-L 398.194922 104.1264 
-L 293.569922 104.1264 
+    <path d="M 293.108359 133.5096 
+L 397.733359 133.5096 
+L 397.733359 104.1264 
+L 293.108359 104.1264 
 z
-" clip-path="url(#pc3c08d5fa9)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p3d3f3a08b8)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 398.194922 133.5096 
-L 502.819922 133.5096 
-L 502.819922 104.1264 
-L 398.194922 104.1264 
+    <path d="M 397.733359 133.5096 
+L 502.358359 133.5096 
+L 502.358359 104.1264 
+L 397.733359 104.1264 
 z
-" clip-path="url(#pc3c08d5fa9)" style="fill: #fdb768; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p3d3f3a08b8)" style="fill: #fdb768; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 188.944922 162.8928 
-L 293.569922 162.8928 
-L 293.569922 133.5096 
-L 188.944922 133.5096 
+    <path d="M 188.483359 162.8928 
+L 293.108359 162.8928 
+L 293.108359 133.5096 
+L 188.483359 133.5096 
 z
-" clip-path="url(#pc3c08d5fa9)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p3d3f3a08b8)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 293.569922 162.8928 
-L 398.194922 162.8928 
-L 398.194922 133.5096 
-L 293.569922 133.5096 
+    <path d="M 293.108359 162.8928 
+L 397.733359 162.8928 
+L 397.733359 133.5096 
+L 293.108359 133.5096 
 z
-" clip-path="url(#pc3c08d5fa9)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p3d3f3a08b8)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 398.194922 162.8928 
-L 502.819922 162.8928 
-L 502.819922 133.5096 
-L 398.194922 133.5096 
+    <path d="M 397.733359 162.8928 
+L 502.358359 162.8928 
+L 502.358359 133.5096 
+L 397.733359 133.5096 
 z
-" clip-path="url(#pc3c08d5fa9)" style="fill: #bbe278; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p3d3f3a08b8)" style="fill: #bbe278; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 188.944922 192.276 
-L 293.569922 192.276 
-L 293.569922 162.8928 
-L 188.944922 162.8928 
+    <path d="M 188.483359 192.276 
+L 293.108359 192.276 
+L 293.108359 162.8928 
+L 188.483359 162.8928 
 z
-" clip-path="url(#pc3c08d5fa9)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p3d3f3a08b8)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 293.569922 192.276 
-L 398.194922 192.276 
-L 398.194922 162.8928 
-L 293.569922 162.8928 
+    <path d="M 293.108359 192.276 
+L 397.733359 192.276 
+L 397.733359 162.8928 
+L 293.108359 162.8928 
 z
-" clip-path="url(#pc3c08d5fa9)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p3d3f3a08b8)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 398.194922 192.276 
-L 502.819922 192.276 
-L 502.819922 162.8928 
-L 398.194922 162.8928 
+    <path d="M 397.733359 192.276 
+L 502.358359 192.276 
+L 502.358359 162.8928 
+L 397.733359 162.8928 
 z
-" clip-path="url(#pc3c08d5fa9)" style="fill: #fdc776; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p3d3f3a08b8)" style="fill: #fdc776; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 188.944922 221.6592 
-L 293.569922 221.6592 
-L 293.569922 192.276 
-L 188.944922 192.276 
+    <path d="M 188.483359 221.6592 
+L 293.108359 221.6592 
+L 293.108359 192.276 
+L 188.483359 192.276 
 z
-" clip-path="url(#pc3c08d5fa9)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p3d3f3a08b8)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 293.569922 221.6592 
-L 398.194922 221.6592 
-L 398.194922 192.276 
-L 293.569922 192.276 
+    <path d="M 293.108359 221.6592 
+L 397.733359 221.6592 
+L 397.733359 192.276 
+L 293.108359 192.276 
 z
-" clip-path="url(#pc3c08d5fa9)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p3d3f3a08b8)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 398.194922 221.6592 
-L 502.819922 221.6592 
-L 502.819922 192.276 
-L 398.194922 192.276 
+    <path d="M 397.733359 221.6592 
+L 502.358359 221.6592 
+L 502.358359 192.276 
+L 397.733359 192.276 
 z
-" clip-path="url(#pc3c08d5fa9)" style="fill: #addc6f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p3d3f3a08b8)" style="fill: #addc6f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 188.944922 251.0424 
-L 293.569922 251.0424 
-L 293.569922 221.6592 
-L 188.944922 221.6592 
+    <path d="M 188.483359 251.0424 
+L 293.108359 251.0424 
+L 293.108359 221.6592 
+L 188.483359 221.6592 
 z
-" clip-path="url(#pc3c08d5fa9)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p3d3f3a08b8)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 293.569922 251.0424 
-L 398.194922 251.0424 
-L 398.194922 221.6592 
-L 293.569922 221.6592 
+    <path d="M 293.108359 251.0424 
+L 397.733359 251.0424 
+L 397.733359 221.6592 
+L 293.108359 221.6592 
 z
-" clip-path="url(#pc3c08d5fa9)" style="fill: #fdbd6d; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p3d3f3a08b8)" style="fill: #fdbd6d; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 398.194922 251.0424 
-L 502.819922 251.0424 
-L 502.819922 221.6592 
-L 398.194922 221.6592 
+    <path d="M 397.733359 251.0424 
+L 502.358359 251.0424 
+L 502.358359 221.6592 
+L 397.733359 221.6592 
 z
-" clip-path="url(#pc3c08d5fa9)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p3d3f3a08b8)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 188.944922 280.4256 
-L 293.569922 280.4256 
-L 293.569922 251.0424 
-L 188.944922 251.0424 
+    <path d="M 188.483359 280.4256 
+L 293.108359 280.4256 
+L 293.108359 251.0424 
+L 188.483359 251.0424 
 z
-" clip-path="url(#pc3c08d5fa9)" style="fill: #ebf7a3; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p3d3f3a08b8)" style="fill: #ebf7a3; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 293.569922 280.4256 
-L 398.194922 280.4256 
-L 398.194922 251.0424 
-L 293.569922 251.0424 
+    <path d="M 293.108359 280.4256 
+L 397.733359 280.4256 
+L 397.733359 251.0424 
+L 293.108359 251.0424 
 z
-" clip-path="url(#pc3c08d5fa9)" style="fill: #fca85e; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p3d3f3a08b8)" style="fill: #fca85e; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 398.194922 280.4256 
-L 502.819922 280.4256 
-L 502.819922 251.0424 
-L 398.194922 251.0424 
+    <path d="M 397.733359 280.4256 
+L 502.358359 280.4256 
+L 502.358359 251.0424 
+L 397.733359 251.0424 
 z
-" clip-path="url(#pc3c08d5fa9)" style="fill: #fca55d; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p3d3f3a08b8)" style="fill: #fca85e; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 188.944922 309.8088 
-L 293.569922 309.8088 
-L 293.569922 280.4256 
-L 188.944922 280.4256 
+    <path d="M 188.483359 309.8088 
+L 293.108359 309.8088 
+L 293.108359 280.4256 
+L 188.483359 280.4256 
 z
-" clip-path="url(#pc3c08d5fa9)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p3d3f3a08b8)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 293.569922 309.8088 
-L 398.194922 309.8088 
-L 398.194922 280.4256 
-L 293.569922 280.4256 
+    <path d="M 293.108359 309.8088 
+L 397.733359 309.8088 
+L 397.733359 280.4256 
+L 293.108359 280.4256 
 z
-" clip-path="url(#pc3c08d5fa9)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p3d3f3a08b8)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 398.194922 309.8088 
-L 502.819922 309.8088 
-L 502.819922 280.4256 
-L 398.194922 280.4256 
+    <path d="M 397.733359 309.8088 
+L 502.358359 309.8088 
+L 502.358359 280.4256 
+L 397.733359 280.4256 
 z
-" clip-path="url(#pc3c08d5fa9)" style="fill: #ee613e; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p3d3f3a08b8)" style="fill: #ee613e; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 188.944922 339.192 
-L 293.569922 339.192 
-L 293.569922 309.8088 
-L 188.944922 309.8088 
+    <path d="M 188.483359 339.192 
+L 293.108359 339.192 
+L 293.108359 309.8088 
+L 188.483359 309.8088 
 z
-" clip-path="url(#pc3c08d5fa9)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p3d3f3a08b8)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 293.569922 339.192 
-L 398.194922 339.192 
-L 398.194922 309.8088 
-L 293.569922 309.8088 
+    <path d="M 293.108359 339.192 
+L 397.733359 339.192 
+L 397.733359 309.8088 
+L 293.108359 309.8088 
 z
-" clip-path="url(#pc3c08d5fa9)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p3d3f3a08b8)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 398.194922 339.192 
-L 502.819922 339.192 
-L 502.819922 309.8088 
-L 398.194922 309.8088 
+    <path d="M 397.733359 339.192 
+L 502.358359 339.192 
+L 502.358359 309.8088 
+L 397.733359 309.8088 
 z
-" clip-path="url(#pc3c08d5fa9)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p3d3f3a08b8)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(121.932188 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(121.470625 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(229.216406 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(228.754844 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(307.788516 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(307.326953 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(406.140234 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(405.678672 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(117.869922 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(117.408359 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.296 -->
-    <g transform="translate(229.806172 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(229.344609 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -946,7 +946,7 @@ z
    </g>
    <g id="text_7">
     <!-- 158 -->
-    <g transform="translate(338.247422 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(337.785859 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -1034,7 +1034,7 @@ z
    </g>
    <g id="text_8">
     <!-- 925 -->
-    <g transform="translate(442.872422 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(442.410859 91.6423) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-39"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
@@ -1042,7 +1042,7 @@ z
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(112.508047 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(112.046484 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1141,7 +1141,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.299 -->
-    <g transform="translate(229.806172 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(229.344609 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1151,7 +1151,7 @@ z
    </g>
    <g id="text_11">
     <!-- 73 -->
-    <g transform="translate(340.792422 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(340.330859 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -1202,7 +1202,7 @@ z
    </g>
    <g id="text_12">
     <!-- 283 -->
-    <g transform="translate(442.872422 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(442.410859 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(127.246094 0)"/>
@@ -1210,7 +1210,7 @@ z
    </g>
    <g id="text_13">
     <!-- zlib -->
-    <g transform="translate(129.771172 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(129.309609 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1234,7 +1234,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.299 -->
-    <g transform="translate(229.806172 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(229.344609 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1244,14 +1244,14 @@ z
    </g>
    <g id="text_15">
     <!-- 55 -->
-    <g transform="translate(340.792422 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(340.330859 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
     <!-- 692 -->
-    <g transform="translate(442.872422 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(442.410859 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-36"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
@@ -1259,7 +1259,7 @@ z
    </g>
    <g id="text_17">
     <!-- Go compress/flate -->
-    <g transform="translate(100.201172 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(99.739609 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -1430,7 +1430,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.299 -->
-    <g transform="translate(229.806172 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(229.344609 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1440,14 +1440,14 @@ z
    </g>
    <g id="text_19">
     <!-- 52 -->
-    <g transform="translate(340.792422 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(340.330859 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
     <!-- 323 -->
-    <g transform="translate(442.872422 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(442.410859 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(127.246094 0)"/>
@@ -1455,7 +1455,7 @@ z
    </g>
    <g id="text_21">
     <!-- miniz_oxide -->
-    <g transform="translate(113.077422 209.06385) scale(0.08 -0.08)">
+    <g transform="translate(112.615859 209.06385) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6e" d="M 3513 2113 
 L 3513 0 
@@ -1514,7 +1514,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.299 -->
-    <g transform="translate(229.806172 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(229.344609 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1524,14 +1524,14 @@ z
    </g>
    <g id="text_23">
     <!-- 51 -->
-    <g transform="translate(340.792422 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(340.330859 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_24">
     <!-- 729 -->
-    <g transform="translate(442.872422 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(442.410859 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-37"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(127.246094 0)"/>
@@ -1539,7 +1539,7 @@ z
    </g>
    <g id="text_25">
     <!-- JS fflate -->
-    <g transform="translate(121.233672 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(120.772109 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1599,7 +1599,7 @@ z
    </g>
    <g id="text_26">
     <!-- 0.307 -->
-    <g transform="translate(229.806172 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(229.344609 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1609,7 +1609,7 @@ z
    </g>
    <g id="text_27">
     <!-- 41 -->
-    <g transform="translate(340.792422 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(340.330859 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1637,14 +1637,14 @@ z
    </g>
    <g id="text_28">
     <!-- 80 -->
-    <g transform="translate(445.417422 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(444.955859 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-38"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_29">
     <!-- lean-zip (native) -->
-    <g transform="translate(99.579297 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(99.117734 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1753,7 +1753,7 @@ z
    </g>
    <g id="text_30">
     <!-- 0.297 -->
-    <g transform="translate(228.605547 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(228.143984 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1854,8 +1854,8 @@ z
     </g>
    </g>
    <g id="text_31">
-    <!-- 32 -->
-    <g transform="translate(340.316172 267.9415) scale(0.08 -0.08)">
+    <!-- 33 -->
+    <g transform="translate(339.854609 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-33" d="M 2981 2516 
 Q 3453 2394 3698 2092 
@@ -1891,12 +1891,12 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-Bold-33"/>
-     <use xlink:href="#DejaVuSans-Bold-32" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-33" transform="translate(69.580078 0)"/>
     </g>
    </g>
    <g id="text_32">
-    <!-- 247 -->
-    <g transform="translate(442.158047 267.9415) scale(0.08 -0.08)">
+    <!-- 248 -->
+    <g transform="translate(441.696484 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-34" d="M 2356 3675 
 L 1038 1722 
@@ -1917,15 +1917,54 @@ L 288 1881
 L 2156 4666 
 z
 " transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-38" d="M 2228 2088 
+Q 1891 2088 1709 1903 
+Q 1528 1719 1528 1375 
+Q 1528 1031 1709 848 
+Q 1891 666 2228 666 
+Q 2563 666 2741 848 
+Q 2919 1031 2919 1375 
+Q 2919 1722 2741 1905 
+Q 2563 2088 2228 2088 
+z
+M 1350 2484 
+Q 925 2613 709 2878 
+Q 494 3144 494 3541 
+Q 494 4131 934 4440 
+Q 1375 4750 2228 4750 
+Q 3075 4750 3515 4442 
+Q 3956 4134 3956 3541 
+Q 3956 3144 3739 2878 
+Q 3522 2613 3097 2484 
+Q 3572 2353 3814 2058 
+Q 4056 1763 4056 1313 
+Q 4056 619 3595 264 
+Q 3134 -91 2228 -91 
+Q 1319 -91 855 264 
+Q 391 619 391 1313 
+Q 391 1763 633 2058 
+Q 875 2353 1350 2484 
+z
+M 1631 3419 
+Q 1631 3141 1786 2991 
+Q 1941 2841 2228 2841 
+Q 2509 2841 2662 2991 
+Q 2816 3141 2816 3419 
+Q 2816 3697 2662 3845 
+Q 2509 3994 2228 3994 
+Q 1941 3994 1786 3844 
+Q 1631 3694 1631 3419 
+z
+" transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-Bold-32"/>
      <use xlink:href="#DejaVuSans-Bold-34" transform="translate(69.580078 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-37" transform="translate(139.160156 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-38" transform="translate(139.160156 0)"/>
     </g>
    </g>
    <g id="text_33">
     <!-- OCaml decompress -->
-    <g transform="translate(97.694297 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(97.232734 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -1990,7 +2029,7 @@ z
    </g>
    <g id="text_34">
     <!-- 0.321 -->
-    <g transform="translate(229.806172 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(229.344609 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -2000,14 +2039,14 @@ z
    </g>
    <g id="text_35">
     <!-- 23 -->
-    <g transform="translate(340.792422 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(340.330859 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_36">
     <!-- 117 -->
-    <g transform="translate(442.872422 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(442.410859 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
@@ -2015,7 +2054,7 @@ z
    </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(125.915547 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(125.453984 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -2026,7 +2065,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.279 -->
-    <g transform="translate(229.806172 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(229.344609 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -2036,13 +2075,13 @@ z
    </g>
    <g id="text_39">
     <!-- 0 -->
-    <g transform="translate(343.337422 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(342.875859 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(446.507422 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(446.045859 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2058,7 +2097,7 @@ z
   </g>
   <g id="text_41">
    <!-- canterbury — geomean over files, level 6 -->
-   <g transform="translate(136.328672 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(135.867109 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-62" d="M 2400 722 
 Q 2759 722 2948 984 
@@ -2271,7 +2310,7 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-07-08T20:00:36Z  ·  Linux chungus2 x86_64  ·  commit 29539fd5  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-07-08T20:16:47Z  ·  Linux chungus2 x86_64  ·  commit 74c19afa  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2415,11 +2454,11 @@ z
     <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2459,110 +2498,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3262.744141 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3326.367188 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3389.990234 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3425.195312 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3488.671875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3552.294922 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3584.082031 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3615.869141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3647.65625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3679.443359 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3711.230469 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3739.013672 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3800.537109 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3861.816406 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3925.195312 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3988.671875 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4027.535156 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4088.716797 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4147.896484 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4209.419922 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4250.533203 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4284.224609 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4312.007812 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4373.53125 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4434.810547 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4498.189453 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4561.8125 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4595.503906 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4654.683594 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4718.306641 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4750.09375 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4813.716797 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4877.339844 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4909.126953 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4972.75 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5008.833984 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5047.697266 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5102.677734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5166.300781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5198.087891 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5229.875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5261.662109 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5293.449219 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5325.236328 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5364.445312 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5427.824219 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5466.6875 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5527.869141 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5591.248047 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5654.724609 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5718.103516 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5781.580078 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5844.958984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5884.167969 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5915.955078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5999.744141 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6031.53125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6128.943359 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6190.466797 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6253.943359 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6281.726562 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6343.005859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6406.384766 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6438.171875 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6490.271484 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6553.650391 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6614.929688 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6678.40625 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6730.505859 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6793.884766 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6855.066406 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6894.275391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6927.966797 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6959.753906 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7000.867188 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7062.146484 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7101.355469 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7129.138672 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7190.320312 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7222.107422 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7249.890625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7301.990234 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7333.777344 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7397.253906 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7458.777344 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7497.986328 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7559.509766 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7598.873047 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7696.285156 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7724.068359 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7787.447266 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7815.230469 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7867.330078 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7906.539062 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7934.322266 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3254.101562 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3317.724609 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3381.347656 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3442.626953 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3477.832031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3539.111328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3570.898438 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3602.685547 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3634.472656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3666.259766 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3698.046875 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3725.830078 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3787.353516 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3848.632812 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3912.011719 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3975.488281 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4014.351562 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4075.533203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4134.712891 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4196.236328 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4237.349609 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4271.041016 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4298.824219 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4360.347656 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4421.626953 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4485.005859 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4548.628906 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4582.320312 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4641.5 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4705.123047 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4736.910156 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4800.533203 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4864.15625 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4895.943359 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4959.566406 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4995.650391 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5034.513672 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5089.494141 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5153.117188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5184.904297 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5216.691406 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5248.478516 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5280.265625 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5312.052734 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5351.261719 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5414.640625 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5453.503906 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5514.685547 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5578.064453 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5641.541016 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5704.919922 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5768.396484 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5831.775391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5870.984375 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5902.771484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5986.560547 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6018.347656 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6115.759766 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6177.283203 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6240.759766 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6268.542969 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6329.822266 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6393.201172 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6424.988281 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6477.087891 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6540.466797 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6601.746094 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6665.222656 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6717.322266 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6780.701172 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6841.882812 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6881.091797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6914.783203 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6946.570312 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6987.683594 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7048.962891 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7088.171875 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7115.955078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7177.136719 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7208.923828 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7236.707031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7288.806641 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7320.59375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7384.070312 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7445.59375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7484.802734 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7546.326172 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7585.689453 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7683.101562 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7710.884766 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7774.263672 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7802.046875 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7854.146484 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7893.355469 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7921.138672 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pc3c08d5fa9">
-   <rect x="84.319922" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="p3d3f3a08b8">
+   <rect x="83.858359" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/graphs/silesia_compress_heatmap.svg
+++ b/bench/graphs/silesia_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.34175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#pc2016efa0c)">
+   <g clip-path="url(#pc20051694a)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAqAAAAGaCAYAAADQNfGTAAAJ90lEQVR4nO3YMY5kVxmG4emumnZPWxrGtmg8yAkICSECy0gWYhusg4iUNbABModeAAEJAQGSSRw6AUu2AY0MjLA1DEV3dTeLGJ33b189zwq+0ql7661zcvuvD+4ebNnVy+kFa52cTi9Y6/Y4vWCtrZ/f8Wp6wVoXT6YXrPW/F9MLeBW7s+kFa239+/nwfHrBUhv/9QMA4L4RoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApPYfHz+f3rDU2cP99ISlDser6QlLPX383ekJS3329RfTE5Y6ntxMT1jqR4/enJ6w1PG18+kJS/3txV+nJyx1+ehyesJSh7Pj9ISlTh68nJ6wlBtQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgtb+8uJzesNTT178/PWGpL19+Pj1hqbcP2/6P9Pitd6cnLHW2O5+esNTN7XF6wlJbP7/Nf77TbX++/ek70xOWOj8cpicste1fdwAA7h0BCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBAav/a7mJ6w1LPD8+mJyy19fO7eePN6QlLffHvj6cnLPXi+jA9Yan333h/esJSV3fH6QlLffb1p9MTlvrxWz+ZnrDUR8/+OD1hqfe+ve3zcwMKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkDq5+cMv76ZHLHV7O72AV7H18zv1HxDGbP358/78ZjsepxcstfHTAwDgvhGgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACk9pcffTK9Yand2W56wlJffvKP6QlL/eYX701PWOrXf9r2+f3sncfTE5b68PefTk9Y6lc//+H0hKV++5evpics9b0nj6YnLPX8v9fTE5b66dOL6QlLuQEFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSJ9c3v7ubHrHS7vpqesJau7PpBWsdD9ML1tqfTy9Ya7efXrDW3e30grWuN/78nWz8DuZ028/f9cm2n7+Hx+P0hKU2/vQBAHDfCFAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFL7fx7+Pr1hqe88eDI9Yan/nB6nJyz1+u30gsV2++kFvIKvrp9PT1jqW9fbvqO4uXg8PWGp27ttv0AfPvvz9IS1Ln8wvWCpbb9dAAC4dwQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAACp/wOn/XvO0MvcQwAAAABJRU5ErkJggg==" id="imaged6a9a0f1d8" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="483.84" height="295.2"/>
+iVBORw0KGgoAAAANSUhEUgAAAqAAAAGaCAYAAADQNfGTAAAJ9klEQVR4nO3YP45kVx2GYXdXTbunLQ0e2zQMmgQShAiQkSzL22AdRE5ZAxsgI2QBBCQEBEgmcegIS/4DsgweYWsYl7uru1nE6Ly/5up5VvCVTp2q996T269+f/fKll29mF6w1snp9IK1bo/TC9ba+vkdr6YXrHXx+vSCtb57Pr2Al7E7m16w1ta/nw/OpxcstfF/PwAA7hsBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBAav/h8dPpDUudPdhPT1jqcLyanrDUk0c/mp6w1CfffDY9Yanjyc30hKV+9vCN6QlLHV89n56w1D+efz49YanLh5fTE5Y6nB2nJyx18sqL6QlLeQMKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACk9pcXl9Mblnry2k+mJyz15YtPpycs9cPDtp+RHr35i+kJS53tzqcnLHVze5yesNTWz2/zn+90259vf/p0esJS54fD9ISltv3vDgDAvSNAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBI7V/dXUxvWOrZ4YvpCUtt/fxuHr8xPWGpz/7z4fSEpZ5fH6YnLPXO43emJyx1dXecnrDUJ998PD1hqZ+/+cvpCUt98MVfpycs9fb3t31+3oACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApE5u/vL+3fSIpW5vpxfwMrZ+fqeeAWHM1u+f38//b8fj9IKlNn56AADcNwIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAIDU/vKDj6Y3LLU7201PWOrLj/41PWGp3/367ekJS/32b9s+v/eePpqesNQf/vzx9ISlfvOrn05PWOqPf/96esJSP3794fSEpZ59ez09Yal3n1xMT1jKG1AAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACB1cn3zp7vpESvtrq+mJ6y1O5tesNbxML1grf359IK1dvvpBWvd3U4vWOt64/fvZOPvYE63ff+uT7Z9/x4cj9MTltr47QMA4L4RoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApPb/PvxzesNSP9i9NT1hqf/evZiesNRrW39G2u2nF/ASvr5+Nj1hqe9db/v+3Vw8mp6w1O3d7fSEpR589fn0hLUeP51esNS2f10AALh3BCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAAKn/AcIqe9C4En4wAAAAAElFTkSuQmCC" id="image4e0f6f9cfd" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="483.84" height="295.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m44834e04e1" d="M 0 0 
+       <path id="mf759a82a94" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m44834e04e1" x="115.814949" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf759a82a94" x="115.814949" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m44834e04e1" x="156.092348" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf759a82a94" x="156.092348" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m44834e04e1" x="196.369746" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf759a82a94" x="196.369746" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m44834e04e1" x="236.647145" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf759a82a94" x="236.647145" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m44834e04e1" x="276.924544" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf759a82a94" x="276.924544" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m44834e04e1" x="317.201942" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf759a82a94" x="317.201942" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m44834e04e1" x="357.479341" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf759a82a94" x="357.479341" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m44834e04e1" x="397.756739" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf759a82a94" x="397.756739" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m44834e04e1" x="438.034138" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf759a82a94" x="438.034138" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m44834e04e1" x="478.311536" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf759a82a94" x="478.311536" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m44834e04e1" x="518.588935" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf759a82a94" x="518.588935" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m44834e04e1" x="558.866334" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf759a82a94" x="558.866334" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="m95f8f61b39" d="M 0 0 
+       <path id="m71c38e0436" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m95f8f61b39" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m71c38e0436" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m95f8f61b39" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m71c38e0436" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m95f8f61b39" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m71c38e0436" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m95f8f61b39" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m71c38e0436" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -836,7 +836,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m95f8f61b39" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m71c38e0436" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -899,7 +899,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m95f8f61b39" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m71c38e0436" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -966,7 +966,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m95f8f61b39" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m71c38e0436" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1047,7 +1047,7 @@ z
     <g id="ytick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m95f8f61b39" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m71c38e0436" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -1138,7 +1138,7 @@ L 579.005033 49.34175
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_21">
-    <!-- +38 -->
+    <!-- +37 -->
     <g transform="translate(108.955926 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-2b" d="M 2944 4013 
@@ -1188,6 +1188,74 @@ Q 3450 3153 3228 2886
 Q 3006 2619 2597 2516 
 z
 " transform="scale(0.015625)"/>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_22">
+    <!-- -12 -->
+    <g transform="translate(150.784184 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_23">
+    <!-- +18 -->
+    <g transform="translate(189.510723 69.553235) scale(0.065 -0.065)">
+     <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
 Q 1069 1734 1069 1313 
@@ -1229,96 +1297,60 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
     </g>
    </g>
-   <g id="text_22">
-    <!-- -17 -->
-    <g transform="translate(150.784184 69.553235) scale(0.065 -0.065)">
+   <g id="text_24">
+    <!-- -16 -->
+    <g transform="translate(231.338981 69.553235) scale(0.065 -0.065)">
      <defs>
-      <path id="DejaVuSans-31" d="M 794 531 
-L 1825 531 
-L 1825 4091 
-L 703 3866 
-L 703 4441 
-L 1819 4666 
-L 2450 4666 
-L 2450 531 
-L 3481 531 
-L 3481 0 
-L 794 0 
-L 794 531 
+      <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
 z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_23">
-    <!-- +17 -->
-    <g transform="translate(189.510723 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_24">
-    <!-- -17 -->
-    <g transform="translate(231.338981 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_25">
-    <!-- -1 -->
-    <g transform="translate(273.684192 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+    <!-- +2 -->
+    <g transform="translate(272.133333 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_26">
     <!-- +2 -->
     <g transform="translate(312.410731 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-32" d="M 1228 531 
-L 3431 531 
-L 3431 0 
-L 469 0 
-L 469 531 
-Q 828 903 1448 1529 
-Q 2069 2156 2228 2338 
-Q 2531 2678 2651 2914 
-Q 2772 3150 2772 3378 
-Q 2772 3750 2511 3984 
-Q 2250 4219 1831 4219 
-Q 1534 4219 1204 4116 
-Q 875 4013 500 3803 
-L 500 4441 
-Q 881 4594 1212 4672 
-Q 1544 4750 1819 4750 
-Q 2544 4750 2975 4387 
-Q 3406 4025 3406 3419 
-Q 3406 3131 3298 2873 
-Q 3191 2616 2906 2266 
-Q 2828 2175 2409 1742 
-Q 1991 1309 1228 531 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
     </g>
@@ -1353,11 +1385,11 @@ z
     </g>
    </g>
    <g id="text_28">
-    <!-- -23 -->
+    <!-- -22 -->
     <g transform="translate(392.448575 69.553235) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_29">
@@ -1402,34 +1434,11 @@ z
     </g>
    </g>
    <g id="text_31">
-    <!-- -50 -->
+    <!-- -42 -->
     <g transform="translate(513.280771 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-30" d="M 2034 4250 
-Q 1547 4250 1301 3770 
-Q 1056 3291 1056 2328 
-Q 1056 1369 1301 889 
-Q 1547 409 2034 409 
-Q 2525 409 2770 889 
-Q 3016 1369 3016 2328 
-Q 3016 3291 2770 3770 
-Q 2525 4250 2034 4250 
-z
-M 2034 4750 
-Q 2819 4750 3233 4129 
-Q 3647 3509 3647 2328 
-Q 3647 1150 3233 529 
-Q 2819 -91 2034 -91 
-Q 1250 -91 836 529 
-Q 422 1150 422 2328 
-Q 422 3509 836 4129 
-Q 1250 4750 2034 4750 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_32">
@@ -1496,38 +1505,6 @@ z
    <g id="text_36">
     <!-- -16 -->
     <g transform="translate(231.338981 106.389018) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-36" d="M 2113 2584 
-Q 1688 2584 1439 2293 
-Q 1191 2003 1191 1497 
-Q 1191 994 1439 701 
-Q 1688 409 2113 409 
-Q 2538 409 2786 701 
-Q 3034 994 3034 1497 
-Q 3034 2003 2786 2293 
-Q 2538 2584 2113 2584 
-z
-M 3366 4563 
-L 3366 3988 
-Q 3128 4100 2886 4159 
-Q 2644 4219 2406 4219 
-Q 1781 4219 1451 3797 
-Q 1122 3375 1075 2522 
-Q 1259 2794 1537 2939 
-Q 1816 3084 2150 3084 
-Q 2853 3084 3261 2657 
-Q 3669 2231 3669 1497 
-Q 3669 778 3244 343 
-Q 2819 -91 2113 -91 
-Q 1303 -91 875 529 
-Q 447 1150 447 2328 
-Q 447 3434 972 4092 
-Q 1497 4750 2381 4750 
-Q 2619 4750 2861 4703 
-Q 3103 4656 3366 4563 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
@@ -1543,6 +1520,29 @@ z
    <g id="text_38">
     <!-- -0 -->
     <g transform="translate(313.961591 106.389018) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(36.083984 0)"/>
     </g>
@@ -2189,18 +2189,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB1ElEQVR4nO2b0a3DMAwD7cSzvM3fmI47gvpxCK6ENABhnkQ5aZH5P/7OAGpdFyEzBiQDnija2qSEghnZhIIZCa3NyWQkmZFOKJhRsDXsOopmJJwjaEPOmxHirE3MWjOqhSBr2EAGMyKtMVpc+ynYwe3viNQVbA0LrZDRFbxGbNbWyM3auG0RGbo1Qp0IZCSMiG2OgtNvbL+Oke6BvddIWaQ1qP3RjGSTLXypwdaIMP2ctWb0olAzKkr4LhLMCPvnOJiRbo6CrTWjF4WCGYHWJtU1TKgZvSZkfNAKZhRsDftFa96MkJCRrf29ausyWrOtWiMjmxDH6FAfDJzzIEKctQc60ToDEqJOBLbfZs04RxQjobWOSFXrjM0IdURqIaG1jkhVPmvGOUqOCPLJMdh+6kRk+zFGMtjKOdK13zbZ2EBGMxLOkSz90YygK9tozSbUa6Qu4RxtRifZ2np0jDY32YiOc44gIQo2aI1ZkB2Rb4SiIyJbtcr0Q0IPdCQyIpCQDnZHpC5uQ27uOtJFBBptH2zlHOnab+uaMSK29htXrW2NKK0hOtlrxLaPjIxys4a99x9dRKgTgUK69gsZ9RxVFWzNyIi6RZIZtbXfE+qI1BU8R5i1D2e5X2tFkZmlAAAAAElFTkSuQmCC" id="imageefd82aa64f" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-69.84" width="12.96" height="253.44"/>
+iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB1ElEQVR4nO2b0a3DMAwD7cSzvM3fmI47gvpxCK6ENABhnkQ5aZH5P/7OAGpdFyEzBiQDnija2qSEghnZhIIZCa3NyWQkmZFOKJhRsDXsOopmJJwjaEPOmxHirE3MWjOqhSBr2EAGMyKtMVpc+ynYwe3viNQVbA0LrZDRFbxGbNbWyM3auG0RGbo1Qp0IZCSMiG2OgtNvbL+Oke6BvddIWaQ1qP3RjGSTLXypwdaIMP2ctWb0olAzKkr4LhLMCPvnOJiRbo6CrTWjF4WCGYHWJtU1TKgZvSZkfNAKZhRsDftFa96MkJCRrf29ausyWrOtWiMjmxDH6FAfDJzzIEKctQc60ToDEqJOBLbfZs04RxQjobWOSFXrjM0IdURqIaG1jkhVPmvGOUqOCPLJMdh+6kRk+zFGMtjKOdK13zbZ2EBGMxLOkSz90YygK9tozSbUa6Qu4RxtRifZ2np0jDY32YiOc44gIQo2aI1ZkB2Rb4SiIyJbtcr0Q0IPdCQyIpCQDnZHpC5uQ27uOtJFBBptH2zlHOnab+uaMSK29htXrW2NKK0hOtlrxLaPjIxys4a99x9dRKgTgUK69gsZ9RxVFWzNyIi6RZIZtbXfE+qI1BU8R5i1D2e5X2tFkZmlAAAAAElFTkSuQmCC" id="image78bc9cc51e" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-69.84" width="12.96" height="253.44"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_21">
       <defs>
-       <path id="md2e26757d4" d="M 0 0 
+       <path id="mfb3ced30c2" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#md2e26757d4" x="601.779688" y="322.507463" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfb3ced30c2" x="601.779688" y="322.507463" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_117">
@@ -2223,7 +2223,7 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#md2e26757d4" x="601.779688" y="280.566603" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfb3ced30c2" x="601.779688" y="280.566603" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_118">
@@ -2237,7 +2237,7 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#md2e26757d4" x="601.779688" y="238.625742" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfb3ced30c2" x="601.779688" y="238.625742" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_119">
@@ -2251,7 +2251,7 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#md2e26757d4" x="601.779688" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfb3ced30c2" x="601.779688" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_120">
@@ -2264,7 +2264,7 @@ z
     <g id="ytick_13">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#md2e26757d4" x="601.779688" y="154.74402" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfb3ced30c2" x="601.779688" y="154.74402" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_121">
@@ -2277,7 +2277,7 @@ z
     <g id="ytick_14">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#md2e26757d4" x="601.779688" y="112.803159" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfb3ced30c2" x="601.779688" y="112.803159" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_122">
@@ -2290,7 +2290,7 @@ z
     <g id="ytick_15">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#md2e26757d4" x="601.779688" y="70.862298" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfb3ced30c2" x="601.779688" y="70.862298" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_123">
@@ -2906,8 +2906,8 @@ z
    </g>
   </g>
   <g id="text_126">
-   <!-- 2026-07-08T20:00:36Z  ·  Linux chungus2 x86_64  ·  commit 29539fd5  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(44.380078 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-08T20:16:47Z  ·  Linux chungus2 x86_64  ·  commit 74c19afa  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(44.841641 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -3001,11 +3001,11 @@ z
     <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3045,109 +3045,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3262.744141 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3326.367188 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3389.990234 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3425.195312 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3488.671875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3552.294922 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3584.082031 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3615.869141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3647.65625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3679.443359 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3711.230469 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3739.013672 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3800.537109 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3861.816406 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3925.195312 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3988.671875 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4027.535156 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4088.716797 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4147.896484 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4209.419922 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4250.533203 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4284.224609 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4312.007812 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4373.53125 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4434.810547 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4498.189453 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4561.8125 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4595.503906 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4654.683594 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4718.306641 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4750.09375 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4813.716797 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4877.339844 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4909.126953 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4972.75 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5008.833984 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5047.697266 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5102.677734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5166.300781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5198.087891 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5229.875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5261.662109 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5293.449219 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5325.236328 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5364.445312 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5427.824219 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5466.6875 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5527.869141 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5591.248047 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5654.724609 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5718.103516 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5781.580078 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5844.958984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5884.167969 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5915.955078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5999.744141 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6031.53125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6128.943359 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6190.466797 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6253.943359 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6281.726562 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6343.005859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6406.384766 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6438.171875 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6490.271484 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6553.650391 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6614.929688 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6678.40625 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6730.505859 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6793.884766 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6855.066406 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6894.275391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6927.966797 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6959.753906 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7000.867188 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7062.146484 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7101.355469 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7129.138672 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7190.320312 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7222.107422 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7249.890625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7301.990234 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7333.777344 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7397.253906 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7458.777344 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7497.986328 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7559.509766 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7598.873047 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7696.285156 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7724.068359 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7787.447266 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7815.230469 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7867.330078 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7906.539062 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7934.322266 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3254.101562 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3317.724609 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3381.347656 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3442.626953 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3477.832031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3539.111328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3570.898438 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3602.685547 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3634.472656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3666.259766 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3698.046875 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3725.830078 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3787.353516 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3848.632812 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3912.011719 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3975.488281 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4014.351562 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4075.533203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4134.712891 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4196.236328 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4237.349609 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4271.041016 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4298.824219 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4360.347656 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4421.626953 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4485.005859 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4548.628906 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4582.320312 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4641.5 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4705.123047 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4736.910156 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4800.533203 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4864.15625 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4895.943359 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4959.566406 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4995.650391 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5034.513672 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5089.494141 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5153.117188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5184.904297 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5216.691406 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5248.478516 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5280.265625 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5312.052734 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5351.261719 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5414.640625 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5453.503906 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5514.685547 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5578.064453 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5641.541016 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5704.919922 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5768.396484 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5831.775391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5870.984375 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5902.771484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5986.560547 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6018.347656 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6115.759766 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6177.283203 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6240.759766 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6268.542969 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6329.822266 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6393.201172 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6424.988281 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6477.087891 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6540.466797 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6601.746094 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6665.222656 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6717.322266 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6780.701172 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6841.882812 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6881.091797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6914.783203 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6946.570312 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6987.683594 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7048.962891 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7088.171875 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7115.955078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7177.136719 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7208.923828 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7236.707031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7288.806641 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7320.59375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7384.070312 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7445.59375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7484.802734 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7546.326172 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7585.689453 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7683.101562 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7710.884766 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7774.263672 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7802.046875 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7854.146484 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7893.355469 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7921.138672 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pc2016efa0c">
+  <clipPath id="pc20051694a">
    <rect x="95.67625" y="49.34175" width="483.328783" height="294.686261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_compress_pareto.svg
+++ b/bench/graphs/silesia_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 61.085542 412.80375 
 L 61.085542 48.323125 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="ma62549c883" d="M 0 0 
+       <path id="m83617a424c" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#ma62549c883" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m83617a424c" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -130,11 +130,11 @@ z
      <g id="line2d_3">
       <path d="M 145.270284 412.80375 
 L 145.270284 48.323125 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#ma62549c883" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m83617a424c" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -177,11 +177,11 @@ z
      <g id="line2d_5">
       <path d="M 229.455026 412.80375 
 L 229.455026 48.323125 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#ma62549c883" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m83617a424c" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -219,11 +219,11 @@ z
      <g id="line2d_7">
       <path d="M 313.639768 412.80375 
 L 313.639768 48.323125 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#ma62549c883" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m83617a424c" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -272,11 +272,11 @@ z
      <g id="line2d_9">
       <path d="M 397.82451 412.80375 
 L 397.82451 48.323125 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#ma62549c883" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m83617a424c" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -334,11 +334,11 @@ z
      <g id="line2d_11">
       <path d="M 482.009253 412.80375 
 L 482.009253 48.323125 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#ma62549c883" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m83617a424c" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -355,11 +355,11 @@ L 482.009253 48.323125
      <g id="line2d_13">
       <path d="M 566.193995 412.80375 
 L 566.193995 48.323125 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#ma62549c883" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m83617a424c" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -856,16 +856,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 368.08164 
 L 637.2 368.08164 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="m403beea01e" d="M 0 0 
+       <path id="m680e5ab90d" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m403beea01e" x="49.078125" y="368.08164" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m680e5ab90d" x="49.078125" y="368.08164" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -897,11 +897,11 @@ z
      <g id="line2d_17">
       <path d="M 49.078125 243.439835 
 L 637.2 243.439835 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m403beea01e" x="49.078125" y="243.439835" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m680e5ab90d" x="49.078125" y="243.439835" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -917,11 +917,11 @@ L 637.2 243.439835
      <g id="line2d_19">
       <path d="M 49.078125 118.798029 
 L 637.2 118.798029 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m403beea01e" x="49.078125" y="118.798029" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m680e5ab90d" x="49.078125" y="118.798029" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -937,16 +937,16 @@ L 637.2 118.798029
      <g id="line2d_21">
       <path d="M 49.078125 405.602562 
 L 637.2 405.602562 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="m1016849102" d="M 0 0 
+       <path id="m620317a40c" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m1016849102" x="49.078125" y="405.602562" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m620317a40c" x="49.078125" y="405.602562" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -954,11 +954,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 395.733268 
 L 637.2 395.733268 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m1016849102" x="49.078125" y="395.733268" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m620317a40c" x="49.078125" y="395.733268" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -966,11 +966,11 @@ L 637.2 395.733268
      <g id="line2d_25">
       <path d="M 49.078125 387.3889 
 L 637.2 387.3889 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m1016849102" x="49.078125" y="387.3889" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m620317a40c" x="49.078125" y="387.3889" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -978,11 +978,11 @@ L 637.2 387.3889
      <g id="line2d_27">
       <path d="M 49.078125 380.160679 
 L 637.2 380.160679 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m1016849102" x="49.078125" y="380.160679" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m620317a40c" x="49.078125" y="380.160679" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -990,11 +990,11 @@ L 637.2 380.160679
      <g id="line2d_29">
       <path d="M 49.078125 373.784936 
 L 637.2 373.784936 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m1016849102" x="49.078125" y="373.784936" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m620317a40c" x="49.078125" y="373.784936" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1002,11 +1002,11 @@ L 637.2 373.784936
      <g id="line2d_31">
       <path d="M 49.078125 330.560718 
 L 637.2 330.560718 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m1016849102" x="49.078125" y="330.560718" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m620317a40c" x="49.078125" y="330.560718" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1014,11 +1014,11 @@ L 637.2 330.560718
      <g id="line2d_33">
       <path d="M 49.078125 308.612385 
 L 637.2 308.612385 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m1016849102" x="49.078125" y="308.612385" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m620317a40c" x="49.078125" y="308.612385" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1026,11 +1026,11 @@ L 637.2 308.612385
      <g id="line2d_35">
       <path d="M 49.078125 293.039796 
 L 637.2 293.039796 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m1016849102" x="49.078125" y="293.039796" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m620317a40c" x="49.078125" y="293.039796" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1038,11 +1038,11 @@ L 637.2 293.039796
      <g id="line2d_37">
       <path d="M 49.078125 280.960757 
 L 637.2 280.960757 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m1016849102" x="49.078125" y="280.960757" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m620317a40c" x="49.078125" y="280.960757" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1050,11 +1050,11 @@ L 637.2 280.960757
      <g id="line2d_39">
       <path d="M 49.078125 271.091463 
 L 637.2 271.091463 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m1016849102" x="49.078125" y="271.091463" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m620317a40c" x="49.078125" y="271.091463" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1062,11 +1062,11 @@ L 637.2 271.091463
      <g id="line2d_41">
       <path d="M 49.078125 262.747094 
 L 637.2 262.747094 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m1016849102" x="49.078125" y="262.747094" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m620317a40c" x="49.078125" y="262.747094" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1074,11 +1074,11 @@ L 637.2 262.747094
      <g id="line2d_43">
       <path d="M 49.078125 255.518874 
 L 637.2 255.518874 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m1016849102" x="49.078125" y="255.518874" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m620317a40c" x="49.078125" y="255.518874" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1086,11 +1086,11 @@ L 637.2 255.518874
      <g id="line2d_45">
       <path d="M 49.078125 249.143131 
 L 637.2 249.143131 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m1016849102" x="49.078125" y="249.143131" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m620317a40c" x="49.078125" y="249.143131" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1098,11 +1098,11 @@ L 637.2 249.143131
      <g id="line2d_47">
       <path d="M 49.078125 205.918912 
 L 637.2 205.918912 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m1016849102" x="49.078125" y="205.918912" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m620317a40c" x="49.078125" y="205.918912" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1110,11 +1110,11 @@ L 637.2 205.918912
      <g id="line2d_49">
       <path d="M 49.078125 183.97058 
 L 637.2 183.97058 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m1016849102" x="49.078125" y="183.97058" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m620317a40c" x="49.078125" y="183.97058" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1122,11 +1122,11 @@ L 637.2 183.97058
      <g id="line2d_51">
       <path d="M 49.078125 168.39799 
 L 637.2 168.39799 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m1016849102" x="49.078125" y="168.39799" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m620317a40c" x="49.078125" y="168.39799" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1134,11 +1134,11 @@ L 637.2 168.39799
      <g id="line2d_53">
       <path d="M 49.078125 156.318951 
 L 637.2 156.318951 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#m1016849102" x="49.078125" y="156.318951" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m620317a40c" x="49.078125" y="156.318951" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1146,11 +1146,11 @@ L 637.2 156.318951
      <g id="line2d_55">
       <path d="M 49.078125 146.449658 
 L 637.2 146.449658 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#m1016849102" x="49.078125" y="146.449658" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m620317a40c" x="49.078125" y="146.449658" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1158,11 +1158,11 @@ L 637.2 146.449658
      <g id="line2d_57">
       <path d="M 49.078125 138.105289 
 L 637.2 138.105289 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#m1016849102" x="49.078125" y="138.105289" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m620317a40c" x="49.078125" y="138.105289" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1170,11 +1170,11 @@ L 637.2 138.105289
      <g id="line2d_59">
       <path d="M 49.078125 130.877068 
 L 637.2 130.877068 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#m1016849102" x="49.078125" y="130.877068" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m620317a40c" x="49.078125" y="130.877068" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1182,11 +1182,11 @@ L 637.2 130.877068
      <g id="line2d_61">
       <path d="M 49.078125 124.501326 
 L 637.2 124.501326 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#m1016849102" x="49.078125" y="124.501326" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m620317a40c" x="49.078125" y="124.501326" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1194,11 +1194,11 @@ L 637.2 124.501326
      <g id="line2d_63">
       <path d="M 49.078125 81.277107 
 L 637.2 81.277107 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#m1016849102" x="49.078125" y="81.277107" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m620317a40c" x="49.078125" y="81.277107" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1206,11 +1206,11 @@ L 637.2 81.277107
      <g id="line2d_65">
       <path d="M 49.078125 59.328775 
 L 637.2 59.328775 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#m1016849102" x="49.078125" y="59.328775" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m620317a40c" x="49.078125" y="59.328775" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1332,7 +1332,7 @@ L 637.2 48.323125
    </g>
    <g id="text_13">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(324.643112 118.461471) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(324.643112 118.657817) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1364,7 +1364,7 @@ z
    </g>
    <g id="text_14">
     <!-- L10 -->
-    <g style="fill: #d62728" transform="translate(102.799363 309.867541) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(102.814287 308.642983) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1686,23 +1686,23 @@ z
    </g>
    <g id="line2d_67">
     <defs>
-     <path id="mc56fce18eb" d="M -2.5 2.5 
+     <path id="m99c2ebe25d" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pd7db26d2c3)">
-     <use xlink:href="#mc56fce18eb" x="377.110281" y="104.685421" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc56fce18eb" x="323.801439" y="110.409833" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc56fce18eb" x="272.665744" y="126.308323" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc56fce18eb" x="235.168828" y="128.026741" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc56fce18eb" x="186.228265" y="149.377587" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc56fce18eb" x="158.303164" y="171.457731" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc56fce18eb" x="149.489547" y="182.192614" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc56fce18eb" x="140.563162" y="202.482797" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc56fce18eb" x="138.984853" y="209.328911" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pe54303e94f)">
+     <use xlink:href="#m99c2ebe25d" x="377.110281" y="104.685421" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m99c2ebe25d" x="323.801439" y="110.409833" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m99c2ebe25d" x="272.665744" y="126.308323" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m99c2ebe25d" x="235.168828" y="128.026741" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m99c2ebe25d" x="186.228265" y="149.377587" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m99c2ebe25d" x="158.303164" y="171.457731" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m99c2ebe25d" x="149.489547" y="182.192614" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m99c2ebe25d" x="140.563162" y="202.482797" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m99c2ebe25d" x="138.984853" y="209.328911" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_68">
@@ -1755,7 +1755,7 @@ L 327.133241 110.069256
 L 326.02264 110.18302 
 L 324.91204 110.296545 
 L 323.801439 110.409833 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_69">
     <path d="M 323.801439 110.409833 
@@ -1807,7 +1807,7 @@ L 275.861725 125.44037
 L 274.796398 125.731236 
 L 273.731071 126.020548 
 L 272.665744 126.308323 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_70">
     <path d="M 272.665744 126.308323 
@@ -1859,7 +1859,7 @@ L 237.512385 127.920923
 L 236.7312 127.956219 
 L 235.950014 127.991491 
 L 235.168828 128.026741 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_71">
     <path d="M 235.168828 128.026741 
@@ -1911,7 +1911,7 @@ L 189.28705 148.263499
 L 188.267455 148.637415 
 L 187.24786 149.008766 
 L 186.228265 149.377587 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_72">
     <path d="M 186.228265 149.377587 
@@ -1963,7 +1963,7 @@ L 160.048483 170.312481
 L 159.46671 170.696929 
 L 158.884937 171.078667 
 L 158.303164 171.457731 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_73">
     <path d="M 158.303164 171.457731 
@@ -2015,7 +2015,7 @@ L 150.040398 181.580576
 L 149.856781 181.785359 
 L 149.673164 181.989369 
 L 149.489547 182.192614 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_74">
     <path d="M 149.489547 182.192614 
@@ -2067,7 +2067,7 @@ L 141.121061 201.414753
 L 140.935095 201.773114 
 L 140.749129 202.129119 
 L 140.563162 202.482797 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_75">
     <path d="M 140.563162 202.482797 
@@ -2119,26 +2119,26 @@ L 139.083497 208.925481
 L 139.050616 209.060292 
 L 139.017734 209.194768 
 L 138.984853 209.328911 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_76">
     <defs>
-     <path id="mba75ea4ead" d="M 0 -2.5 
+     <path id="m42c56d396a" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pd7db26d2c3)">
-     <use xlink:href="#mba75ea4ead" x="610.467187" y="71.939349" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mba75ea4ead" x="319.880958" y="101.884157" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mba75ea4ead" x="210.281253" y="129.778154" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mba75ea4ead" x="196.287076" y="133.586625" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mba75ea4ead" x="176.054419" y="147.38645" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mba75ea4ead" x="152.161413" y="174.753272" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mba75ea4ead" x="146.720208" y="186.587648" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mba75ea4ead" x="143.994022" y="196.356323" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mba75ea4ead" x="142.666037" y="200.180971" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pe54303e94f)">
+     <use xlink:href="#m42c56d396a" x="610.467187" y="71.939349" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m42c56d396a" x="319.880958" y="101.884157" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m42c56d396a" x="210.281253" y="129.778154" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m42c56d396a" x="196.287076" y="133.586625" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m42c56d396a" x="176.054419" y="147.38645" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m42c56d396a" x="152.161413" y="174.753272" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m42c56d396a" x="146.720208" y="186.587648" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m42c56d396a" x="143.994022" y="196.356323" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m42c56d396a" x="142.666037" y="200.180971" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_77">
@@ -2191,7 +2191,7 @@ L 338.042598 100.427247
 L 331.988718 100.917253 
 L 325.934838 101.402864 
 L 319.880958 101.884157 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_78">
     <path d="M 319.880958 101.884157 
@@ -2243,7 +2243,7 @@ L 217.131235 128.398367
 L 214.847908 128.862215 
 L 212.564581 129.322122 
 L 210.281253 129.778154 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_79">
     <path d="M 210.281253 129.778154 
@@ -2295,7 +2295,7 @@ L 197.161712 133.356286
 L 196.870166 133.433175 
 L 196.578621 133.509954 
 L 196.287076 133.586625 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_80">
     <path d="M 196.287076 133.586625 
@@ -2347,7 +2347,7 @@ L 177.31896 146.619719
 L 176.897447 146.876504 
 L 176.475933 147.132078 
 L 176.054419 147.38645 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_81">
     <path d="M 176.054419 147.38645 
@@ -2399,7 +2399,7 @@ L 153.654726 173.393769
 L 153.156955 173.850741 
 L 152.659184 174.303887 
 L 152.161413 174.753272 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_82">
     <path d="M 152.161413 174.753272 
@@ -2451,7 +2451,7 @@ L 147.060283 185.919158
 L 146.946925 186.142906 
 L 146.833566 186.365734 
 L 146.720208 186.587648 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_83">
     <path d="M 146.720208 186.587648 
@@ -2503,7 +2503,7 @@ L 144.164409 195.794799
 L 144.107613 195.982622 
 L 144.050817 196.169795 
 L 143.994022 196.356323 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_84">
     <path d="M 143.994022 196.356323 
@@ -2555,30 +2555,30 @@ L 142.749036 199.949687
 L 142.72137 200.026891 
 L 142.693704 200.103986 
 L 142.666037 200.180971 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_85">
     <defs>
-     <path id="md4542bef4d" d="M -0 3.535534 
+     <path id="md65f8c2892" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pd7db26d2c3)">
-     <use xlink:href="#md4542bef4d" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md4542bef4d" x="242.839153" y="80.778898" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md4542bef4d" x="218.251194" y="86.377096" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md4542bef4d" x="197.814984" y="90.309617" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md4542bef4d" x="166.378359" y="99.066934" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md4542bef4d" x="145.830392" y="110.431955" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md4542bef4d" x="134.598477" y="126.026287" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md4542bef4d" x="124.077268" y="149.033155" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md4542bef4d" x="122.462976" y="157.476606" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md4542bef4d" x="81.012077" y="220.06889" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md4542bef4d" x="77.44276" y="239.652656" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md4542bef4d" x="76.953425" y="252.706566" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pe54303e94f)">
+     <use xlink:href="#md65f8c2892" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md65f8c2892" x="242.839153" y="80.778898" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md65f8c2892" x="218.251194" y="86.377096" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md65f8c2892" x="197.814984" y="90.309617" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md65f8c2892" x="166.378359" y="99.066934" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md65f8c2892" x="145.830392" y="110.431955" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md65f8c2892" x="134.598477" y="126.026287" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md65f8c2892" x="124.077268" y="149.033155" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md65f8c2892" x="122.462976" y="157.476606" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md65f8c2892" x="81.012077" y="220.06889" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md65f8c2892" x="77.44276" y="239.652656" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md65f8c2892" x="76.953425" y="252.706566" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_86">
@@ -2631,7 +2631,7 @@ L 245.91379 79.91142
 L 244.888911 80.202126 
 L 243.864032 80.49128 
 L 242.839153 80.778898 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_87">
     <path d="M 242.839153 80.778898 
@@ -2683,7 +2683,7 @@ L 219.787941 86.043669
 L 219.275692 86.155039 
 L 218.763443 86.266182 
 L 218.251194 86.377096 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_88">
     <path d="M 218.251194 86.377096 
@@ -2735,7 +2735,7 @@ L 199.092247 90.072029
 L 198.666492 90.151341 
 L 198.240738 90.230537 
 L 197.814984 90.309617 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_89">
     <path d="M 197.814984 90.309617 
@@ -2787,7 +2787,7 @@ L 168.343148 98.559208
 L 167.688219 98.72898 
 L 167.033289 98.898221 
 L 166.378359 99.066934 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_90">
     <path d="M 166.378359 99.066934 
@@ -2839,7 +2839,7 @@ L 147.11464 109.78743
 L 146.686557 110.003126 
 L 146.258475 110.217965 
 L 145.830392 110.431955 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_91">
     <path d="M 145.830392 110.431955 
@@ -2891,7 +2891,7 @@ L 135.300472 125.172774
 L 135.066474 125.458776 
 L 134.832476 125.743276 
 L 134.598477 126.026287 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_92">
     <path d="M 134.598477 126.026287 
@@ -2943,7 +2943,7 @@ L 124.734843 147.848882
 L 124.515652 148.246526 
 L 124.29646 148.641269 
 L 124.077268 149.033155 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_93">
     <path d="M 124.077268 149.033155 
@@ -2995,7 +2995,7 @@ L 122.56387 156.985769
 L 122.530239 157.149876 
 L 122.496607 157.313488 
 L 122.462976 157.476606 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_94">
     <path d="M 122.462976 157.476606 
@@ -3047,7 +3047,7 @@ L 83.602758 217.699074
 L 82.739198 218.500595 
 L 81.875637 219.290422 
 L 81.012077 220.06889 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_95">
     <path d="M 81.012077 220.06889 
@@ -3099,7 +3099,7 @@ L 77.665842 238.615761
 L 77.591481 238.963605 
 L 77.517121 239.309227 
 L 77.44276 239.652656 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_96">
     <path d="M 77.44276 239.652656 
@@ -3151,23 +3151,23 @@ L 76.984008 251.97672
 L 76.973814 252.221097 
 L 76.96362 252.464376 
 L 76.953425 252.706566 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_97">
     <defs>
-     <path id="m2407f1bdb2" d="M -0 2.5 
+     <path id="m1174f5cf53" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pd7db26d2c3)">
-     <use xlink:href="#m2407f1bdb2" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pe54303e94f)">
+     <use xlink:href="#m1174f5cf53" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_98">
     <defs>
-     <path id="m5056de2257" d="M -0.833333 2.5 
+     <path id="md1f43da565" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -3182,16 +3182,16 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pd7db26d2c3)">
-     <use xlink:href="#m5056de2257" x="432.495268" y="96.067622" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5056de2257" x="300.62247" y="112.493412" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5056de2257" x="266.967623" y="120.8136" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5056de2257" x="226.040946" y="122.099593" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5056de2257" x="180.985721" y="141.85872" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5056de2257" x="164.441833" y="156.106179" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5056de2257" x="157.761315" y="165.23787" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5056de2257" x="151.269082" y="178.700983" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5056de2257" x="150.327087" y="185.23695" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pe54303e94f)">
+     <use xlink:href="#md1f43da565" x="432.495268" y="96.067622" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md1f43da565" x="300.62247" y="112.493412" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md1f43da565" x="266.967623" y="120.8136" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md1f43da565" x="226.040946" y="122.099593" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md1f43da565" x="180.985721" y="141.85872" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md1f43da565" x="164.441833" y="156.106179" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md1f43da565" x="157.761315" y="165.23787" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md1f43da565" x="151.269082" y="178.700983" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md1f43da565" x="150.327087" y="185.23695" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_99">
@@ -3244,7 +3244,7 @@ L 308.86452 111.600609
 L 306.11717 111.899849 
 L 303.36982 112.197444 
 L 300.62247 112.493412 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_100">
     <path d="M 300.62247 112.493412 
@@ -3296,7 +3296,7 @@ L 269.071051 120.329422
 L 268.369908 120.491297 
 L 267.668766 120.652688 
 L 266.967623 120.8136 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_101">
     <path d="M 266.967623 120.8136 
@@ -3348,7 +3348,7 @@ L 228.598863 122.020108
 L 227.746224 122.046616 
 L 226.893585 122.073111 
 L 226.040946 122.099593 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_102">
     <path d="M 226.040946 122.099593 
@@ -3400,7 +3400,7 @@ L 183.801673 140.814056
 L 182.863022 141.164522 
 L 181.924372 141.512734 
 L 180.985721 141.85872 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_103">
     <path d="M 180.985721 141.85872 
@@ -3452,7 +3452,7 @@ L 165.475826 155.317544
 L 165.131161 155.581701 
 L 164.786497 155.844575 
 L 164.441833 156.106179 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_104">
     <path d="M 164.441833 156.106179 
@@ -3504,7 +3504,7 @@ L 158.178848 164.710119
 L 158.03967 164.886608 
 L 157.900493 165.062524 
 L 157.761315 165.23787 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_105">
     <path d="M 157.761315 165.23787 
@@ -3556,7 +3556,7 @@ L 151.674847 177.950842
 L 151.539592 178.202046 
 L 151.404337 178.452089 
 L 151.269082 178.700983 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_106">
     <path d="M 151.269082 178.700983 
@@ -3608,11 +3608,11 @@ L 150.385962 184.850776
 L 150.366337 184.979807 
 L 150.346712 185.108531 
 L 150.327087 185.23695 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_107">
     <defs>
-     <path id="m0dc743cc7b" d="M -1.25 2.5 
+     <path id="me31bc75c73" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -3627,16 +3627,16 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pd7db26d2c3)">
-     <use xlink:href="#m0dc743cc7b" x="345.030867" y="136.859359" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0dc743cc7b" x="273.364924" y="143.571257" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0dc743cc7b" x="240.719951" y="149.310846" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0dc743cc7b" x="221.353978" y="154.160538" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0dc743cc7b" x="207.129625" y="156.092215" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0dc743cc7b" x="181.064802" y="166.758473" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0dc743cc7b" x="179.282169" y="170.289343" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0dc743cc7b" x="177.719335" y="175.489948" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0dc743cc7b" x="177.643939" y="181.552088" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pe54303e94f)">
+     <use xlink:href="#me31bc75c73" x="345.030867" y="136.859359" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me31bc75c73" x="273.364924" y="143.571257" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me31bc75c73" x="240.719951" y="149.310846" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me31bc75c73" x="221.353978" y="154.160538" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me31bc75c73" x="207.129625" y="156.092215" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me31bc75c73" x="181.064802" y="166.758473" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me31bc75c73" x="179.282169" y="170.289343" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me31bc75c73" x="177.719335" y="175.489948" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me31bc75c73" x="177.643939" y="181.552088" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_108">
@@ -3689,7 +3689,7 @@ L 277.844045 143.175283
 L 276.351005 143.307597 
 L 274.857964 143.439587 
 L 273.364924 143.571257 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_109">
     <path d="M 273.364924 143.571257 
@@ -3741,7 +3741,7 @@ L 242.760262 148.96941
 L 242.080158 149.083462 
 L 241.400055 149.197273 
 L 240.719951 149.310846 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_110">
     <path d="M 240.719951 149.310846 
@@ -3793,7 +3793,7 @@ L 222.564351 153.869835
 L 222.160893 153.966909 
 L 221.757435 154.06381 
 L 221.353978 154.160538 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_111">
     <path d="M 221.353978 154.160538 
@@ -3845,7 +3845,7 @@ L 208.018647 155.973483
 L 207.722306 156.013089 
 L 207.425965 156.052666 
 L 207.129625 156.092215 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_112">
     <path d="M 207.129625 156.092215 
@@ -3897,7 +3897,7 @@ L 182.693853 166.149994
 L 182.150836 166.353581 
 L 181.607819 166.556405 
 L 181.064802 166.758473 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_113">
     <path d="M 181.064802 166.758473 
@@ -3949,7 +3949,7 @@ L 179.393584 170.075284
 L 179.356445 170.146731 
 L 179.319307 170.218084 
 L 179.282169 170.289343 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_114">
     <path d="M 179.282169 170.289343 
@@ -4001,7 +4001,7 @@ L 177.817012 175.179146
 L 177.784453 175.282945 
 L 177.751894 175.386546 
 L 177.719335 175.489948 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_115">
     <path d="M 177.719335 175.489948 
@@ -4053,11 +4053,11 @@ L 177.648651 181.192458
 L 177.64708 181.3126 
 L 177.645509 181.432477 
 L 177.643939 181.552088 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_116">
     <defs>
-     <path id="m436259ff96" d="M 0 -2.5 
+     <path id="m929fd909d6" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -4070,16 +4070,16 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#pd7db26d2c3)">
-     <use xlink:href="#m436259ff96" x="226.871027" y="113.224491" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m436259ff96" x="226.871027" y="113.066324" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m436259ff96" x="226.871027" y="113.178221" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m436259ff96" x="226.871027" y="113.089884" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m436259ff96" x="177.768423" y="132.327899" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m436259ff96" x="160.37503" y="145.652356" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m436259ff96" x="153.995779" y="152.678629" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m436259ff96" x="147.106887" y="168.143801" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m436259ff96" x="145.871703" y="175.118358" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#pe54303e94f)">
+     <use xlink:href="#m929fd909d6" x="226.871027" y="113.224491" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m929fd909d6" x="226.871027" y="113.066324" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m929fd909d6" x="226.871027" y="113.178221" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m929fd909d6" x="226.871027" y="113.089884" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m929fd909d6" x="177.768423" y="132.327899" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m929fd909d6" x="160.37503" y="145.652356" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m929fd909d6" x="153.995779" y="152.678629" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m929fd909d6" x="147.106887" y="168.143801" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m929fd909d6" x="145.871703" y="175.118358" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_117">
@@ -4132,7 +4132,7 @@ L 226.871027 113.076223
 L 226.871027 113.072924 
 L 226.871027 113.069624 
 L 226.871027 113.066324 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_118">
     <path d="M 226.871027 113.066324 
@@ -4184,7 +4184,7 @@ L 226.871027 113.171234
 L 226.871027 113.173563 
 L 226.871027 113.175892 
 L 226.871027 113.178221 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_119">
     <path d="M 226.871027 113.178221 
@@ -4236,7 +4236,7 @@ L 226.871027 113.09541
 L 226.871027 113.093568 
 L 226.871027 113.091726 
 L 226.871027 113.089884 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_120">
     <path d="M 226.871027 113.089884 
@@ -4288,7 +4288,7 @@ L 180.837336 131.306392
 L 179.814365 131.649041 
 L 178.791394 131.989534 
 L 177.768423 132.327899 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_121">
     <path d="M 177.768423 132.327899 
@@ -4340,7 +4340,7 @@ L 161.462117 144.909076
 L 161.099755 145.157972 
 L 160.737393 145.405728 
 L 160.37503 145.652356 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_122">
     <path d="M 160.37503 145.652356 
@@ -4392,7 +4392,7 @@ L 154.394483 152.265218
 L 154.261581 152.403373 
 L 154.12868 152.541176 
 L 153.995779 152.678629 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_123">
     <path d="M 153.995779 152.678629 
@@ -4444,7 +4444,7 @@ L 147.537442 167.296442
 L 147.393924 167.580372 
 L 147.250405 167.862819 
 L 147.106887 168.143801 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_124">
     <path d="M 147.106887 168.143801 
@@ -4496,11 +4496,11 @@ L 145.948902 174.70781
 L 145.923169 174.845005 
 L 145.897436 174.981854 
 L 145.871703 175.118358 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_125">
     <defs>
-     <path id="ma985c8d7cd" d="M 0 -2.5 
+     <path id="m318ae91d0c" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -4509,16 +4509,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pd7db26d2c3)">
-     <use xlink:href="#ma985c8d7cd" x="585.66883" y="173.051371" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma985c8d7cd" x="527.144592" y="175.326465" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma985c8d7cd" x="457.339427" y="183.688849" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma985c8d7cd" x="292.124837" y="178.486631" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma985c8d7cd" x="243.129344" y="190.369032" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma985c8d7cd" x="213.541392" y="204.43395" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma985c8d7cd" x="204.551957" y="212.140784" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma985c8d7cd" x="195.860087" y="228.582256" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma985c8d7cd" x="194.019853" y="234.294862" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pe54303e94f)">
+     <use xlink:href="#m318ae91d0c" x="585.66883" y="173.051371" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m318ae91d0c" x="527.144592" y="175.326465" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m318ae91d0c" x="457.339427" y="183.688849" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m318ae91d0c" x="292.124837" y="178.486631" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m318ae91d0c" x="243.129344" y="190.369032" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m318ae91d0c" x="213.541392" y="204.43395" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m318ae91d0c" x="204.551957" y="212.140784" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m318ae91d0c" x="195.860087" y="228.582256" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m318ae91d0c" x="194.019853" y="234.294862" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_126">
@@ -4571,7 +4571,7 @@ L 530.802357 175.187039
 L 529.583102 175.233554 
 L 528.363847 175.28003 
 L 527.144592 175.326465 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_127">
     <path d="M 527.144592 175.326465 
@@ -4623,7 +4623,7 @@ L 461.70225 183.20239
 L 460.247976 183.36503 
 L 458.793701 183.527182 
 L 457.339427 183.688849 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_128">
     <path d="M 457.339427 183.688849 
@@ -4675,7 +4675,7 @@ L 302.450749 178.826834
 L 299.008779 178.713671 
 L 295.566808 178.60027 
 L 292.124837 178.486631 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_129">
     <path d="M 292.124837 178.486631 
@@ -4727,7 +4727,7 @@ L 246.191563 189.6981
 L 245.170823 189.922669 
 L 244.150084 190.146311 
 L 243.129344 190.369032 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_130">
     <path d="M 243.129344 190.369032 
@@ -4779,7 +4779,7 @@ L 215.390639 203.654226
 L 214.774224 203.915384 
 L 214.157808 204.175288 
 L 213.541392 204.43395 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_131">
     <path d="M 213.541392 204.43395 
@@ -4831,7 +4831,7 @@ L 205.113797 211.689953
 L 204.926517 211.840648 
 L 204.739237 211.990924 
 L 204.551957 212.140784 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_132">
     <path d="M 204.551957 212.140784 
@@ -4883,7 +4883,7 @@ L 196.403329 227.688717
 L 196.222248 227.988205 
 L 196.041168 228.286045 
 L 195.860087 228.582256 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_133">
     <path d="M 195.860087 228.582256 
@@ -4935,7 +4935,7 @@ L 194.134867 233.954953
 L 194.096529 234.068494 
 L 194.058191 234.181796 
 L 194.019853 234.294862 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="legend_1">
     <g id="patch_7">
@@ -4953,7 +4953,7 @@ z
     </g>
     <g id="line2d_134">
      <defs>
-      <path id="m22ec9a9984" d="M 0 3.5 
+      <path id="m8b8ff3f75a" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -4966,7 +4966,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m22ec9a9984" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m8b8ff3f75a" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -5025,7 +5025,7 @@ z
     </g>
     <g id="line2d_135">
      <g>
-      <use xlink:href="#mc56fce18eb" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m99c2ebe25d" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -5039,7 +5039,7 @@ z
     </g>
     <g id="line2d_136">
      <g>
-      <use xlink:href="#mba75ea4ead" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m42c56d396a" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -5084,7 +5084,7 @@ z
     </g>
     <g id="line2d_137">
      <g>
-      <use xlink:href="#md4542bef4d" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#md65f8c2892" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -5127,7 +5127,7 @@ z
     </g>
     <g id="line2d_138">
      <g>
-      <use xlink:href="#m2407f1bdb2" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m1174f5cf53" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -5143,7 +5143,7 @@ z
     </g>
     <g id="line2d_139">
      <g>
-      <use xlink:href="#m5056de2257" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#md1f43da565" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -5197,7 +5197,7 @@ z
     </g>
     <g id="line2d_140">
      <g>
-      <use xlink:href="#m0dc743cc7b" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#me31bc75c73" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -5262,7 +5262,7 @@ z
     </g>
     <g id="line2d_141">
      <g>
-      <use xlink:href="#m436259ff96" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#m929fd909d6" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -5300,7 +5300,7 @@ z
     </g>
     <g id="line2d_142">
      <g>
-      <use xlink:href="#ma985c8d7cd" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m318ae91d0c" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -5370,486 +5370,486 @@ z
     </g>
    </g>
    <g id="line2d_143">
-    <g clip-path="url(#pd7db26d2c3)">
-     <use xlink:href="#m22ec9a9984" x="319.643112" y="123.461471" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m22ec9a9984" x="269.129958" y="138.871439" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m22ec9a9984" x="247.452898" y="143.997761" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m22ec9a9984" x="192.820547" y="152.686437" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m22ec9a9984" x="180.389901" y="163.860986" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m22ec9a9984" x="156.350594" y="174.058052" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m22ec9a9984" x="147.843012" y="183.802047" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m22ec9a9984" x="146.231533" y="187.809062" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m22ec9a9984" x="119.590386" y="285.972112" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m22ec9a9984" x="97.799363" y="314.867541" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <g clip-path="url(#pe54303e94f)">
+     <use xlink:href="#m8b8ff3f75a" x="319.643112" y="123.657817" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m8b8ff3f75a" x="269.129958" y="139.062532" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m8b8ff3f75a" x="247.452898" y="144.221198" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m8b8ff3f75a" x="192.820547" y="152.969666" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m8b8ff3f75a" x="180.389901" y="164.017653" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m8b8ff3f75a" x="156.380826" y="172.983011" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m8b8ff3f75a" x="147.895047" y="182.69281" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m8b8ff3f75a" x="146.261627" y="186.801762" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m8b8ff3f75a" x="119.666036" y="285.330846" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m8b8ff3f75a" x="97.814287" y="313.642983" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
    <g id="line2d_144">
-    <path d="M 319.643112 123.461471 
-L 318.590755 123.831603 
-L 317.538397 124.199222 
-L 316.48604 124.564362 
-L 315.433682 124.927054 
-L 314.381325 125.287333 
-L 313.328968 125.64523 
-L 312.27661 126.000776 
-L 311.224253 126.354001 
-L 310.171896 126.704937 
-L 309.119538 127.053613 
-L 308.067181 127.400057 
-L 307.014823 127.744297 
-L 305.962466 128.086362 
-L 304.910109 128.42628 
-L 303.857751 128.764076 
-L 302.805394 129.099777 
-L 301.753037 129.433409 
-L 300.700679 129.764998 
-L 299.648322 130.094567 
-L 298.595965 130.422143 
-L 297.543607 130.747747 
-L 296.49125 131.071405 
-L 295.438892 131.39314 
-L 294.386535 131.712973 
-L 293.334178 132.030928 
-L 292.28182 132.347026 
-L 291.229463 132.661288 
-L 290.177106 132.973737 
-L 289.124748 133.284393 
-L 288.072391 133.593276 
-L 287.020033 133.900407 
-L 285.967676 134.205804 
-L 284.915319 134.509489 
-L 283.862961 134.811479 
-L 282.810604 135.111794 
-L 281.758247 135.410452 
-L 280.705889 135.707471 
-L 279.653532 136.002869 
-L 278.601175 136.296664 
-L 277.548817 136.588873 
-L 276.49646 136.879514 
-L 275.444102 137.168601 
-L 274.391745 137.456154 
-L 273.339388 137.742187 
-L 272.28703 138.026716 
-L 271.234673 138.309758 
-L 270.182316 138.591327 
-L 269.129958 138.871439 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 319.643112 123.657817 
+L 318.590755 124.027805 
+L 317.538397 124.395282 
+L 316.48604 124.76028 
+L 315.433682 125.122834 
+L 314.381325 125.482976 
+L 313.328968 125.840738 
+L 312.27661 126.19615 
+L 311.224253 126.549244 
+L 310.171896 126.90005 
+L 309.119538 127.248598 
+L 308.067181 127.594915 
+L 307.014823 127.93903 
+L 305.962466 128.280972 
+L 304.910109 128.620768 
+L 303.857751 128.958444 
+L 302.805394 129.294026 
+L 301.753037 129.627541 
+L 300.700679 129.959013 
+L 299.648322 130.288468 
+L 298.595965 130.61593 
+L 297.543607 130.941423 
+L 296.49125 131.264971 
+L 295.438892 131.586596 
+L 294.386535 131.906321 
+L 293.334178 132.224169 
+L 292.28182 132.540162 
+L 291.229463 132.854321 
+L 290.177106 133.166667 
+L 289.124748 133.477221 
+L 288.072391 133.786003 
+L 287.020033 134.093034 
+L 285.967676 134.398333 
+L 284.915319 134.701921 
+L 283.862961 135.003815 
+L 282.810604 135.304034 
+L 281.758247 135.602598 
+L 280.705889 135.899524 
+L 279.653532 136.194831 
+L 278.601175 136.488534 
+L 277.548817 136.780653 
+L 276.49646 137.071205 
+L 275.444102 137.360204 
+L 274.391745 137.647669 
+L 273.339388 137.933616 
+L 272.28703 138.21806 
+L 271.234673 138.501017 
+L 270.182316 138.782503 
+L 269.129958 139.062532 
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_145">
-    <path d="M 269.129958 138.871439 
-L 268.678353 138.983342 
-L 268.226747 139.095015 
-L 267.775142 139.206457 
-L 267.323537 139.31767 
-L 266.871931 139.428656 
-L 266.420326 139.539414 
-L 265.96872 139.649946 
-L 265.517115 139.760253 
-L 265.065509 139.870336 
-L 264.613904 139.980195 
-L 264.162299 140.089831 
-L 263.710693 140.199246 
-L 263.259088 140.308441 
-L 262.807482 140.417415 
-L 262.355877 140.526171 
-L 261.904271 140.634708 
-L 261.452666 140.743028 
-L 261.001061 140.851132 
-L 260.549455 140.959021 
-L 260.09785 141.066695 
-L 259.646244 141.174155 
-L 259.194639 141.281402 
-L 258.743034 141.388437 
-L 258.291428 141.495261 
-L 257.839823 141.601875 
-L 257.388217 141.708279 
-L 256.936612 141.814474 
-L 256.485006 141.920462 
-L 256.033401 142.026242 
-L 255.581796 142.131816 
-L 255.13019 142.237184 
-L 254.678585 142.342348 
-L 254.226979 142.447308 
-L 253.775374 142.552064 
-L 253.323769 142.656619 
-L 252.872163 142.760971 
-L 252.420558 142.865123 
-L 251.968952 142.969075 
-L 251.517347 143.072828 
-L 251.065741 143.176382 
-L 250.614136 143.279739 
-L 250.162531 143.382898 
-L 249.710925 143.485862 
-L 249.25932 143.58863 
-L 248.807714 143.691203 
-L 248.356109 143.793582 
-L 247.904503 143.895768 
-L 247.452898 143.997761 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 269.129958 139.062532 
+L 268.678353 139.175175 
+L 268.226747 139.287584 
+L 267.775142 139.399759 
+L 267.323537 139.511703 
+L 266.871931 139.623416 
+L 266.420326 139.734898 
+L 265.96872 139.846152 
+L 265.517115 139.957177 
+L 265.065509 140.067975 
+L 264.613904 140.178547 
+L 264.162299 140.288893 
+L 263.710693 140.399015 
+L 263.259088 140.508913 
+L 262.807482 140.618589 
+L 262.355877 140.728043 
+L 261.904271 140.837276 
+L 261.452666 140.946289 
+L 261.001061 141.055083 
+L 260.549455 141.163658 
+L 260.09785 141.272017 
+L 259.646244 141.380159 
+L 259.194639 141.488085 
+L 258.743034 141.595796 
+L 258.291428 141.703294 
+L 257.839823 141.810579 
+L 257.388217 141.917651 
+L 256.936612 142.024512 
+L 256.485006 142.131162 
+L 256.033401 142.237603 
+L 255.581796 142.343835 
+L 255.13019 142.449859 
+L 254.678585 142.555675 
+L 254.226979 142.661285 
+L 253.775374 142.76669 
+L 253.323769 142.871889 
+L 252.872163 142.976885 
+L 252.420558 143.081677 
+L 251.968952 143.186267 
+L 251.517347 143.290655 
+L 251.065741 143.394842 
+L 250.614136 143.498829 
+L 250.162531 143.602617 
+L 249.710925 143.706206 
+L 249.25932 143.809597 
+L 248.807714 143.912791 
+L 248.356109 144.015789 
+L 247.904503 144.118591 
+L 247.452898 144.221198 
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_146">
-    <path d="M 247.452898 143.997761 
-L 246.314724 144.193757 
-L 245.17655 144.389045 
-L 244.038376 144.583632 
-L 242.900202 144.777522 
-L 241.762028 144.970719 
-L 240.623854 145.16323 
-L 239.48568 145.355058 
-L 238.347506 145.546209 
-L 237.209332 145.736687 
-L 236.071158 145.926498 
-L 234.932984 146.115645 
-L 233.79481 146.304134 
-L 232.656636 146.491968 
-L 231.518462 146.679153 
-L 230.380288 146.865693 
-L 229.242114 147.051592 
-L 228.10394 147.236855 
-L 226.965766 147.421487 
-L 225.827592 147.60549 
-L 224.689418 147.78887 
-L 223.551244 147.971631 
-L 222.41307 148.153777 
-L 221.274896 148.335313 
-L 220.136722 148.516241 
-L 218.998548 148.696567 
-L 217.860374 148.876294 
-L 216.7222 149.055426 
-L 215.584026 149.233968 
-L 214.445852 149.411922 
-L 213.307678 149.589294 
-L 212.169505 149.766086 
-L 211.031331 149.942302 
-L 209.893157 150.117947 
-L 208.754983 150.293024 
-L 207.616809 150.467536 
-L 206.478635 150.641488 
-L 205.340461 150.814882 
-L 204.202287 150.987722 
-L 203.064113 151.160013 
-L 201.925939 151.331757 
-L 200.787765 151.502958 
-L 199.649591 151.673618 
-L 198.511417 151.843743 
-L 197.373243 152.013335 
-L 196.235069 152.182397 
-L 195.096895 152.350932 
-L 193.958721 152.518945 
-L 192.820547 152.686437 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 247.452898 144.221198 
+L 246.314724 144.418652 
+L 245.17655 144.615388 
+L 244.038376 144.811412 
+L 242.900202 145.006728 
+L 241.762028 145.201342 
+L 240.623854 145.395259 
+L 239.48568 145.588484 
+L 238.347506 145.781022 
+L 237.209332 145.972877 
+L 236.071158 146.164054 
+L 234.932984 146.354559 
+L 233.79481 146.544396 
+L 232.656636 146.733569 
+L 231.518462 146.922083 
+L 230.380288 147.109944 
+L 229.242114 147.297154 
+L 228.10394 147.483719 
+L 226.965766 147.669644 
+L 225.827592 147.854932 
+L 224.689418 148.039588 
+L 223.551244 148.223616 
+L 222.41307 148.407021 
+L 221.274896 148.589806 
+L 220.136722 148.771976 
+L 218.998548 148.953536 
+L 217.860374 149.134488 
+L 216.7222 149.314837 
+L 215.584026 149.494588 
+L 214.445852 149.673744 
+L 213.307678 149.852308 
+L 212.169505 150.030286 
+L 211.031331 150.20768 
+L 209.893157 150.384495 
+L 208.754983 150.560734 
+L 207.616809 150.736401 
+L 206.478635 150.9115 
+L 205.340461 151.086035 
+L 204.202287 151.260008 
+L 203.064113 151.433425 
+L 201.925939 151.606287 
+L 200.787765 151.778599 
+L 199.649591 151.950364 
+L 198.511417 152.121586 
+L 197.373243 152.292269 
+L 196.235069 152.462414 
+L 195.096895 152.632027 
+L 193.958721 152.80111 
+L 192.820547 152.969666 
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_147">
-    <path d="M 192.820547 152.686437 
-L 192.561575 152.944396 
-L 192.302603 153.201132 
-L 192.043631 153.456656 
-L 191.78466 153.710979 
-L 191.525688 153.964113 
-L 191.266716 154.216069 
-L 191.007744 154.466858 
-L 190.748773 154.71649 
-L 190.489801 154.964976 
-L 190.230829 155.212326 
-L 189.971857 155.458552 
-L 189.712885 155.703662 
-L 189.453914 155.947668 
-L 189.194942 156.190579 
-L 188.93597 156.432404 
-L 188.676998 156.673154 
-L 188.418027 156.912838 
-L 188.159055 157.151466 
-L 187.900083 157.389046 
-L 187.641111 157.625588 
-L 187.382139 157.8611 
-L 187.123168 158.095593 
-L 186.864196 158.329074 
-L 186.605224 158.561552 
-L 186.346252 158.793037 
-L 186.087281 159.023535 
-L 185.828309 159.253056 
-L 185.569337 159.481608 
-L 185.310365 159.709199 
-L 185.051393 159.935838 
-L 184.792422 160.161531 
-L 184.53345 160.386287 
-L 184.274478 160.610114 
-L 184.015506 160.833019 
-L 183.756535 161.05501 
-L 183.497563 161.276095 
-L 183.238591 161.49628 
-L 182.979619 161.715573 
-L 182.720647 161.933981 
-L 182.461676 162.151512 
-L 182.202704 162.368172 
-L 181.943732 162.583968 
-L 181.68476 162.798908 
-L 181.425789 163.012997 
-L 181.166817 163.226243 
-L 180.907845 163.438652 
-L 180.648873 163.650231 
-L 180.389901 163.860986 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 192.820547 152.969666 
+L 192.561575 153.224403 
+L 192.302603 153.477947 
+L 192.043631 153.730309 
+L 191.78466 153.981499 
+L 191.525688 154.23153 
+L 191.266716 154.480411 
+L 191.007744 154.728153 
+L 190.748773 154.974766 
+L 190.489801 155.220261 
+L 190.230829 155.464647 
+L 189.971857 155.707936 
+L 189.712885 155.950135 
+L 189.453914 156.191256 
+L 189.194942 156.431307 
+L 188.93597 156.670299 
+L 188.676998 156.90824 
+L 188.418027 157.14514 
+L 188.159055 157.381007 
+L 187.900083 157.615851 
+L 187.641111 157.849681 
+L 187.382139 158.082505 
+L 187.123168 158.314332 
+L 186.864196 158.54517 
+L 186.605224 158.775028 
+L 186.346252 159.003914 
+L 186.087281 159.231837 
+L 185.828309 159.458804 
+L 185.569337 159.684823 
+L 185.310365 159.909902 
+L 185.051393 160.134049 
+L 184.792422 160.357272 
+L 184.53345 160.579578 
+L 184.274478 160.800975 
+L 184.015506 161.021471 
+L 183.756535 161.241071 
+L 183.497563 161.459785 
+L 183.238591 161.677618 
+L 182.979619 161.894578 
+L 182.720647 162.110672 
+L 182.461676 162.325907 
+L 182.202704 162.540289 
+L 181.943732 162.753826 
+L 181.68476 162.966523 
+L 181.425789 163.178389 
+L 181.166817 163.389428 
+L 180.907845 163.599647 
+L 180.648873 163.809054 
+L 180.389901 164.017653 
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_148">
-    <path d="M 180.389901 163.860986 
-L 179.889083 164.094249 
-L 179.388264 164.32651 
-L 178.887445 164.55778 
-L 178.386626 164.788066 
-L 177.885807 165.017376 
-L 177.384988 165.245719 
-L 176.884169 165.473102 
-L 176.38335 165.699535 
-L 175.882531 165.925024 
-L 175.381713 166.149578 
-L 174.880894 166.373204 
-L 174.380075 166.59591 
-L 173.879256 166.817704 
-L 173.378437 167.038593 
-L 172.877618 167.258584 
-L 172.376799 167.477684 
-L 171.87598 167.695901 
-L 171.375161 167.913242 
-L 170.874342 168.129714 
-L 170.373524 168.345324 
-L 169.872705 168.560078 
-L 169.371886 168.773984 
-L 168.871067 168.987048 
-L 168.370248 169.199276 
-L 167.869429 169.410676 
-L 167.36861 169.621253 
-L 166.867791 169.831014 
-L 166.366972 170.039966 
-L 165.866154 170.248114 
-L 165.365335 170.455464 
-L 164.864516 170.662024 
-L 164.363697 170.867798 
-L 163.862878 171.072793 
-L 163.362059 171.277015 
-L 162.86124 171.480469 
-L 162.360421 171.683161 
-L 161.859602 171.885097 
-L 161.358783 172.086283 
-L 160.857965 172.286723 
-L 160.357146 172.486424 
-L 159.856327 172.685391 
-L 159.355508 172.88363 
-L 158.854689 173.081145 
-L 158.35387 173.277942 
-L 157.853051 173.474026 
-L 157.352232 173.669402 
-L 156.851413 173.864076 
-L 156.350594 174.058052 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 180.389901 164.017653 
+L 179.889712 164.220409 
+L 179.389523 164.422408 
+L 178.889334 164.623657 
+L 178.389145 164.824159 
+L 177.888956 165.023922 
+L 177.388767 165.222951 
+L 176.888578 165.42125 
+L 176.388389 165.618826 
+L 175.8882 165.815683 
+L 175.388011 166.011827 
+L 174.887822 166.207262 
+L 174.387633 166.401995 
+L 173.887443 166.596029 
+L 173.387254 166.789371 
+L 172.887065 166.982024 
+L 172.386876 167.173994 
+L 171.886687 167.365286 
+L 171.386498 167.555904 
+L 170.886309 167.745854 
+L 170.38612 167.935139 
+L 169.885931 168.123764 
+L 169.385742 168.311735 
+L 168.885553 168.499055 
+L 168.385364 168.685729 
+L 167.885175 168.871761 
+L 167.384985 169.057156 
+L 166.884796 169.241919 
+L 166.384607 169.426053 
+L 165.884418 169.609563 
+L 165.384229 169.792453 
+L 164.88404 169.974726 
+L 164.383851 170.156389 
+L 163.883662 170.337443 
+L 163.383473 170.517894 
+L 162.883284 170.697746 
+L 162.383095 170.877002 
+L 161.882906 171.055666 
+L 161.382717 171.233743 
+L 160.882527 171.411235 
+L 160.382338 171.588148 
+L 159.882149 171.764484 
+L 159.38196 171.940248 
+L 158.881771 172.115443 
+L 158.381582 172.290072 
+L 157.881393 172.46414 
+L 157.381204 172.637651 
+L 156.881015 172.810606 
+L 156.380826 172.983011 
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_149">
-    <path d="M 156.350594 174.058052 
-L 156.173353 174.280015 
-L 155.996112 174.501071 
-L 155.818871 174.721227 
-L 155.641629 174.940492 
-L 155.464388 175.158873 
-L 155.287147 175.376376 
-L 155.109905 175.593009 
-L 154.932664 175.808778 
-L 154.755423 176.02369 
-L 154.578182 176.237753 
-L 154.40094 176.450972 
-L 154.223699 176.663355 
-L 154.046458 176.874907 
-L 153.869216 177.085637 
-L 153.691975 177.295549 
-L 153.514734 177.50465 
-L 153.337492 177.712946 
-L 153.160251 177.920445 
-L 152.98301 178.12715 
-L 152.805769 178.33307 
-L 152.628527 178.538209 
-L 152.451286 178.742573 
-L 152.274045 178.946169 
-L 152.096803 179.149002 
-L 151.919562 179.351078 
-L 151.742321 179.552402 
-L 151.56508 179.752981 
-L 151.387838 179.952819 
-L 151.210597 180.151921 
-L 151.033356 180.350295 
-L 150.856114 180.547943 
-L 150.678873 180.744873 
-L 150.501632 180.941089 
-L 150.32439 181.136596 
-L 150.147149 181.3314 
-L 149.969908 181.525505 
-L 149.792667 181.718917 
-L 149.615425 181.91164 
-L 149.438184 182.103679 
-L 149.260943 182.29504 
-L 149.083701 182.485726 
-L 148.90646 182.675743 
-L 148.729219 182.865095 
-L 148.551977 183.053787 
-L 148.374736 183.241824 
-L 148.197495 183.42921 
-L 148.020254 183.615949 
-L 147.843012 183.802047 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 156.380826 172.983011 
+L 156.204039 173.204124 
+L 156.027252 173.424338 
+L 155.850465 173.643659 
+L 155.673678 173.862096 
+L 155.496891 174.079654 
+L 155.320103 174.296342 
+L 155.143316 174.512165 
+L 154.966529 174.727132 
+L 154.789742 174.941248 
+L 154.612955 175.154521 
+L 154.436168 175.366956 
+L 154.259381 175.578562 
+L 154.082594 175.789343 
+L 153.905807 175.999307 
+L 153.72902 176.208459 
+L 153.552233 176.416806 
+L 153.375446 176.624355 
+L 153.198659 176.831111 
+L 153.021872 177.03708 
+L 152.845085 177.242268 
+L 152.668298 177.446682 
+L 152.491511 177.650326 
+L 152.314724 177.853208 
+L 152.137937 178.055331 
+L 151.96115 178.256703 
+L 151.784362 178.457329 
+L 151.607575 178.657213 
+L 151.430788 178.856363 
+L 151.254001 179.054782 
+L 151.077214 179.252476 
+L 150.900427 179.449452 
+L 150.72364 179.645713 
+L 150.546853 179.841265 
+L 150.370066 180.036113 
+L 150.193279 180.230262 
+L 150.016492 180.423718 
+L 149.839705 180.616484 
+L 149.662918 180.808567 
+L 149.486131 180.99997 
+L 149.309344 181.190699 
+L 149.132557 181.380758 
+L 148.95577 181.570153 
+L 148.778983 181.758886 
+L 148.602196 181.946965 
+L 148.425408 182.134392 
+L 148.248621 182.321172 
+L 148.071834 182.50731 
+L 147.895047 182.69281 
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_150">
-    <path d="M 147.843012 183.802047 
-L 147.80944 183.888624 
-L 147.775867 183.975064 
-L 147.742295 184.061365 
-L 147.708722 184.147529 
-L 147.67515 184.233557 
-L 147.641577 184.319447 
-L 147.608005 184.405202 
-L 147.574432 184.490821 
-L 147.54086 184.576305 
-L 147.507287 184.661654 
-L 147.473715 184.746869 
-L 147.440142 184.83195 
-L 147.40657 184.916897 
-L 147.372997 185.001711 
-L 147.339425 185.086392 
-L 147.305852 185.170942 
-L 147.27228 185.255359 
-L 147.238707 185.339645 
-L 147.205135 185.4238 
-L 147.171562 185.507824 
-L 147.13799 185.591718 
-L 147.104417 185.675482 
-L 147.070845 185.759117 
-L 147.037273 185.842623 
-L 147.0037 185.926 
-L 146.970128 186.009249 
-L 146.936555 186.09237 
-L 146.902983 186.175364 
-L 146.86941 186.25823 
-L 146.835838 186.34097 
-L 146.802265 186.423584 
-L 146.768693 186.506072 
-L 146.73512 186.588434 
-L 146.701548 186.670671 
-L 146.667975 186.752783 
-L 146.634403 186.834771 
-L 146.60083 186.916635 
-L 146.567258 186.998376 
-L 146.533685 187.079993 
-L 146.500113 187.161487 
-L 146.46654 187.242859 
-L 146.432968 187.324109 
-L 146.399395 187.405236 
-L 146.365823 187.486243 
-L 146.33225 187.567128 
-L 146.298678 187.647893 
-L 146.265105 187.728538 
-L 146.231533 187.809062 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 147.895047 182.69281 
+L 147.861018 182.781673 
+L 147.826988 182.87039 
+L 147.792959 182.958962 
+L 147.758929 183.04739 
+L 147.724899 183.135673 
+L 147.69087 183.223812 
+L 147.65684 183.311809 
+L 147.622811 183.399662 
+L 147.588781 183.487373 
+L 147.554751 183.574942 
+L 147.520722 183.66237 
+L 147.486692 183.749657 
+L 147.452663 183.836803 
+L 147.418633 183.923809 
+L 147.384604 184.010675 
+L 147.350574 184.097403 
+L 147.316544 184.183991 
+L 147.282515 184.270442 
+L 147.248485 184.356754 
+L 147.214456 184.442929 
+L 147.180426 184.528967 
+L 147.146396 184.614869 
+L 147.112367 184.700634 
+L 147.078337 184.786264 
+L 147.044308 184.871759 
+L 147.010278 184.957118 
+L 146.976249 185.042344 
+L 146.942219 185.127435 
+L 146.908189 185.212393 
+L 146.87416 185.297218 
+L 146.84013 185.38191 
+L 146.806101 185.466469 
+L 146.772071 185.550897 
+L 146.738041 185.635193 
+L 146.704012 185.719359 
+L 146.669982 185.803393 
+L 146.635953 185.887298 
+L 146.601923 185.971072 
+L 146.567893 186.054717 
+L 146.533864 186.138233 
+L 146.499834 186.22162 
+L 146.465805 186.304879 
+L 146.431775 186.388011 
+L 146.397746 186.471014 
+L 146.363716 186.553891 
+L 146.329686 186.636641 
+L 146.295657 186.719265 
+L 146.261627 186.801762 
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_151">
-    <path d="M 146.231533 187.809062 
-L 145.676509 193.307037 
-L 145.121485 198.297725 
-L 144.566461 202.866881 
-L 144.011437 207.080201 
-L 143.456413 210.989126 
-L 142.901389 214.634692 
-L 142.346365 218.050155 
-L 141.791342 221.262847 
-L 141.236318 224.295501 
-L 140.681294 227.167229 
-L 140.12627 229.894253 
-L 139.571246 232.490459 
-L 139.016222 234.967825 
-L 138.461198 237.336758 
-L 137.906174 239.606351 
-L 137.35115 241.784602 
-L 136.796126 243.878581 
-L 136.241103 245.894565 
-L 135.686079 247.838157 
-L 135.131055 249.714376 
-L 134.576031 251.527736 
-L 134.021007 253.282314 
-L 133.465983 254.981802 
-L 132.910959 256.629553 
-L 132.355935 258.228624 
-L 131.800911 259.781811 
-L 131.245887 261.291672 
-L 130.690864 262.760559 
-L 130.13584 264.190638 
-L 129.580816 265.583907 
-L 129.025792 266.942212 
-L 128.470768 268.267267 
-L 127.915744 269.560659 
-L 127.36072 270.823868 
-L 126.805696 272.058269 
-L 126.250672 273.265147 
-L 125.695648 274.445704 
-L 125.140625 275.601062 
-L 124.585601 276.732275 
-L 124.030577 277.840332 
-L 123.475553 278.926161 
-L 122.920529 279.990636 
-L 122.365505 281.034583 
-L 121.810481 282.058776 
-L 121.255457 283.063951 
-L 120.700433 284.0508 
-L 120.145409 285.019979 
-L 119.590386 285.972112 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 146.261627 186.801762 
+L 145.707552 192.342105 
+L 145.153478 197.367672 
+L 144.599403 201.966044 
+L 144.045328 206.204191 
+L 143.491253 210.134476 
+L 142.937178 213.798611 
+L 142.383103 217.230368 
+L 141.829029 220.457472 
+L 141.274954 223.502965 
+L 140.720879 226.386202 
+L 140.166804 229.123602 
+L 139.612729 231.729211 
+L 139.058654 234.215137 
+L 138.50458 236.591895 
+L 137.950505 238.86867 
+L 137.39643 241.053536 
+L 136.842355 243.153627 
+L 136.28828 245.175275 
+L 135.734206 247.124131 
+L 135.180131 249.005255 
+L 134.626056 250.823198 
+L 134.071981 252.582065 
+L 133.517906 254.285576 
+L 132.963831 255.937109 
+L 132.409757 257.539742 
+L 131.855682 259.096288 
+L 131.301607 260.609324 
+L 130.747532 262.081216 
+L 130.193457 263.514143 
+L 129.639382 264.910115 
+L 129.085308 266.270989 
+L 128.531233 267.598488 
+L 127.977158 268.89421 
+L 127.423083 270.15964 
+L 126.869008 271.396162 
+L 126.314933 272.605068 
+L 125.760859 273.787565 
+L 125.206784 274.944781 
+L 124.652709 276.077775 
+L 124.098634 277.187541 
+L 123.544559 278.275011 
+L 122.990485 279.341064 
+L 122.43641 280.386527 
+L 121.882335 281.41218 
+L 121.32826 282.418761 
+L 120.774185 283.406965 
+L 120.22011 284.377452 
+L 119.666036 285.330846 
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_152">
-    <path d="M 119.590386 285.972112 
-L 119.136406 286.761833 
-L 118.682426 287.540199 
-L 118.228447 288.307531 
-L 117.774467 289.064138 
-L 117.320487 289.810315 
-L 116.866508 290.546346 
-L 116.412528 291.272503 
-L 115.958549 291.989048 
-L 115.504569 292.696231 
-L 115.050589 293.394295 
-L 114.59661 294.083471 
-L 114.14263 294.763983 
-L 113.68865 295.436046 
-L 113.234671 296.099867 
-L 112.780691 296.755646 
-L 112.326712 297.403576 
-L 111.872732 298.043842 
-L 111.418752 298.676623 
-L 110.964773 299.302093 
-L 110.510793 299.920418 
-L 110.056813 300.53176 
-L 109.602834 301.136274 
-L 109.148854 301.734112 
-L 108.694874 302.325419 
-L 108.240895 302.910337 
-L 107.786915 303.489002 
-L 107.332936 304.061547 
-L 106.878956 304.628099 
-L 106.424976 305.188783 
-L 105.970997 305.743718 
-L 105.517017 306.293023 
-L 105.063037 306.836809 
-L 104.609058 307.375187 
-L 104.155078 307.908263 
-L 103.701099 308.43614 
-L 103.247119 308.958919 
-L 102.793139 309.476698 
-L 102.33916 309.989571 
-L 101.88518 310.49763 
-L 101.4312 311.000965 
-L 100.977221 311.499663 
-L 100.523241 311.993809 
-L 100.069262 312.483484 
-L 99.615282 312.968769 
-L 99.161302 313.449743 
-L 98.707323 313.92648 
-L 98.253343 314.399056 
-L 97.799363 314.867541 
-" clip-path="url(#pd7db26d2c3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 119.666036 285.330846 
+L 119.210791 286.100249 
+L 118.755546 286.85887 
+L 118.300301 287.607006 
+L 117.845056 288.344943 
+L 117.389812 289.072955 
+L 116.934567 289.791306 
+L 116.479322 290.500248 
+L 116.024077 291.200026 
+L 115.568833 291.890873 
+L 115.113588 292.573014 
+L 114.658343 293.246665 
+L 114.203098 293.912036 
+L 113.747854 294.569328 
+L 113.292609 295.218734 
+L 112.837364 295.860442 
+L 112.382119 296.494631 
+L 111.926875 297.121477 
+L 111.47163 297.741146 
+L 111.016385 298.353802 
+L 110.56114 298.959602 
+L 110.105895 299.558696 
+L 109.650651 300.151233 
+L 109.195406 300.737354 
+L 108.740161 301.317196 
+L 108.284916 301.890893 
+L 107.829672 302.458574 
+L 107.374427 303.020363 
+L 106.919182 303.576381 
+L 106.463937 304.126747 
+L 106.008693 304.671572 
+L 105.553448 305.210969 
+L 105.098203 305.745044 
+L 104.642958 306.273901 
+L 104.187713 306.797641 
+L 103.732469 307.316362 
+L 103.277224 307.83016 
+L 102.821979 308.339126 
+L 102.366734 308.843352 
+L 101.91149 309.342924 
+L 101.456245 309.837928 
+L 101.001 310.328446 
+L 100.545755 310.814559 
+L 100.090511 311.296346 
+L 99.635266 311.773882 
+L 99.180021 312.247242 
+L 98.724776 312.716499 
+L 98.269531 313.181723 
+L 97.814287 313.642983 
+" clip-path="url(#pe54303e94f)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
   </g>
   <g id="text_25">
@@ -6166,8 +6166,8 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-07-08T20:00:36Z  ·  Linux chungus2 x86_64  ·  commit 29539fd5  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(44.380078 465.66) scale(0.07 -0.07)">
+   <!-- 2026-07-08T20:16:47Z  ·  Linux chungus2 x86_64  ·  commit 74c19afa  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(44.841641 465.66) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -6290,31 +6290,6 @@ Q 1038 2656 1286 2365
 Q 1534 2075 1959 2075 
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
-z
-" transform="scale(0.015625)"/>
      <path id="DejaVuSans-3d" d="M 678 2906 
 L 4684 2906 
 L 4684 2381 
@@ -6358,11 +6333,11 @@ z
     <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -6402,109 +6377,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3262.744141 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3326.367188 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3389.990234 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3425.195312 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3488.671875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3552.294922 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3584.082031 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3615.869141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3647.65625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3679.443359 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3711.230469 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3739.013672 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3800.537109 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3861.816406 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3925.195312 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3988.671875 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4027.535156 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4088.716797 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4147.896484 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4209.419922 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4250.533203 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4284.224609 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4312.007812 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4373.53125 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4434.810547 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4498.189453 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4561.8125 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4595.503906 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4654.683594 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4718.306641 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4750.09375 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4813.716797 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4877.339844 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4909.126953 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4972.75 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5008.833984 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5047.697266 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5102.677734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5166.300781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5198.087891 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5229.875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5261.662109 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5293.449219 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5325.236328 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5364.445312 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5427.824219 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5466.6875 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5527.869141 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5591.248047 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5654.724609 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5718.103516 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5781.580078 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5844.958984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5884.167969 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5915.955078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5999.744141 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6031.53125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6128.943359 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6190.466797 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6253.943359 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6281.726562 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6343.005859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6406.384766 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6438.171875 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6490.271484 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6553.650391 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6614.929688 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6678.40625 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6730.505859 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6793.884766 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6855.066406 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6894.275391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6927.966797 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6959.753906 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7000.867188 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7062.146484 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7101.355469 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7129.138672 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7190.320312 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7222.107422 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7249.890625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7301.990234 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7333.777344 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7397.253906 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7458.777344 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7497.986328 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7559.509766 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7598.873047 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7696.285156 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7724.068359 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7787.447266 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7815.230469 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7867.330078 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7906.539062 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7934.322266 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3254.101562 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3317.724609 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3381.347656 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3442.626953 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3477.832031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3539.111328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3570.898438 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3602.685547 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3634.472656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3666.259766 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3698.046875 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3725.830078 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3787.353516 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3848.632812 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3912.011719 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3975.488281 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4014.351562 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4075.533203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4134.712891 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4196.236328 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4237.349609 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4271.041016 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4298.824219 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4360.347656 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4421.626953 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4485.005859 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4548.628906 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4582.320312 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4641.5 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4705.123047 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4736.910156 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4800.533203 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4864.15625 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4895.943359 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4959.566406 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4995.650391 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5034.513672 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5089.494141 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5153.117188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5184.904297 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5216.691406 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5248.478516 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5280.265625 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5312.052734 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5351.261719 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5414.640625 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5453.503906 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5514.685547 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5578.064453 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5641.541016 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5704.919922 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5768.396484 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5831.775391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5870.984375 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5902.771484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5986.560547 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6018.347656 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6115.759766 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6177.283203 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6240.759766 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6268.542969 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6329.822266 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6393.201172 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6424.988281 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6477.087891 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6540.466797 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6601.746094 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6665.222656 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6717.322266 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6780.701172 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6841.882812 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6881.091797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6914.783203 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6946.570312 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6987.683594 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7048.962891 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7088.171875 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7115.955078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7177.136719 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7208.923828 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7236.707031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7288.806641 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7320.59375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7384.070312 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7445.59375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7484.802734 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7546.326172 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7585.689453 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7683.101562 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7710.884766 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7774.263672 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7802.046875 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7854.146484 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7893.355469 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7921.138672 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pd7db26d2c3">
+  <clipPath id="pe54303e94f">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_decode_density.svg
+++ b/bench/graphs/silesia_decode_density.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 82.373685 412.80375 
 L 82.373685 47.3475 
-" clip-path="url(#p74e1a3303b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p482b3a1732)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m23c9bc81cc" d="M 0 0 
+       <path id="mf9e22cc409" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m23c9bc81cc" x="82.373685" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf9e22cc409" x="82.373685" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -111,11 +111,11 @@ z
      <g id="line2d_3">
       <path d="M 165.44644 412.80375 
 L 165.44644 47.3475 
-" clip-path="url(#p74e1a3303b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p482b3a1732)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m23c9bc81cc" x="165.44644" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf9e22cc409" x="165.44644" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -157,11 +157,11 @@ z
      <g id="line2d_5">
       <path d="M 248.519195 412.80375 
 L 248.519195 47.3475 
-" clip-path="url(#p74e1a3303b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p482b3a1732)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m23c9bc81cc" x="248.519195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf9e22cc409" x="248.519195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -211,11 +211,11 @@ z
      <g id="line2d_7">
       <path d="M 331.59195 412.80375 
 L 331.59195 47.3475 
-" clip-path="url(#p74e1a3303b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p482b3a1732)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m23c9bc81cc" x="331.59195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf9e22cc409" x="331.59195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -252,11 +252,11 @@ z
      <g id="line2d_9">
       <path d="M 414.664704 412.80375 
 L 414.664704 47.3475 
-" clip-path="url(#p74e1a3303b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p482b3a1732)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m23c9bc81cc" x="414.664704" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf9e22cc409" x="414.664704" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -299,11 +299,11 @@ z
      <g id="line2d_11">
       <path d="M 497.737459 412.80375 
 L 497.737459 47.3475 
-" clip-path="url(#p74e1a3303b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p482b3a1732)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m23c9bc81cc" x="497.737459" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf9e22cc409" x="497.737459" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -351,11 +351,11 @@ z
      <g id="line2d_13">
       <path d="M 580.810214 412.80375 
 L 580.810214 47.3475 
-" clip-path="url(#p74e1a3303b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p482b3a1732)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m23c9bc81cc" x="580.810214" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf9e22cc409" x="580.810214" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -897,16 +897,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 391.33747 
 L 637.2 391.33747 
-" clip-path="url(#p74e1a3303b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p482b3a1732)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="m4527163a49" d="M 0 0 
+       <path id="m5e2a973582" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m4527163a49" x="49.078125" y="391.33747" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5e2a973582" x="49.078125" y="391.33747" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -922,11 +922,11 @@ L -3.5 0
      <g id="line2d_17">
       <path d="M 49.078125 263.934445 
 L 637.2 263.934445 
-" clip-path="url(#p74e1a3303b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p482b3a1732)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m4527163a49" x="49.078125" y="263.934445" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5e2a973582" x="49.078125" y="263.934445" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -942,11 +942,11 @@ L 637.2 263.934445
      <g id="line2d_19">
       <path d="M 49.078125 136.53142 
 L 637.2 136.53142 
-" clip-path="url(#p74e1a3303b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p482b3a1732)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m4527163a49" x="49.078125" y="136.53142" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5e2a973582" x="49.078125" y="136.53142" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -962,16 +962,16 @@ L 637.2 136.53142
      <g id="line2d_21">
       <path d="M 49.078125 411.072449 
 L 637.2 411.072449 
-" clip-path="url(#p74e1a3303b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p482b3a1732)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="m94ab70279b" d="M 0 0 
+       <path id="m2b0e05a77b" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m94ab70279b" x="49.078125" y="411.072449" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2b0e05a77b" x="49.078125" y="411.072449" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -979,11 +979,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 403.684099 
 L 637.2 403.684099 
-" clip-path="url(#p74e1a3303b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p482b3a1732)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m94ab70279b" x="49.078125" y="403.684099" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2b0e05a77b" x="49.078125" y="403.684099" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -991,11 +991,11 @@ L 637.2 403.684099
      <g id="line2d_25">
       <path d="M 49.078125 397.167113 
 L 637.2 397.167113 
-" clip-path="url(#p74e1a3303b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p482b3a1732)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m94ab70279b" x="49.078125" y="397.167113" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2b0e05a77b" x="49.078125" y="397.167113" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1003,11 +1003,11 @@ L 637.2 397.167113
      <g id="line2d_27">
       <path d="M 49.078125 352.985338 
 L 637.2 352.985338 
-" clip-path="url(#p74e1a3303b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p482b3a1732)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m94ab70279b" x="49.078125" y="352.985338" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2b0e05a77b" x="49.078125" y="352.985338" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1015,11 +1015,11 @@ L 637.2 352.985338
      <g id="line2d_29">
       <path d="M 49.078125 330.550779 
 L 637.2 330.550779 
-" clip-path="url(#p74e1a3303b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p482b3a1732)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m94ab70279b" x="49.078125" y="330.550779" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2b0e05a77b" x="49.078125" y="330.550779" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1027,11 +1027,11 @@ L 637.2 330.550779
      <g id="line2d_31">
       <path d="M 49.078125 314.633206 
 L 637.2 314.633206 
-" clip-path="url(#p74e1a3303b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p482b3a1732)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m94ab70279b" x="49.078125" y="314.633206" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2b0e05a77b" x="49.078125" y="314.633206" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1039,11 +1039,11 @@ L 637.2 314.633206
      <g id="line2d_33">
       <path d="M 49.078125 302.286577 
 L 637.2 302.286577 
-" clip-path="url(#p74e1a3303b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p482b3a1732)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m94ab70279b" x="49.078125" y="302.286577" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2b0e05a77b" x="49.078125" y="302.286577" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1051,11 +1051,11 @@ L 637.2 302.286577
      <g id="line2d_35">
       <path d="M 49.078125 292.198647 
 L 637.2 292.198647 
-" clip-path="url(#p74e1a3303b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p482b3a1732)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m94ab70279b" x="49.078125" y="292.198647" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2b0e05a77b" x="49.078125" y="292.198647" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1063,11 +1063,11 @@ L 637.2 292.198647
      <g id="line2d_37">
       <path d="M 49.078125 283.669424 
 L 637.2 283.669424 
-" clip-path="url(#p74e1a3303b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p482b3a1732)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m94ab70279b" x="49.078125" y="283.669424" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2b0e05a77b" x="49.078125" y="283.669424" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1075,11 +1075,11 @@ L 637.2 283.669424
      <g id="line2d_39">
       <path d="M 49.078125 276.281074 
 L 637.2 276.281074 
-" clip-path="url(#p74e1a3303b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p482b3a1732)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m94ab70279b" x="49.078125" y="276.281074" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2b0e05a77b" x="49.078125" y="276.281074" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1087,11 +1087,11 @@ L 637.2 276.281074
      <g id="line2d_41">
       <path d="M 49.078125 269.764088 
 L 637.2 269.764088 
-" clip-path="url(#p74e1a3303b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p482b3a1732)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m94ab70279b" x="49.078125" y="269.764088" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2b0e05a77b" x="49.078125" y="269.764088" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1099,11 +1099,11 @@ L 637.2 269.764088
      <g id="line2d_43">
       <path d="M 49.078125 225.582313 
 L 637.2 225.582313 
-" clip-path="url(#p74e1a3303b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p482b3a1732)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m94ab70279b" x="49.078125" y="225.582313" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2b0e05a77b" x="49.078125" y="225.582313" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1111,11 +1111,11 @@ L 637.2 225.582313
      <g id="line2d_45">
       <path d="M 49.078125 203.147754 
 L 637.2 203.147754 
-" clip-path="url(#p74e1a3303b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p482b3a1732)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m94ab70279b" x="49.078125" y="203.147754" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2b0e05a77b" x="49.078125" y="203.147754" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1123,11 +1123,11 @@ L 637.2 203.147754
      <g id="line2d_47">
       <path d="M 49.078125 187.230181 
 L 637.2 187.230181 
-" clip-path="url(#p74e1a3303b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p482b3a1732)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m94ab70279b" x="49.078125" y="187.230181" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2b0e05a77b" x="49.078125" y="187.230181" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1135,11 +1135,11 @@ L 637.2 187.230181
      <g id="line2d_49">
       <path d="M 49.078125 174.883552 
 L 637.2 174.883552 
-" clip-path="url(#p74e1a3303b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p482b3a1732)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m94ab70279b" x="49.078125" y="174.883552" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2b0e05a77b" x="49.078125" y="174.883552" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1147,11 +1147,11 @@ L 637.2 174.883552
      <g id="line2d_51">
       <path d="M 49.078125 164.795622 
 L 637.2 164.795622 
-" clip-path="url(#p74e1a3303b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p482b3a1732)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m94ab70279b" x="49.078125" y="164.795622" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2b0e05a77b" x="49.078125" y="164.795622" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1159,11 +1159,11 @@ L 637.2 164.795622
      <g id="line2d_53">
       <path d="M 49.078125 156.266399 
 L 637.2 156.266399 
-" clip-path="url(#p74e1a3303b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p482b3a1732)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#m94ab70279b" x="49.078125" y="156.266399" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2b0e05a77b" x="49.078125" y="156.266399" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1171,11 +1171,11 @@ L 637.2 156.266399
      <g id="line2d_55">
       <path d="M 49.078125 148.878049 
 L 637.2 148.878049 
-" clip-path="url(#p74e1a3303b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p482b3a1732)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#m94ab70279b" x="49.078125" y="148.878049" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2b0e05a77b" x="49.078125" y="148.878049" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1183,11 +1183,11 @@ L 637.2 148.878049
      <g id="line2d_57">
       <path d="M 49.078125 142.361063 
 L 637.2 142.361063 
-" clip-path="url(#p74e1a3303b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p482b3a1732)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#m94ab70279b" x="49.078125" y="142.361063" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2b0e05a77b" x="49.078125" y="142.361063" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1195,11 +1195,11 @@ L 637.2 142.361063
      <g id="line2d_59">
       <path d="M 49.078125 98.179288 
 L 637.2 98.179288 
-" clip-path="url(#p74e1a3303b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p482b3a1732)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#m94ab70279b" x="49.078125" y="98.179288" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2b0e05a77b" x="49.078125" y="98.179288" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1207,11 +1207,11 @@ L 637.2 98.179288
      <g id="line2d_61">
       <path d="M 49.078125 75.744729 
 L 637.2 75.744729 
-" clip-path="url(#p74e1a3303b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p482b3a1732)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#m94ab70279b" x="49.078125" y="75.744729" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2b0e05a77b" x="49.078125" y="75.744729" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1219,11 +1219,11 @@ L 637.2 75.744729
      <g id="line2d_63">
       <path d="M 49.078125 59.827156 
 L 637.2 59.827156 
-" clip-path="url(#p74e1a3303b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p482b3a1732)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#m94ab70279b" x="49.078125" y="59.827156" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2b0e05a77b" x="49.078125" y="59.827156" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1231,11 +1231,11 @@ L 637.2 59.827156
      <g id="line2d_65">
       <path d="M 49.078125 47.480527 
 L 637.2 47.480527 
-" clip-path="url(#p74e1a3303b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p482b3a1732)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#m94ab70279b" x="49.078125" y="47.480527" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2b0e05a77b" x="49.078125" y="47.480527" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1398,7 +1398,7 @@ z
    <g id="line2d_67">
     <path d="M 49.078125 63.959148 
 L 637.2 63.959148 
-" clip-path="url(#p74e1a3303b)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
+" clip-path="url(#p482b3a1732)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
    </g>
    <g id="patch_3">
     <path d="M 49.078125 412.80375 
@@ -1762,78 +1762,78 @@ z
    </g>
    <g id="line2d_68">
     <defs>
-     <path id="m111343f80f" d="M -2.5 2.5 
+     <path id="mf018328023" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p74e1a3303b)">
-     <use xlink:href="#m111343f80f" x="75.810937" y="263.190298" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m111343f80f" x="105.634056" y="267.887378" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m111343f80f" x="204.490635" y="300.240046" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m111343f80f" x="234.479899" y="306.367428" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m111343f80f" x="242.537956" y="316.909198" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m111343f80f" x="300.771958" y="297.352079" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m111343f80f" x="303.26414" y="310.698625" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m111343f80f" x="304.261013" y="317.548512" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m111343f80f" x="313.897453" y="317.953886" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m111343f80f" x="414.166268" y="334.149272" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m111343f80f" x="587.289889" y="327.780982" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m111343f80f" x="610.467187" y="318.981257" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p482b3a1732)">
+     <use xlink:href="#mf018328023" x="75.810937" y="263.190298" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf018328023" x="105.634056" y="267.887378" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf018328023" x="204.490635" y="300.240046" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf018328023" x="234.479899" y="306.367428" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf018328023" x="242.537956" y="316.909198" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf018328023" x="300.771958" y="297.352079" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf018328023" x="303.26414" y="310.698625" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf018328023" x="304.261013" y="317.548512" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf018328023" x="313.897453" y="317.953886" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf018328023" x="414.166268" y="334.149272" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf018328023" x="587.289889" y="327.780982" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf018328023" x="610.467187" y="318.981257" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_69">
     <defs>
-     <path id="me85919f9d7" d="M 0 -2.5 
+     <path id="m49a2c7402b" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p74e1a3303b)">
-     <use xlink:href="#me85919f9d7" x="75.810937" y="260.629553" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me85919f9d7" x="105.634056" y="253.888028" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me85919f9d7" x="204.490635" y="301.454063" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me85919f9d7" x="234.479899" y="296.198152" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me85919f9d7" x="242.537956" y="306.497434" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me85919f9d7" x="300.771958" y="285.157082" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me85919f9d7" x="303.26414" y="299.127298" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me85919f9d7" x="304.261013" y="312.289143" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me85919f9d7" x="313.897453" y="305.55147" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me85919f9d7" x="414.166268" y="323.799851" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me85919f9d7" x="587.289889" y="327.192921" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me85919f9d7" x="610.467187" y="316.49707" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p482b3a1732)">
+     <use xlink:href="#m49a2c7402b" x="75.810937" y="260.629553" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m49a2c7402b" x="105.634056" y="253.888028" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m49a2c7402b" x="204.490635" y="301.454063" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m49a2c7402b" x="234.479899" y="296.198152" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m49a2c7402b" x="242.537956" y="306.497434" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m49a2c7402b" x="300.771958" y="285.157082" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m49a2c7402b" x="303.26414" y="299.127298" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m49a2c7402b" x="304.261013" y="312.289143" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m49a2c7402b" x="313.897453" y="305.55147" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m49a2c7402b" x="414.166268" y="323.799851" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m49a2c7402b" x="587.289889" y="327.192921" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m49a2c7402b" x="610.467187" y="316.49707" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_70">
     <defs>
-     <path id="m9d5cee1b73" d="M -0 3.535534 
+     <path id="m84dab8f19a" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p74e1a3303b)">
-     <use xlink:href="#m9d5cee1b73" x="75.810937" y="229.675972" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9d5cee1b73" x="105.634056" y="230.807252" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9d5cee1b73" x="204.490635" y="262.817606" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9d5cee1b73" x="234.479899" y="260.308889" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9d5cee1b73" x="242.537956" y="274.651617" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9d5cee1b73" x="300.771958" y="258.820574" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9d5cee1b73" x="303.26414" y="270.569757" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9d5cee1b73" x="304.261013" y="279.042037" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9d5cee1b73" x="313.897453" y="275.908162" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9d5cee1b73" x="414.166268" y="294.938772" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9d5cee1b73" x="587.289889" y="301.872049" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9d5cee1b73" x="610.467187" y="298.545064" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p482b3a1732)">
+     <use xlink:href="#m84dab8f19a" x="75.810937" y="229.675972" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m84dab8f19a" x="105.634056" y="230.807252" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m84dab8f19a" x="204.490635" y="262.817606" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m84dab8f19a" x="234.479899" y="260.308889" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m84dab8f19a" x="242.537956" y="274.651617" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m84dab8f19a" x="300.771958" y="258.820574" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m84dab8f19a" x="303.26414" y="270.569757" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m84dab8f19a" x="304.261013" y="279.042037" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m84dab8f19a" x="313.897453" y="275.908162" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m84dab8f19a" x="414.166268" y="294.938772" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m84dab8f19a" x="587.289889" y="301.872049" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m84dab8f19a" x="610.467187" y="298.545064" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_71">
     <defs>
-     <path id="m53f2183930" d="M -0.833333 2.5 
+     <path id="m5bfc92ada2" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -1848,24 +1848,24 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p74e1a3303b)">
-     <use xlink:href="#m53f2183930" x="75.810937" y="286.028664" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m53f2183930" x="105.634056" y="293.887771" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m53f2183930" x="204.490635" y="326.335201" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m53f2183930" x="234.479899" y="337.903307" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m53f2183930" x="242.537956" y="341.092058" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m53f2183930" x="300.771958" y="336.485034" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m53f2183930" x="303.26414" y="344.754119" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m53f2183930" x="304.261013" y="344.606502" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m53f2183930" x="313.897453" y="351.527394" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m53f2183930" x="414.166268" y="363.295034" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m53f2183930" x="587.289889" y="368.159128" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m53f2183930" x="610.467187" y="356.976913" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p482b3a1732)">
+     <use xlink:href="#m5bfc92ada2" x="75.810937" y="286.028664" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5bfc92ada2" x="105.634056" y="293.887771" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5bfc92ada2" x="204.490635" y="326.335201" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5bfc92ada2" x="234.479899" y="337.903307" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5bfc92ada2" x="242.537956" y="341.092058" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5bfc92ada2" x="300.771958" y="336.485034" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5bfc92ada2" x="303.26414" y="344.754119" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5bfc92ada2" x="304.261013" y="344.606502" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5bfc92ada2" x="313.897453" y="351.527394" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5bfc92ada2" x="414.166268" y="363.295034" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5bfc92ada2" x="587.289889" y="368.159128" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5bfc92ada2" x="610.467187" y="356.976913" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_72">
     <defs>
-     <path id="mb61db27148" d="M -1.25 2.5 
+     <path id="m2f7afd1d99" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -1880,24 +1880,24 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p74e1a3303b)">
-     <use xlink:href="#mb61db27148" x="75.810937" y="327.723121" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb61db27148" x="105.634056" y="342.646685" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb61db27148" x="204.490635" y="362.850184" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb61db27148" x="234.479899" y="371.338643" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb61db27148" x="242.537956" y="367.245927" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb61db27148" x="300.771958" y="360.026985" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb61db27148" x="303.26414" y="374.683393" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb61db27148" x="304.261013" y="357.457726" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb61db27148" x="313.897453" y="374.58929" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb61db27148" x="414.166268" y="385.027438" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb61db27148" x="587.289889" y="394.333029" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb61db27148" x="610.467187" y="391.249012" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p482b3a1732)">
+     <use xlink:href="#m2f7afd1d99" x="75.810937" y="327.723121" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2f7afd1d99" x="105.634056" y="342.646685" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2f7afd1d99" x="204.490635" y="362.850184" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2f7afd1d99" x="234.479899" y="371.338643" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2f7afd1d99" x="242.537956" y="367.245927" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2f7afd1d99" x="300.771958" y="360.026985" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2f7afd1d99" x="303.26414" y="374.683393" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2f7afd1d99" x="304.261013" y="357.457726" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2f7afd1d99" x="313.897453" y="374.58929" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2f7afd1d99" x="414.166268" y="385.027438" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2f7afd1d99" x="587.289889" y="394.333029" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2f7afd1d99" x="610.467187" y="391.249012" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_73">
     <defs>
-     <path id="m1100545eaf" d="M 0 -2.5 
+     <path id="m0167fd575f" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -1910,24 +1910,24 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p74e1a3303b)">
-     <use xlink:href="#m1100545eaf" x="75.810937" y="273.778134" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m1100545eaf" x="105.634056" y="286.227815" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m1100545eaf" x="204.490635" y="319.608779" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m1100545eaf" x="234.479899" y="321.188418" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m1100545eaf" x="242.537956" y="325.921453" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m1100545eaf" x="300.771958" y="333.05015" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m1100545eaf" x="303.26414" y="336.951003" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m1100545eaf" x="304.261013" y="345.759761" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m1100545eaf" x="313.897453" y="336.754653" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m1100545eaf" x="414.166268" y="357.454726" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m1100545eaf" x="587.289889" y="366.280671" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m1100545eaf" x="610.467187" y="360.878702" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p482b3a1732)">
+     <use xlink:href="#m0167fd575f" x="75.810937" y="273.778134" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m0167fd575f" x="105.634056" y="286.227815" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m0167fd575f" x="204.490635" y="319.608779" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m0167fd575f" x="234.479899" y="321.188418" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m0167fd575f" x="242.537956" y="325.921453" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m0167fd575f" x="300.771958" y="333.05015" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m0167fd575f" x="303.26414" y="336.951003" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m0167fd575f" x="304.261013" y="345.759761" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m0167fd575f" x="313.897453" y="336.754653" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m0167fd575f" x="414.166268" y="357.454726" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m0167fd575f" x="587.289889" y="366.280671" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m0167fd575f" x="610.467187" y="360.878702" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_74">
     <defs>
-     <path id="mf573266066" d="M 0 -2.5 
+     <path id="m0d7e7c68ae" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -1936,19 +1936,19 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p74e1a3303b)">
-     <use xlink:href="#mf573266066" x="75.810937" y="347.176172" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf573266066" x="105.634056" y="348.704001" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf573266066" x="204.490635" y="367.31757" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf573266066" x="234.479899" y="373.033423" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf573266066" x="242.537956" y="380.00037" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf573266066" x="300.771958" y="370.53122" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf573266066" x="303.26414" y="375.375651" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf573266066" x="304.261013" y="383.030012" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf573266066" x="313.897453" y="385.215351" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf573266066" x="414.166268" y="391.648192" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf573266066" x="587.289889" y="396.192102" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf573266066" x="610.467187" y="383.710333" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p482b3a1732)">
+     <use xlink:href="#m0d7e7c68ae" x="75.810937" y="347.176172" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0d7e7c68ae" x="105.634056" y="348.704001" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0d7e7c68ae" x="204.490635" y="367.31757" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0d7e7c68ae" x="234.479899" y="373.033423" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0d7e7c68ae" x="242.537956" y="380.00037" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0d7e7c68ae" x="300.771958" y="370.53122" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0d7e7c68ae" x="303.26414" y="375.375651" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0d7e7c68ae" x="304.261013" y="383.030012" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0d7e7c68ae" x="313.897453" y="385.215351" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0d7e7c68ae" x="414.166268" y="391.648192" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0d7e7c68ae" x="587.289889" y="396.192102" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0d7e7c68ae" x="610.467187" y="383.710333" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="legend_1">
@@ -1967,7 +1967,7 @@ z
     </g>
     <g id="line2d_75">
      <defs>
-      <path id="m439afb6d8e" d="M 0 3.5 
+      <path id="m0b641e34e2" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -1980,7 +1980,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m439afb6d8e" x="434.04625" y="211.758125" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m0b641e34e2" x="434.04625" y="211.758125" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_15">
@@ -2039,7 +2039,7 @@ z
     </g>
     <g id="line2d_76">
      <g>
-      <use xlink:href="#m111343f80f" x="434.04625" y="223.500625" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mf018328023" x="434.04625" y="223.500625" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_16">
@@ -2053,7 +2053,7 @@ z
     </g>
     <g id="line2d_77">
      <g>
-      <use xlink:href="#me85919f9d7" x="434.04625" y="235.243125" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m49a2c7402b" x="434.04625" y="235.243125" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -2098,7 +2098,7 @@ z
     </g>
     <g id="line2d_78">
      <g>
-      <use xlink:href="#m9d5cee1b73" x="434.04625" y="247.208125" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m84dab8f19a" x="434.04625" y="247.208125" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -2118,7 +2118,7 @@ z
     </g>
     <g id="line2d_79">
      <g>
-      <use xlink:href="#m53f2183930" x="537.72375" y="211.758125" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m5bfc92ada2" x="537.72375" y="211.758125" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -2145,7 +2145,7 @@ z
     </g>
     <g id="line2d_80">
      <g>
-      <use xlink:href="#mb61db27148" x="537.72375" y="223.500625" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m2f7afd1d99" x="537.72375" y="223.500625" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -2210,7 +2210,7 @@ z
     </g>
     <g id="line2d_81">
      <g>
-      <use xlink:href="#m1100545eaf" x="537.72375" y="235.243125" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#m0167fd575f" x="537.72375" y="235.243125" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_21">
@@ -2248,7 +2248,7 @@ z
     </g>
     <g id="line2d_82">
      <g>
-      <use xlink:href="#mf573266066" x="537.72375" y="246.985625" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m0d7e7c68ae" x="537.72375" y="246.985625" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -2318,19 +2318,19 @@ z
     </g>
    </g>
    <g id="line2d_83">
-    <g clip-path="url(#p74e1a3303b)">
-     <use xlink:href="#m439afb6d8e" x="75.810937" y="272.143954" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m439afb6d8e" x="105.634056" y="288.399073" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m439afb6d8e" x="204.490635" y="322.103822" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m439afb6d8e" x="234.479899" y="324.29343" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m439afb6d8e" x="242.537956" y="324.418753" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m439afb6d8e" x="300.771958" y="312.453798" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m439afb6d8e" x="303.26414" y="333.249253" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m439afb6d8e" x="304.261013" y="351.748791" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m439afb6d8e" x="313.897453" y="337.048403" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m439afb6d8e" x="414.166268" y="356.441315" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m439afb6d8e" x="587.289889" y="359.296601" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m439afb6d8e" x="610.467187" y="343.193293" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <g clip-path="url(#p482b3a1732)">
+     <use xlink:href="#m0b641e34e2" x="75.810937" y="272.143954" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m0b641e34e2" x="105.634056" y="288.399073" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m0b641e34e2" x="204.490635" y="322.103822" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m0b641e34e2" x="234.479899" y="324.29343" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m0b641e34e2" x="242.537956" y="324.418753" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m0b641e34e2" x="300.771958" y="312.453798" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m0b641e34e2" x="303.26414" y="333.249253" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m0b641e34e2" x="304.261013" y="351.748791" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m0b641e34e2" x="313.897453" y="337.048403" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m0b641e34e2" x="414.166268" y="356.441315" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m0b641e34e2" x="587.289889" y="359.296601" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m0b641e34e2" x="610.467187" y="343.193293" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
   </g>
@@ -3154,7 +3154,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p74e1a3303b">
+  <clipPath id="p482b3a1732">
    <rect x="49.078125" y="47.3475" width="588.121875" height="365.45625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_decode_ranking.svg
+++ b/bench/graphs/silesia_decode_ranking.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 292.269187 308.04375 
 L 292.269187 56.7075 
-" clip-path="url(#pe2f80bcf71)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb2f8164573)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m2f581f6f22" d="M 0 0 
+       <path id="mf9d9e2c816" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m2f581f6f22" x="292.269187" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf9d9e2c816" x="292.269187" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -136,11 +136,11 @@ z
      <g id="line2d_3">
       <path d="M 449.991563 308.04375 
 L 449.991563 56.7075 
-" clip-path="url(#pe2f80bcf71)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb2f8164573)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m2f581f6f22" x="449.991563" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf9d9e2c816" x="449.991563" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -177,16 +177,16 @@ z
      <g id="line2d_5">
       <path d="M 182.025977 308.04375 
 L 182.025977 56.7075 
-" clip-path="url(#pe2f80bcf71)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb2f8164573)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <defs>
-       <path id="mcda166c4cf" d="M 0 0 
+       <path id="m1df9925dca" d="M 0 0 
 L 0 2 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#mcda166c4cf" x="182.025977" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1df9925dca" x="182.025977" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -194,11 +194,11 @@ L 0 2
      <g id="line2d_7">
       <path d="M 209.799509 308.04375 
 L 209.799509 56.7075 
-" clip-path="url(#pe2f80bcf71)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb2f8164573)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#mcda166c4cf" x="209.799509" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1df9925dca" x="209.799509" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -206,11 +206,11 @@ L 209.799509 56.7075
      <g id="line2d_9">
       <path d="M 229.505143 308.04375 
 L 229.505143 56.7075 
-" clip-path="url(#pe2f80bcf71)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb2f8164573)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#mcda166c4cf" x="229.505143" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1df9925dca" x="229.505143" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -218,11 +218,11 @@ L 229.505143 56.7075
      <g id="line2d_11">
       <path d="M 244.790021 308.04375 
 L 244.790021 56.7075 
-" clip-path="url(#pe2f80bcf71)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb2f8164573)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#mcda166c4cf" x="244.790021" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1df9925dca" x="244.790021" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -230,11 +230,11 @@ L 244.790021 56.7075
      <g id="line2d_13">
       <path d="M 257.278675 308.04375 
 L 257.278675 56.7075 
-" clip-path="url(#pe2f80bcf71)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb2f8164573)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mcda166c4cf" x="257.278675" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1df9925dca" x="257.278675" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -242,11 +242,11 @@ L 257.278675 56.7075
      <g id="line2d_15">
       <path d="M 267.837682 308.04375 
 L 267.837682 56.7075 
-" clip-path="url(#pe2f80bcf71)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb2f8164573)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <g>
-       <use xlink:href="#mcda166c4cf" x="267.837682" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1df9925dca" x="267.837682" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -254,11 +254,11 @@ L 267.837682 56.7075
      <g id="line2d_17">
       <path d="M 276.984309 308.04375 
 L 276.984309 56.7075 
-" clip-path="url(#pe2f80bcf71)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb2f8164573)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mcda166c4cf" x="276.984309" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1df9925dca" x="276.984309" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -266,11 +266,11 @@ L 276.984309 56.7075
      <g id="line2d_19">
       <path d="M 285.052207 308.04375 
 L 285.052207 56.7075 
-" clip-path="url(#pe2f80bcf71)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb2f8164573)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#mcda166c4cf" x="285.052207" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1df9925dca" x="285.052207" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -278,11 +278,11 @@ L 285.052207 56.7075
      <g id="line2d_21">
       <path d="M 339.748353 308.04375 
 L 339.748353 56.7075 
-" clip-path="url(#pe2f80bcf71)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb2f8164573)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#mcda166c4cf" x="339.748353" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1df9925dca" x="339.748353" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -290,11 +290,11 @@ L 339.748353 56.7075
      <g id="line2d_23">
       <path d="M 367.521885 308.04375 
 L 367.521885 56.7075 
-" clip-path="url(#pe2f80bcf71)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb2f8164573)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mcda166c4cf" x="367.521885" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1df9925dca" x="367.521885" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -302,11 +302,11 @@ L 367.521885 56.7075
      <g id="line2d_25">
       <path d="M 387.227519 308.04375 
 L 387.227519 56.7075 
-" clip-path="url(#pe2f80bcf71)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb2f8164573)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mcda166c4cf" x="387.227519" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1df9925dca" x="387.227519" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -314,11 +314,11 @@ L 387.227519 56.7075
      <g id="line2d_27">
       <path d="M 402.512397 308.04375 
 L 402.512397 56.7075 
-" clip-path="url(#pe2f80bcf71)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb2f8164573)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#mcda166c4cf" x="402.512397" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1df9925dca" x="402.512397" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -326,11 +326,11 @@ L 402.512397 56.7075
      <g id="line2d_29">
       <path d="M 415.001051 308.04375 
 L 415.001051 56.7075 
-" clip-path="url(#pe2f80bcf71)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb2f8164573)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#mcda166c4cf" x="415.001051" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1df9925dca" x="415.001051" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -338,11 +338,11 @@ L 415.001051 56.7075
      <g id="line2d_31">
       <path d="M 425.560057 308.04375 
 L 425.560057 56.7075 
-" clip-path="url(#pe2f80bcf71)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb2f8164573)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#mcda166c4cf" x="425.560057" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1df9925dca" x="425.560057" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -350,11 +350,11 @@ L 425.560057 56.7075
      <g id="line2d_33">
       <path d="M 434.706685 308.04375 
 L 434.706685 56.7075 
-" clip-path="url(#pe2f80bcf71)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb2f8164573)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#mcda166c4cf" x="434.706685" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1df9925dca" x="434.706685" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -362,11 +362,11 @@ L 434.706685 56.7075
      <g id="line2d_35">
       <path d="M 442.774583 308.04375 
 L 442.774583 56.7075 
-" clip-path="url(#pe2f80bcf71)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb2f8164573)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#mcda166c4cf" x="442.774583" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1df9925dca" x="442.774583" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -374,11 +374,11 @@ L 442.774583 56.7075
      <g id="line2d_37">
       <path d="M 497.470729 308.04375 
 L 497.470729 56.7075 
-" clip-path="url(#pe2f80bcf71)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb2f8164573)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#mcda166c4cf" x="497.470729" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1df9925dca" x="497.470729" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -386,11 +386,11 @@ L 497.470729 56.7075
      <g id="line2d_39">
       <path d="M 525.24426 308.04375 
 L 525.24426 56.7075 
-" clip-path="url(#pe2f80bcf71)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb2f8164573)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#mcda166c4cf" x="525.24426" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1df9925dca" x="525.24426" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -398,11 +398,11 @@ L 525.24426 56.7075
      <g id="line2d_41">
       <path d="M 544.949895 308.04375 
 L 544.949895 56.7075 
-" clip-path="url(#pe2f80bcf71)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb2f8164573)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#mcda166c4cf" x="544.949895" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1df9925dca" x="544.949895" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -410,11 +410,11 @@ L 544.949895 56.7075
      <g id="line2d_43">
       <path d="M 560.234772 308.04375 
 L 560.234772 56.7075 
-" clip-path="url(#pe2f80bcf71)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb2f8164573)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#mcda166c4cf" x="560.234772" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1df9925dca" x="560.234772" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1016,12 +1016,12 @@ z
     <g id="ytick_1">
      <g id="line2d_45">
       <defs>
-       <path id="md27d4d5f07" d="M 0 0 
+       <path id="m459fea81d0" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#md27d4d5f07" x="139.360469" y="296.619375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m459fea81d0" x="139.360469" y="296.619375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -1093,7 +1093,7 @@ z
     <g id="ytick_2">
      <g id="line2d_46">
       <g>
-       <use xlink:href="#md27d4d5f07" x="139.360469" y="263.978304" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m459fea81d0" x="139.360469" y="263.978304" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -1160,7 +1160,7 @@ z
     <g id="ytick_3">
      <g id="line2d_47">
       <g>
-       <use xlink:href="#md27d4d5f07" x="139.360469" y="231.337232" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m459fea81d0" x="139.360469" y="231.337232" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -1216,7 +1216,7 @@ z
     <g id="ytick_4">
      <g id="line2d_48">
       <g>
-       <use xlink:href="#md27d4d5f07" x="139.360469" y="198.696161" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m459fea81d0" x="139.360469" y="198.696161" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -1263,7 +1263,7 @@ z
     <g id="ytick_5">
      <g id="line2d_49">
       <g>
-       <use xlink:href="#md27d4d5f07" x="139.360469" y="166.055089" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m459fea81d0" x="139.360469" y="166.055089" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -1376,7 +1376,7 @@ z
     <g id="ytick_6">
      <g id="line2d_50">
       <g>
-       <use xlink:href="#md27d4d5f07" x="139.360469" y="133.414018" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m459fea81d0" x="139.360469" y="133.414018" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -1392,7 +1392,7 @@ z
     <g id="ytick_7">
      <g id="line2d_51">
       <g>
-       <use xlink:href="#md27d4d5f07" x="139.360469" y="100.772946" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m459fea81d0" x="139.360469" y="100.772946" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -1439,7 +1439,7 @@ z
     <g id="ytick_8">
      <g id="line2d_52">
       <g>
-       <use xlink:href="#md27d4d5f07" x="139.360469" y="68.131875" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m459fea81d0" x="139.360469" y="68.131875" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -1462,47 +1462,47 @@ z
    <g id="LineCollection_1">
     <path d="M 139.360469 296.619375 
 L 154.645346 296.619375 
-" clip-path="url(#pe2f80bcf71)" style="fill: none; stroke: #17becf; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#pb2f8164573)" style="fill: none; stroke: #17becf; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_2">
     <path d="M 139.360469 263.978304 
 L 161.142927 263.978304 
-" clip-path="url(#pe2f80bcf71)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#pb2f8164573)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_3">
     <path d="M 139.360469 231.337232 
 L 200.65327 231.337232 
-" clip-path="url(#pe2f80bcf71)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#pb2f8164573)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_4">
     <path d="M 139.360469 198.696161 
 L 208.426981 198.696161 
-" clip-path="url(#pe2f80bcf71)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#pb2f8164573)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_5">
     <path d="M 139.360469 166.055089 
 L 212.673671 166.055089 
-" clip-path="url(#pe2f80bcf71)" style="fill: none; stroke: #d62728; stroke-opacity: 0.9; stroke-width: 2.4"/>
+" clip-path="url(#pb2f8164573)" style="fill: none; stroke: #d62728; stroke-opacity: 0.9; stroke-width: 2.4"/>
    </g>
    <g id="LineCollection_6">
     <path d="M 139.360469 133.414018 
 L 239.878265 133.414018 
-" clip-path="url(#pe2f80bcf71)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#pb2f8164573)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_7">
     <path d="M 139.360469 100.772946 
 L 248.943982 100.772946 
-" clip-path="url(#pe2f80bcf71)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#pb2f8164573)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_8">
     <path d="M 139.360469 68.131875 
 L 284.774562 68.131875 
-" clip-path="url(#pe2f80bcf71)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#pb2f8164573)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="line2d_53">
     <path d="M 542.152339 308.04375 
 L 542.152339 56.7075 
-" clip-path="url(#pe2f80bcf71)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
+" clip-path="url(#pb2f8164573)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
    </g>
    <g id="patch_3">
     <path d="M 139.360469 308.04375 
@@ -1888,7 +1888,7 @@ z
    </g>
    <g id="line2d_54">
     <defs>
-     <path id="mfc337bc62c" d="M 0 3 
+     <path id="m65726f3321" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1900,13 +1900,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #17becf"/>
     </defs>
-    <g clip-path="url(#pe2f80bcf71)">
-     <use xlink:href="#mfc337bc62c" x="154.645346" y="296.619375" style="fill: #17becf; stroke: #17becf"/>
+    <g clip-path="url(#pb2f8164573)">
+     <use xlink:href="#m65726f3321" x="154.645346" y="296.619375" style="fill: #17becf; stroke: #17becf"/>
     </g>
    </g>
    <g id="line2d_55">
     <defs>
-     <path id="m3041c60d46" d="M 0 3 
+     <path id="m6e6eff6516" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1918,13 +1918,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #e377c2"/>
     </defs>
-    <g clip-path="url(#pe2f80bcf71)">
-     <use xlink:href="#m3041c60d46" x="161.142927" y="263.978304" style="fill: #e377c2; stroke: #e377c2"/>
+    <g clip-path="url(#pb2f8164573)">
+     <use xlink:href="#m6e6eff6516" x="161.142927" y="263.978304" style="fill: #e377c2; stroke: #e377c2"/>
     </g>
    </g>
    <g id="line2d_56">
     <defs>
-     <path id="m7fa0b158de" d="M 0 3 
+     <path id="m6a004fb50d" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1936,13 +1936,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #8c564b"/>
     </defs>
-    <g clip-path="url(#pe2f80bcf71)">
-     <use xlink:href="#m7fa0b158de" x="200.65327" y="231.337232" style="fill: #8c564b; stroke: #8c564b"/>
+    <g clip-path="url(#pb2f8164573)">
+     <use xlink:href="#m6a004fb50d" x="200.65327" y="231.337232" style="fill: #8c564b; stroke: #8c564b"/>
     </g>
    </g>
    <g id="line2d_57">
     <defs>
-     <path id="m921519ae90" d="M 0 3 
+     <path id="mcbe8002771" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1954,13 +1954,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #bcbd22"/>
     </defs>
-    <g clip-path="url(#pe2f80bcf71)">
-     <use xlink:href="#m921519ae90" x="208.426981" y="198.696161" style="fill: #bcbd22; stroke: #bcbd22"/>
+    <g clip-path="url(#pb2f8164573)">
+     <use xlink:href="#mcbe8002771" x="208.426981" y="198.696161" style="fill: #bcbd22; stroke: #bcbd22"/>
     </g>
    </g>
    <g id="line2d_58">
     <defs>
-     <path id="mba3e866370" d="M 0 5 
+     <path id="m1d45526457" d="M 0 5 
 C 1.326016 5 2.597899 4.473168 3.535534 3.535534 
 C 4.473168 2.597899 5 1.326016 5 0 
 C 5 -1.326016 4.473168 -2.597899 3.535534 -3.535534 
@@ -1972,13 +1972,13 @@ C -2.597899 4.473168 -1.326016 5 0 5
 z
 " style="stroke: #d62728"/>
     </defs>
-    <g clip-path="url(#pe2f80bcf71)">
-     <use xlink:href="#mba3e866370" x="212.673671" y="166.055089" style="fill: #d62728; stroke: #d62728"/>
+    <g clip-path="url(#pb2f8164573)">
+     <use xlink:href="#m1d45526457" x="212.673671" y="166.055089" style="fill: #d62728; stroke: #d62728"/>
     </g>
    </g>
    <g id="line2d_59">
     <defs>
-     <path id="m8ae57a6488" d="M 0 3 
+     <path id="mfbdce0101b" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1990,13 +1990,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #1f77b4"/>
     </defs>
-    <g clip-path="url(#pe2f80bcf71)">
-     <use xlink:href="#m8ae57a6488" x="239.878265" y="133.414018" style="fill: #1f77b4; stroke: #1f77b4"/>
+    <g clip-path="url(#pb2f8164573)">
+     <use xlink:href="#mfbdce0101b" x="239.878265" y="133.414018" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_60">
     <defs>
-     <path id="m722586ba8b" d="M 0 3 
+     <path id="m6d2152a6d5" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -2008,13 +2008,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #2ca02c"/>
     </defs>
-    <g clip-path="url(#pe2f80bcf71)">
-     <use xlink:href="#m722586ba8b" x="248.943982" y="100.772946" style="fill: #2ca02c; stroke: #2ca02c"/>
+    <g clip-path="url(#pb2f8164573)">
+     <use xlink:href="#m6d2152a6d5" x="248.943982" y="100.772946" style="fill: #2ca02c; stroke: #2ca02c"/>
     </g>
    </g>
    <g id="line2d_61">
     <defs>
-     <path id="m77d75128cb" d="M 0 3 
+     <path id="m87fa5e3e39" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -2026,8 +2026,8 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #9467bd"/>
     </defs>
-    <g clip-path="url(#pe2f80bcf71)">
-     <use xlink:href="#m77d75128cb" x="284.774562" y="68.131875" style="fill: #9467bd; stroke: #9467bd"/>
+    <g clip-path="url(#pb2f8164573)">
+     <use xlink:href="#m87fa5e3e39" x="284.774562" y="68.131875" style="fill: #9467bd; stroke: #9467bd"/>
     </g>
    </g>
   </g>
@@ -2967,7 +2967,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="pe2f80bcf71">
+  <clipPath id="pb2f8164573">
    <rect x="139.360469" y="56.7075" width="425.839531" height="251.33625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_ratio_heatmap.svg
+++ b/bench/graphs/silesia_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.34175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p05aa98dd99)">
+   <g clip-path="url(#p1091ef30aa)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAosAAAGaCAYAAABniAm0AAAJ/klEQVR4nO3Yu45eVx2H4ZnM+IDHmbEtSCLCQcJRQAqBEoWCKhWCgmvgCmioqBB3QMUN0KGI0k1KpACBEAogSkIQB1lDjB1jGXs8Mx9X8BYoWvqjT89zBT9pb6397rV7fvsnm50tdPLTW9MTlrjw6svTE5bZfebT0xOW2Lz1u+kJS+x+5aXpCUtsHt6fnrDM8fdfm56wxDM/+tb0hCV2bzw7PWGNk4fTC5Y5/+V2nvdPTQ8AAOD/l1gEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACDt/vvktc30iBUO/nU8PWGJDw+vTE9Y5j+nD6YnLPHZj06mJyzx0aeem56wxPnmfHrCMtf3b0xPWOPOB9MLlrh/fTuf19N//tP0hGU2L35tesISbhYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEj7B3duT29Y48q16QVLbDYn0xOW+czrv56esMar35xesMTRh/+YnrDG+en0gnUOtvT8uHR1esESh//czu/z3c/fnJ6wzPW/vj09YQk3iwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEDafXJ2azM9YoW94/enJyxx++mL0xOWefDk3vSEJW7+5d70hCVOv/z16QlLPDy9Pz1hmaO9a9MTlti896vpCUs8+sLL0xOWuPz2G9MTlnn81VemJyzhZhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIuz9/73ub6REr3Lh8MD1hiXfu3ZmesMx3f/yb6QlL/PaH356esMTRpaPpCUv84BdvTk9Y5hvPX56esMR3br4yPWGJ1//2xvSEJa5e2M73cGdnZ+dn796dnrCEm0UAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAg7T45u7WZHrHC3cfH0xOWONg/nJ6wzDv3fj89YYkXrr00PWGJzeZ8esISV0+39x/67+fbeS4+f/DC9IQlHp09nJ6wxLaeHTs7Ozt7T+1PT1hie09FAAA+NrEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAApP293f3pDUt8cu/G9IQ19i5OL1jm6NLR9IQlDvYPpycscbY5nZ6wxPmF7f2Hfm5zZXoC/4Nt/T6fbB5NT1jm/uPj6QlLbO+pCADAxyYWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBI+4/OHk5vWOLy7v70hCU+ePDH6QnLnJ6fTE9Y4/jd6QVL3D86nJ6wxOHFG9MTljk5ezQ9YYlP3H5/esISj5/93PSEJQ7+8Nb0hGUef/FL0xOWcLMIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAApP8Cc6OciHDVLsgAAAAASUVORK5CYII=" id="imagea2b04bf5f3" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="468.72" height="295.2"/>
+iVBORw0KGgoAAAANSUhEUgAAAosAAAGaCAYAAABniAm0AAAJ/UlEQVR4nO3Yu45eVx2H4ZnM+IDHmbEtSCLCQcIRIIVAiUJBlQpBwTVwBTRUVIg7oOIG6FBE6SZlpHAMoQCiJARxkDXE2DGWsccz83EFb4HC0h99ep4r+El7a+13r93z2z/e7Gyhk5/cmp6wxIVXXpqesMzuM5+cnrDE5s3fTk9YYvfLL05PWGLz8P70hGWOv/fq9IQlnvnhN6cnLLF749npCWucPJxesMz5z7fzvH9qegAAAP+/xCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAGn3XyevbqZHrHDwz+PpCUt8cHhlesIy/z59MD1hiU9/eDI9YYkPP/Hc9IQlzjfn0xOWub5/Y3rCGnfen16wxP3r2/m8nv7TH6cnLLP5/FenJyzhZhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgLR/cOf29IY1rlybXrDEZnMyPWGZT732y+kJa7zyjekFSxx98PfpCWucn04vWOdgS8+PS1enFyxx+I/t/D7f/ezN6QnLXP/LW9MTlnCzCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAAKTdJ2e3NtMjVtg7fm96whK3n744PWGZB0/uTU9Y4uaf701PWOL0S1+bnrDEw9P70xOWOdq7Nj1hic27v5iesMSjz700PWGJy2+9MT1hmcdfeXl6whJuFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIC0+7N3v7uZHrHCjcsH0xOWePvenekJy3znR7+enrDEb37wrekJSxxdOpqesMT3X//V9IRlvv785ekJS3z75svTE5Z47a9vTE9Y4uqF7XwPd3Z2dn76zt3pCUu4WQQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAADS7pOzW5vpESvcfXw8PWGJg/3D6QnLvH3vd9MTlnjh2ovTE5bYbM6nJyxx9XR7/6H/dr6d5+LzBy9MT1ji0dnD6QlLbOvZsbOzs7P31P70hCW291QEAOAjE4sAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA2t/b3Z/esMTH925MT1hj7+L0gmWOLh1NT1jiYP9wesISZ5vT6QlLnF/Y3n/o5zZXpifwX9jW7/PJ5tH0hGXuPz6enrDE9p6KAAB8ZGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIC0/+js4fSGJS5vaQe//+AP0xOWOT0/mZ6wxvE70wuWuH90OD1hicOLN6YnLHNy9mh6whIfu/3e9IQlHj/7mekJSxz8/s3pCcs8/sIXpycssZ1FBQDA/4RYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAg/Qdg9JyFmQO2bgAAAABJRU5ErkJggg==" id="imagec02579f729" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="468.72" height="295.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="ma885b7056f" d="M 0 0 
+       <path id="ma0c56d3a59" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#ma885b7056f" x="115.182137" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma0c56d3a59" x="115.182137" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#ma885b7056f" x="154.193912" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma0c56d3a59" x="154.193912" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#ma885b7056f" x="193.205687" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma0c56d3a59" x="193.205687" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#ma885b7056f" x="232.217462" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma0c56d3a59" x="232.217462" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#ma885b7056f" x="271.229237" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma0c56d3a59" x="271.229237" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#ma885b7056f" x="310.241012" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma0c56d3a59" x="310.241012" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#ma885b7056f" x="349.252787" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma0c56d3a59" x="349.252787" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#ma885b7056f" x="388.264562" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma0c56d3a59" x="388.264562" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#ma885b7056f" x="427.276336" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma0c56d3a59" x="427.276336" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#ma885b7056f" x="466.288111" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma0c56d3a59" x="466.288111" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#ma885b7056f" x="505.299886" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma0c56d3a59" x="505.299886" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#ma885b7056f" x="544.311661" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma0c56d3a59" x="544.311661" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="mbad40e8655" d="M 0 0 
+       <path id="mbbf4e96a03" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mbad40e8655" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbbf4e96a03" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mbad40e8655" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbbf4e96a03" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#mbad40e8655" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbbf4e96a03" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#mbad40e8655" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbbf4e96a03" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -836,7 +836,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#mbad40e8655" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbbf4e96a03" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -899,7 +899,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mbad40e8655" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbbf4e96a03" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -966,7 +966,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#mbad40e8655" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbbf4e96a03" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1047,7 +1047,7 @@ z
     <g id="ytick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#mbad40e8655" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbbf4e96a03" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -2060,18 +2060,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABEAAAFUCAYAAADCj9eRAAAB2ElEQVR4nO2aQY7EIAwEIeFP+6X9/33C3MPcKKSS1TygZRftNlLS2//fbJtn9KvvajAi17ZCM7Uzeg+TEyJhsh4TE8D25ZhYRMJkPSYmmZ0zIhfQEMPkJq74JpgQlUBMABkIrOV2KLMRItXMhrQjqcQUSszsbGuomFSbHULEAlblE0klor1zMaG0XwnDBDAsBVY0O4CIBizlE4ntEbCijK3mE8vKUPkEEIF8YslYje2RZFP5BJkdCxOonf1i6jEhRICOyjEBzFaPiWd2iChoYbKKhMkqgmSsh4kkHkU+6UyeACJEJaLZ6QQTzy7WtGPyicX2Kp/c+yKaATTliSWoTXsnPllEEtTLGX37f+7WRpuPQ4RhomlntCdMTohATIDbKceEaGfOD1BJZueIiImJZQBNTCxgw2Q91N7Zf7RBsxMmR0TqMdmvxPRmI0TmDJNVJExWkTBZRcJkFSnFZH6Q5aVhQrQzkYUOVEIxIXxSjAnRDjQ7mndsZud9VEwsPtFcsWjvaNZofHKoEpFPELCPJmORdqblMWxiYjEbw+QJk/dR+SQD+BbROFbEJAP4Q4RgQpiNCupKIhAT4gewakws7YTJIREoY4FPeNWYaNoJk18iQNqXY1LKJ1/07Ct/l+QCQgAAAABJRU5ErkJggg==" id="image54096a7caf" transform="scale(1 -1) translate(0 -244.8)" x="573.84" y="-74.16" width="12.24" height="244.8"/>
+iVBORw0KGgoAAAANSUhEUgAAABEAAAFUCAYAAADCj9eRAAAB2ElEQVR4nO2aQY7EIAwEIeFP+6X9/33C3MPcKKSS1TygZRftNlLS2//fbJtn9KvvajAi17ZCM7Uzeg+TEyJhsh4TE8D25ZhYRMJkPSYmmZ0zIhfQEMPkJq74JpgQlUBMABkIrOV2KLMRItXMhrQjqcQUSszsbGuomFSbHULEAlblE0klor1zMaG0XwnDBDAsBVY0O4CIBizlE4ntEbCijK3mE8vKUPkEEIF8YslYje2RZFP5BJkdCxOonf1i6jEhRICOyjEBzFaPiWd2iChoYbKKhMkqgmSsh4kkHkU+6UyeACJEJaLZ6QQTzy7WtGPyicX2Kp/c+yKaATTliSWoTXsnPllEEtTLGX37f+7WRpuPQ4RhomlntCdMTohATIDbKceEaGfOD1BJZueIiImJZQBNTCxgw2Q91N7Zf7RBsxMmR0TqMdmvxPRmI0TmDJNVJExWkTBZRcJkFSnFZH6Q5aVhQrQzkYUOVEIxIXxSjAnRDjQ7mndsZud9VEwsPtFcsWjvaNZofHKoEpFPELCPJmORdqblMWxiYjEbw+QJk/dR+SQD+BbROFbEJAP4Q4RgQpiNCupKIhAT4gewakws7YTJIREoY4FPeNWYaNoJk18iQNqXY1LKJ1/07Ct/l+QCQgAAAABJRU5ErkJggg==" id="image3a0ee1fd1d" transform="scale(1 -1) translate(0 -244.8)" x="573.84" y="-74.16" width="12.24" height="244.8"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_21">
       <defs>
-       <path id="m831af795b8" d="M 0 0 
+       <path id="m5a7d6d341d" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m831af795b8" x="585.876562" y="282.022672" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5a7d6d341d" x="585.876562" y="282.022672" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_117">
@@ -2097,7 +2097,7 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m831af795b8" x="585.876562" y="239.353777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5a7d6d341d" x="585.876562" y="239.353777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_118">
@@ -2114,7 +2114,7 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m831af795b8" x="585.876562" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5a7d6d341d" x="585.876562" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_119">
@@ -2130,7 +2130,7 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m831af795b8" x="585.876562" y="154.015985" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5a7d6d341d" x="585.876562" y="154.015985" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_120">
@@ -2146,7 +2146,7 @@ z
     <g id="ytick_13">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m831af795b8" x="585.876562" y="111.347089" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5a7d6d341d" x="585.876562" y="111.347089" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_121">
@@ -2739,8 +2739,8 @@ z
    </g>
   </g>
   <g id="text_124">
-   <!-- 2026-07-08T20:00:36Z  ·  Linux chungus2 x86_64  ·  commit 29539fd5  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(44.380078 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-08T20:16:47Z  ·  Linux chungus2 x86_64  ·  commit 74c19afa  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(44.841641 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -2873,11 +2873,11 @@ z
     <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2917,109 +2917,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3262.744141 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3326.367188 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3389.990234 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3425.195312 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3488.671875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3552.294922 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3584.082031 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3615.869141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3647.65625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3679.443359 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3711.230469 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3739.013672 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3800.537109 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3861.816406 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3925.195312 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3988.671875 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4027.535156 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4088.716797 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4147.896484 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4209.419922 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4250.533203 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4284.224609 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4312.007812 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4373.53125 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4434.810547 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4498.189453 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4561.8125 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4595.503906 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4654.683594 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4718.306641 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4750.09375 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4813.716797 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4877.339844 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4909.126953 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4972.75 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5008.833984 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5047.697266 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5102.677734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5166.300781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5198.087891 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5229.875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5261.662109 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5293.449219 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5325.236328 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5364.445312 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5427.824219 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5466.6875 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5527.869141 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5591.248047 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5654.724609 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5718.103516 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5781.580078 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5844.958984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5884.167969 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5915.955078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5999.744141 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6031.53125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6128.943359 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6190.466797 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6253.943359 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6281.726562 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6343.005859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6406.384766 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6438.171875 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6490.271484 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6553.650391 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6614.929688 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6678.40625 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6730.505859 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6793.884766 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6855.066406 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6894.275391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6927.966797 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6959.753906 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7000.867188 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7062.146484 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7101.355469 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7129.138672 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7190.320312 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7222.107422 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7249.890625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7301.990234 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7333.777344 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7397.253906 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7458.777344 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7497.986328 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7559.509766 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7598.873047 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7696.285156 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7724.068359 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7787.447266 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7815.230469 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7867.330078 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7906.539062 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7934.322266 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3254.101562 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3317.724609 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3381.347656 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3442.626953 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3477.832031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3539.111328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3570.898438 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3602.685547 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3634.472656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3666.259766 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3698.046875 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3725.830078 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3787.353516 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3848.632812 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3912.011719 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3975.488281 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4014.351562 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4075.533203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4134.712891 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4196.236328 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4237.349609 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4271.041016 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4298.824219 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4360.347656 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4421.626953 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4485.005859 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4548.628906 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4582.320312 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4641.5 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4705.123047 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4736.910156 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4800.533203 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4864.15625 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4895.943359 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4959.566406 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4995.650391 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5034.513672 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5089.494141 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5153.117188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5184.904297 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5216.691406 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5248.478516 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5280.265625 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5312.052734 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5351.261719 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5414.640625 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5453.503906 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5514.685547 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5578.064453 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5641.541016 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5704.919922 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5768.396484 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5831.775391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5870.984375 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5902.771484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5986.560547 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6018.347656 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6115.759766 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6177.283203 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6240.759766 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6268.542969 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6329.822266 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6393.201172 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6424.988281 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6477.087891 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6540.466797 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6601.746094 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6665.222656 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6717.322266 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6780.701172 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6841.882812 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6881.091797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6914.783203 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6946.570312 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6987.683594 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7048.962891 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7088.171875 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7115.955078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7177.136719 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7208.923828 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7236.707031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7288.806641 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7320.59375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7384.070312 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7445.59375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7484.802734 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7546.326172 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7585.689453 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7683.101562 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7710.884766 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7774.263672 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7802.046875 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7854.146484 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7893.355469 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7921.138672 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p05aa98dd99">
+  <clipPath id="p1091ef30aa">
    <rect x="95.67625" y="49.34175" width="468.141298" height="294.686261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_summary.svg
+++ b/bench/graphs/silesia_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="573.639844pt" height="386.202469pt" viewBox="0 0 573.639844 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="572.716719pt" height="386.202469pt" viewBox="0 0 572.716719 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,232 +22,232 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 386.202469 
-L 573.639844 386.202469 
-L 573.639844 0 
+L 572.716719 386.202469 
+L 572.716719 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 188.944922 104.1264 
-L 293.569922 104.1264 
-L 293.569922 74.7432 
-L 188.944922 74.7432 
+    <path d="M 188.483359 104.1264 
+L 293.108359 104.1264 
+L 293.108359 74.7432 
+L 188.483359 74.7432 
 z
-" clip-path="url(#p735a86a554)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p724545c2c4)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 293.569922 104.1264 
-L 398.194922 104.1264 
-L 398.194922 74.7432 
-L 293.569922 74.7432 
+    <path d="M 293.108359 104.1264 
+L 397.733359 104.1264 
+L 397.733359 74.7432 
+L 293.108359 74.7432 
 z
-" clip-path="url(#p735a86a554)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p724545c2c4)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 398.194922 104.1264 
-L 502.819922 104.1264 
-L 502.819922 74.7432 
-L 398.194922 74.7432 
+    <path d="M 397.733359 104.1264 
+L 502.358359 104.1264 
+L 502.358359 74.7432 
+L 397.733359 74.7432 
 z
-" clip-path="url(#p735a86a554)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p724545c2c4)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 188.944922 133.5096 
-L 293.569922 133.5096 
-L 293.569922 104.1264 
-L 188.944922 104.1264 
+    <path d="M 188.483359 133.5096 
+L 293.108359 133.5096 
+L 293.108359 104.1264 
+L 188.483359 104.1264 
 z
-" clip-path="url(#p735a86a554)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p724545c2c4)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 293.569922 133.5096 
-L 398.194922 133.5096 
-L 398.194922 104.1264 
-L 293.569922 104.1264 
+    <path d="M 293.108359 133.5096 
+L 397.733359 133.5096 
+L 397.733359 104.1264 
+L 293.108359 104.1264 
 z
-" clip-path="url(#p735a86a554)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p724545c2c4)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 398.194922 133.5096 
-L 502.819922 133.5096 
-L 502.819922 104.1264 
-L 398.194922 104.1264 
+    <path d="M 397.733359 133.5096 
+L 502.358359 133.5096 
+L 502.358359 104.1264 
+L 397.733359 104.1264 
 z
-" clip-path="url(#p735a86a554)" style="fill: #fece7c; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p724545c2c4)" style="fill: #fece7c; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 188.944922 162.8928 
-L 293.569922 162.8928 
-L 293.569922 133.5096 
-L 188.944922 133.5096 
+    <path d="M 188.483359 162.8928 
+L 293.108359 162.8928 
+L 293.108359 133.5096 
+L 188.483359 133.5096 
 z
-" clip-path="url(#p735a86a554)" style="fill: #fee08b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p724545c2c4)" style="fill: #fee08b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 293.569922 162.8928 
-L 398.194922 162.8928 
-L 398.194922 133.5096 
-L 293.569922 133.5096 
+    <path d="M 293.108359 162.8928 
+L 397.733359 162.8928 
+L 397.733359 133.5096 
+L 293.108359 133.5096 
 z
-" clip-path="url(#p735a86a554)" style="fill: #feefa3; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p724545c2c4)" style="fill: #feefa3; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 398.194922 162.8928 
-L 502.819922 162.8928 
-L 502.819922 133.5096 
-L 398.194922 133.5096 
+    <path d="M 397.733359 162.8928 
+L 502.358359 162.8928 
+L 502.358359 133.5096 
+L 397.733359 133.5096 
 z
-" clip-path="url(#p735a86a554)" style="fill: #fdbf6f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p724545c2c4)" style="fill: #fdbf6f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 188.944922 192.276 
-L 293.569922 192.276 
-L 293.569922 162.8928 
-L 188.944922 162.8928 
+    <path d="M 188.483359 192.276 
+L 293.108359 192.276 
+L 293.108359 162.8928 
+L 188.483359 162.8928 
 z
-" clip-path="url(#p735a86a554)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p724545c2c4)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 293.569922 192.276 
-L 398.194922 192.276 
-L 398.194922 162.8928 
-L 293.569922 162.8928 
+    <path d="M 293.108359 192.276 
+L 397.733359 192.276 
+L 397.733359 162.8928 
+L 293.108359 162.8928 
 z
-" clip-path="url(#p735a86a554)" style="fill: #fede89; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p724545c2c4)" style="fill: #fede89; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 398.194922 192.276 
-L 502.819922 192.276 
-L 502.819922 162.8928 
-L 398.194922 162.8928 
+    <path d="M 397.733359 192.276 
+L 502.358359 192.276 
+L 502.358359 162.8928 
+L 397.733359 162.8928 
 z
-" clip-path="url(#p735a86a554)" style="fill: #f7814c; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p724545c2c4)" style="fill: #f7814c; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 188.944922 221.6592 
-L 293.569922 221.6592 
-L 293.569922 192.276 
-L 188.944922 192.276 
+    <path d="M 188.483359 221.6592 
+L 293.108359 221.6592 
+L 293.108359 192.276 
+L 188.483359 192.276 
 z
-" clip-path="url(#p735a86a554)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p724545c2c4)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 293.569922 221.6592 
-L 398.194922 221.6592 
-L 398.194922 192.276 
-L 293.569922 192.276 
+    <path d="M 293.108359 221.6592 
+L 397.733359 221.6592 
+L 397.733359 192.276 
+L 293.108359 192.276 
 z
-" clip-path="url(#p735a86a554)" style="fill: #fed27f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p724545c2c4)" style="fill: #fed27f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 398.194922 221.6592 
-L 502.819922 221.6592 
-L 502.819922 192.276 
-L 398.194922 192.276 
+    <path d="M 397.733359 221.6592 
+L 502.358359 221.6592 
+L 502.358359 192.276 
+L 397.733359 192.276 
 z
-" clip-path="url(#p735a86a554)" style="fill: #fffcba; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p724545c2c4)" style="fill: #fffcba; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 188.944922 251.0424 
-L 293.569922 251.0424 
-L 293.569922 221.6592 
-L 188.944922 221.6592 
+    <path d="M 188.483359 251.0424 
+L 293.108359 251.0424 
+L 293.108359 221.6592 
+L 188.483359 221.6592 
 z
-" clip-path="url(#p735a86a554)" style="fill: #feec9f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p724545c2c4)" style="fill: #feec9f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 293.569922 251.0424 
-L 398.194922 251.0424 
-L 398.194922 221.6592 
-L 293.569922 221.6592 
+    <path d="M 293.108359 251.0424 
+L 397.733359 251.0424 
+L 397.733359 221.6592 
+L 293.108359 221.6592 
 z
-" clip-path="url(#p735a86a554)" style="fill: #fece7c; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p724545c2c4)" style="fill: #fed07e; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 398.194922 251.0424 
-L 502.819922 251.0424 
-L 502.819922 221.6592 
-L 398.194922 221.6592 
+    <path d="M 397.733359 251.0424 
+L 502.358359 251.0424 
+L 502.358359 221.6592 
+L 397.733359 221.6592 
 z
-" clip-path="url(#p735a86a554)" style="fill: #fec877; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p724545c2c4)" style="fill: #feca79; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 188.944922 280.4256 
-L 293.569922 280.4256 
-L 293.569922 251.0424 
-L 188.944922 251.0424 
+    <path d="M 188.483359 280.4256 
+L 293.108359 280.4256 
+L 293.108359 251.0424 
+L 188.483359 251.0424 
 z
-" clip-path="url(#p735a86a554)" style="fill: #fff3ac; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p724545c2c4)" style="fill: #fff3ac; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 293.569922 280.4256 
-L 398.194922 280.4256 
-L 398.194922 251.0424 
-L 293.569922 251.0424 
+    <path d="M 293.108359 280.4256 
+L 397.733359 280.4256 
+L 397.733359 251.0424 
+L 293.108359 251.0424 
 z
-" clip-path="url(#p735a86a554)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p724545c2c4)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 398.194922 280.4256 
-L 502.819922 280.4256 
-L 502.819922 251.0424 
-L 398.194922 251.0424 
+    <path d="M 397.733359 280.4256 
+L 502.358359 280.4256 
+L 502.358359 251.0424 
+L 397.733359 251.0424 
 z
-" clip-path="url(#p735a86a554)" style="fill: #e8f59f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p724545c2c4)" style="fill: #e8f59f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 188.944922 309.8088 
-L 293.569922 309.8088 
-L 293.569922 280.4256 
-L 188.944922 280.4256 
+    <path d="M 188.483359 309.8088 
+L 293.108359 309.8088 
+L 293.108359 280.4256 
+L 188.483359 280.4256 
 z
-" clip-path="url(#p735a86a554)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p724545c2c4)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 293.569922 309.8088 
-L 398.194922 309.8088 
-L 398.194922 280.4256 
-L 293.569922 280.4256 
+    <path d="M 293.108359 309.8088 
+L 397.733359 309.8088 
+L 397.733359 280.4256 
+L 293.108359 280.4256 
 z
-" clip-path="url(#p735a86a554)" style="fill: #fa9b58; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p724545c2c4)" style="fill: #fa9b58; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 398.194922 309.8088 
-L 502.819922 309.8088 
-L 502.819922 280.4256 
-L 398.194922 280.4256 
+    <path d="M 397.733359 309.8088 
+L 502.358359 309.8088 
+L 502.358359 280.4256 
+L 397.733359 280.4256 
 z
-" clip-path="url(#p735a86a554)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p724545c2c4)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 188.944922 339.192 
-L 293.569922 339.192 
-L 293.569922 309.8088 
-L 188.944922 309.8088 
+    <path d="M 188.483359 339.192 
+L 293.108359 339.192 
+L 293.108359 309.8088 
+L 188.483359 309.8088 
 z
-" clip-path="url(#p735a86a554)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p724545c2c4)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 293.569922 339.192 
-L 398.194922 339.192 
-L 398.194922 309.8088 
-L 293.569922 309.8088 
+    <path d="M 293.108359 339.192 
+L 397.733359 339.192 
+L 397.733359 309.8088 
+L 293.108359 309.8088 
 z
-" clip-path="url(#p735a86a554)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p724545c2c4)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 398.194922 339.192 
-L 502.819922 339.192 
-L 502.819922 309.8088 
-L 398.194922 309.8088 
+    <path d="M 397.733359 339.192 
+L 502.358359 339.192 
+L 502.358359 309.8088 
+L 397.733359 309.8088 
 z
-" clip-path="url(#p735a86a554)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p724545c2c4)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(121.932188 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(121.470625 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(229.216406 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(228.754844 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(307.788516 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(307.326953 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(406.140234 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(405.678672 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(117.869922 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(117.408359 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.320 -->
-    <g transform="translate(229.806172 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(229.344609 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -918,7 +918,7 @@ z
    </g>
    <g id="text_7">
     <!-- 117 -->
-    <g transform="translate(338.247422 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(337.785859 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -952,7 +952,7 @@ z
    </g>
    <g id="text_8">
     <!-- 852 -->
-    <g transform="translate(442.872422 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(442.410859 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -1026,7 +1026,7 @@ z
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(112.508047 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(112.046484 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1125,7 +1125,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.324 -->
-    <g transform="translate(229.806172 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(229.344609 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1156,7 +1156,7 @@ z
    </g>
    <g id="text_11">
     <!-- 61 -->
-    <g transform="translate(340.792422 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(340.330859 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -1195,7 +1195,7 @@ z
    </g>
    <g id="text_12">
     <!-- 312 -->
-    <g transform="translate(442.872422 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(442.410859 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
@@ -1203,7 +1203,7 @@ z
    </g>
    <g id="text_13">
     <!-- Go compress/flate -->
-    <g transform="translate(100.201172 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(99.739609 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -1374,7 +1374,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.325 -->
-    <g transform="translate(229.806172 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(229.344609 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1384,14 +1384,14 @@ z
    </g>
    <g id="text_15">
     <!-- 50 -->
-    <g transform="translate(340.792422 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(340.330859 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
     <!-- 275 -->
-    <g transform="translate(442.872422 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(442.410859 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
@@ -1399,7 +1399,7 @@ z
    </g>
    <g id="text_17">
     <!-- JS fflate -->
-    <g transform="translate(121.233672 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(120.772109 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1459,7 +1459,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.329 -->
-    <g transform="translate(229.806172 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(229.344609 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-39" d="M 703 97 
 L 703 672 
@@ -1501,14 +1501,14 @@ z
    </g>
    <g id="text_19">
     <!-- 41 -->
-    <g transform="translate(340.792422 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(340.330859 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
     <!-- 160 -->
-    <g transform="translate(442.872422 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(442.410859 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -1516,7 +1516,7 @@ z
    </g>
    <g id="text_21">
     <!-- zlib -->
-    <g transform="translate(129.771172 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(129.309609 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1540,7 +1540,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.323 -->
-    <g transform="translate(229.806172 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(229.344609 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1550,14 +1550,14 @@ z
    </g>
    <g id="text_23">
     <!-- 38 -->
-    <g transform="translate(340.792422 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(340.330859 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_24">
     <!-- 448 -->
-    <g transform="translate(442.872422 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(442.410859 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(127.246094 0)"/>
@@ -1565,7 +1565,7 @@ z
    </g>
    <g id="text_25">
     <!-- lean-zip (native) -->
-    <g transform="translate(99.579297 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(99.117734 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1674,7 +1674,7 @@ z
    </g>
    <g id="text_26">
     <!-- 0.323 -->
-    <g transform="translate(228.605547 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(228.143984 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1767,126 +1767,35 @@ z
     </g>
    </g>
    <g id="text_27">
-    <!-- 36 -->
-    <g transform="translate(340.316172 238.5583) scale(0.08 -0.08)">
+    <!-- 37 -->
+    <g transform="translate(339.854609 238.5583) scale(0.08 -0.08)">
      <defs>
-      <path id="DejaVuSans-Bold-36" d="M 2316 2303 
-Q 2000 2303 1842 2098 
-Q 1684 1894 1684 1484 
-Q 1684 1075 1842 870 
-Q 2000 666 2316 666 
-Q 2634 666 2792 870 
-Q 2950 1075 2950 1484 
-Q 2950 1894 2792 2098 
-Q 2634 2303 2316 2303 
-z
-M 3803 4544 
-L 3803 3681 
-Q 3506 3822 3243 3889 
-Q 2981 3956 2731 3956 
-Q 2194 3956 1894 3657 
-Q 1594 3359 1544 2772 
-Q 1750 2925 1990 3001 
-Q 2231 3078 2516 3078 
-Q 3231 3078 3670 2659 
-Q 4109 2241 4109 1563 
-Q 4109 813 3618 361 
-Q 3128 -91 2303 -91 
-Q 1394 -91 895 523 
-Q 397 1138 397 2266 
-Q 397 3422 980 4083 
-Q 1563 4744 2578 4744 
-Q 2900 4744 3203 4694 
-Q 3506 4644 3803 4544 
+      <path id="DejaVuSans-Bold-37" d="M 428 4666 
+L 3944 4666 
+L 3944 3988 
+L 2125 0 
+L 953 0 
+L 2675 3781 
+L 428 3781 
+L 428 4666 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-Bold-33"/>
-     <use xlink:href="#DejaVuSans-Bold-36" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-37" transform="translate(69.580078 0)"/>
     </g>
    </g>
    <g id="text_28">
-    <!-- 298 -->
-    <g transform="translate(442.158047 238.5583) scale(0.08 -0.08)">
-     <defs>
-      <path id="DejaVuSans-Bold-39" d="M 641 103 
-L 641 966 
-Q 928 831 1190 764 
-Q 1453 697 1709 697 
-Q 2247 697 2547 995 
-Q 2847 1294 2900 1881 
-Q 2688 1725 2447 1647 
-Q 2206 1569 1925 1569 
-Q 1209 1569 770 1986 
-Q 331 2403 331 3084 
-Q 331 3838 820 4291 
-Q 1309 4744 2131 4744 
-Q 3044 4744 3544 4128 
-Q 4044 3513 4044 2388 
-Q 4044 1231 3459 570 
-Q 2875 -91 1856 -91 
-Q 1528 -91 1228 -42 
-Q 928 6 641 103 
-z
-M 2125 2350 
-Q 2441 2350 2600 2554 
-Q 2759 2759 2759 3169 
-Q 2759 3575 2600 3781 
-Q 2441 3988 2125 3988 
-Q 1809 3988 1650 3781 
-Q 1491 3575 1491 3169 
-Q 1491 2759 1650 2554 
-Q 1809 2350 2125 2350 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-38" d="M 2228 2088 
-Q 1891 2088 1709 1903 
-Q 1528 1719 1528 1375 
-Q 1528 1031 1709 848 
-Q 1891 666 2228 666 
-Q 2563 666 2741 848 
-Q 2919 1031 2919 1375 
-Q 2919 1722 2741 1905 
-Q 2563 2088 2228 2088 
-z
-M 1350 2484 
-Q 925 2613 709 2878 
-Q 494 3144 494 3541 
-Q 494 4131 934 4440 
-Q 1375 4750 2228 4750 
-Q 3075 4750 3515 4442 
-Q 3956 4134 3956 3541 
-Q 3956 3144 3739 2878 
-Q 3522 2613 3097 2484 
-Q 3572 2353 3814 2058 
-Q 4056 1763 4056 1313 
-Q 4056 619 3595 264 
-Q 3134 -91 2228 -91 
-Q 1319 -91 855 264 
-Q 391 619 391 1313 
-Q 391 1763 633 2058 
-Q 875 2353 1350 2484 
-z
-M 1631 3419 
-Q 1631 3141 1786 2991 
-Q 1941 2841 2228 2841 
-Q 2509 2841 2662 2991 
-Q 2816 3141 2816 3419 
-Q 2816 3697 2662 3845 
-Q 2509 3994 2228 3994 
-Q 1941 3994 1786 3844 
-Q 1631 3694 1631 3419 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-Bold-32"/>
-     <use xlink:href="#DejaVuSans-Bold-39" transform="translate(69.580078 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-38" transform="translate(139.160156 0)"/>
+    <!-- 300 -->
+    <g transform="translate(441.696484 238.5583) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-Bold-33"/>
+     <use xlink:href="#DejaVuSans-Bold-30" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-30" transform="translate(139.160156 0)"/>
     </g>
    </g>
    <g id="text_29">
     <!-- miniz_oxide -->
-    <g transform="translate(113.077422 267.83025) scale(0.08 -0.08)">
+    <g transform="translate(112.615859 267.83025) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6e" d="M 3513 2113 
 L 3513 0 
@@ -1945,7 +1854,7 @@ z
    </g>
    <g id="text_30">
     <!-- 0.322 -->
-    <g transform="translate(229.806172 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(229.344609 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1955,14 +1864,14 @@ z
    </g>
    <g id="text_31">
     <!-- 36 -->
-    <g transform="translate(340.792422 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(340.330859 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_32">
     <!-- 527 -->
-    <g transform="translate(442.872422 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(442.410859 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
@@ -1970,7 +1879,7 @@ z
    </g>
    <g id="text_33">
     <!-- OCaml decompress -->
-    <g transform="translate(97.694297 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(97.232734 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -2035,7 +1944,7 @@ z
    </g>
    <g id="text_34">
     <!-- 0.336 -->
-    <g transform="translate(229.806172 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(229.344609 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -2045,21 +1954,21 @@ z
    </g>
    <g id="text_35">
     <!-- 21 -->
-    <g transform="translate(340.792422 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(340.330859 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_36">
     <!-- 69 -->
-    <g transform="translate(445.417422 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(444.955859 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-36"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(125.915547 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(125.453984 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -2070,7 +1979,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.303 -->
-    <g transform="translate(229.806172 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(229.344609 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -2080,13 +1989,13 @@ z
    </g>
    <g id="text_39">
     <!-- 1 -->
-    <g transform="translate(343.337422 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(342.875859 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(446.507422 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(446.045859 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2102,7 +2011,7 @@ z
   </g>
   <g id="text_41">
    <!-- silesia — geomean over files, level 6 -->
-   <g transform="translate(153.421641 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(152.960078 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-2014" d="M 344 2156 
 L 6056 2156 
@@ -2175,6 +2084,36 @@ L 653 256
 L 653 1209 
 z
 " transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-36" d="M 2316 2303 
+Q 2000 2303 1842 2098 
+Q 1684 1894 1684 1484 
+Q 1684 1075 1842 870 
+Q 2000 666 2316 666 
+Q 2634 666 2792 870 
+Q 2950 1075 2950 1484 
+Q 2950 1894 2792 2098 
+Q 2634 2303 2316 2303 
+z
+M 3803 4544 
+L 3803 3681 
+Q 3506 3822 3243 3889 
+Q 2981 3956 2731 3956 
+Q 2194 3956 1894 3657 
+Q 1594 3359 1544 2772 
+Q 1750 2925 1990 3001 
+Q 2231 3078 2516 3078 
+Q 3231 3078 3670 2659 
+Q 4109 2241 4109 1563 
+Q 4109 813 3618 361 
+Q 3128 -91 2303 -91 
+Q 1394 -91 895 523 
+Q 397 1138 397 2266 
+Q 397 3422 980 4083 
+Q 1563 4744 2578 4744 
+Q 2900 4744 3203 4694 
+Q 3506 4644 3803 4544 
+z
+" transform="scale(0.015625)"/>
     </defs>
     <use xlink:href="#DejaVuSans-Bold-73"/>
     <use xlink:href="#DejaVuSans-Bold-69" transform="translate(59.521484 0)"/>
@@ -2216,7 +2155,7 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-07-08T20:00:36Z  ·  Linux chungus2 x86_64  ·  commit 29539fd5  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-07-08T20:16:47Z  ·  Linux chungus2 x86_64  ·  commit 74c19afa  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2360,11 +2299,11 @@ z
     <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2404,110 +2343,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3262.744141 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3326.367188 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3389.990234 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3425.195312 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3488.671875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3552.294922 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3584.082031 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3615.869141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3647.65625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3679.443359 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3711.230469 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3739.013672 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3800.537109 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3861.816406 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3925.195312 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3988.671875 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4027.535156 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4088.716797 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4147.896484 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4209.419922 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4250.533203 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4284.224609 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4312.007812 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4373.53125 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4434.810547 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4498.189453 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4561.8125 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4595.503906 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4654.683594 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4718.306641 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4750.09375 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4813.716797 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4877.339844 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4909.126953 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4972.75 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5008.833984 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5047.697266 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5102.677734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5166.300781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5198.087891 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5229.875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5261.662109 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5293.449219 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5325.236328 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5364.445312 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5427.824219 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5466.6875 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5527.869141 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5591.248047 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5654.724609 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5718.103516 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5781.580078 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5844.958984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5884.167969 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5915.955078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5999.744141 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6031.53125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6128.943359 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6190.466797 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6253.943359 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6281.726562 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6343.005859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6406.384766 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6438.171875 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6490.271484 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6553.650391 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6614.929688 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6678.40625 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6730.505859 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6793.884766 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6855.066406 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6894.275391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6927.966797 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6959.753906 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7000.867188 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7062.146484 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7101.355469 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7129.138672 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7190.320312 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7222.107422 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7249.890625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7301.990234 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7333.777344 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7397.253906 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7458.777344 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7497.986328 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7559.509766 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7598.873047 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7696.285156 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7724.068359 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7787.447266 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7815.230469 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7867.330078 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7906.539062 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7934.322266 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3254.101562 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3317.724609 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3381.347656 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3442.626953 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3477.832031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3539.111328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3570.898438 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3602.685547 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3634.472656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3666.259766 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3698.046875 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3725.830078 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3787.353516 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3848.632812 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3912.011719 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3975.488281 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4014.351562 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4075.533203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4134.712891 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4196.236328 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4237.349609 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4271.041016 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4298.824219 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4360.347656 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4421.626953 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4485.005859 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4548.628906 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4582.320312 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4641.5 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4705.123047 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4736.910156 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4800.533203 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4864.15625 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4895.943359 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4959.566406 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4995.650391 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5034.513672 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5089.494141 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5153.117188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5184.904297 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5216.691406 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5248.478516 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5280.265625 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5312.052734 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5351.261719 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5414.640625 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5453.503906 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5514.685547 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5578.064453 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5641.541016 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5704.919922 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5768.396484 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5831.775391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5870.984375 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5902.771484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5986.560547 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6018.347656 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6115.759766 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6177.283203 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6240.759766 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6268.542969 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6329.822266 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6393.201172 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6424.988281 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6477.087891 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6540.466797 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6601.746094 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6665.222656 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6717.322266 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6780.701172 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6841.882812 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6881.091797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6914.783203 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6946.570312 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6987.683594 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7048.962891 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7088.171875 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7115.955078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7177.136719 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7208.923828 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7236.707031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7288.806641 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7320.59375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7384.070312 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7445.59375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7484.802734 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7546.326172 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7585.689453 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7683.101562 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7710.884766 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7774.263672 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7802.046875 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7854.146484 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7893.355469 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7921.138672 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p735a86a554">
-   <rect x="84.319922" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="p724545c2c4">
+   <rect x="83.858359" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/results/latest.json
+++ b/bench/results/latest.json
@@ -1,8 +1,8 @@
 {
  "meta": {
-  "date": "2026-07-08T20:00:36Z",
+  "date": "2026-07-08T20:16:47Z",
   "machine": "Linux chungus2 x86_64",
-  "git_commit": "29539fd5",
+  "git_commit": "74c19afa",
   "toolchain": "leanprover/lean4:v4.30.0-rc2",
   "note": "compress_mbps/decompress_mbps are a median-of-5 snapshot on the machine above; ratio is deterministic"
  },
@@ -14,8 +14,8 @@
    "level": 1,
    "out_size": 60455,
    "ratio": 0.3975,
-   "compress_mbps": 74.44,
-   "decompress_mbps": 213.59
+   "compress_mbps": 72.47,
+   "decompress_mbps": 215.57
   },
   {
    "compressor": "native",
@@ -24,8 +24,8 @@
    "level": 2,
    "out_size": 56316,
    "ratio": 0.3703,
-   "compress_mbps": 52.58,
-   "decompress_mbps": 245.65
+   "compress_mbps": 52.81,
+   "decompress_mbps": 247.29
   },
   {
    "compressor": "native",
@@ -34,8 +34,8 @@
    "level": 3,
    "out_size": 55646,
    "ratio": 0.3659,
-   "compress_mbps": 47.33,
-   "decompress_mbps": 268.44
+   "compress_mbps": 46.82,
+   "decompress_mbps": 269.96
   },
   {
    "compressor": "native",
@@ -44,8 +44,8 @@
    "level": 4,
    "out_size": 54357,
    "ratio": 0.3574,
-   "compress_mbps": 38.14,
-   "decompress_mbps": 271.88
+   "compress_mbps": 38.12,
+   "decompress_mbps": 271.96
   },
   {
    "compressor": "native",
@@ -54,8 +54,8 @@
    "level": 5,
    "out_size": 54078,
    "ratio": 0.3556,
-   "compress_mbps": 30.28,
-   "decompress_mbps": 271.92
+   "compress_mbps": 30.33,
+   "decompress_mbps": 272.47
   },
   {
    "compressor": "native",
@@ -64,8 +64,8 @@
    "level": 6,
    "out_size": 54013,
    "ratio": 0.3551,
-   "compress_mbps": 29.81,
-   "decompress_mbps": 279.03
+   "compress_mbps": 29.53,
+   "decompress_mbps": 281.05
   },
   {
    "compressor": "native",
@@ -74,8 +74,8 @@
    "level": 7,
    "out_size": 53772,
    "ratio": 0.3536,
-   "compress_mbps": 24.83,
-   "decompress_mbps": 278.85
+   "compress_mbps": 24.59,
+   "decompress_mbps": 281.21
   },
   {
    "compressor": "native",
@@ -84,8 +84,8 @@
    "level": 8,
    "out_size": 53753,
    "ratio": 0.3534,
-   "compress_mbps": 23.77,
-   "decompress_mbps": 279.92
+   "compress_mbps": 23.6,
+   "decompress_mbps": 281.79
   },
   {
    "compressor": "native",
@@ -94,8 +94,8 @@
    "level": 9,
    "out_size": 52732,
    "ratio": 0.3467,
-   "compress_mbps": 4.28,
-   "decompress_mbps": 279.83
+   "compress_mbps": 4.33,
+   "decompress_mbps": 280.83
   },
   {
    "compressor": "native",
@@ -104,7 +104,7 @@
    "level": 10,
    "out_size": 52078,
    "ratio": 0.3424,
-   "compress_mbps": 2.35,
+   "compress_mbps": 2.43,
    "decompress_mbps": null
   },
   {
@@ -114,8 +114,8 @@
    "level": 1,
    "out_size": 53135,
    "ratio": 0.4245,
-   "compress_mbps": 66.57,
-   "decompress_mbps": 207.0
+   "compress_mbps": 66.03,
+   "decompress_mbps": 208.12
   },
   {
    "compressor": "native",
@@ -124,8 +124,8 @@
    "level": 2,
    "out_size": 50187,
    "ratio": 0.4009,
-   "compress_mbps": 49.7,
-   "decompress_mbps": 224.57
+   "compress_mbps": 49.24,
+   "decompress_mbps": 226.76
   },
   {
    "compressor": "native",
@@ -134,8 +134,8 @@
    "level": 3,
    "out_size": 49810,
    "ratio": 0.3979,
-   "compress_mbps": 44.77,
-   "decompress_mbps": 245.71
+   "compress_mbps": 44.35,
+   "decompress_mbps": 248.22
   },
   {
    "compressor": "native",
@@ -144,8 +144,8 @@
    "level": 4,
    "out_size": 48687,
    "ratio": 0.3889,
-   "compress_mbps": 35.82,
-   "decompress_mbps": 250.37
+   "compress_mbps": 35.44,
+   "decompress_mbps": 251.36
   },
   {
    "compressor": "native",
@@ -154,8 +154,8 @@
    "level": 5,
    "out_size": 48586,
    "ratio": 0.3881,
-   "compress_mbps": 30.73,
-   "decompress_mbps": 250.08
+   "compress_mbps": 30.34,
+   "decompress_mbps": 251.45
   },
   {
    "compressor": "native",
@@ -164,18 +164,18 @@
    "level": 6,
    "out_size": 48373,
    "ratio": 0.3864,
-   "compress_mbps": 28.41,
-   "decompress_mbps": 253.69
+   "compress_mbps": 28.14,
+   "decompress_mbps": 254.54
   },
   {
    "compressor": "native",
    "pattern": "canterbury/asyoulik.txt",
    "size": 125179,
    "level": 7,
-   "out_size": 48288,
-   "ratio": 0.3858,
-   "compress_mbps": 25.7,
-   "decompress_mbps": 255.09
+   "out_size": 48287,
+   "ratio": 0.3857,
+   "compress_mbps": 25.44,
+   "decompress_mbps": 256.44
   },
   {
    "compressor": "native",
@@ -184,27 +184,27 @@
    "level": 8,
    "out_size": 48284,
    "ratio": 0.3857,
-   "compress_mbps": 25.39,
-   "decompress_mbps": 255.86
+   "compress_mbps": 25.17,
+   "decompress_mbps": 256.31
   },
   {
    "compressor": "native",
    "pattern": "canterbury/asyoulik.txt",
    "size": 125179,
    "level": 9,
-   "out_size": 47430,
+   "out_size": 47433,
    "ratio": 0.3789,
-   "compress_mbps": 4.63,
-   "decompress_mbps": 255.63
+   "compress_mbps": 4.65,
+   "decompress_mbps": 256.34
   },
   {
    "compressor": "native",
    "pattern": "canterbury/asyoulik.txt",
    "size": 125179,
    "level": 10,
-   "out_size": 46865,
+   "out_size": 46866,
    "ratio": 0.3744,
-   "compress_mbps": 2.74,
+   "compress_mbps": 2.82,
    "decompress_mbps": null
   },
   {
@@ -214,8 +214,8 @@
    "level": 1,
    "out_size": 8476,
    "ratio": 0.3445,
-   "compress_mbps": 64.82,
-   "decompress_mbps": 273.33
+   "compress_mbps": 65.24,
+   "decompress_mbps": 274.06
   },
   {
    "compressor": "native",
@@ -224,18 +224,18 @@
    "level": 2,
    "out_size": 8271,
    "ratio": 0.3362,
-   "compress_mbps": 54.49,
-   "decompress_mbps": 283.56
+   "compress_mbps": 54.72,
+   "decompress_mbps": 282.9
   },
   {
    "compressor": "native",
    "pattern": "canterbury/cp.html",
    "size": 24603,
    "level": 3,
-   "out_size": 8158,
+   "out_size": 8159,
    "ratio": 0.3316,
-   "compress_mbps": 52.61,
-   "decompress_mbps": 287.36
+   "compress_mbps": 52.89,
+   "decompress_mbps": 287.68
   },
   {
    "compressor": "native",
@@ -244,8 +244,8 @@
    "level": 4,
    "out_size": 7948,
    "ratio": 0.3231,
-   "compress_mbps": 49.28,
-   "decompress_mbps": 294.35
+   "compress_mbps": 49.98,
+   "decompress_mbps": 291.77
   },
   {
    "compressor": "native",
@@ -254,8 +254,8 @@
    "level": 5,
    "out_size": 7899,
    "ratio": 0.3211,
-   "compress_mbps": 42.08,
-   "decompress_mbps": 302.22
+   "compress_mbps": 42.09,
+   "decompress_mbps": 302.4
   },
   {
    "compressor": "native",
@@ -264,8 +264,8 @@
    "level": 6,
    "out_size": 7912,
    "ratio": 0.3216,
-   "compress_mbps": 41.19,
-   "decompress_mbps": 301.37
+   "compress_mbps": 41.35,
+   "decompress_mbps": 301.69
   },
   {
    "compressor": "native",
@@ -274,8 +274,8 @@
    "level": 7,
    "out_size": 7897,
    "ratio": 0.321,
-   "compress_mbps": 37.36,
-   "decompress_mbps": 306.22
+   "compress_mbps": 37.38,
+   "decompress_mbps": 307.39
   },
   {
    "compressor": "native",
@@ -284,8 +284,8 @@
    "level": 8,
    "out_size": 7897,
    "ratio": 0.321,
-   "compress_mbps": 37.25,
-   "decompress_mbps": 306.25
+   "compress_mbps": 37.38,
+   "decompress_mbps": 306.91
   },
   {
    "compressor": "native",
@@ -294,8 +294,8 @@
    "level": 9,
    "out_size": 7803,
    "ratio": 0.3172,
-   "compress_mbps": 5.01,
-   "decompress_mbps": 307.54
+   "compress_mbps": 4.96,
+   "decompress_mbps": 306.94
   },
   {
    "compressor": "native",
@@ -304,7 +304,7 @@
    "level": 10,
    "out_size": 7737,
    "ratio": 0.3145,
-   "compress_mbps": 2.9,
+   "compress_mbps": 2.95,
    "decompress_mbps": null
   },
   {
@@ -314,8 +314,8 @@
    "level": 1,
    "out_size": 3509,
    "ratio": 0.3147,
-   "compress_mbps": 48.69,
-   "decompress_mbps": 185.92
+   "compress_mbps": 49.58,
+   "decompress_mbps": 185.62
   },
   {
    "compressor": "native",
@@ -324,18 +324,18 @@
    "level": 2,
    "out_size": 3269,
    "ratio": 0.2932,
-   "compress_mbps": 42.82,
-   "decompress_mbps": 187.06
+   "compress_mbps": 43.31,
+   "decompress_mbps": 187.57
   },
   {
    "compressor": "native",
    "pattern": "canterbury/fields.c",
    "size": 11150,
    "level": 3,
-   "out_size": 3208,
-   "ratio": 0.2877,
-   "compress_mbps": 41.59,
-   "decompress_mbps": 191.77
+   "out_size": 3209,
+   "ratio": 0.2878,
+   "compress_mbps": 42.43,
+   "decompress_mbps": 191.57
   },
   {
    "compressor": "native",
@@ -344,48 +344,48 @@
    "level": 4,
    "out_size": 3128,
    "ratio": 0.2805,
-   "compress_mbps": 41.32,
-   "decompress_mbps": 196.18
+   "compress_mbps": 41.83,
+   "decompress_mbps": 195.9
   },
   {
    "compressor": "native",
    "pattern": "canterbury/fields.c",
    "size": 11150,
    "level": 5,
-   "out_size": 3111,
-   "ratio": 0.279,
-   "compress_mbps": 36.84,
-   "decompress_mbps": 196.5
+   "out_size": 3112,
+   "ratio": 0.2791,
+   "compress_mbps": 37.35,
+   "decompress_mbps": 196.51
   },
   {
    "compressor": "native",
    "pattern": "canterbury/fields.c",
    "size": 11150,
    "level": 6,
-   "out_size": 3119,
-   "ratio": 0.2797,
-   "compress_mbps": 37.21,
-   "decompress_mbps": 196.97
+   "out_size": 3120,
+   "ratio": 0.2798,
+   "compress_mbps": 37.6,
+   "decompress_mbps": 197.43
   },
   {
    "compressor": "native",
    "pattern": "canterbury/fields.c",
    "size": 11150,
    "level": 7,
-   "out_size": 3111,
-   "ratio": 0.279,
-   "compress_mbps": 34.63,
-   "decompress_mbps": 196.89
+   "out_size": 3112,
+   "ratio": 0.2791,
+   "compress_mbps": 35.17,
+   "decompress_mbps": 197.41
   },
   {
    "compressor": "native",
    "pattern": "canterbury/fields.c",
    "size": 11150,
    "level": 8,
-   "out_size": 3111,
-   "ratio": 0.279,
-   "compress_mbps": 34.52,
-   "decompress_mbps": 197.17
+   "out_size": 3112,
+   "ratio": 0.2791,
+   "compress_mbps": 34.97,
+   "decompress_mbps": 197.3
   },
   {
    "compressor": "native",
@@ -394,17 +394,17 @@
    "level": 9,
    "out_size": 3056,
    "ratio": 0.2741,
-   "compress_mbps": 5.48,
-   "decompress_mbps": 196.87
+   "compress_mbps": 5.55,
+   "decompress_mbps": 197.99
   },
   {
    "compressor": "native",
    "pattern": "canterbury/fields.c",
    "size": 11150,
    "level": 10,
-   "out_size": 3032,
-   "ratio": 0.2719,
-   "compress_mbps": 3.02,
+   "out_size": 3031,
+   "ratio": 0.2718,
+   "compress_mbps": 3.11,
    "decompress_mbps": null
   },
   {
@@ -412,10 +412,10 @@
    "pattern": "canterbury/grammar.lsp",
    "size": 3721,
    "level": 1,
-   "out_size": 1282,
-   "ratio": 0.3445,
-   "compress_mbps": 25.08,
-   "decompress_mbps": 84.57
+   "out_size": 1283,
+   "ratio": 0.3448,
+   "compress_mbps": 24.8,
+   "decompress_mbps": 84.67
   },
   {
    "compressor": "native",
@@ -424,18 +424,18 @@
    "level": 2,
    "out_size": 1225,
    "ratio": 0.3292,
-   "compress_mbps": 23.87,
-   "decompress_mbps": 85.54
+   "compress_mbps": 23.64,
+   "decompress_mbps": 85.98
   },
   {
    "compressor": "native",
    "pattern": "canterbury/grammar.lsp",
    "size": 3721,
    "level": 3,
-   "out_size": 1220,
-   "ratio": 0.3279,
-   "compress_mbps": 23.57,
-   "decompress_mbps": 85.31
+   "out_size": 1222,
+   "ratio": 0.3284,
+   "compress_mbps": 23.28,
+   "decompress_mbps": 85.74
   },
   {
    "compressor": "native",
@@ -444,8 +444,8 @@
    "level": 4,
    "out_size": 1213,
    "ratio": 0.326,
-   "compress_mbps": 23.63,
-   "decompress_mbps": 85.47
+   "compress_mbps": 23.55,
+   "decompress_mbps": 85.94
   },
   {
    "compressor": "native",
@@ -454,8 +454,8 @@
    "level": 5,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 22.91,
-   "decompress_mbps": 86.05
+   "compress_mbps": 22.86,
+   "decompress_mbps": 86.44
   },
   {
    "compressor": "native",
@@ -464,8 +464,8 @@
    "level": 6,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 22.45,
-   "decompress_mbps": 86.14
+   "compress_mbps": 22.38,
+   "decompress_mbps": 86.61
   },
   {
    "compressor": "native",
@@ -475,7 +475,7 @@
    "out_size": 1209,
    "ratio": 0.3249,
    "compress_mbps": 22.23,
-   "decompress_mbps": 86.24
+   "decompress_mbps": 86.67
   },
   {
    "compressor": "native",
@@ -484,8 +484,8 @@
    "level": 8,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 22.25,
-   "decompress_mbps": 86.16
+   "compress_mbps": 22.19,
+   "decompress_mbps": 86.69
   },
   {
    "compressor": "native",
@@ -494,8 +494,8 @@
    "level": 9,
    "out_size": 1205,
    "ratio": 0.3238,
-   "compress_mbps": 5.03,
-   "decompress_mbps": 86.23
+   "compress_mbps": 5.01,
+   "decompress_mbps": 86.82
   },
   {
    "compressor": "native",
@@ -504,7 +504,7 @@
    "level": 10,
    "out_size": 1191,
    "ratio": 0.3201,
-   "compress_mbps": 2.92,
+   "compress_mbps": 3.0,
    "decompress_mbps": null
   },
   {
@@ -514,8 +514,8 @@
    "level": 1,
    "out_size": 251793,
    "ratio": 0.2445,
-   "compress_mbps": 141.44,
-   "decompress_mbps": 398.28
+   "compress_mbps": 142.7,
+   "decompress_mbps": 398.89
   },
   {
    "compressor": "native",
@@ -524,8 +524,8 @@
    "level": 2,
    "out_size": 242565,
    "ratio": 0.2356,
-   "compress_mbps": 107.23,
-   "decompress_mbps": 427.23
+   "compress_mbps": 108.81,
+   "decompress_mbps": 429.1
   },
   {
    "compressor": "native",
@@ -534,8 +534,8 @@
    "level": 3,
    "out_size": 242532,
    "ratio": 0.2355,
-   "compress_mbps": 87.7,
-   "decompress_mbps": 455.55
+   "compress_mbps": 90.12,
+   "decompress_mbps": 456.94
   },
   {
    "compressor": "native",
@@ -544,8 +544,8 @@
    "level": 4,
    "out_size": 239953,
    "ratio": 0.233,
-   "compress_mbps": 97.86,
-   "decompress_mbps": 483.75
+   "compress_mbps": 98.05,
+   "decompress_mbps": 485.1
   },
   {
    "compressor": "native",
@@ -554,55 +554,55 @@
    "level": 5,
    "out_size": 218565,
    "ratio": 0.2123,
-   "compress_mbps": 59.94,
-   "decompress_mbps": 466.7
+   "compress_mbps": 60.82,
+   "decompress_mbps": 467.89
   },
   {
    "compressor": "native",
    "pattern": "canterbury/kennedy.xls",
    "size": 1029744,
    "level": 6,
-   "out_size": 202676,
-   "ratio": 0.1968,
-   "compress_mbps": 43.54,
-   "decompress_mbps": 483.6
+   "out_size": 202718,
+   "ratio": 0.1969,
+   "compress_mbps": 46.08,
+   "decompress_mbps": 485.57
   },
   {
    "compressor": "native",
    "pattern": "canterbury/kennedy.xls",
    "size": 1029744,
    "level": 7,
-   "out_size": 201403,
+   "out_size": 201435,
    "ratio": 0.1956,
-   "compress_mbps": 30.97,
-   "decompress_mbps": 488.2
+   "compress_mbps": 32.75,
+   "decompress_mbps": 489.68
   },
   {
    "compressor": "native",
    "pattern": "canterbury/kennedy.xls",
    "size": 1029744,
    "level": 8,
-   "out_size": 200798,
+   "out_size": 200825,
    "ratio": 0.195,
-   "compress_mbps": 22.98,
-   "decompress_mbps": 497.39
+   "compress_mbps": 24.03,
+   "decompress_mbps": 498.49
   },
   {
    "compressor": "native",
    "pattern": "canterbury/kennedy.xls",
    "size": 1029744,
    "level": 9,
-   "out_size": 182508,
+   "out_size": 182511,
    "ratio": 0.1772,
-   "compress_mbps": 3.51,
-   "decompress_mbps": 497.36
+   "compress_mbps": 3.54,
+   "decompress_mbps": 498.32
   },
   {
    "compressor": "native",
    "pattern": "canterbury/kennedy.xls",
    "size": 1029744,
    "level": 10,
-   "out_size": 178067,
+   "out_size": 178069,
    "ratio": 0.1729,
    "compress_mbps": 1.48,
    "decompress_mbps": null
@@ -614,8 +614,8 @@
    "level": 1,
    "out_size": 160674,
    "ratio": 0.3765,
-   "compress_mbps": 79.51,
-   "decompress_mbps": 221.95
+   "compress_mbps": 78.72,
+   "decompress_mbps": 224.31
   },
   {
    "compressor": "native",
@@ -624,8 +624,8 @@
    "level": 2,
    "out_size": 149787,
    "ratio": 0.351,
-   "compress_mbps": 56.49,
-   "decompress_mbps": 240.77
+   "compress_mbps": 56.67,
+   "decompress_mbps": 243.23
   },
   {
    "compressor": "native",
@@ -634,8 +634,8 @@
    "level": 3,
    "out_size": 148055,
    "ratio": 0.3469,
-   "compress_mbps": 50.0,
-   "decompress_mbps": 268.9
+   "compress_mbps": 50.06,
+   "decompress_mbps": 271.04
   },
   {
    "compressor": "native",
@@ -644,8 +644,8 @@
    "level": 4,
    "out_size": 144750,
    "ratio": 0.3392,
-   "compress_mbps": 41.24,
-   "decompress_mbps": 272.59
+   "compress_mbps": 41.38,
+   "decompress_mbps": 273.9
   },
   {
    "compressor": "native",
@@ -654,57 +654,57 @@
    "level": 5,
    "out_size": 144408,
    "ratio": 0.3384,
-   "compress_mbps": 33.73,
-   "decompress_mbps": 273.64
+   "compress_mbps": 32.9,
+   "decompress_mbps": 274.81
   },
   {
    "compressor": "native",
    "pattern": "canterbury/lcet10.txt",
    "size": 426754,
    "level": 6,
-   "out_size": 144070,
+   "out_size": 144071,
    "ratio": 0.3376,
-   "compress_mbps": 31.9,
-   "decompress_mbps": 278.38
+   "compress_mbps": 31.92,
+   "decompress_mbps": 280.37
   },
   {
    "compressor": "native",
    "pattern": "canterbury/lcet10.txt",
    "size": 426754,
    "level": 7,
-   "out_size": 143628,
+   "out_size": 143631,
    "ratio": 0.3366,
-   "compress_mbps": 26.64,
-   "decompress_mbps": 279.63
+   "compress_mbps": 26.69,
+   "decompress_mbps": 280.71
   },
   {
    "compressor": "native",
    "pattern": "canterbury/lcet10.txt",
    "size": 426754,
    "level": 8,
-   "out_size": 143569,
+   "out_size": 143573,
    "ratio": 0.3364,
-   "compress_mbps": 25.71,
-   "decompress_mbps": 279.83
+   "compress_mbps": 25.78,
+   "decompress_mbps": 280.7
   },
   {
    "compressor": "native",
    "pattern": "canterbury/lcet10.txt",
    "size": 426754,
    "level": 9,
-   "out_size": 140322,
+   "out_size": 140323,
    "ratio": 0.3288,
-   "compress_mbps": 4.33,
-   "decompress_mbps": 280.56
+   "compress_mbps": 4.24,
+   "decompress_mbps": 280.13
   },
   {
    "compressor": "native",
    "pattern": "canterbury/lcet10.txt",
    "size": 426754,
    "level": 10,
-   "out_size": 138830,
+   "out_size": 138833,
    "ratio": 0.3253,
-   "compress_mbps": 2.5,
+   "compress_mbps": 2.52,
    "decompress_mbps": null
   },
   {
@@ -714,8 +714,8 @@
    "level": 1,
    "out_size": 212588,
    "ratio": 0.4412,
-   "compress_mbps": 67.07,
-   "decompress_mbps": 192.82
+   "compress_mbps": 66.37,
+   "decompress_mbps": 193.08
   },
   {
    "compressor": "native",
@@ -724,8 +724,8 @@
    "level": 2,
    "out_size": 199981,
    "ratio": 0.415,
-   "compress_mbps": 48.37,
-   "decompress_mbps": 215.15
+   "compress_mbps": 48.31,
+   "decompress_mbps": 216.67
   },
   {
    "compressor": "native",
@@ -734,8 +734,8 @@
    "level": 3,
    "out_size": 198551,
    "ratio": 0.4121,
-   "compress_mbps": 42.67,
-   "decompress_mbps": 237.47
+   "compress_mbps": 42.51,
+   "decompress_mbps": 239.54
   },
   {
    "compressor": "native",
@@ -744,8 +744,8 @@
    "level": 4,
    "out_size": 193783,
    "ratio": 0.4022,
-   "compress_mbps": 32.01,
-   "decompress_mbps": 240.99
+   "compress_mbps": 31.9,
+   "decompress_mbps": 242.06
   },
   {
    "compressor": "native",
@@ -754,18 +754,18 @@
    "level": 5,
    "out_size": 193223,
    "ratio": 0.401,
-   "compress_mbps": 26.67,
-   "decompress_mbps": 237.35
+   "compress_mbps": 26.63,
+   "decompress_mbps": 238.55
   },
   {
    "compressor": "native",
    "pattern": "canterbury/plrabn12.txt",
    "size": 481861,
    "level": 6,
-   "out_size": 193416,
+   "out_size": 193415,
    "ratio": 0.4014,
-   "compress_mbps": 27.03,
-   "decompress_mbps": 241.32
+   "compress_mbps": 26.97,
+   "decompress_mbps": 242.61
   },
   {
    "compressor": "native",
@@ -774,8 +774,8 @@
    "level": 7,
    "out_size": 192664,
    "ratio": 0.3998,
-   "compress_mbps": 22.43,
-   "decompress_mbps": 240.76
+   "compress_mbps": 22.48,
+   "decompress_mbps": 243.09
   },
   {
    "compressor": "native",
@@ -784,27 +784,27 @@
    "level": 8,
    "out_size": 192638,
    "ratio": 0.3998,
-   "compress_mbps": 21.78,
-   "decompress_mbps": 241.01
+   "compress_mbps": 21.79,
+   "decompress_mbps": 242.66
   },
   {
    "compressor": "native",
    "pattern": "canterbury/plrabn12.txt",
    "size": 481861,
    "level": 9,
-   "out_size": 189365,
+   "out_size": 189368,
    "ratio": 0.393,
-   "compress_mbps": 4.11,
-   "decompress_mbps": 240.66
+   "compress_mbps": 4.03,
+   "decompress_mbps": 242.67
   },
   {
    "compressor": "native",
    "pattern": "canterbury/plrabn12.txt",
    "size": 481861,
    "level": 10,
-   "out_size": 186147,
+   "out_size": 186146,
    "ratio": 0.3863,
-   "compress_mbps": 2.42,
+   "compress_mbps": 2.46,
    "decompress_mbps": null
   },
   {
@@ -814,8 +814,8 @@
    "level": 1,
    "out_size": 60161,
    "ratio": 0.1172,
-   "compress_mbps": 230.43,
-   "decompress_mbps": 585.04
+   "compress_mbps": 229.23,
+   "decompress_mbps": 590.21
   },
   {
    "compressor": "native",
@@ -824,8 +824,8 @@
    "level": 2,
    "out_size": 58873,
    "ratio": 0.1147,
-   "compress_mbps": 171.41,
-   "decompress_mbps": 610.73
+   "compress_mbps": 171.45,
+   "decompress_mbps": 618.89
   },
   {
    "compressor": "native",
@@ -834,18 +834,18 @@
    "level": 3,
    "out_size": 58327,
    "ratio": 0.1137,
-   "compress_mbps": 148.85,
-   "decompress_mbps": 641.52
+   "compress_mbps": 148.97,
+   "decompress_mbps": 649.2
   },
   {
    "compressor": "native",
    "pattern": "canterbury/ptt5",
    "size": 513216,
    "level": 4,
-   "out_size": 55588,
+   "out_size": 55586,
    "ratio": 0.1083,
-   "compress_mbps": 121.66,
-   "decompress_mbps": 663.44
+   "compress_mbps": 121.3,
+   "decompress_mbps": 665.09
   },
   {
    "compressor": "native",
@@ -854,57 +854,57 @@
    "level": 5,
    "out_size": 55097,
    "ratio": 0.1074,
-   "compress_mbps": 93.7,
-   "decompress_mbps": 684.31
+   "compress_mbps": 93.21,
+   "decompress_mbps": 693.48
   },
   {
    "compressor": "native",
    "pattern": "canterbury/ptt5",
    "size": 513216,
    "level": 6,
-   "out_size": 55195,
-   "ratio": 0.1075,
-   "compress_mbps": 70.92,
-   "decompress_mbps": 706.88
+   "out_size": 55199,
+   "ratio": 0.1076,
+   "compress_mbps": 70.84,
+   "decompress_mbps": 712.22
   },
   {
    "compressor": "native",
    "pattern": "canterbury/ptt5",
    "size": 513216,
    "level": 7,
-   "out_size": 54316,
+   "out_size": 54313,
    "ratio": 0.1058,
-   "compress_mbps": 57.75,
-   "decompress_mbps": 719.34
+   "compress_mbps": 57.62,
+   "decompress_mbps": 728.31
   },
   {
    "compressor": "native",
    "pattern": "canterbury/ptt5",
    "size": 513216,
    "level": 8,
-   "out_size": 53091,
-   "ratio": 0.1034,
-   "compress_mbps": 47.38,
-   "decompress_mbps": 746.83
+   "out_size": 53095,
+   "ratio": 0.1035,
+   "compress_mbps": 47.32,
+   "decompress_mbps": 748.77
   },
   {
    "compressor": "native",
    "pattern": "canterbury/ptt5",
    "size": 513216,
    "level": 9,
-   "out_size": 52605,
+   "out_size": 52603,
    "ratio": 0.1025,
-   "compress_mbps": 5.99,
-   "decompress_mbps": 758.93
+   "compress_mbps": 6.06,
+   "decompress_mbps": 764.87
   },
   {
    "compressor": "native",
    "pattern": "canterbury/ptt5",
    "size": 513216,
    "level": 10,
-   "out_size": 52234,
+   "out_size": 52236,
    "ratio": 0.1018,
-   "compress_mbps": 3.84,
+   "compress_mbps": 3.89,
    "decompress_mbps": null
   },
   {
@@ -914,8 +914,8 @@
    "level": 1,
    "out_size": 14249,
    "ratio": 0.3726,
-   "compress_mbps": 53.89,
-   "decompress_mbps": 242.73
+   "compress_mbps": 59.9,
+   "decompress_mbps": 240.94
   },
   {
    "compressor": "native",
@@ -924,8 +924,8 @@
    "level": 2,
    "out_size": 13825,
    "ratio": 0.3615,
-   "compress_mbps": 47.43,
-   "decompress_mbps": 249.22
+   "compress_mbps": 52.06,
+   "decompress_mbps": 248.13
   },
   {
    "compressor": "native",
@@ -934,58 +934,58 @@
    "level": 3,
    "out_size": 13751,
    "ratio": 0.3596,
-   "compress_mbps": 45.58,
-   "decompress_mbps": 247.82
+   "compress_mbps": 50.04,
+   "decompress_mbps": 250.37
   },
   {
    "compressor": "native",
    "pattern": "canterbury/sum",
    "size": 38240,
    "level": 4,
-   "out_size": 13287,
+   "out_size": 13290,
    "ratio": 0.3475,
-   "compress_mbps": 43.28,
-   "decompress_mbps": 256.96
+   "compress_mbps": 46.84,
+   "decompress_mbps": 258.22
   },
   {
    "compressor": "native",
    "pattern": "canterbury/sum",
    "size": 38240,
    "level": 5,
-   "out_size": 13240,
-   "ratio": 0.3462,
-   "compress_mbps": 38.25,
-   "decompress_mbps": 266.4
+   "out_size": 13244,
+   "ratio": 0.3463,
+   "compress_mbps": 40.94,
+   "decompress_mbps": 268.68
   },
   {
    "compressor": "native",
    "pattern": "canterbury/sum",
    "size": 38240,
    "level": 6,
-   "out_size": 12944,
+   "out_size": 12946,
    "ratio": 0.3385,
-   "compress_mbps": 20.2,
-   "decompress_mbps": 271.58
+   "compress_mbps": 22.19,
+   "decompress_mbps": 270.86
   },
   {
    "compressor": "native",
    "pattern": "canterbury/sum",
    "size": 38240,
    "level": 7,
-   "out_size": 12929,
+   "out_size": 12930,
    "ratio": 0.3381,
-   "compress_mbps": 18.51,
-   "decompress_mbps": 274.47
+   "compress_mbps": 20.05,
+   "decompress_mbps": 274.19
   },
   {
    "compressor": "native",
    "pattern": "canterbury/sum",
    "size": 38240,
    "level": 8,
-   "out_size": 12921,
+   "out_size": 12922,
    "ratio": 0.3379,
-   "compress_mbps": 17.13,
-   "decompress_mbps": 273.99
+   "compress_mbps": 18.59,
+   "decompress_mbps": 273.31
   },
   {
    "compressor": "native",
@@ -994,17 +994,17 @@
    "level": 9,
    "out_size": 12427,
    "ratio": 0.325,
-   "compress_mbps": 5.41,
-   "decompress_mbps": 276.26
+   "compress_mbps": 5.59,
+   "decompress_mbps": 277.74
   },
   {
    "compressor": "native",
    "pattern": "canterbury/sum",
    "size": 38240,
    "level": 10,
-   "out_size": 12274,
-   "ratio": 0.321,
-   "compress_mbps": 3.06,
+   "out_size": 12273,
+   "ratio": 0.3209,
+   "compress_mbps": 3.16,
    "decompress_mbps": null
   },
   {
@@ -1014,8 +1014,8 @@
    "level": 1,
    "out_size": 1800,
    "ratio": 0.4258,
-   "compress_mbps": 26.59,
-   "decompress_mbps": 92.3
+   "compress_mbps": 26.62,
+   "decompress_mbps": 92.75
   },
   {
    "compressor": "native",
@@ -1024,8 +1024,8 @@
    "level": 2,
    "out_size": 1750,
    "ratio": 0.414,
-   "compress_mbps": 25.23,
-   "decompress_mbps": 92.55
+   "compress_mbps": 25.25,
+   "decompress_mbps": 92.81
   },
   {
    "compressor": "native",
@@ -1034,8 +1034,8 @@
    "level": 3,
    "out_size": 1742,
    "ratio": 0.4121,
-   "compress_mbps": 25.11,
-   "decompress_mbps": 92.26
+   "compress_mbps": 25.14,
+   "decompress_mbps": 92.66
   },
   {
    "compressor": "native",
@@ -1044,8 +1044,8 @@
    "level": 4,
    "out_size": 1726,
    "ratio": 0.4083,
-   "compress_mbps": 25.41,
-   "decompress_mbps": 93.52
+   "compress_mbps": 25.29,
+   "decompress_mbps": 93.91
   },
   {
    "compressor": "native",
@@ -1054,8 +1054,8 @@
    "level": 5,
    "out_size": 1722,
    "ratio": 0.4074,
-   "compress_mbps": 25.04,
-   "decompress_mbps": 93.67
+   "compress_mbps": 24.96,
+   "decompress_mbps": 94.03
   },
   {
    "compressor": "native",
@@ -1064,8 +1064,8 @@
    "level": 6,
    "out_size": 1722,
    "ratio": 0.4074,
-   "compress_mbps": 24.03,
-   "decompress_mbps": 93.59
+   "compress_mbps": 23.91,
+   "decompress_mbps": 94.07
   },
   {
    "compressor": "native",
@@ -1074,8 +1074,8 @@
    "level": 7,
    "out_size": 1722,
    "ratio": 0.4074,
-   "compress_mbps": 24.08,
-   "decompress_mbps": 93.49
+   "compress_mbps": 24.03,
+   "decompress_mbps": 94.03
   },
   {
    "compressor": "native",
@@ -1084,8 +1084,8 @@
    "level": 8,
    "out_size": 1722,
    "ratio": 0.4074,
-   "compress_mbps": 24.06,
-   "decompress_mbps": 93.66
+   "compress_mbps": 24.03,
+   "decompress_mbps": 93.96
   },
   {
    "compressor": "native",
@@ -1094,8 +1094,8 @@
    "level": 9,
    "out_size": 1708,
    "ratio": 0.4041,
-   "compress_mbps": 5.5,
-   "decompress_mbps": 93.34
+   "compress_mbps": 5.51,
+   "decompress_mbps": 94.08
   },
   {
    "compressor": "native",
@@ -1104,7 +1104,7 @@
    "level": 10,
    "out_size": 1693,
    "ratio": 0.4005,
-   "compress_mbps": 3.24,
+   "compress_mbps": 3.35,
    "decompress_mbps": null
   },
   {
@@ -4414,8 +4414,8 @@
    "level": 1,
    "out_size": 4259644,
    "ratio": 0.4179,
-   "compress_mbps": 69.18,
-   "decompress_mbps": 197.96
+   "compress_mbps": 69.24,
+   "decompress_mbps": 197.55
   },
   {
    "compressor": "native",
@@ -4424,8 +4424,8 @@
    "level": 2,
    "out_size": 3977395,
    "ratio": 0.3902,
-   "compress_mbps": 50.3,
-   "decompress_mbps": 215.65
+   "compress_mbps": 49.92,
+   "decompress_mbps": 217.69
   },
   {
    "compressor": "native",
@@ -4434,8 +4434,8 @@
    "level": 3,
    "out_size": 3945296,
    "ratio": 0.3871,
-   "compress_mbps": 44.16,
-   "decompress_mbps": 239.97
+   "compress_mbps": 44.12,
+   "decompress_mbps": 241.04
   },
   {
    "compressor": "native",
@@ -4444,8 +4444,8 @@
    "level": 4,
    "out_size": 3851998,
    "ratio": 0.3779,
-   "compress_mbps": 34.83,
-   "decompress_mbps": 238.6
+   "compress_mbps": 34.47,
+   "decompress_mbps": 240.67
   },
   {
    "compressor": "native",
@@ -4454,28 +4454,28 @@
    "level": 5,
    "out_size": 3840481,
    "ratio": 0.3768,
-   "compress_mbps": 28.8,
-   "decompress_mbps": 237.65
+   "compress_mbps": 28.66,
+   "decompress_mbps": 238.47
   },
   {
    "compressor": "native",
    "pattern": "silesia/dickens",
    "size": 10192446,
    "level": 6,
-   "out_size": 3847941,
+   "out_size": 3847942,
    "ratio": 0.3775,
-   "compress_mbps": 29.11,
-   "decompress_mbps": 242.44
+   "compress_mbps": 28.97,
+   "decompress_mbps": 243.15
   },
   {
    "compressor": "native",
    "pattern": "silesia/dickens",
    "size": 10192446,
    "level": 7,
-   "out_size": 3834802,
+   "out_size": 3834801,
    "ratio": 0.3762,
-   "compress_mbps": 24.13,
-   "decompress_mbps": 244.62
+   "compress_mbps": 23.94,
+   "decompress_mbps": 244.05
   },
   {
    "compressor": "native",
@@ -4484,27 +4484,27 @@
    "level": 8,
    "out_size": 3833946,
    "ratio": 0.3762,
-   "compress_mbps": 23.24,
-   "decompress_mbps": 243.57
+   "compress_mbps": 23.14,
+   "decompress_mbps": 241.5
   },
   {
    "compressor": "native",
    "pattern": "silesia/dickens",
    "size": 10192446,
    "level": 9,
-   "out_size": 3766584,
-   "ratio": 0.3695,
-   "compress_mbps": 4.19,
-   "decompress_mbps": 254.99
+   "out_size": 3766619,
+   "ratio": 0.3696,
+   "compress_mbps": 4.17,
+   "decompress_mbps": 255.07
   },
   {
    "compressor": "native",
    "pattern": "silesia/dickens",
    "size": 10192446,
    "level": 10,
-   "out_size": 3711172,
+   "out_size": 3711208,
    "ratio": 0.3641,
-   "compress_mbps": 2.43,
+   "compress_mbps": 2.47,
    "decompress_mbps": null
   },
   {
@@ -4514,8 +4514,8 @@
    "level": 1,
    "out_size": 21267086,
    "ratio": 0.4152,
-   "compress_mbps": 86.25,
-   "decompress_mbps": 217.88
+   "compress_mbps": 86.07,
+   "decompress_mbps": 212.26
   },
   {
    "compressor": "native",
@@ -4524,8 +4524,8 @@
    "level": 2,
    "out_size": 20802983,
    "ratio": 0.4061,
-   "compress_mbps": 68.76,
-   "decompress_mbps": 228.75
+   "compress_mbps": 68.26,
+   "decompress_mbps": 226.86
   },
   {
    "compressor": "native",
@@ -4534,8 +4534,8 @@
    "level": 3,
    "out_size": 20665485,
    "ratio": 0.4035,
-   "compress_mbps": 64.83,
-   "decompress_mbps": 235.33
+   "compress_mbps": 63.82,
+   "decompress_mbps": 236.42
   },
   {
    "compressor": "native",
@@ -4544,8 +4544,8 @@
    "level": 4,
    "out_size": 20356893,
    "ratio": 0.3974,
-   "compress_mbps": 55.55,
-   "decompress_mbps": 244.39
+   "compress_mbps": 55.1,
+   "decompress_mbps": 244.36
   },
   {
    "compressor": "native",
@@ -4554,57 +4554,57 @@
    "level": 5,
    "out_size": 20209289,
    "ratio": 0.3946,
-   "compress_mbps": 43.33,
-   "decompress_mbps": 246.35
+   "compress_mbps": 43.17,
+   "decompress_mbps": 245.96
   },
   {
    "compressor": "native",
    "pattern": "silesia/mozilla",
    "size": 51220480,
    "level": 6,
-   "out_size": 19174181,
-   "ratio": 0.3743,
-   "compress_mbps": 28.58,
-   "decompress_mbps": 257.63
+   "out_size": 19175370,
+   "ratio": 0.3744,
+   "compress_mbps": 30.07,
+   "decompress_mbps": 257.02
   },
   {
    "compressor": "native",
    "pattern": "silesia/mozilla",
    "size": 51220480,
    "level": 7,
-   "out_size": 19127630,
-   "ratio": 0.3734,
-   "compress_mbps": 23.41,
-   "decompress_mbps": 259.25
+   "out_size": 19128614,
+   "ratio": 0.3735,
+   "compress_mbps": 24.46,
+   "decompress_mbps": 258.05
   },
   {
    "compressor": "native",
    "pattern": "silesia/mozilla",
    "size": 51220480,
    "level": 8,
-   "out_size": 19117840,
-   "ratio": 0.3732,
-   "compress_mbps": 20.04,
-   "decompress_mbps": 259.51
+   "out_size": 19118971,
+   "ratio": 0.3733,
+   "compress_mbps": 20.82,
+   "decompress_mbps": 259.25
   },
   {
    "compressor": "native",
    "pattern": "silesia/mozilla",
    "size": 51220480,
    "level": 9,
-   "out_size": 18686872,
-   "ratio": 0.3648,
-   "compress_mbps": 4.37,
-   "decompress_mbps": 259.51
+   "out_size": 18688252,
+   "ratio": 0.3649,
+   "compress_mbps": 4.49,
+   "decompress_mbps": 260.43
   },
   {
    "compressor": "native",
    "pattern": "silesia/mozilla",
    "size": 51220480,
    "level": 10,
-   "out_size": 18539905,
+   "out_size": 18541040,
    "ratio": 0.362,
-   "compress_mbps": 2.3,
+   "compress_mbps": 2.37,
    "decompress_mbps": null
   },
   {
@@ -4614,8 +4614,8 @@
    "level": 1,
    "out_size": 3864163,
    "ratio": 0.3876,
-   "compress_mbps": 86.53,
-   "decompress_mbps": 240.99
+   "compress_mbps": 86.26,
+   "decompress_mbps": 239.94
   },
   {
    "compressor": "native",
@@ -4624,8 +4624,8 @@
    "level": 2,
    "out_size": 3734957,
    "ratio": 0.3746,
-   "compress_mbps": 66.28,
-   "decompress_mbps": 251.81
+   "compress_mbps": 66.18,
+   "decompress_mbps": 252.25
   },
   {
    "compressor": "native",
@@ -4634,8 +4634,8 @@
    "level": 3,
    "out_size": 3708443,
    "ratio": 0.3719,
-   "compress_mbps": 56.36,
-   "decompress_mbps": 265.01
+   "compress_mbps": 56.24,
+   "decompress_mbps": 262.93
   },
   {
    "compressor": "native",
@@ -4644,8 +4644,8 @@
    "level": 4,
    "out_size": 3683603,
    "ratio": 0.3694,
-   "compress_mbps": 41.72,
-   "decompress_mbps": 250.74
+   "compress_mbps": 41.73,
+   "decompress_mbps": 250.34
   },
   {
    "compressor": "native",
@@ -4654,57 +4654,57 @@
    "level": 5,
    "out_size": 3677014,
    "ratio": 0.3688,
-   "compress_mbps": 33.55,
-   "decompress_mbps": 242.34
+   "compress_mbps": 33.77,
+   "decompress_mbps": 241.46
   },
   {
    "compressor": "native",
    "pattern": "silesia/mr",
    "size": 9970564,
    "level": 6,
-   "out_size": 3588221,
+   "out_size": 3588296,
    "ratio": 0.3599,
-   "compress_mbps": 30.67,
-   "decompress_mbps": 247.95
+   "compress_mbps": 31.09,
+   "decompress_mbps": 248.69
   },
   {
    "compressor": "native",
    "pattern": "silesia/mr",
    "size": 9970564,
    "level": 7,
-   "out_size": 3581006,
+   "out_size": 3581081,
    "ratio": 0.3592,
-   "compress_mbps": 25.1,
-   "decompress_mbps": 249.9
+   "compress_mbps": 25.37,
+   "decompress_mbps": 252.07
   },
   {
    "compressor": "native",
    "pattern": "silesia/mr",
    "size": 9970564,
    "level": 8,
-   "out_size": 3580944,
+   "out_size": 3581042,
    "ratio": 0.3592,
-   "compress_mbps": 23.63,
-   "decompress_mbps": 257.19
+   "compress_mbps": 23.88,
+   "decompress_mbps": 257.27
   },
   {
    "compressor": "native",
    "pattern": "silesia/mr",
    "size": 9970564,
    "level": 9,
-   "out_size": 3581441,
+   "out_size": 3581643,
    "ratio": 0.3592,
-   "compress_mbps": 4.82,
-   "decompress_mbps": 271.86
+   "compress_mbps": 4.89,
+   "decompress_mbps": 268.11
   },
   {
    "compressor": "native",
    "pattern": "silesia/mr",
    "size": 9970564,
    "level": 10,
-   "out_size": 3512886,
+   "out_size": 3513006,
    "ratio": 0.3523,
-   "compress_mbps": 2.9,
+   "compress_mbps": 2.97,
    "decompress_mbps": null
   },
   {
@@ -4714,8 +4714,8 @@
    "level": 1,
    "out_size": 3785443,
    "ratio": 0.1128,
-   "compress_mbps": 265.96,
-   "decompress_mbps": 679.18
+   "compress_mbps": 263.43,
+   "decompress_mbps": 656.39
   },
   {
    "compressor": "native",
@@ -4724,8 +4724,8 @@
    "level": 2,
    "out_size": 3761560,
    "ratio": 0.1121,
-   "compress_mbps": 168.47,
-   "decompress_mbps": 753.95
+   "compress_mbps": 168.66,
+   "decompress_mbps": 752.81
   },
   {
    "compressor": "native",
@@ -4734,8 +4734,8 @@
    "level": 3,
    "out_size": 3606997,
    "ratio": 0.1075,
-   "compress_mbps": 143.56,
-   "decompress_mbps": 801.03
+   "compress_mbps": 144.92,
+   "decompress_mbps": 836.45
   },
   {
    "compressor": "native",
@@ -4744,8 +4744,8 @@
    "level": 4,
    "out_size": 3201209,
    "ratio": 0.0954,
-   "compress_mbps": 136.72,
-   "decompress_mbps": 849.49
+   "compress_mbps": 136.66,
+   "decompress_mbps": 846.94
   },
   {
    "compressor": "native",
@@ -4754,38 +4754,38 @@
    "level": 5,
    "out_size": 3091564,
    "ratio": 0.0921,
-   "compress_mbps": 99.09,
-   "decompress_mbps": 925.83
+   "compress_mbps": 98.66,
+   "decompress_mbps": 924.16
   },
   {
    "compressor": "native",
    "pattern": "silesia/nci",
    "size": 33553445,
    "level": 6,
-   "out_size": 3112756,
+   "out_size": 3112786,
    "ratio": 0.0928,
-   "compress_mbps": 95.34,
-   "decompress_mbps": 972.4
+   "compress_mbps": 95.42,
+   "decompress_mbps": 977.35
   },
   {
    "compressor": "native",
    "pattern": "silesia/nci",
    "size": 33553445,
    "level": 7,
-   "out_size": 3062314,
+   "out_size": 3062338,
    "ratio": 0.0913,
-   "compress_mbps": 71.36,
-   "decompress_mbps": 985.66
+   "compress_mbps": 70.88,
+   "decompress_mbps": 995.74
   },
   {
    "compressor": "native",
    "pattern": "silesia/nci",
    "size": 33553445,
    "level": 8,
-   "out_size": 3045348,
+   "out_size": 3045373,
    "ratio": 0.0908,
-   "compress_mbps": 59.09,
-   "decompress_mbps": 989.42
+   "compress_mbps": 58.87,
+   "decompress_mbps": 1001.72
   },
   {
    "compressor": "native",
@@ -4794,17 +4794,17 @@
    "level": 9,
    "out_size": 3031645,
    "ratio": 0.0904,
-   "compress_mbps": 3.59,
-   "decompress_mbps": 1018.01
+   "compress_mbps": 3.57,
+   "decompress_mbps": 1018.25
   },
   {
    "compressor": "native",
    "pattern": "silesia/nci",
    "size": 33553445,
    "level": 10,
-   "out_size": 2902186,
+   "out_size": 2902212,
    "ratio": 0.0865,
-   "compress_mbps": 1.98,
+   "compress_mbps": 2.03,
    "decompress_mbps": null
   },
   {
@@ -4814,8 +4814,8 @@
    "level": 1,
    "out_size": 3357083,
    "ratio": 0.5457,
-   "compress_mbps": 60.81,
-   "decompress_mbps": 148.72
+   "compress_mbps": 60.27,
+   "decompress_mbps": 148.3
   },
   {
    "compressor": "native",
@@ -4824,7 +4824,7 @@
    "level": 2,
    "out_size": 3285077,
    "ratio": 0.534,
-   "compress_mbps": 50.46,
+   "compress_mbps": 49.56,
    "decompress_mbps": 148.97
   },
   {
@@ -4834,8 +4834,8 @@
    "level": 3,
    "out_size": 3272746,
    "ratio": 0.532,
-   "compress_mbps": 47.91,
-   "decompress_mbps": 154.28
+   "compress_mbps": 47.5,
+   "decompress_mbps": 157.94
   },
   {
    "compressor": "native",
@@ -4844,8 +4844,8 @@
    "level": 4,
    "out_size": 3228052,
    "ratio": 0.5247,
-   "compress_mbps": 41.58,
-   "decompress_mbps": 164.64
+   "compress_mbps": 41.16,
+   "decompress_mbps": 168.7
   },
   {
    "compressor": "native",
@@ -4854,57 +4854,57 @@
    "level": 5,
    "out_size": 3223415,
    "ratio": 0.5239,
-   "compress_mbps": 37.45,
-   "decompress_mbps": 170.62
+   "compress_mbps": 37.18,
+   "decompress_mbps": 171.48
   },
   {
    "compressor": "native",
    "pattern": "silesia/ooffice",
    "size": 6152192,
    "level": 6,
-   "out_size": 3159522,
+   "out_size": 3159592,
    "ratio": 0.5136,
-   "compress_mbps": 26.13,
-   "decompress_mbps": 172.72
+   "compress_mbps": 27.0,
+   "decompress_mbps": 173.76
   },
   {
    "compressor": "native",
    "pattern": "silesia/ooffice",
    "size": 6152192,
    "level": 7,
-   "out_size": 3156358,
-   "ratio": 0.513,
-   "compress_mbps": 24.14,
-   "decompress_mbps": 173.84
+   "out_size": 3156403,
+   "ratio": 0.5131,
+   "compress_mbps": 24.73,
+   "decompress_mbps": 173.77
   },
   {
    "compressor": "native",
    "pattern": "silesia/ooffice",
    "size": 6152192,
    "level": 8,
-   "out_size": 3155368,
+   "out_size": 3155458,
    "ratio": 0.5129,
-   "compress_mbps": 23.1,
-   "decompress_mbps": 174.92
+   "compress_mbps": 23.65,
+   "decompress_mbps": 174.72
   },
   {
    "compressor": "native",
    "pattern": "silesia/ooffice",
    "size": 6152192,
    "level": 9,
-   "out_size": 3048772,
+   "out_size": 3049028,
    "ratio": 0.4956,
-   "compress_mbps": 5.12,
-   "decompress_mbps": 180.74
+   "compress_mbps": 5.17,
+   "decompress_mbps": 178.03
   },
   {
    "compressor": "native",
    "pattern": "silesia/ooffice",
    "size": 6152192,
    "level": 10,
-   "out_size": 3021986,
+   "out_size": 3022127,
    "ratio": 0.4912,
-   "compress_mbps": 3.13,
+   "compress_mbps": 3.24,
    "decompress_mbps": null
   },
   {
@@ -4914,8 +4914,8 @@
    "level": 1,
    "out_size": 3838828,
    "ratio": 0.3806,
-   "compress_mbps": 99.1,
-   "decompress_mbps": 265.97
+   "compress_mbps": 98.8,
+   "decompress_mbps": 265.98
   },
   {
    "compressor": "native",
@@ -4924,8 +4924,8 @@
    "level": 2,
    "out_size": 3792520,
    "ratio": 0.376,
-   "compress_mbps": 72.91,
-   "decompress_mbps": 273.81
+   "compress_mbps": 73.1,
+   "decompress_mbps": 274.52
   },
   {
    "compressor": "native",
@@ -4934,8 +4934,8 @@
    "level": 3,
    "out_size": 3783171,
    "ratio": 0.3751,
-   "compress_mbps": 70.12,
-   "decompress_mbps": 280.5
+   "compress_mbps": 69.97,
+   "decompress_mbps": 278.45
   },
   {
    "compressor": "native",
@@ -4944,8 +4944,8 @@
    "level": 4,
    "out_size": 3648458,
    "ratio": 0.3617,
-   "compress_mbps": 68.62,
-   "decompress_mbps": 293.96
+   "compress_mbps": 68.55,
+   "decompress_mbps": 294.61
   },
   {
    "compressor": "native",
@@ -4954,8 +4954,8 @@
    "level": 5,
    "out_size": 3648472,
    "ratio": 0.3617,
-   "compress_mbps": 63.59,
-   "decompress_mbps": 295.08
+   "compress_mbps": 63.36,
+   "decompress_mbps": 297.24
   },
   {
    "compressor": "native",
@@ -4964,8 +4964,8 @@
    "level": 6,
    "out_size": 3648595,
    "ratio": 0.3618,
-   "compress_mbps": 50.51,
-   "decompress_mbps": 286.0
+   "compress_mbps": 50.41,
+   "decompress_mbps": 307.62
   },
   {
    "compressor": "native",
@@ -4974,8 +4974,8 @@
    "level": 7,
    "out_size": 3648160,
    "ratio": 0.3617,
-   "compress_mbps": 49.96,
-   "decompress_mbps": 294.5
+   "compress_mbps": 50.25,
+   "decompress_mbps": 313.33
   },
   {
    "compressor": "native",
@@ -4984,8 +4984,8 @@
    "level": 8,
    "out_size": 3648156,
    "ratio": 0.3617,
-   "compress_mbps": 50.27,
-   "decompress_mbps": 310.93
+   "compress_mbps": 50.09,
+   "decompress_mbps": 313.9
   },
   {
    "compressor": "native",
@@ -4994,17 +4994,17 @@
    "level": 9,
    "out_size": 3648156,
    "ratio": 0.3617,
-   "compress_mbps": 6.04,
-   "decompress_mbps": 306.12
+   "compress_mbps": 6.14,
+   "decompress_mbps": 305.18
   },
   {
    "compressor": "native",
    "pattern": "silesia/osdb",
    "size": 10085684,
    "level": 10,
-   "out_size": 3647321,
+   "out_size": 3647385,
    "ratio": 0.3616,
-   "compress_mbps": 3.42,
+   "compress_mbps": 3.47,
    "decompress_mbps": null
   },
   {
@@ -5014,8 +5014,8 @@
    "level": 1,
    "out_size": 2254442,
    "ratio": 0.3402,
-   "compress_mbps": 90.32,
-   "decompress_mbps": 237.49
+   "compress_mbps": 89.9,
+   "decompress_mbps": 246.93
   },
   {
    "compressor": "native",
@@ -5024,8 +5024,8 @@
    "level": 2,
    "out_size": 2044843,
    "ratio": 0.3086,
-   "compress_mbps": 61.08,
-   "decompress_mbps": 275.45
+   "compress_mbps": 60.9,
+   "decompress_mbps": 267.33
   },
   {
    "compressor": "native",
@@ -5034,8 +5034,8 @@
    "level": 3,
    "out_size": 1992105,
    "ratio": 0.3006,
-   "compress_mbps": 49.61,
-   "decompress_mbps": 288.49
+   "compress_mbps": 49.51,
+   "decompress_mbps": 305.12
   },
   {
    "compressor": "native",
@@ -5044,8 +5044,8 @@
    "level": 4,
    "out_size": 1890729,
    "ratio": 0.2853,
-   "compress_mbps": 36.12,
-   "decompress_mbps": 311.13
+   "compress_mbps": 36.2,
+   "decompress_mbps": 298.88
   },
   {
    "compressor": "native",
@@ -5054,18 +5054,18 @@
    "level": 5,
    "out_size": 1858234,
    "ratio": 0.2804,
-   "compress_mbps": 23.16,
-   "decompress_mbps": 292.61
+   "compress_mbps": 23.17,
+   "decompress_mbps": 293.86
   },
   {
    "compressor": "native",
    "pattern": "silesia/reymont",
    "size": 6627202,
    "level": 6,
-   "out_size": 1856235,
+   "out_size": 1856238,
    "ratio": 0.2801,
-   "compress_mbps": 28.28,
-   "decompress_mbps": 318.67
+   "compress_mbps": 28.39,
+   "decompress_mbps": 308.81
   },
   {
    "compressor": "native",
@@ -5074,37 +5074,37 @@
    "level": 7,
    "out_size": 1823963,
    "ratio": 0.2752,
-   "compress_mbps": 17.69,
-   "decompress_mbps": 310.64
+   "compress_mbps": 17.76,
+   "decompress_mbps": 313.15
   },
   {
    "compressor": "native",
    "pattern": "silesia/reymont",
    "size": 6627202,
    "level": 8,
-   "out_size": 1820112,
+   "out_size": 1820116,
    "ratio": 0.2746,
-   "compress_mbps": 15.32,
-   "decompress_mbps": 326.32
+   "compress_mbps": 15.34,
+   "decompress_mbps": 314.57
   },
   {
    "compressor": "native",
    "pattern": "silesia/reymont",
    "size": 6627202,
    "level": 9,
-   "out_size": 1773447,
+   "out_size": 1773469,
    "ratio": 0.2676,
-   "compress_mbps": 2.99,
-   "decompress_mbps": 323.84
+   "compress_mbps": 2.97,
+   "decompress_mbps": 326.68
   },
   {
    "compressor": "native",
    "pattern": "silesia/reymont",
    "size": 6627202,
    "level": 10,
-   "out_size": 1718500,
+   "out_size": 1718509,
    "ratio": 0.2593,
-   "compress_mbps": 1.59,
+   "compress_mbps": 1.6,
    "decompress_mbps": null
   },
   {
@@ -5114,8 +5114,8 @@
    "level": 1,
    "out_size": 6406301,
    "ratio": 0.2965,
-   "compress_mbps": 119.04,
-   "decompress_mbps": 340.16
+   "compress_mbps": 118.24,
+   "decompress_mbps": 341.81
   },
   {
    "compressor": "native",
@@ -5124,8 +5124,8 @@
    "level": 2,
    "out_size": 6102377,
    "ratio": 0.2824,
-   "compress_mbps": 87.91,
-   "decompress_mbps": 359.92
+   "compress_mbps": 89.22,
+   "decompress_mbps": 360.22
   },
   {
    "compressor": "native",
@@ -5134,8 +5134,8 @@
    "level": 3,
    "out_size": 6022184,
    "ratio": 0.2787,
-   "compress_mbps": 80.59,
-   "decompress_mbps": 375.49
+   "compress_mbps": 81.04,
+   "decompress_mbps": 375.26
   },
   {
    "compressor": "native",
@@ -5144,8 +5144,8 @@
    "level": 4,
    "out_size": 5880892,
    "ratio": 0.2722,
-   "compress_mbps": 68.94,
-   "decompress_mbps": 392.75
+   "compress_mbps": 68.77,
+   "decompress_mbps": 392.38
   },
   {
    "compressor": "native",
@@ -5154,57 +5154,57 @@
    "level": 5,
    "out_size": 5834363,
    "ratio": 0.27,
-   "compress_mbps": 53.42,
-   "decompress_mbps": 401.65
+   "compress_mbps": 52.86,
+   "decompress_mbps": 401.54
   },
   {
    "compressor": "native",
    "pattern": "silesia/samba",
    "size": 21606400,
    "level": 6,
-   "out_size": 5409792,
+   "out_size": 5409868,
    "ratio": 0.2504,
-   "compress_mbps": 43.61,
-   "decompress_mbps": 405.65
+   "compress_mbps": 43.97,
+   "decompress_mbps": 408.38
   },
   {
    "compressor": "native",
    "pattern": "silesia/samba",
    "size": 21606400,
    "level": 7,
-   "out_size": 5393735,
+   "out_size": 5393825,
    "ratio": 0.2496,
-   "compress_mbps": 36.85,
-   "decompress_mbps": 406.57
+   "compress_mbps": 37.41,
+   "decompress_mbps": 407.56
   },
   {
    "compressor": "native",
    "pattern": "silesia/samba",
    "size": 21606400,
    "level": 8,
-   "out_size": 5389952,
+   "out_size": 5390050,
    "ratio": 0.2495,
-   "compress_mbps": 34.45,
-   "decompress_mbps": 407.86
+   "compress_mbps": 34.84,
+   "decompress_mbps": 407.43
   },
   {
    "compressor": "native",
    "pattern": "silesia/samba",
    "size": 21606400,
    "level": 9,
-   "out_size": 5235865,
+   "out_size": 5236015,
    "ratio": 0.2423,
-   "compress_mbps": 4.86,
-   "decompress_mbps": 411.64
+   "compress_mbps": 4.9,
+   "decompress_mbps": 411.82
   },
   {
    "compressor": "native",
    "pattern": "silesia/samba",
    "size": 21606400,
    "level": 10,
-   "out_size": 5177560,
+   "out_size": 5177683,
    "ratio": 0.2396,
-   "compress_mbps": 2.59,
+   "compress_mbps": 2.64,
    "decompress_mbps": null
   },
   {
@@ -5214,8 +5214,8 @@
    "level": 1,
    "out_size": 5612204,
    "ratio": 0.7739,
-   "compress_mbps": 50.26,
-   "decompress_mbps": 147.6
+   "compress_mbps": 50.44,
+   "decompress_mbps": 147.42
   },
   {
    "compressor": "native",
@@ -5224,8 +5224,8 @@
    "level": 2,
    "out_size": 5533875,
    "ratio": 0.7631,
-   "compress_mbps": 41.88,
-   "decompress_mbps": 155.08
+   "compress_mbps": 41.44,
+   "decompress_mbps": 155.03
   },
   {
    "compressor": "native",
@@ -5234,8 +5234,8 @@
    "level": 3,
    "out_size": 5522436,
    "ratio": 0.7615,
-   "compress_mbps": 39.41,
-   "decompress_mbps": 159.9
+   "compress_mbps": 39.15,
+   "decompress_mbps": 158.04
   },
   {
    "compressor": "native",
@@ -5244,8 +5244,8 @@
    "level": 4,
    "out_size": 5494383,
    "ratio": 0.7576,
-   "compress_mbps": 33.9,
-   "decompress_mbps": 166.47
+   "compress_mbps": 33.71,
+   "decompress_mbps": 164.08
   },
   {
    "compressor": "native",
@@ -5254,8 +5254,8 @@
    "level": 5,
    "out_size": 5489807,
    "ratio": 0.757,
-   "compress_mbps": 31.62,
-   "decompress_mbps": 162.57
+   "compress_mbps": 31.94,
+   "decompress_mbps": 160.54
   },
   {
    "compressor": "native",
@@ -5264,8 +5264,8 @@
    "level": 6,
    "out_size": 5470520,
    "ratio": 0.7544,
-   "compress_mbps": 24.23,
-   "decompress_mbps": 164.8
+   "compress_mbps": 24.15,
+   "decompress_mbps": 165.01
   },
   {
    "compressor": "native",
@@ -5274,8 +5274,8 @@
    "level": 7,
    "out_size": 5463682,
    "ratio": 0.7534,
-   "compress_mbps": 22.72,
-   "decompress_mbps": 164.49
+   "compress_mbps": 23.0,
+   "decompress_mbps": 162.7
   },
   {
    "compressor": "native",
@@ -5284,27 +5284,27 @@
    "level": 8,
    "out_size": 5463761,
    "ratio": 0.7534,
-   "compress_mbps": 22.48,
-   "decompress_mbps": 164.87
+   "compress_mbps": 22.78,
+   "decompress_mbps": 162.42
   },
   {
    "compressor": "native",
    "pattern": "silesia/sao",
    "size": 7251944,
    "level": 9,
-   "out_size": 5284536,
+   "out_size": 5284606,
    "ratio": 0.7287,
-   "compress_mbps": 5.12,
-   "decompress_mbps": 163.49
+   "compress_mbps": 5.33,
+   "decompress_mbps": 163.38
   },
   {
    "compressor": "native",
    "pattern": "silesia/sao",
    "size": 7251944,
    "level": 10,
-   "out_size": 5262319,
-   "ratio": 0.7256,
-   "compress_mbps": 3.58,
+   "out_size": 5262387,
+   "ratio": 0.7257,
+   "compress_mbps": 3.68,
    "decompress_mbps": null
   },
   {
@@ -5314,8 +5314,8 @@
    "level": 1,
    "out_size": 13727247,
    "ratio": 0.3311,
-   "compress_mbps": 89.48,
-   "decompress_mbps": 251.03
+   "compress_mbps": 88.83,
+   "decompress_mbps": 252.78
   },
   {
    "compressor": "native",
@@ -5324,8 +5324,8 @@
    "level": 2,
    "out_size": 12940398,
    "ratio": 0.3121,
-   "compress_mbps": 65.78,
-   "decompress_mbps": 272.94
+   "compress_mbps": 66.01,
+   "decompress_mbps": 274.88
   },
   {
    "compressor": "native",
@@ -5334,8 +5334,8 @@
    "level": 3,
    "out_size": 12703756,
    "ratio": 0.3064,
-   "compress_mbps": 60.3,
-   "decompress_mbps": 293.89
+   "compress_mbps": 60.04,
+   "decompress_mbps": 295.44
   },
   {
    "compressor": "native",
@@ -5344,8 +5344,8 @@
    "level": 4,
    "out_size": 12177338,
    "ratio": 0.2937,
-   "compress_mbps": 49.6,
-   "decompress_mbps": 298.12
+   "compress_mbps": 49.55,
+   "decompress_mbps": 298.99
   },
   {
    "compressor": "native",
@@ -5354,8 +5354,8 @@
    "level": 5,
    "out_size": 12051075,
    "ratio": 0.2907,
-   "compress_mbps": 37.75,
-   "decompress_mbps": 301.84
+   "compress_mbps": 37.84,
+   "decompress_mbps": 303.44
   },
   {
    "compressor": "native",
@@ -5364,8 +5364,8 @@
    "level": 6,
    "out_size": 12103573,
    "ratio": 0.2919,
-   "compress_mbps": 39.36,
-   "decompress_mbps": 310.84
+   "compress_mbps": 39.23,
+   "decompress_mbps": 310.64
   },
   {
    "compressor": "native",
@@ -5374,8 +5374,8 @@
    "level": 7,
    "out_size": 12027976,
    "ratio": 0.2901,
-   "compress_mbps": 30.92,
-   "decompress_mbps": 311.74
+   "compress_mbps": 30.85,
+   "decompress_mbps": 312.53
   },
   {
    "compressor": "native",
@@ -5384,27 +5384,27 @@
    "level": 8,
    "out_size": 12019953,
    "ratio": 0.2899,
-   "compress_mbps": 29.11,
-   "decompress_mbps": 313.35
+   "compress_mbps": 28.95,
+   "decompress_mbps": 302.33
   },
   {
    "compressor": "native",
    "pattern": "silesia/webster",
    "size": 41458703,
    "level": 9,
-   "out_size": 11806466,
+   "out_size": 11806641,
    "ratio": 0.2848,
-   "compress_mbps": 3.93,
-   "decompress_mbps": 310.89
+   "compress_mbps": 3.92,
+   "decompress_mbps": 313.72
   },
   {
    "compressor": "native",
    "pattern": "silesia/webster",
    "size": 41458703,
    "level": 10,
-   "out_size": 11636727,
+   "out_size": 11636945,
    "ratio": 0.2807,
-   "compress_mbps": 2.01,
+   "compress_mbps": 2.04,
    "decompress_mbps": null
   },
   {
@@ -5414,8 +5414,8 @@
    "level": 1,
    "out_size": 6438176,
    "ratio": 0.7597,
-   "compress_mbps": 45.25,
-   "decompress_mbps": 145.17
+   "compress_mbps": 45.28,
+   "decompress_mbps": 143.99
   },
   {
    "compressor": "native",
@@ -5424,8 +5424,8 @@
    "level": 2,
    "out_size": 6392101,
    "ratio": 0.7543,
-   "compress_mbps": 43.89,
-   "decompress_mbps": 147.13
+   "compress_mbps": 43.19,
+   "decompress_mbps": 147.38
   },
   {
    "compressor": "native",
@@ -5434,8 +5434,8 @@
    "level": 3,
    "out_size": 6392124,
    "ratio": 0.7543,
-   "compress_mbps": 43.78,
-   "decompress_mbps": 149.21
+   "compress_mbps": 42.79,
+   "decompress_mbps": 149.34
   },
   {
    "compressor": "native",
@@ -5444,8 +5444,8 @@
    "level": 4,
    "out_size": 6360604,
    "ratio": 0.7506,
-   "compress_mbps": 40.87,
-   "decompress_mbps": 133.82
+   "compress_mbps": 40.05,
+   "decompress_mbps": 134.1
   },
   {
    "compressor": "native",
@@ -5454,57 +5454,57 @@
    "level": 5,
    "out_size": 6360567,
    "ratio": 0.7506,
-   "compress_mbps": 41.01,
-   "decompress_mbps": 136.39
+   "compress_mbps": 40.49,
+   "decompress_mbps": 136.23
   },
   {
    "compressor": "native",
    "pattern": "silesia/x-ray",
    "size": 8474240,
    "level": 6,
-   "out_size": 6271453,
+   "out_size": 6271790,
    "ratio": 0.7401,
-   "compress_mbps": 17.49,
-   "decompress_mbps": 137.34
+   "compress_mbps": 20.26,
+   "decompress_mbps": 136.25
   },
   {
    "compressor": "native",
    "pattern": "silesia/x-ray",
    "size": 8474240,
    "level": 7,
-   "out_size": 6271447,
+   "out_size": 6271785,
    "ratio": 0.7401,
-   "compress_mbps": 17.43,
-   "decompress_mbps": 137.83
+   "compress_mbps": 20.23,
+   "decompress_mbps": 136.46
   },
   {
    "compressor": "native",
    "pattern": "silesia/x-ray",
    "size": 8474240,
    "level": 8,
-   "out_size": 6271447,
+   "out_size": 6271785,
    "ratio": 0.7401,
-   "compress_mbps": 17.49,
-   "decompress_mbps": 139.3
+   "compress_mbps": 20.26,
+   "decompress_mbps": 136.69
   },
   {
    "compressor": "native",
    "pattern": "silesia/x-ray",
    "size": 8474240,
    "level": 9,
-   "out_size": 5952505,
-   "ratio": 0.7024,
-   "compress_mbps": 6.06,
-   "decompress_mbps": 140.88
+   "out_size": 5952975,
+   "ratio": 0.7025,
+   "compress_mbps": 6.33,
+   "decompress_mbps": 140.23
   },
   {
    "compressor": "native",
    "pattern": "silesia/x-ray",
    "size": 8474240,
    "level": 10,
-   "out_size": 5848663,
+   "out_size": 5849157,
    "ratio": 0.6902,
-   "compress_mbps": 4.32,
+   "compress_mbps": 4.54,
    "decompress_mbps": null
   },
   {
@@ -5514,8 +5514,8 @@
    "level": 1,
    "out_size": 858525,
    "ratio": 0.1606,
-   "compress_mbps": 196.43,
-   "decompress_mbps": 472.63
+   "compress_mbps": 195.8,
+   "decompress_mbps": 440.96
   },
   {
    "compressor": "native",
@@ -5524,8 +5524,8 @@
    "level": 2,
    "out_size": 846807,
    "ratio": 0.1584,
-   "compress_mbps": 126.61,
-   "decompress_mbps": 570.7
+   "compress_mbps": 126.56,
+   "decompress_mbps": 516.9
   },
   {
    "compressor": "native",
@@ -5534,8 +5534,8 @@
    "level": 3,
    "out_size": 806798,
    "ratio": 0.1509,
-   "compress_mbps": 115.81,
-   "decompress_mbps": 633.61
+   "compress_mbps": 115.9,
+   "decompress_mbps": 632.06
   },
   {
    "compressor": "native",
@@ -5544,8 +5544,8 @@
    "level": 4,
    "out_size": 717301,
    "ratio": 0.1342,
-   "compress_mbps": 101.37,
-   "decompress_mbps": 625.62
+   "compress_mbps": 100.79,
+   "decompress_mbps": 625.98
   },
   {
    "compressor": "native",
@@ -5554,57 +5554,57 @@
    "level": 5,
    "out_size": 701552,
    "ratio": 0.1312,
-   "compress_mbps": 76.66,
-   "decompress_mbps": 680.03
+   "compress_mbps": 76.12,
+   "decompress_mbps": 678.8
   },
   {
    "compressor": "native",
    "pattern": "silesia/xml",
    "size": 5345280,
    "level": 6,
-   "out_size": 678544,
+   "out_size": 678560,
    "ratio": 0.1269,
-   "compress_mbps": 72.43,
-   "decompress_mbps": 728.31
+   "compress_mbps": 72.04,
+   "decompress_mbps": 731.52
   },
   {
    "compressor": "native",
    "pattern": "silesia/xml",
    "size": 5345280,
    "level": 7,
-   "out_size": 663716,
+   "out_size": 663724,
    "ratio": 0.1242,
-   "compress_mbps": 56.64,
-   "decompress_mbps": 736.78
+   "compress_mbps": 56.53,
+   "decompress_mbps": 740.46
   },
   {
    "compressor": "native",
    "pattern": "silesia/xml",
    "size": 5345280,
    "level": 8,
-   "out_size": 660481,
+   "out_size": 660492,
    "ratio": 0.1236,
-   "compress_mbps": 49.75,
-   "decompress_mbps": 749.98
+   "compress_mbps": 49.52,
+   "decompress_mbps": 745.2
   },
   {
    "compressor": "native",
    "pattern": "silesia/xml",
    "size": 5345280,
    "level": 9,
-   "out_size": 659417,
+   "out_size": 659422,
    "ratio": 0.1234,
-   "compress_mbps": 4.63,
-   "decompress_mbps": 664.47
+   "compress_mbps": 4.64,
+   "decompress_mbps": 657.51
   },
   {
    "compressor": "native",
    "pattern": "silesia/xml",
    "size": 5345280,
    "level": 10,
-   "out_size": 643093,
+   "out_size": 643101,
    "ratio": 0.1203,
-   "compress_mbps": 3.02,
+   "compress_mbps": 3.05,
    "decompress_mbps": null
   },
   {


### PR DESCRIPTION
This PR replaces the per-block Huffman tree construction — still `List.mergeSort` + the O(n²) `insertByWeight` spec build after #2769 array-ified only the assignment step — with a van Leeuwen two-queue build over flat arrays (sorted leaf queue + merged-node queue, parent pointers upward, one reverse pass for depths): O(n) merging, no per-node allocation. On stat-shifting binaries the observation-divergence splitter produces hundreds of blocks, each paying two of the old builds; `insertByWeight` was the single largest profile entry on Silesia x-ray at L6 (16.5% self).

The new build is a heuristic replacement, not a byte-identical one: every property the roundtrip proof consumes (result size, lengths in [1,15], Kraft validity via `fixKraftList`, nonzero lengths for used symbols) depends only on the `symsByFreq.zip (expandBl bl ++ padding)` output shape, which is unchanged — those lemmas are re-proven for `limitedPairsN` on the shared infrastructure, the spec pipeline and all its theorems stay untouched, and tree optimality remains a ratio concern validated by the corpus: the corpus-weighted Silesia delta is at most +0.0026% (L6 +1797 bytes of 68.3 MB; L4/L5 byte-identical, dynamic path untriggered). No `sorry`.

Measured (chungus2, pinned, best-of-5 interleaved A/B vs master): x-ray L6 +21.6% (17.6 to 21.5 MB/s), x-ray L7 +20.7%, mozilla L6 +9.6%, osdb L6 +5.4%, sao L6 +4.4%, dickens L6 +4.3%, xml L6 +2.7%. `lake exe test` green including native/FFI roundtrip conformance.

🤖 Prepared with Claude Code