### PR TITLE
perf: hash3-singleton length-3 coverage at the split tier (L6-L8)

### DIFF
--- a/Zip/Native/Deflate.lean
+++ b/Zip/Native/Deflate.lean
@@ -886,6 +886,46 @@ walk is orders of magnitude deeper per position. -/
     else 0
   else 0
 
+/-- Reject length-3 singleton seeds farther than this (zlib `deflate.c`
+    `TOO_FAR`): a length-3 match at a large distance costs more bits than three
+    literals. The split-tier singleton probe caps its seed distance at
+    `min windowSize tooFar3`, exactly as the L9/L10 cache build already does;
+    measured optimal at 4096 (#2742 / the split-tier sweep). -/
+def tooFar3 : Nat := 4096
+
+/-- The hash3-singleton chain-walk seed at `pos`: when `useH3` is set, read the
+    most-recent length-3 candidate from `h3tab` and `hash3Probe`-verify it within
+    `min windowSize tooFar3`, returning the packed `cand3*512+3` on a hit (else
+    `0`); when `useH3` is clear, the empty seed `0`. The result is *always* a real
+    in-window backward match or empty (`h3Seed_spec`), so the seeded chain walk
+    may return it and the loop emit it as a verified length-3 reference — this is
+    how the split tier (L6–L8) sees the length-3 matches its hash4 chains miss.
+    The `h3tab` contents are pure heuristic state: the probe re-verifies the
+    bytes and the window, so they never enter a validity proof. -/
+@[inline] def h3Seed (useH3 : Bool) (data : ByteArray) (h3tab : Array Nat)
+    (windowSize pos : Nat) (hlt : pos + 2 < data.size) : Nat :=
+  if useH3 then
+    hash3Probe data (min windowSize tooFar3) pos (headProbeGuarded h3tab (hash3Single data pos hlt)) hlt
+  else 0
+
+/-- Interior-position hash3-singleton insertion, the length-3 twin of
+    `lz77Chain.updateHashes`' chain insertion: for each `j ∈ [j, matchLen)` (also
+    `≤ insertCap`) with three readable bytes, store `pos+j` into
+    `h3tab[hash3Single data (pos+j)]`. Runs at exactly the interior positions the
+    hash4 insertion covers, so the singleton stays as fresh as the chain. Pure
+    heuristic state — never enters a validity proof. -/
+def updateHash3 (data : ByteArray) (h3tab : Array Nat) (pos j matchLen insertCap : Nat) :
+    Array Nat :=
+  if j < matchLen ∧ j ≤ insertCap then
+    if h : pos + j + 2 < data.size then
+      updateHash3 data (guardedSet h3tab (hash3Single data (pos + j) h) (pos + j))
+        pos (j + 1) matchLen insertCap
+    else
+      updateHash3 data h3tab pos (j + 1) matchLen insertCap
+  else h3tab
+termination_by matchLen - j
+decreasing_by all_goals omega
+
 /-- Greedy LZ77 with bounded-depth hash chains: at each position, walk the
     `prev` chain from the bucket head up to `maxChain` candidates and keep the
     longest in-window match. This finds far longer matches than the single-probe
@@ -1376,25 +1416,28 @@ theorem lazyAcceptCost_lt {len1 dist1 len2 dist2 : Nat}
     `LZ77ChainLazyCorrect`. -/
 def lz77ChainLazy (data : ByteArray) (maxChain : Nat) (windowSize : Nat := 32768)
     (insertCap : Nat := 1000000000) (goodMatch : Nat := 259) (niceLen : Nat := 258)
-    (lazyDepth : Nat := maxChain) :
+    (lazyDepth : Nat := maxChain) (useH3 : Bool := false) :
     Array LZ77Token :=
   if data.size < 3 then
     (lz77Greedy.trailing data 0).toArray
   else
     let hashSize := 65536
-    (mainLoop data windowSize hashSize maxChain
-      (.replicate hashSize data.size) (.replicate (min chainWinSize data.size) data.size) 0 insertCap goodMatch niceLen lazyDepth).toArray
+    (mainLoop data windowSize hashSize maxChain useH3
+      (.replicate hashSize data.size) (.replicate (min chainWinSize data.size) data.size)
+      (.replicate 32768 data.size) 0 insertCap goodMatch niceLen lazyDepth).toArray
 where
-  mainLoop (data : ByteArray) (windowSize hashSize maxChain : Nat)
-      (hashTable : Array Nat) (prev : Array Nat) (pos insertCap goodMatch niceLen lazyDepth : Nat) : List LZ77Token :=
+  mainLoop (data : ByteArray) (windowSize hashSize maxChain : Nat) (useH3 : Bool)
+      (hashTable : Array Nat) (prev h3tab : Array Nat) (pos insertCap goodMatch niceLen lazyDepth : Nat) : List LZ77Token :=
     if hlt : pos + 2 < data.size then
       let h := lz77Greedy.hash3 data pos hashSize hlt
       let head := headProbeGuarded hashTable h
       let hashTable := guardedSet hashTable h pos
       let prev := guardedSet prev (pos &&& 0x7FFF) head
+      let seed := h3Seed useH3 data h3tab windowSize pos hlt
+      let h3tab := if useH3 then guardedSet h3tab (hash3Single data pos hlt) pos else h3tab
       let maxLen := min 258 (data.size - pos)
       have hmaxLenP : pos + maxLen ≤ data.size := by omega
-      let m := lz77Chain.chainWalk data prev windowSize pos maxLen niceLen hmaxLenP head maxChain 0 0
+      let m := lz77Chain.chainWalk data prev windowSize pos maxLen niceLen hmaxLenP head maxChain (seed % 512) (seed / 512)
       let matchLen := m.1
       let matchPos := m.2
       if hge : matchLen ≥ 3 then
@@ -1418,41 +1461,45 @@ where
                   have : data.size - (pos + 1 + matchLen2) < data.size - pos := by omega
                   let (hashTable, prev) :=
                     lz77Chain.updateHashes data hashSize hashTable prev pos 1 (matchLen2 + 1) insertCap
+                  let h3tab := if useH3 then updateHash3 data h3tab pos 1 (matchLen2 + 1) insertCap else h3tab
                   .literal (data[pos]'(by omega)) ::
                     .reference matchLen2 (pos + 1 - matchPos2) ::
-                    mainLoop data windowSize hashSize maxChain hashTable prev (pos + 1 + matchLen2) insertCap goodMatch niceLen lazyDepth
+                    mainLoop data windowSize hashSize maxChain useH3 hashTable prev h3tab (pos + 1 + matchLen2) insertCap goodMatch niceLen lazyDepth
                 else
                   -- matchLen2 spills past data: keep match at pos
                   have : data.size - (pos + matchLen) < data.size - pos := by omega
                   let (hashTable, prev) :=
                     lz77Chain.updateHashes data hashSize hashTable prev pos 1 matchLen insertCap
+                  let h3tab := if useH3 then updateHash3 data h3tab pos 1 matchLen insertCap else h3tab
                   .reference matchLen (pos - matchPos) ::
-                    mainLoop data windowSize hashSize maxChain hashTable prev (pos + matchLen) insertCap goodMatch niceLen lazyDepth
+                    mainLoop data windowSize hashSize maxChain useH3 hashTable prev h3tab (pos + matchLen) insertCap goodMatch niceLen lazyDepth
               else
                 -- No better match at pos+1: keep match at pos
                 have : data.size - (pos + matchLen) < data.size - pos := by omega
                 let (hashTable, prev) :=
                   lz77Chain.updateHashes data hashSize hashTable prev pos 1 matchLen insertCap
+                let h3tab := if useH3 then updateHash3 data h3tab pos 1 matchLen insertCap else h3tab
                 .reference matchLen (pos - matchPos) ::
-                  mainLoop data windowSize hashSize maxChain hashTable prev (pos + matchLen) insertCap goodMatch niceLen lazyDepth
+                  mainLoop data windowSize hashSize maxChain useH3 hashTable prev h3tab (pos + matchLen) insertCap goodMatch niceLen lazyDepth
             else
               -- Gated: long first match, skip the lookahead; still insert interior hashes.
               have : data.size - (pos + matchLen) < data.size - pos := by omega
               let (hashTable, prev) :=
                 lz77Chain.updateHashes data hashSize hashTable prev pos 1 matchLen insertCap
+              let h3tab := if useH3 then updateHash3 data h3tab pos 1 matchLen insertCap else h3tab
               .reference matchLen (pos - matchPos) ::
-                mainLoop data windowSize hashSize maxChain hashTable prev (pos + matchLen) insertCap goodMatch niceLen lazyDepth
+                mainLoop data windowSize hashSize maxChain useH3 hashTable prev h3tab (pos + matchLen) insertCap goodMatch niceLen lazyDepth
           else
             -- Near end of data: keep match at pos
             have : data.size - (pos + matchLen) < data.size - pos := by omega
             .reference matchLen (pos - matchPos) ::
-              mainLoop data windowSize hashSize maxChain hashTable prev (pos + matchLen) insertCap goodMatch niceLen lazyDepth
+              mainLoop data windowSize hashSize maxChain useH3 hashTable prev h3tab (pos + matchLen) insertCap goodMatch niceLen lazyDepth
         else
           .literal (data[pos]'(by omega)) ::
-            mainLoop data windowSize hashSize maxChain hashTable prev (pos + 1) insertCap goodMatch niceLen lazyDepth
+            mainLoop data windowSize hashSize maxChain useH3 hashTable prev h3tab (pos + 1) insertCap goodMatch niceLen lazyDepth
       else
         .literal (data[pos]'(by omega)) ::
-          mainLoop data windowSize hashSize maxChain hashTable prev (pos + 1) insertCap goodMatch niceLen lazyDepth
+          mainLoop data windowSize hashSize maxChain useH3 hashTable prev h3tab (pos + 1) insertCap goodMatch niceLen lazyDepth
     else
       lz77Greedy.trailing data pos
   termination_by data.size - pos
@@ -1465,26 +1512,29 @@ where
     `lz77ChainLazy` in `LZ77ChainLazyCorrect`. -/
 def lz77ChainLazyIter (data : ByteArray) (maxChain : Nat) (windowSize : Nat := 32768)
     (insertCap : Nat := 1000000000) (goodMatch : Nat := 259) (niceLen : Nat := 258)
-    (lazyDepth : Nat := maxChain) :
+    (lazyDepth : Nat := maxChain) (useH3 : Bool := false) :
     Array LZ77Token :=
   if data.size < 3 then
     lz77GreedyIter.trailing data 0 #[]
   else
     let hashSize := 65536
-    mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth
-      (.replicate hashSize data.size) (.replicate (min chainWinSize data.size) data.size) 0 #[]
+    mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth useH3
+      (.replicate hashSize data.size) (.replicate (min chainWinSize data.size) data.size)
+      (.replicate 32768 data.size) 0 #[]
 where
-  mainLoop (data : ByteArray) (windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth : Nat)
-      (hashTable : Array Nat) (prev : Array Nat) (pos : Nat) (acc : Array LZ77Token) :
+  mainLoop (data : ByteArray) (windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth : Nat) (useH3 : Bool)
+      (hashTable : Array Nat) (prev h3tab : Array Nat) (pos : Nat) (acc : Array LZ77Token) :
       Array LZ77Token :=
     if hlt : pos + 2 < data.size then
       let h := lz77Greedy.hash3 data pos hashSize hlt
       let head := headProbeGuarded hashTable h
       let hashTable := guardedSet hashTable h pos
       let prev := guardedSet prev (pos &&& 0x7FFF) head
+      let seed := h3Seed useH3 data h3tab windowSize pos hlt
+      let h3tab := if useH3 then guardedSet h3tab (hash3Single data pos hlt) pos else h3tab
       let maxLen := min 258 (data.size - pos)
       have hmaxLenP : pos + maxLen ≤ data.size := by omega
-      let r := chainWalkGuardedPacked data prev windowSize pos maxLen niceLen hmaxLenP head maxChain 0 0
+      let r := chainWalkGuardedPacked data prev windowSize pos maxLen niceLen hmaxLenP head maxChain (seed % 512) (seed / 512)
       let matchLen := r % 512
       let matchPos := r / 512
       if hge : matchLen ≥ 3 then
@@ -1506,37 +1556,41 @@ where
                   have : data.size - (pos + 1 + matchLen2) < data.size - pos := by omega
                   let (hashTable, prev) :=
                     updateHashesGuarded data hashSize hashTable prev pos 1 (matchLen2 + 1) insertCap
-                  mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth hashTable prev (pos + 1 + matchLen2)
+                  let h3tab := if useH3 then updateHash3 data h3tab pos 1 (matchLen2 + 1) insertCap else h3tab
+                  mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth useH3 hashTable prev h3tab (pos + 1 + matchLen2)
                     (acc.push (.literal (data[pos]'(by omega))) |>.push
                       (.reference matchLen2 (pos + 1 - matchPos2)))
                 else
                   have : data.size - (pos + matchLen) < data.size - pos := by omega
                   let (hashTable, prev) :=
                     updateHashesGuarded data hashSize hashTable prev pos 1 matchLen insertCap
-                  mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth hashTable prev (pos + matchLen)
+                  let h3tab := if useH3 then updateHash3 data h3tab pos 1 matchLen insertCap else h3tab
+                  mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth useH3 hashTable prev h3tab (pos + matchLen)
                     (acc.push (.reference matchLen (pos - matchPos)))
               else
                 have : data.size - (pos + matchLen) < data.size - pos := by omega
                 let (hashTable, prev) :=
                   updateHashesGuarded data hashSize hashTable prev pos 1 matchLen insertCap
-                mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth hashTable prev (pos + matchLen)
+                let h3tab := if useH3 then updateHash3 data h3tab pos 1 matchLen insertCap else h3tab
+                mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth useH3 hashTable prev h3tab (pos + matchLen)
                   (acc.push (.reference matchLen (pos - matchPos)))
             else
               -- Gated: long first match, skip the lookahead; still insert interior hashes.
               have : data.size - (pos + matchLen) < data.size - pos := by omega
               let (hashTable, prev) :=
                 updateHashesGuarded data hashSize hashTable prev pos 1 matchLen insertCap
-              mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth hashTable prev (pos + matchLen)
+              let h3tab := if useH3 then updateHash3 data h3tab pos 1 matchLen insertCap else h3tab
+              mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth useH3 hashTable prev h3tab (pos + matchLen)
                 (acc.push (.reference matchLen (pos - matchPos)))
           else
             have : data.size - (pos + matchLen) < data.size - pos := by omega
-            mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth hashTable prev (pos + matchLen)
+            mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth useH3 hashTable prev h3tab (pos + matchLen)
               (acc.push (.reference matchLen (pos - matchPos)))
         else
-          mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth hashTable prev (pos + 1)
+          mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth useH3 hashTable prev h3tab (pos + 1)
             (acc.push (.literal (data[pos]'(by omega))))
       else
-        mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth hashTable prev (pos + 1)
+        mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth useH3 hashTable prev h3tab (pos + 1)
           (acc.push (.literal (data[pos]'(by omega))))
     else
       lz77GreedyIter.trailing data pos acc
@@ -1611,27 +1665,30 @@ where
     Equal to `(lz77ChainLazyIter ..).map packTok` (`lz77ChainLazyIterP_eq`). -/
 def lz77ChainLazyIterP (data : ByteArray) (maxChain : Nat) (windowSize : Nat := 32768)
     (insertCap : Nat := 1000000000) (goodMatch : Nat := 259) (niceLen : Nat := 258)
-    (lazyDepth : Nat := maxChain) :
+    (lazyDepth : Nat := maxChain) (useH3 : Bool := false) :
     Array UInt32 :=
   if data.size < 3 then
     trailingP data 0 #[]
   else
     let hashSize := 65536
-    mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth
-      (.replicate hashSize data.size) (.replicate (min chainWinSize data.size) data.size) 0
+    mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth useH3
+      (.replicate hashSize data.size) (.replicate (min chainWinSize data.size) data.size)
+      (.replicate 32768 data.size) 0
       (Array.emptyWithCapacity data.size)
 where
-  mainLoop (data : ByteArray) (windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth : Nat)
-      (hashTable : Array Nat) (prev : Array Nat) (pos : Nat) (acc : Array UInt32) :
+  mainLoop (data : ByteArray) (windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth : Nat) (useH3 : Bool)
+      (hashTable : Array Nat) (prev h3tab : Array Nat) (pos : Nat) (acc : Array UInt32) :
       Array UInt32 :=
     if hlt : pos + 2 < data.size then
       let h := lz77Greedy.hash3 data pos hashSize hlt
       let head := headProbeGuarded hashTable h
       let hashTable := guardedSet hashTable h pos
       let prev := guardedSet prev (pos &&& 0x7FFF) head
+      let seed := h3Seed useH3 data h3tab windowSize pos hlt
+      let h3tab := if useH3 then guardedSet h3tab (hash3Single data pos hlt) pos else h3tab
       let maxLen := min 258 (data.size - pos)
       have hmaxLenP : pos + maxLen ≤ data.size := by omega
-      let r := chainWalkGuardedPackedU data prev windowSize pos maxLen niceLen hmaxLenP head maxChain 0 0
+      let r := chainWalkGuardedPackedU data prev windowSize pos maxLen niceLen hmaxLenP head maxChain (seed % 512) (seed / 512)
       let matchLen := r % 512
       let matchPos := r / 512
       if hge : matchLen ≥ 3 then
@@ -1656,20 +1713,23 @@ where
                   have : data.size - (pos + 1 + matchLen2) < data.size - pos := by omega
                   let (hashTable, prev) :=
                     updateHashesGuarded data hashSize hashTable prev pos 1 (matchLen2 + 1) insertCap
-                  mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth hashTable prev (pos + 1 + matchLen2)
+                  let h3tab := if useH3 then updateHash3 data h3tab pos 1 (matchLen2 + 1) insertCap else h3tab
+                  mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth useH3 hashTable prev h3tab (pos + 1 + matchLen2)
                     (acc.push (packTok (.literal (data[pos]'(by omega)))) |>.push
                       (packTok (.reference matchLen2 (pos + 1 - matchPos2))))
                 else
                   have : data.size - (pos + matchLen) < data.size - pos := by omega
                   let (hashTable, prev) :=
                     updateHashesGuarded data hashSize hashTable prev pos 1 matchLen insertCap
-                  mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth hashTable prev (pos + matchLen)
+                  let h3tab := if useH3 then updateHash3 data h3tab pos 1 matchLen insertCap else h3tab
+                  mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth useH3 hashTable prev h3tab (pos + matchLen)
                     (acc.push (packTok (.reference matchLen (pos - matchPos))))
               else
                 have : data.size - (pos + matchLen) < data.size - pos := by omega
                 let (hashTable, prev) :=
                   updateHashesGuarded data hashSize hashTable prev pos 1 matchLen insertCap
-                mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth hashTable prev (pos + matchLen)
+                let h3tab := if useH3 then updateHash3 data h3tab pos 1 matchLen insertCap else h3tab
+                mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth useH3 hashTable prev h3tab (pos + matchLen)
                   (acc.push (packTok (.reference matchLen (pos - matchPos))))
             else
               -- Gated: first match already long; skip the lookahead, but still insert
@@ -1677,17 +1737,18 @@ where
               have : data.size - (pos + matchLen) < data.size - pos := by omega
               let (hashTable, prev) :=
                 updateHashesGuarded data hashSize hashTable prev pos 1 matchLen insertCap
-              mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth hashTable prev (pos + matchLen)
+              let h3tab := if useH3 then updateHash3 data h3tab pos 1 matchLen insertCap else h3tab
+              mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth useH3 hashTable prev h3tab (pos + matchLen)
                 (acc.push (packTok (.reference matchLen (pos - matchPos))))
           else
             have : data.size - (pos + matchLen) < data.size - pos := by omega
-            mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth hashTable prev (pos + matchLen)
+            mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth useH3 hashTable prev h3tab (pos + matchLen)
               (acc.push (packTok (.reference matchLen (pos - matchPos))))
         else
-          mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth hashTable prev (pos + 1)
+          mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth useH3 hashTable prev h3tab (pos + 1)
             (acc.push (packTok (.literal (data[pos]'(by omega)))))
       else
-        mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth hashTable prev (pos + 1)
+        mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth useH3 hashTable prev h3tab (pos + 1)
           (acc.push (packTok (.literal (data[pos]'(by omega)))))
     else
       trailingP data pos acc
@@ -1900,16 +1961,18 @@ decreasing_by
     hash table at offset `prevSize`). The per-position insertion goes through
     `updateHashesMerged` (returns one array), so no Prod is allocated. -/
 def lz77LazyMergedLoop (data : ByteArray)
-    (windowSize hashSize prevSize maxChain insertCap goodMatch niceLen lazyDepth : Nat)
-    (c : Array Nat) (pos : Nat) (acc : Array UInt32) : Array UInt32 :=
+    (windowSize hashSize prevSize maxChain insertCap goodMatch niceLen lazyDepth : Nat) (useH3 : Bool)
+    (c h3tab : Array Nat) (pos : Nat) (acc : Array UInt32) : Array UInt32 :=
   if hlt : pos + 2 < data.size then
     let h := lz77Greedy.hash3 data pos hashSize hlt
     let head := headProbeGuarded c (prevSize + h)
     let c := guardedSet c (prevSize + h) pos
     let c := guardedSet c (pos &&& 0x7FFF) head
+    let seed := h3Seed useH3 data h3tab windowSize pos hlt
+    let h3tab := if useH3 then guardedSet h3tab (hash3Single data pos hlt) pos else h3tab
     let maxLen := min 258 (data.size - pos)
     have hmaxLenP : pos + maxLen ≤ data.size := by omega
-    let r := chainWalkGuardedPackedU data c windowSize pos maxLen niceLen hmaxLenP head maxChain 0 0
+    let r := chainWalkGuardedPackedU data c windowSize pos maxLen niceLen hmaxLenP head maxChain (seed % 512) (seed / 512)
     let matchLen := r % 512
     let matchPos := r / 512
     if hge : matchLen ≥ 3 then
@@ -1938,35 +2001,39 @@ def lz77LazyMergedLoop (data : ByteArray)
               if hle2 : pos + 1 + matchLen2 ≤ data.size then
                 have : data.size - (pos + 1 + matchLen2) < data.size - pos := by omega
                 let c := updateHashesMergedGuarded data hashSize prevSize c pos 1 (matchLen2 + 1) insertCap
-                lz77LazyMergedLoop data windowSize hashSize prevSize maxChain insertCap goodMatch niceLen lazyDepth c (pos + 1 + matchLen2)
+                let h3tab := if useH3 then updateHash3 data h3tab pos 1 (matchLen2 + 1) insertCap else h3tab
+                lz77LazyMergedLoop data windowSize hashSize prevSize maxChain insertCap goodMatch niceLen lazyDepth useH3 c h3tab (pos + 1 + matchLen2)
                   (acc.push (packTok (.literal (data[pos]'(by omega)))) |>.push
                     (packTok (.reference matchLen2 (pos + 1 - matchPos2))))
               else
                 have : data.size - (pos + matchLen) < data.size - pos := by omega
                 let c := updateHashesMergedGuarded data hashSize prevSize c pos 1 matchLen insertCap
-                lz77LazyMergedLoop data windowSize hashSize prevSize maxChain insertCap goodMatch niceLen lazyDepth c (pos + matchLen)
+                let h3tab := if useH3 then updateHash3 data h3tab pos 1 matchLen insertCap else h3tab
+                lz77LazyMergedLoop data windowSize hashSize prevSize maxChain insertCap goodMatch niceLen lazyDepth useH3 c h3tab (pos + matchLen)
                   (acc.push (packTok (.reference matchLen (pos - matchPos))))
             else
               have : data.size - (pos + matchLen) < data.size - pos := by omega
               let c := updateHashesMergedGuarded data hashSize prevSize c pos 1 matchLen insertCap
-              lz77LazyMergedLoop data windowSize hashSize prevSize maxChain insertCap goodMatch niceLen lazyDepth c (pos + matchLen)
+              let h3tab := if useH3 then updateHash3 data h3tab pos 1 matchLen insertCap else h3tab
+              lz77LazyMergedLoop data windowSize hashSize prevSize maxChain insertCap goodMatch niceLen lazyDepth useH3 c h3tab (pos + matchLen)
                 (acc.push (packTok (.reference matchLen (pos - matchPos))))
           else
             have : data.size - (pos + matchLen) < data.size - pos := by omega
             let c := updateHashesMergedGuarded data hashSize prevSize c pos 1 matchLen insertCap
-            lz77LazyMergedLoop data windowSize hashSize prevSize maxChain insertCap goodMatch niceLen lazyDepth c (pos + matchLen)
+            let h3tab := if useH3 then updateHash3 data h3tab pos 1 matchLen insertCap else h3tab
+            lz77LazyMergedLoop data windowSize hashSize prevSize maxChain insertCap goodMatch niceLen lazyDepth useH3 c h3tab (pos + matchLen)
               (acc.push (packTok (.reference matchLen (pos - matchPos))))
         else
           have : data.size - (pos + matchLen) < data.size - pos := by omega
-          lz77LazyMergedLoop data windowSize hashSize prevSize maxChain insertCap goodMatch niceLen lazyDepth c (pos + matchLen)
+          lz77LazyMergedLoop data windowSize hashSize prevSize maxChain insertCap goodMatch niceLen lazyDepth useH3 c h3tab (pos + matchLen)
             (acc.push (packTok (.reference matchLen (pos - matchPos))))
       else
         have : data.size - (pos + 1) < data.size - pos := by omega
-        lz77LazyMergedLoop data windowSize hashSize prevSize maxChain insertCap goodMatch niceLen lazyDepth c (pos + 1)
+        lz77LazyMergedLoop data windowSize hashSize prevSize maxChain insertCap goodMatch niceLen lazyDepth useH3 c h3tab (pos + 1)
           (acc.push (packTok (.literal (data[pos]'(by omega)))))
     else
       have : data.size - (pos + 1) < data.size - pos := by omega
-      lz77LazyMergedLoop data windowSize hashSize prevSize maxChain insertCap goodMatch niceLen lazyDepth c (pos + 1)
+      lz77LazyMergedLoop data windowSize hashSize prevSize maxChain insertCap goodMatch niceLen lazyDepth useH3 c h3tab (pos + 1)
         (acc.push (packTok (.literal (data[pos]'(by omega)))))
   else
     trailingP data pos acc
@@ -1978,15 +2045,15 @@ decreasing_by all_goals omega
     `lz77ChainLazyIterP` (`lz77ChainLazyIterPMerged_eq`). -/
 def lz77ChainLazyIterPMerged (data : ByteArray) (maxChain : Nat) (windowSize : Nat := 32768)
     (insertCap : Nat := 1000000000) (goodMatch : Nat := 259) (niceLen : Nat := 258)
-    (lazyDepth : Nat := maxChain) :
+    (lazyDepth : Nat := maxChain) (useH3 : Bool := false) :
     Array UInt32 :=
   if data.size < 3 then
     trailingP data 0 #[]
   else
     let hashSize := 65536
     let prevSize := min chainWinSize data.size
-    lz77LazyMergedLoop data windowSize hashSize prevSize maxChain insertCap goodMatch niceLen lazyDepth
-      (.replicate (prevSize + hashSize) data.size) 0
+    lz77LazyMergedLoop data windowSize hashSize prevSize maxChain insertCap goodMatch niceLen lazyDepth useH3
+      (.replicate (prevSize + hashSize) data.size) (.replicate 32768 data.size) 0
       (Array.emptyWithCapacity data.size)
 
 /-- Emit LZ77 tokens as fixed Huffman codes into a BitWriter. -/

--- a/Zip/Native/Deflate.lean
+++ b/Zip/Native/Deflate.lean
@@ -1858,6 +1858,38 @@ theorem hash3U_toNat_lt (data : ByteArray) (p hashSize : Nat) (pU hashSizeU : US
   simp only [USize.toNat_mod, hhsU]
   exact Nat.mod_lt _ hhs
 
+/-- `USize`-argument twin of `hash3Single` for the de-boxed insertion loop: the
+    hoisted addressability witness (`hsz` at the wrapper) lets it skip
+    `hash3Single`'s per-call `data.size.toUSize.toNat = data.size` check and take
+    the wide load directly. Same word, same 24-bit mask, same 15-bit bucket
+    (`hash3SingleU_toNat` in `LZ77MergedCorrect` shows the value is exactly
+    `hash3Single`'s). The word computation is deliberately identical to
+    `hash3U`'s load so the two per-insertion hashes share one wide load (CSE). -/
+@[inline] def hash3SingleU (data : ByteArray) (p : Nat) (pU : USize)
+    (hpU : pU.toNat = p) (h : p + 2 < data.size) : USize :=
+  let word :=
+    if h4 : p + 4 ≤ data.size then
+      ByteArray.ugetUInt32LE data pU (by rw [hpU]; omega)
+    else
+      let a := (data[p]'(by omega)).toUInt32
+      let b := (data[p + 1]'(by omega)).toUInt32
+      let c := (data[p + 2]'(by omega)).toUInt32
+      a ||| (b <<< 8) ||| (c <<< 16)
+  ((((word &&& 0xFFFFFF) * 2654435761)) >>> 17).toUSize
+
+/-- The `USize` singleton bucket is always in the 32768-entry table: a
+    `UInt32 >>> 17` has 15 bits. Discharges the `h3tab` write bounds inside the
+    fused insertion loop. -/
+theorem hash3SingleU_toNat_lt (data : ByteArray) (p : Nat) (pU : USize)
+    (hpU : pU.toNat = p) (h : p + 2 < data.size) :
+    (hash3SingleU data p pU hpU h).toNat < 32768 := by
+  unfold hash3SingleU
+  generalize (if h4 : p + 4 ≤ data.size then _ else _ : UInt32) = word
+  rw [UInt32.toNat_toUSize, UInt32.toNat_shiftRight,
+    show ((17 : UInt32).toNat % 32) = 17 from rfl]
+  have := UInt32.toNat_lt ((word &&& 0xFFFFFF) * 2654435761)
+  omega
+
 /-- USize-native de-boxed twin of `updateHashesMergedFast` (the interior-hash
     insertion loop, 13–25% of L4–L8 compress time): the per-insertion index
     bookkeeping — the loop counter `jU`, the data-bound test, the bucket index
@@ -1924,6 +1956,74 @@ decreasing_by
       rw [USize.toNat_add, USize.toNat_one]; exact Nat.mod_eq_of_lt (by omega)
     omega
 
+/-- Fused split-tier insertion walk: `updateHashesMergedFastU` with the
+    hash3-singleton store folded into the same traversal. Each step does the two
+    hash4 writes on the combined array `c` *and* one `h3tab.uset` at the
+    `hash3SingleU` bucket — one loop, one data-bound test, one shared wide load
+    (`hash3U`/`hash3SingleU` read the same word; CSE folds them), instead of the
+    second `updateHash3` traversal with its per-step `guardedSet` bounds checks.
+    The pair is only constructed at the base case (the recursion is a tail
+    call), so no Prod churns per step. Byte-identical state: `.1` is exactly
+    `updateHashesMerged` and `.2` exactly `updateHash3`
+    (`updateHashesMergedH3FastU_eq` in `LZ77MergedCorrect`). -/
+def updateHashesMergedH3FastU (data : ByteArray) (hashSize prevSize pos : Nat)
+    (c h3tab : Array Nat)
+    (hhs : 0 < hashSize) (hph : prevSize + hashSize ≤ c.size)
+    (hpv : min chainWinSize data.size ≤ prevSize) (hh3 : 32768 ≤ h3tab.size)
+    (hsz : data.size < USize.size) (hphlt : prevSize + hashSize < USize.size)
+    (posU prevSizeU hashSizeU rem2U capU : USize)
+    (hposU : posU.toNat = pos) (hpsU : prevSizeU.toNat = prevSize)
+    (hhsU : hashSizeU.toNat = hashSize)
+    (hrem2U : rem2U.toNat = data.size - pos - 2)
+    (jU matchLenU : USize) : Array Nat × Array Nat :=
+  if jU < matchLenU ∧ jU ≤ capU then
+    if hd : jU < rem2U then
+      have hUS : USize.size = 2 ^ System.Platform.numBits := rfl
+      have hjlt : jU.toNat < data.size - pos - 2 := by
+        rw [← hrem2U]; exact USize.lt_iff_toNat_lt.mp hd
+      have hpjU : (posU + jU).toNat = pos + jU.toNat := by
+        rw [USize.toNat_add, hposU]; exact Nat.mod_eq_of_lt (by omega)
+      have hp2 : (posU + jU).toNat + 2 < data.size := by omega
+      let hshU := hash3U data ((posU + jU).toNat) (posU + jU) hashSizeU rfl hp2
+      have hshlt : hshU.toNat < hashSize :=
+        hash3U_toNat_lt data ((posU + jU).toNat) hashSize (posU + jU) hashSizeU rfl hp2 hhsU hhs
+      have hidx : (prevSizeU + hshU).toNat = prevSize + hshU.toNat := by
+        rw [USize.toNat_add, hpsU]; exact Nat.mod_eq_of_lt (by omega)
+      have hb : (prevSizeU + hshU).toNat < c.size := by rw [hidx]; omega
+      let head := c.uget (prevSizeU + hshU) hb
+      have hmaskb : ((posU + jU) &&& 0x7FFF).toNat < c.size := by
+        rw [USize.toNat_and,
+          USize.toNat_ofNat_of_lt (Nat.lt_of_lt_of_le (by decide) USize.le_size)]
+        show ((posU + jU).toNat &&& 0x7FFF) < c.size
+        have h1 := winMask_lt ((posU + jU).toNat)
+        have h2 := Nat.and_le_left (n := (posU + jU).toNat) (m := 0x7FFF)
+        simp only [chainWinSize] at h1 hpv
+        omega
+      let h3U := hash3SingleU data ((posU + jU).toNat) (posU + jU) rfl hp2
+      have hh3b : h3U.toNat < h3tab.size :=
+        Nat.lt_of_lt_of_le (hash3SingleU_toNat_lt data ((posU + jU).toNat) (posU + jU) rfl hp2) hh3
+      updateHashesMergedH3FastU data hashSize prevSize pos
+        ((c.uset (prevSizeU + hshU) ((posU + jU).toNat) hb).uset ((posU + jU) &&& 0x7FFF) head
+          (by rw [Array.size_uset]; exact hmaskb))
+        (h3tab.uset h3U ((posU + jU).toNat) hh3b)
+        hhs (by rw [Array.size_uset, Array.size_uset]; exact hph) hpv
+        (by rw [Array.size_uset]; exact hh3) hsz hphlt
+        posU prevSizeU hashSizeU rem2U capU hposU hpsU hhsU hrem2U (jU + 1) matchLenU
+    else
+      updateHashesMergedH3FastU data hashSize prevSize pos c h3tab hhs hph hpv hh3 hsz hphlt
+        posU prevSizeU hashSizeU rem2U capU hposU hpsU hhsU hrem2U (jU + 1) matchLenU
+  else (c, h3tab)
+termination_by matchLenU.toNat - jU.toNat
+decreasing_by
+  all_goals
+    have hUS : USize.size = 2 ^ System.Platform.numBits := rfl
+    have hc : jU < matchLenU ∧ jU ≤ capU := by assumption
+    have hlt : jU.toNat < matchLenU.toNat := USize.lt_iff_toNat_lt.mp hc.1
+    have hml := USize.toNat_lt_two_pow_numBits matchLenU
+    have hj1 : (jU + 1).toNat = jU.toNat + 1 := by
+      rw [USize.toNat_add, USize.toNat_one]; exact Nat.mod_eq_of_lt (by omega)
+    omega
+
 /-- One runtime `0 < hashSize ∧ prevSize + hashSize ≤ c.size ∧ min chainWinSize
     data.size ≤ prevSize` check guards the whole merged insertion loop, unlocking
     the proven-bounds walk; a second `USize`-faithfulness check (one
@@ -1955,6 +2055,43 @@ decreasing_by
       updateHashesMergedFast data hashSize prevSize c pos j matchLen insertCap hg.1 hg.2.1 hg.2.2
   else
     updateHashesMerged data hashSize prevSize c pos j matchLen insertCap
+
+/-- Split-tier interior insertion: one call updates both the combined chain
+    array and (when `useH3`) the hash3-singleton table, through the fused
+    single-traversal `updateHashesMergedH3FastU` — the production path pays one
+    walk over the interior range instead of two. With `useH3 := false` this is
+    exactly `(updateHashesMergedGuarded …, h3tab)` (the singleton is untouched,
+    no extra work). The `.1`/`.2` are byte-for-byte `updateHashesMerged` and the
+    `useH3`-gated `updateHash3` (`updateHashesMergedH3Guarded_eq` in
+    `LZ77MergedCorrect`), so the fusion cannot change the emitted stream. -/
+@[inline] def updateHashesMergedH3Guarded (useH3 : Bool) (data : ByteArray)
+    (hashSize prevSize : Nat) (c h3tab : Array Nat) (pos j matchLen insertCap : Nat) :
+    Array Nat × Array Nat :=
+  if useH3 then
+    if hg : 0 < hashSize ∧ prevSize + hashSize ≤ c.size ∧
+        min chainWinSize data.size ≤ prevSize ∧ 32768 ≤ h3tab.size then
+      if hu : data.size.toUSize.toNat = data.size ∧
+          (prevSize + hashSize).toUSize.toNat = prevSize + hashSize ∧
+          pos.toUSize.toNat = pos ∧ j.toUSize.toNat = j ∧
+          matchLen.toUSize.toNat = matchLen ∧ insertCap.toUSize.toNat = insertCap then
+        have hsz : data.size < USize.size := by
+          rw [← hu.1]; exact USize.toNat_lt_two_pow_numBits _
+        have hphlt : prevSize + hashSize < USize.size := by
+          rw [← hu.2.1]; exact USize.toNat_lt_two_pow_numBits _
+        updateHashesMergedH3FastU data hashSize prevSize pos c h3tab hg.1 hg.2.1 hg.2.2.1
+          hg.2.2.2 hsz hphlt
+          pos.toUSize prevSize.toUSize hashSize.toUSize (data.size - pos - 2).toUSize
+          insertCap.toUSize hu.2.2.1 (toUSize_toNat_of_lt (by omega))
+          (toUSize_toNat_of_lt (by omega)) (toUSize_toNat_of_lt (by omega))
+          j.toUSize matchLen.toUSize
+      else
+        (updateHashesMergedFast data hashSize prevSize c pos j matchLen insertCap hg.1 hg.2.1 hg.2.2.1,
+         updateHash3 data h3tab pos j matchLen insertCap)
+    else
+      (updateHashesMerged data hashSize prevSize c pos j matchLen insertCap,
+       updateHash3 data h3tab pos j matchLen insertCap)
+  else
+    (updateHashesMergedGuarded data hashSize prevSize c pos j matchLen insertCap, h3tab)
 
 /-- Merged-array twin of `lz77ChainLazyIterP.mainLoop`: identical control flow,
     but the chain state is the single combined array `c` (prev ring at offset 0,
@@ -2000,27 +2137,23 @@ def lz77LazyMergedLoop (data : ByteArray)
             if lazyAcceptCost matchLen (pos - matchPos) matchLen2 (pos + 1 - matchPos2) then
               if hle2 : pos + 1 + matchLen2 ≤ data.size then
                 have : data.size - (pos + 1 + matchLen2) < data.size - pos := by omega
-                let c := updateHashesMergedGuarded data hashSize prevSize c pos 1 (matchLen2 + 1) insertCap
-                let h3tab := if useH3 then updateHash3 data h3tab pos 1 (matchLen2 + 1) insertCap else h3tab
+                let (c, h3tab) := updateHashesMergedH3Guarded useH3 data hashSize prevSize c h3tab pos 1 (matchLen2 + 1) insertCap
                 lz77LazyMergedLoop data windowSize hashSize prevSize maxChain insertCap goodMatch niceLen lazyDepth useH3 c h3tab (pos + 1 + matchLen2)
                   (acc.push (packTok (.literal (data[pos]'(by omega)))) |>.push
                     (packTok (.reference matchLen2 (pos + 1 - matchPos2))))
               else
                 have : data.size - (pos + matchLen) < data.size - pos := by omega
-                let c := updateHashesMergedGuarded data hashSize prevSize c pos 1 matchLen insertCap
-                let h3tab := if useH3 then updateHash3 data h3tab pos 1 matchLen insertCap else h3tab
+                let (c, h3tab) := updateHashesMergedH3Guarded useH3 data hashSize prevSize c h3tab pos 1 matchLen insertCap
                 lz77LazyMergedLoop data windowSize hashSize prevSize maxChain insertCap goodMatch niceLen lazyDepth useH3 c h3tab (pos + matchLen)
                   (acc.push (packTok (.reference matchLen (pos - matchPos))))
             else
               have : data.size - (pos + matchLen) < data.size - pos := by omega
-              let c := updateHashesMergedGuarded data hashSize prevSize c pos 1 matchLen insertCap
-              let h3tab := if useH3 then updateHash3 data h3tab pos 1 matchLen insertCap else h3tab
+              let (c, h3tab) := updateHashesMergedH3Guarded useH3 data hashSize prevSize c h3tab pos 1 matchLen insertCap
               lz77LazyMergedLoop data windowSize hashSize prevSize maxChain insertCap goodMatch niceLen lazyDepth useH3 c h3tab (pos + matchLen)
                 (acc.push (packTok (.reference matchLen (pos - matchPos))))
           else
             have : data.size - (pos + matchLen) < data.size - pos := by omega
-            let c := updateHashesMergedGuarded data hashSize prevSize c pos 1 matchLen insertCap
-            let h3tab := if useH3 then updateHash3 data h3tab pos 1 matchLen insertCap else h3tab
+            let (c, h3tab) := updateHashesMergedH3Guarded useH3 data hashSize prevSize c h3tab pos 1 matchLen insertCap
             lz77LazyMergedLoop data windowSize hashSize prevSize maxChain insertCap goodMatch niceLen lazyDepth useH3 c h3tab (pos + matchLen)
               (acc.push (packTok (.reference matchLen (pos - matchPos))))
         else

--- a/Zip/Native/DeflateDynamic.lean
+++ b/Zip/Native/DeflateDynamic.lean
@@ -673,15 +673,26 @@ def niceLen (level : UInt8) : Nat :=
 def lazyDepth (level : UInt8) : Nat :=
   chainDepth level / 2
 
+/-- Enable the hash3 length-3 singleton at the split tier (levels 6–8). Our
+    lazy matcher walks hash4-keyed chains only, so length-3 matches are invisible
+    below L9; on the barely-compressible Silesia binaries (x-ray/sao/ooffice)
+    this is our whole weighted-ratio deficit to miniz_oxide L6. The singleton
+    probe (`h3Seed`, TOO_FAR-capped) restores them at −0.28pp corpus-weighted
+    Silesia ratio for ≤~5% matcher speed. L1–L5 keep the probe-free loops (the
+    #2742 verdict against probing the fast band stands); L9/L10 already carry
+    their own singleton in the cache build. -/
+def useH3Level (level : UInt8) : Bool := decide (6 ≤ level ∧ level ≤ 8)
+
 /-- The per-level LZ77 matcher (zlib-faithful): levels 1–3 (`deflate_fast`) use the
     greedy hash-chain matcher; levels ≥ 4 (`deflate_slow`) use the one-byte-lookahead
     lazy variant, which improves ratio at equal window/chain depth. Both share the
     same `(chainDepth, insertCap, niceLen)` ladder and satisfy the same encoder
     contracts (`lzMatch_{encodable,empty,resolves}` in `DeflateBlockSplit`), so the
     choice is transparent to the roundtrip proof. The lazy tier probes its `pos+1`
-    lookahead at `lazyDepth` (half-depth), a heuristic knob invisible to the proof. -/
+    lookahead at `lazyDepth` (half-depth), a heuristic knob invisible to the proof.
+    Levels 6–8 additionally enable the hash3 length-3 singleton (`useH3Level`). -/
 def lzMatch (data : ByteArray) (level : UInt8) : Array LZ77Token :=
-  if 4 ≤ level then lz77ChainLazyIter data (chainDepth level) 32768 (insertCap level) (goodMatch level) (niceLen level) (lazyDepth level)
+  if 4 ≤ level then lz77ChainLazyIter data (chainDepth level) 32768 (insertCap level) (goodMatch level) (niceLen level) (lazyDepth level) (useH3Level level)
   else lz77ChainIter data (chainDepth level) 32768 (insertCap level) (niceLen level)
 
 /-- Packed-token form of `lzMatch` (Wave 3b stage A): the same per-level
@@ -690,7 +701,7 @@ def lzMatch (data : ByteArray) (level : UInt8) : Array LZ77Token :=
     `lzMatch` exactly (`lzMatchP_map` in `Zip/Spec/LZ77PackedCorrect.lean`);
     downstream consumers still run on `lzMatch` — stage B moves them here. -/
 def lzMatchP (data : ByteArray) (level : UInt8) : Array UInt32 :=
-  if 4 ≤ level then lz77ChainLazyIterPMerged data (chainDepth level) 32768 (insertCap level) (goodMatch level) (niceLen level) (lazyDepth level)
+  if 4 ≤ level then lz77ChainLazyIterPMerged data (chainDepth level) 32768 (insertCap level) (goodMatch level) (niceLen level) (lazyDepth level) (useH3Level level)
   else lz77ChainIterP data (chainDepth level) 32768 (insertCap level) (niceLen level)
 
 /-! ## Self-contained block-split dynamic compression

--- a/Zip/Spec/DeflateBlockSplit.lean
+++ b/Zip/Spec/DeflateBlockSplit.lean
@@ -34,7 +34,7 @@ theorem lzMatch_encodable (data : ByteArray) (level : UInt8) :
       | .reference len dist => 3 ≤ len ∧ len ≤ 258 ∧ 1 ≤ dist ∧ dist ≤ 32768 := by
   unfold lzMatch
   split
-  · exact lz77ChainLazyIter_encodable data (chainDepth level) 32768 (insertCap level) (goodMatch level) (niceLen level) (lazyDepth level)
+  · exact lz77ChainLazyIter_encodable data (chainDepth level) 32768 (insertCap level) (goodMatch level) (niceLen level) (lazyDepth level) (useH3Level level)
       (by omega) (by omega)
   · exact lz77ChainIter_encodable data (chainDepth level) 32768 (insertCap level) (niceLen level)
       (by omega) (by omega)
@@ -43,7 +43,7 @@ theorem lzMatch_empty (data : ByteArray) (level : UInt8) (hz : data.size = 0) :
     lzMatch data level = #[] := by
   unfold lzMatch
   split
-  · exact lz77ChainLazyIter_empty data (chainDepth level) 32768 (insertCap level) (goodMatch level) (niceLen level) (lazyDepth level) hz
+  · exact lz77ChainLazyIter_empty data (chainDepth level) 32768 (insertCap level) (goodMatch level) (niceLen level) (lazyDepth level) (useH3Level level) hz
   · exact lz77ChainIter_empty data (chainDepth level) 32768 (insertCap level) (niceLen level) hz
 
 theorem lzMatch_resolves (data : ByteArray) (level : UInt8) :
@@ -51,7 +51,7 @@ theorem lzMatch_resolves (data : ByteArray) (level : UInt8) :
       some data.data.toList := by
   unfold lzMatch
   split
-  · exact lz77ChainLazyIter_resolves data (chainDepth level) 32768 (insertCap level) (goodMatch level) (niceLen level) (lazyDepth level) (by omega)
+  · exact lz77ChainLazyIter_resolves data (chainDepth level) 32768 (insertCap level) (goodMatch level) (niceLen level) (lazyDepth level) (useH3Level level) (by omega)
   · exact lz77ChainIter_resolves data (chainDepth level) 32768 (insertCap level) (niceLen level) (by omega)
 
 set_option maxHeartbeats 800000 in

--- a/Zip/Spec/LZ77ChainCorrect.lean
+++ b/Zip/Spec/LZ77ChainCorrect.lean
@@ -47,6 +47,67 @@ theorem chainWalk_spec (data : ByteArray) (prev : Array Nat)
         · exact ih (prev[cand &&& 0x7FFF]!) _ _ hb
     · exact hb
 
+/-- The hash3-singleton probe's decoded seed is a real in-window match (or
+    empty): exactly the initial-accumulator hypothesis `chainWalk_spec` takes at
+    `bestLen := seed % 512`, `bestPos := seed / 512`. `probeWin ≤ windowSize`
+    (the TOO_FAR cap) so an in-`probeWin` candidate is a fortiori in-`windowSize`;
+    the two byte compares plus the `cand3 < pos` guard establish the length-3
+    prefix match. The `h3tab` contents are opaque — only `cand3`'s bytes and the
+    window matter, both re-verified here. -/
+theorem hash3Probe_spec (data : ByteArray) (probeWin windowSize pos cand3 : Nat)
+    (hlt : pos + 2 < data.size) (maxLen : Nat) (hml : 3 ≤ maxLen)
+    (hpm : pos + maxLen ≤ data.size) (hpw : probeWin ≤ windowSize) :
+    hash3Probe data probeWin pos cand3 hlt % 512 = 0 ∨
+      (hash3Probe data probeWin pos cand3 hlt / 512 < pos ∧
+        pos - hash3Probe data probeWin pos cand3 hlt / 512 ≤ windowSize ∧
+        hash3Probe data probeWin pos cand3 hlt / 512 + maxLen ≤ data.size ∧
+        (∀ i, i < hash3Probe data probeWin pos cand3 hlt % 512 →
+          data[pos + i]! = data[hash3Probe data probeWin pos cand3 hlt / 512 + i]!) ∧
+        hash3Probe data probeWin pos cand3 hlt % 512 ≤ maxLen) := by
+  unfold hash3Probe
+  split
+  · rename_i hc
+    split
+    · rename_i hbytes
+      simp only [Bool.and_eq_true, beq_iff_eq] at hbytes
+      have hm : (cand3 * 512 + 3) % 512 = 3 := by omega
+      have hd : (cand3 * 512 + 3) / 512 = cand3 := by omega
+      rw [hm, hd]
+      refine Or.inr ⟨hc.1, by omega, by omega, ?_, by omega⟩
+      intro i hi
+      have h3i : i = 0 ∨ i = 1 ∨ i = 2 := by omega
+      obtain rfl | rfl | rfl := h3i
+      · rw [getElem!_pos data (pos + 0) (by omega), getElem!_pos data (cand3 + 0) (by omega)]
+        simpa using hbytes.1.1.symm
+      · rw [getElem!_pos data (pos + 1) (by omega), getElem!_pos data (cand3 + 1) (by omega)]
+        exact hbytes.1.2.symm
+      · rw [getElem!_pos data (pos + 2) (by omega), getElem!_pos data (cand3 + 2) (by omega)]
+        exact hbytes.2.symm
+    · exact Or.inl rfl
+  · exact Or.inl rfl
+
+/-- The gated split-tier seed `h3Seed` is a real in-window match (or empty): the
+    `useH3 := false` seed is `0` (empty), and the `useH3 := true` seed is the
+    hash3 probe result, covered by `hash3Probe_spec` under the TOO_FAR cap
+    `min windowSize tooFar3 ≤ windowSize`. This is the sole hypothesis the seeded
+    chain walk needs to return-and-emit the length-3 candidate as a valid
+    reference (`chainWalk_spec` at `bestLen := seed % 512`). -/
+theorem h3Seed_spec (useH3 : Bool) (data : ByteArray) (h3tab : Array Nat)
+    (windowSize pos : Nat) (hlt : pos + 2 < data.size) (maxLen : Nat) (hml : 3 ≤ maxLen)
+    (hpm : pos + maxLen ≤ data.size) :
+    h3Seed useH3 data h3tab windowSize pos hlt % 512 = 0 ∨
+      (h3Seed useH3 data h3tab windowSize pos hlt / 512 < pos ∧
+        pos - h3Seed useH3 data h3tab windowSize pos hlt / 512 ≤ windowSize ∧
+        h3Seed useH3 data h3tab windowSize pos hlt / 512 + maxLen ≤ data.size ∧
+        (∀ i, i < h3Seed useH3 data h3tab windowSize pos hlt % 512 →
+          data[pos + i]! = data[h3Seed useH3 data h3tab windowSize pos hlt / 512 + i]!) ∧
+        h3Seed useH3 data h3tab windowSize pos hlt % 512 ≤ maxLen) := by
+  unfold h3Seed
+  split
+  · exact hash3Probe_spec data (min windowSize tooFar3) windowSize pos
+      (headProbeGuarded h3tab (hash3Single data pos hlt)) hlt maxLen hml hpm (Nat.min_le_left _ _)
+  · exact Or.inl rfl
+
 /-! ## Seeding the chain walk's best length (zlib `prev_length` probe seed)
 
 The lazy lookahead probe at `pos+1` starts its chain walk with the current
@@ -592,6 +653,56 @@ theorem chainWalkGuardedPacked_div (data : ByteArray) (prev : Array Nat)
 /-- Every matcher call site clamps `maxLen` to `min 258 _`; this discharges
     the `maxLen ≤ 511` side condition when `simp` applies the decode lemmas. -/
 theorem min258_le_511 (x : Nat) : min 258 x ≤ 511 := by omega
+
+/-- Seed-general form of `chainWalk_fst_le`: the walk result never exceeds
+    `maxLen` provided the *initial* best length does (candidate matches are
+    `countMatch`-bounded by `maxLen`, and a seed already `≤ maxLen` cannot push
+    it over). Needed so the split tier's non-zero hash3 seed still decodes with
+    the mod/div lemmas below. -/
+theorem chainWalk_fst_le' (data : ByteArray) (prev : Array Nat)
+    (windowSize pos maxLen niceLen : Nat) (hpm : pos + maxLen ≤ data.size)
+    (cand fuel bestLen bestPos : Nat) (hbl : bestLen ≤ maxLen) :
+    (lz77Chain.chainWalk data prev windowSize pos maxLen niceLen hpm cand fuel bestLen bestPos).1 ≤ maxLen := by
+  induction fuel generalizing cand bestLen bestPos hbl with
+  | zero => rw [lz77Chain.chainWalk]; exact hbl
+  | succ k ih =>
+    rw [lz77Chain.chainWalk, if_neg (by omega : ¬ (k + 1 = 0))]
+    split
+    · rename_i hc
+      have hcand : cand + maxLen ≤ data.size := by omega
+      have hcm := (lz77Greedy.countMatch_matches data cand pos maxLen hcand hpm).2
+      by_cases hml : lz77Greedy.countMatch data cand pos maxLen hcand hpm > bestLen
+      · simp only [hml, ↓reduceIte]
+        split
+        · exact hcm
+        · exact ih _ _ _ hcm
+      · simp only [hml, ↓reduceIte]
+        split
+        · exact hbl
+        · exact ih _ _ _ hbl
+    · exact hbl
+
+/-- Seed-general `chainWalkGuardedPacked_mod`: decode the low bits for *any*
+    initial best length `≤ maxLen` (not just the `0 0` seed). -/
+theorem chainWalkGuardedPacked_mod' (data : ByteArray) (prev : Array Nat)
+    (windowSize pos maxLen niceLen : Nat) (hpm : pos + maxLen ≤ data.size) (cand fuel bestLen bestPos : Nat)
+    (hml : maxLen ≤ 511) (hbl : bestLen ≤ maxLen) :
+    chainWalkGuardedPacked data prev windowSize pos maxLen niceLen hpm cand fuel bestLen bestPos % 512 =
+      (lz77Chain.chainWalk data prev windowSize pos maxLen niceLen hpm cand fuel bestLen bestPos).1 := by
+  rw [chainWalkGuardedPacked_eq]
+  have h := chainWalk_fst_le' data prev windowSize pos maxLen niceLen hpm cand fuel bestLen bestPos hbl
+  omega
+
+/-- Seed-general `chainWalkGuardedPacked_div`: decode the high bits for *any*
+    initial best length `≤ maxLen`. -/
+theorem chainWalkGuardedPacked_div' (data : ByteArray) (prev : Array Nat)
+    (windowSize pos maxLen niceLen : Nat) (hpm : pos + maxLen ≤ data.size) (cand fuel bestLen bestPos : Nat)
+    (hml : maxLen ≤ 511) (hbl : bestLen ≤ maxLen) :
+    chainWalkGuardedPacked data prev windowSize pos maxLen niceLen hpm cand fuel bestLen bestPos / 512 =
+      (lz77Chain.chainWalk data prev windowSize pos maxLen niceLen hpm cand fuel bestLen bestPos).2 := by
+  rw [chainWalkGuardedPacked_eq]
+  have h := chainWalk_fst_le' data prev windowSize pos maxLen niceLen hpm cand fuel bestLen bestPos hbl
+  omega
 
 /-- Seeding lemma transported to the packed `USize` walk the matcher calls
     (`chainWalkGuardedPackedU`): for a seed `m` below the walk's cutoff, the

--- a/Zip/Spec/LZ77ChainLazyCorrect.lean
+++ b/Zip/Spec/LZ77ChainLazyCorrect.lean
@@ -24,10 +24,10 @@ set_option backward.split false in
 /-- `lz77ChainLazy.mainLoop` produces a valid decomposition from `pos`. The
     reference cases use `chainWalk_spec` (at `pos`, and again at `pos+1` for the
     lookahead) exactly as `lz77Chain_mainLoop_valid` does for the single match. -/
-theorem lz77ChainLazy_mainLoop_valid (data : ByteArray) (windowSize hashSize maxChain : Nat)
-    (hashTable : Array Nat) (prev : Array Nat) (pos insertCap goodMatch niceLen lazyDepth : Nat) (hw : windowSize > 0) :
+theorem lz77ChainLazy_mainLoop_valid (data : ByteArray) (windowSize hashSize maxChain : Nat) (useH3 : Bool)
+    (hashTable : Array Nat) (prev h3tab : Array Nat) (pos insertCap goodMatch niceLen lazyDepth : Nat) (hw : windowSize > 0) :
     ValidDecomp data pos
-      (lz77ChainLazy.mainLoop data windowSize hashSize maxChain hashTable prev pos insertCap goodMatch niceLen lazyDepth) := by
+      (lz77ChainLazy.mainLoop data windowSize hashSize maxChain useH3 hashTable prev h3tab pos insertCap goodMatch niceLen lazyDepth) := by
   unfold lz77ChainLazy.mainLoop
   split
   · rename_i hlt
@@ -36,7 +36,10 @@ theorem lz77ChainLazy_mainLoop_valid (data : ByteArray) (windowSize hashSize max
     have hspec := chainWalk_spec data
       (prev.set! (pos &&& 0x7FFF) hashTable[lz77Greedy.hash3 data pos hashSize hlt]!)
       windowSize pos (min 258 (data.size - pos)) niceLen (by omega)
-      hashTable[lz77Greedy.hash3 data pos hashSize hlt]! maxChain 0 0 (Or.inl rfl)
+      hashTable[lz77Greedy.hash3 data pos hashSize hlt]! maxChain
+      (h3Seed useH3 data h3tab windowSize pos hlt % 512)
+      (h3Seed useH3 data h3tab windowSize pos hlt / 512)
+      (h3Seed_spec useH3 data h3tab windowSize pos hlt (min 258 (data.size - pos)) (by omega) (by omega))
     split
     · rename_i hge
       split
@@ -63,38 +66,38 @@ theorem lz77ChainLazy_mainLoop_valid (data : ByteArray) (windowSize hashSize max
                   · exact .literal (by omega) (getElem!_pos data pos (by omega))
                       (lazyRef_at_pos data (pos + 1) _ _ hQ2.1 (by omega) hle2
                         (fun i hi => hQ2.2.2.2.1 i hi)
-                        (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ _ _ _ hw))
+                        (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ _ _ _ _ _ hw))
                 · exact lazyRef_at_pos data pos _ _ hQ.1 hge hle (fun i hi => hQ.2.2.2.1 i hi)
-                    (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ _ _ _ hw)
+                    (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ _ _ _ _ _ hw)
               · exact lazyRef_at_pos data pos _ _ hQ.1 hge hle (fun i hi => hQ.2.2.2.1 i hi)
-                  (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ _ _ _ hw)
+                  (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ _ _ _ _ _ hw)
             · exact lazyRef_at_pos data pos _ _ hQ.1 hge hle (fun i hi => hQ.2.2.2.1 i hi)
-                (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ _ _ _ hw)
+                (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ _ _ _ _ _ hw)
           · exact lazyRef_at_pos data pos _ _ hQ.1 hge hle (fun i hi => hQ.2.2.2.1 i hi)
-              (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ _ _ _ hw)
+              (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ _ _ _ _ _ hw)
       · exact .literal (by omega) (getElem!_pos data pos (by omega))
-          (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ _ _ _ hw)
+          (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ _ _ _ _ _ hw)
     · exact .literal (by omega) (getElem!_pos data pos (by omega))
-        (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ _ _ _ hw)
+        (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ _ _ _ _ _ hw)
   · exact trailing_valid data pos
 termination_by data.size - pos
 decreasing_by all_goals omega
 
 /-- `lz77ChainLazy` produces a valid decomposition of the input data. -/
-theorem lz77ChainLazy_valid (data : ByteArray) (maxChain windowSize insertCap goodMatch niceLen lazyDepth : Nat)
+theorem lz77ChainLazy_valid (data : ByteArray) (maxChain windowSize insertCap goodMatch niceLen lazyDepth : Nat) (useH3 : Bool)
     (hw : windowSize > 0) :
-    ValidDecomp data 0 (lz77ChainLazy data maxChain windowSize insertCap goodMatch niceLen lazyDepth).toList := by
+    ValidDecomp data 0 (lz77ChainLazy data maxChain windowSize insertCap goodMatch niceLen lazyDepth useH3).toList := by
   simp only [lz77ChainLazy]
   split
   · simp only; exact trailing_valid data 0
-  · simp only; exact lz77ChainLazy_mainLoop_valid data windowSize 65536 maxChain _ _ 0 insertCap goodMatch niceLen lazyDepth hw
+  · simp only; exact lz77ChainLazy_mainLoop_valid data windowSize 65536 maxChain useH3 _ _ _ 0 insertCap goodMatch niceLen lazyDepth hw
 
 /-- Resolving the LZ77 tokens produced by `lz77ChainLazy` recovers the original data. -/
-theorem lz77ChainLazy_resolves (data : ByteArray) (maxChain windowSize insertCap goodMatch niceLen lazyDepth : Nat)
+theorem lz77ChainLazy_resolves (data : ByteArray) (maxChain windowSize insertCap goodMatch niceLen lazyDepth : Nat) (useH3 : Bool)
     (hw : windowSize > 0) :
-    Deflate.Spec.resolveLZ77 (tokensToSymbols (lz77ChainLazy data maxChain windowSize insertCap goodMatch niceLen lazyDepth)) [] =
+    Deflate.Spec.resolveLZ77 (tokensToSymbols (lz77ChainLazy data maxChain windowSize insertCap goodMatch niceLen lazyDepth useH3)) [] =
       some data.data.toList :=
-  validDecomp_resolves data _ (lz77ChainLazy_valid data maxChain windowSize insertCap goodMatch niceLen lazyDepth hw)
+  validDecomp_resolves data _ (lz77ChainLazy_valid data maxChain windowSize insertCap goodMatch niceLen lazyDepth useH3 hw)
 
 /-! ## Encodability -/
 
@@ -105,9 +108,9 @@ private def Enc (t : LZ77Token) : Prop :=
   | .reference len dist => 3 ≤ len ∧ len ≤ 258 ∧ 1 ≤ dist ∧ dist ≤ 32768
 
 set_option backward.split false in
-theorem lz77ChainLazy_mainLoop_encodable (data : ByteArray) (windowSize hashSize maxChain : Nat)
-    (hashTable : Array Nat) (prev : Array Nat) (pos insertCap goodMatch niceLen lazyDepth : Nat) (hw : windowSize > 0) (hws : windowSize ≤ 32768) :
-    ∀ t ∈ lz77ChainLazy.mainLoop data windowSize hashSize maxChain hashTable prev pos insertCap goodMatch niceLen lazyDepth, Enc t := by
+theorem lz77ChainLazy_mainLoop_encodable (data : ByteArray) (windowSize hashSize maxChain : Nat) (useH3 : Bool)
+    (hashTable : Array Nat) (prev h3tab : Array Nat) (pos insertCap goodMatch niceLen lazyDepth : Nat) (hw : windowSize > 0) (hws : windowSize ≤ 32768) :
+    ∀ t ∈ lz77ChainLazy.mainLoop data windowSize hashSize maxChain useH3 hashTable prev h3tab pos insertCap goodMatch niceLen lazyDepth, Enc t := by
   unfold lz77ChainLazy.mainLoop
   split
   · rename_i hlt
@@ -116,7 +119,10 @@ theorem lz77ChainLazy_mainLoop_encodable (data : ByteArray) (windowSize hashSize
     have hspec := chainWalk_spec data
       (prev.set! (pos &&& 0x7FFF) hashTable[lz77Greedy.hash3 data pos hashSize hlt]!)
       windowSize pos (min 258 (data.size - pos)) niceLen (by omega)
-      hashTable[lz77Greedy.hash3 data pos hashSize hlt]! maxChain 0 0 (Or.inl rfl)
+      hashTable[lz77Greedy.hash3 data pos hashSize hlt]! maxChain
+      (h3Seed useH3 data h3tab windowSize pos hlt % 512)
+      (h3Seed useH3 data h3tab windowSize pos hlt / 512)
+      (h3Seed_spec useH3 data h3tab windowSize pos hlt (min 258 (data.size - pos)) (by omega) (by omega))
     split
     · rename_i hge
       split
@@ -146,40 +152,40 @@ theorem lz77ChainLazy_mainLoop_encodable (data : ByteArray) (windowSize hashSize
                     | tail _ h =>
                       cases h with
                       | head => exact ⟨by omega, by omega, by omega, by omega⟩
-                      | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ _ _ _ hw hws t h
+                      | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ _ _ _ _ _ hw hws t h
                 · intro t ht
                   cases ht with
                   | head => exact ⟨hge, by omega, by omega, by omega⟩
-                  | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ _ _ _ hw hws t h
+                  | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ _ _ _ _ _ hw hws t h
               · intro t ht
                 cases ht with
                 | head => exact ⟨hge, by omega, by omega, by omega⟩
-                | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ _ _ _ hw hws t h
+                | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ _ _ _ _ _ hw hws t h
             · intro t ht
               cases ht with
               | head => exact ⟨hge, by omega, by omega, by omega⟩
-              | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ _ _ _ hw hws t h
+              | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ _ _ _ _ _ hw hws t h
           · intro t ht
             cases ht with
             | head => exact ⟨hge, by omega, by omega, by omega⟩
-            | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ _ _ _ hw hws t h
+            | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ _ _ _ _ _ hw hws t h
       · intro t ht
         cases ht with
         | head => trivial
-        | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ _ _ _ hw hws t h
+        | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ _ _ _ _ _ hw hws t h
     · intro t ht
       cases ht with
       | head => trivial
-      | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ _ _ _ hw hws t h
+      | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ _ _ _ _ _ hw hws t h
   · intro t ht
     exact trailing_encodable data pos t ht
 termination_by data.size - pos
 decreasing_by all_goals omega
 
 /-- Every token `lz77ChainLazy` emits satisfies the encoder bounds. -/
-theorem lz77ChainLazy_encodable (data : ByteArray) (maxChain windowSize insertCap goodMatch niceLen lazyDepth : Nat)
+theorem lz77ChainLazy_encodable (data : ByteArray) (maxChain windowSize insertCap goodMatch niceLen lazyDepth : Nat) (useH3 : Bool)
     (hw : windowSize > 0) (hws : windowSize ≤ 32768) :
-    ∀ t ∈ (lz77ChainLazy data maxChain windowSize insertCap goodMatch niceLen lazyDepth).toList,
+    ∀ t ∈ (lz77ChainLazy data maxChain windowSize insertCap goodMatch niceLen lazyDepth useH3).toList,
       match t with
       | .literal _ => True
       | .reference len dist => 3 ≤ len ∧ len ≤ 258 ∧ 1 ≤ dist ∧ dist ≤ 32768 := by
@@ -188,24 +194,42 @@ theorem lz77ChainLazy_encodable (data : ByteArray) (maxChain windowSize insertCa
   · intro t ht
     exact trailing_encodable data 0 t ht
   · intro t ht
-    exact lz77ChainLazy_mainLoop_encodable data windowSize 65536 maxChain _ _ 0 insertCap goodMatch niceLen lazyDepth hw hws t ht
+    exact lz77ChainLazy_mainLoop_encodable data windowSize 65536 maxChain useH3 _ _ _ 0 insertCap goodMatch niceLen lazyDepth hw hws t ht
 
 /-! ## Iterative version: equivalence + transferred contracts -/
 
+set_option maxRecDepth 4000 in
+set_option maxHeartbeats 1000000 in
 /-- The iterative lazy chain `mainLoop` is the accumulator form of the recursive
     one — identical branch structure, push vs. cons at each emission (two pushes in
     the lookahead arm). -/
-private theorem mainLoop_eq_chainLazy (data : ByteArray) (windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth : Nat)
-    (hashTable : Array Nat) (prev : Array Nat) (pos : Nat) (acc : Array LZ77Token) :
-    lz77ChainLazyIter.mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth hashTable prev pos acc =
-    acc ++ (lz77ChainLazy.mainLoop data windowSize hashSize maxChain hashTable prev pos insertCap goodMatch niceLen lazyDepth).toArray := by
-  induction h : data.size - pos using Nat.strongRecOn generalizing pos acc hashTable prev with
+private theorem mainLoop_eq_chainLazy (data : ByteArray) (windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth : Nat) (useH3 : Bool)
+    (hashTable : Array Nat) (prev h3tab : Array Nat) (pos : Nat) (acc : Array LZ77Token) :
+    lz77ChainLazyIter.mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth useH3 hashTable prev h3tab pos acc =
+    acc ++ (lz77ChainLazy.mainLoop data windowSize hashSize maxChain useH3 hashTable prev h3tab pos insertCap goodMatch niceLen lazyDepth).toArray := by
+  induction h : data.size - pos using Nat.strongRecOn generalizing pos acc hashTable prev h3tab with
   | _ n ih =>
     unfold lz77ChainLazyIter.mainLoop lz77ChainLazy.mainLoop
-    simp only [chainWalkGuardedPacked_mod, chainWalkGuardedPacked_div, min258_le_511,
-      updateHashesGuarded_eq]
     by_cases hlt : pos + 2 < data.size
-    · simp only [hlt, ↓reduceDIte]
+    · -- Reduce the outer `pos+2 < data.size` dite with `zeta := false`, so the
+      -- `let r := chainWalk … seed …` binding is NOT inlined yet — otherwise the
+      -- large opaque `h3Seed`/`hash3Single` terms get duplicated across the whole
+      -- branch tree (via `matchLen`/`matchPos`) and blow up. Abstract those two
+      -- opaque terms to variables first, then the (now cheap) zeta-simp aligns
+      -- the two sides' walk decode through `chainWalkGuardedPacked_mod`/`_div`.
+      simp (config := { zeta := false }) only [hlt, ↓reduceDIte]
+      -- The seed's decoded length is `≤ maxLen` (`h3Seed_spec`); keep that fact
+      -- through the abstraction so the seed-general decode lemmas apply.
+      have hbnd : h3Seed useH3 data h3tab windowSize pos hlt % 512 ≤ min 258 (data.size - pos) := by
+        rcases h3Seed_spec useH3 data h3tab windowSize pos hlt (min 258 (data.size - pos))
+          (by omega) (by omega) with hz | hq
+        · omega
+        · exact hq.2.2.2.2
+      generalize hsd : h3Seed useH3 data h3tab windowSize pos hlt = sd
+      rw [hsd] at hbnd
+      generalize hash3Single data pos hlt = hsg
+      simp only [chainWalkGuardedPacked_mod', chainWalkGuardedPacked_div', min258_le_511,
+        hbnd, Nat.zero_le, updateHashesGuarded_eq]
       -- Branch tree: hge / hle / h3lt / gate (matchLen < goodMatch) / (matchLen2 > matchLen) / hle2
       split
       · -- hge : matchLen ≥ 3
@@ -219,63 +243,63 @@ private theorem mainLoop_eq_chainLazy (data : ByteArray) (windowSize hashSize ma
               · -- matchLen2 > matchLen
                 split
                 · -- hle2 : lookahead emits literal + reference(matchLen2), two pushes
-                  rw [ih _ (by omega) _ _ _ _ rfl,
+                  rw [ih _ (by omega) _ _ _ _ _ rfl,
                     Array.push_eq_append, Array.push_eq_append,
                     Array.append_assoc, Array.append_assoc,
                     ← List.toArray_cons, ← List.toArray_cons]
                 · -- ¬hle2 : reference(matchLen) at pos
-                  rw [ih _ (by omega) _ _ _ _ rfl, List.toArray_cons,
+                  rw [ih _ (by omega) _ _ _ _ _ rfl, List.toArray_cons,
                     ← Array.append_assoc, Array.push_eq_append]
               · -- matchLen2 ≤ matchLen : reference(matchLen) at pos
-                rw [ih _ (by omega) _ _ _ _ rfl, List.toArray_cons,
+                rw [ih _ (by omega) _ _ _ _ _ rfl, List.toArray_cons,
                   ← Array.append_assoc, Array.push_eq_append]
             · -- matchLen ≥ goodMatch (gated) : reference(matchLen) at pos
-              rw [ih _ (by omega) _ _ _ _ rfl, List.toArray_cons,
+              rw [ih _ (by omega) _ _ _ _ _ rfl, List.toArray_cons,
                 ← Array.append_assoc, Array.push_eq_append]
           · -- ¬h3lt : reference(matchLen) at pos (near end)
-            rw [ih _ (by omega) _ _ _ _ rfl, List.toArray_cons,
+            rw [ih _ (by omega) _ _ _ _ _ rfl, List.toArray_cons,
               ← Array.append_assoc, Array.push_eq_append]
         · -- ¬hle : literal
-          rw [ih _ (by omega) _ _ _ _ rfl, List.toArray_cons,
+          rw [ih _ (by omega) _ _ _ _ _ rfl, List.toArray_cons,
             ← Array.append_assoc, Array.push_eq_append]
       · -- ¬hge : literal
-        rw [ih _ (by omega) _ _ _ _ rfl, List.toArray_cons,
+        rw [ih _ (by omega) _ _ _ _ _ rfl, List.toArray_cons,
           ← Array.append_assoc, Array.push_eq_append]
     · simp only [hlt, ↓reduceDIte]
       exact trailing_eq data pos acc
 
 /-- `lz77ChainLazyIter` produces exactly the same tokens as `lz77ChainLazy`. -/
-theorem lz77ChainLazyIter_eq_lz77ChainLazy (data : ByteArray) (maxChain windowSize insertCap goodMatch niceLen lazyDepth : Nat) :
-    lz77ChainLazyIter data maxChain windowSize insertCap goodMatch niceLen lazyDepth =
-      lz77ChainLazy data maxChain windowSize insertCap goodMatch niceLen lazyDepth := by
+theorem lz77ChainLazyIter_eq_lz77ChainLazy (data : ByteArray) (maxChain windowSize insertCap goodMatch niceLen lazyDepth : Nat) (useH3 : Bool) :
+    lz77ChainLazyIter data maxChain windowSize insertCap goodMatch niceLen lazyDepth useH3 =
+      lz77ChainLazy data maxChain windowSize insertCap goodMatch niceLen lazyDepth useH3 := by
   unfold lz77ChainLazyIter lz77ChainLazy
   split
   · rw [trailing_eq]; simp only [List.append_toArray, List.nil_append]
   · rw [mainLoop_eq_chainLazy]; simp only [List.append_toArray, List.nil_append]
 
-theorem lz77ChainLazyIter_valid (data : ByteArray) (maxChain windowSize insertCap goodMatch niceLen lazyDepth : Nat)
+theorem lz77ChainLazyIter_valid (data : ByteArray) (maxChain windowSize insertCap goodMatch niceLen lazyDepth : Nat) (useH3 : Bool)
     (hw : windowSize > 0) :
-    ValidDecomp data 0 (lz77ChainLazyIter data maxChain windowSize insertCap goodMatch niceLen lazyDepth).toList := by
-  rw [lz77ChainLazyIter_eq_lz77ChainLazy]; exact lz77ChainLazy_valid data maxChain windowSize insertCap goodMatch niceLen lazyDepth hw
+    ValidDecomp data 0 (lz77ChainLazyIter data maxChain windowSize insertCap goodMatch niceLen lazyDepth useH3).toList := by
+  rw [lz77ChainLazyIter_eq_lz77ChainLazy]; exact lz77ChainLazy_valid data maxChain windowSize insertCap goodMatch niceLen lazyDepth useH3 hw
 
-theorem lz77ChainLazyIter_resolves (data : ByteArray) (maxChain windowSize insertCap goodMatch niceLen lazyDepth : Nat)
+theorem lz77ChainLazyIter_resolves (data : ByteArray) (maxChain windowSize insertCap goodMatch niceLen lazyDepth : Nat) (useH3 : Bool)
     (hw : windowSize > 0) :
-    Deflate.Spec.resolveLZ77 (tokensToSymbols (lz77ChainLazyIter data maxChain windowSize insertCap goodMatch niceLen lazyDepth)) [] =
+    Deflate.Spec.resolveLZ77 (tokensToSymbols (lz77ChainLazyIter data maxChain windowSize insertCap goodMatch niceLen lazyDepth useH3)) [] =
       some data.data.toList := by
-  rw [lz77ChainLazyIter_eq_lz77ChainLazy]; exact lz77ChainLazy_resolves data maxChain windowSize insertCap goodMatch niceLen lazyDepth hw
+  rw [lz77ChainLazyIter_eq_lz77ChainLazy]; exact lz77ChainLazy_resolves data maxChain windowSize insertCap goodMatch niceLen lazyDepth useH3 hw
 
-theorem lz77ChainLazyIter_encodable (data : ByteArray) (maxChain windowSize insertCap goodMatch niceLen lazyDepth : Nat)
+theorem lz77ChainLazyIter_encodable (data : ByteArray) (maxChain windowSize insertCap goodMatch niceLen lazyDepth : Nat) (useH3 : Bool)
     (hw : windowSize > 0) (hws : windowSize ≤ 32768) :
-    ∀ t ∈ (lz77ChainLazyIter data maxChain windowSize insertCap goodMatch niceLen lazyDepth).toList,
+    ∀ t ∈ (lz77ChainLazyIter data maxChain windowSize insertCap goodMatch niceLen lazyDepth useH3).toList,
       match t with
       | .literal _ => True
       | .reference len dist => 3 ≤ len ∧ len ≤ 258 ∧ 1 ≤ dist ∧ dist ≤ 32768 := by
   rw [lz77ChainLazyIter_eq_lz77ChainLazy]
-  exact lz77ChainLazy_encodable data maxChain windowSize insertCap goodMatch niceLen lazyDepth hw hws
+  exact lz77ChainLazy_encodable data maxChain windowSize insertCap goodMatch niceLen lazyDepth useH3 hw hws
 
 /-- The lazy chain matcher emits no tokens on empty input. -/
-theorem lz77ChainLazyIter_empty (data : ByteArray) (maxChain windowSize insertCap goodMatch niceLen lazyDepth : Nat)
-    (hzero : data.size = 0) : lz77ChainLazyIter data maxChain windowSize insertCap goodMatch niceLen lazyDepth = #[] := by
+theorem lz77ChainLazyIter_empty (data : ByteArray) (maxChain windowSize insertCap goodMatch niceLen lazyDepth : Nat) (useH3 : Bool)
+    (hzero : data.size = 0) : lz77ChainLazyIter data maxChain windowSize insertCap goodMatch niceLen lazyDepth useH3 = #[] := by
   rw [lz77ChainLazyIter_eq_lz77ChainLazy]
   simp only [lz77ChainLazy, show data.size < 3 from by omega, ↓reduceIte]
   have htrail : lz77Greedy.trailing data 0 = [] := by

--- a/Zip/Spec/LZ77MergedCorrect.lean
+++ b/Zip/Spec/LZ77MergedCorrect.lean
@@ -375,16 +375,17 @@ private theorem seeded_probe_bridge (data : ByteArray) (prev : Array Nat)
 
 /-! ## The lockstep loop equality -/
 
+set_option maxHeartbeats 1000000 in
 private theorem mergedLoop_eq (data : ByteArray)
-    (windowSize hashSize prevSize maxChain insertCap goodMatch niceLen lazyDepth : Nat)
-    (hashTable prev : Array Nat) (pos : Nat) (acc : Array UInt32)
+    (windowSize hashSize prevSize maxChain insertCap goodMatch niceLen lazyDepth : Nat) (useH3 : Bool)
+    (hashTable prev h3tab : Array Nat) (pos : Nat) (acc : Array UInt32)
     (hhs : 0 < hashSize) (hht : hashTable.size = hashSize) (hps : prev.size = prevSize)
     (hpv : min chainWinSize data.size ≤ prev.size) :
-    lz77LazyMergedLoop data windowSize hashSize prevSize maxChain insertCap goodMatch niceLen lazyDepth
-        (prev ++ hashTable) pos acc =
-      lz77ChainLazyIterP.mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth
-        hashTable prev pos acc := by
-  induction hn : data.size - pos using Nat.strongRecOn generalizing pos acc hashTable prev hht hps hpv with
+    lz77LazyMergedLoop data windowSize hashSize prevSize maxChain insertCap goodMatch niceLen lazyDepth useH3
+        (prev ++ hashTable) h3tab pos acc =
+      lz77ChainLazyIterP.mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth useH3
+        hashTable prev h3tab pos acc := by
+  induction hn : data.size - pos using Nat.strongRecOn generalizing pos acc hashTable prev h3tab hht hps hpv with
   | _ n ih =>
     unfold lz77LazyMergedLoop lz77ChainLazyIterP.mainLoop
     by_cases hlt : pos + 2 < data.size
@@ -395,7 +396,13 @@ private theorem mergedLoop_eq (data : ByteArray)
         have h1 := winMask_lt pos
         have h2 := Nat.and_le_left (n := pos) (m := 0x7FFF)
         simp only [chainWinSize] at h1 hpv; omega
-      simp only [hlt, ↓reduceDIte, headProbeGuarded_eq, guardedSet_eq,
+      -- Reduce the outer dite with `zeta := false`, then abstract the opaque
+      -- hash3 seed (identical on both sides — it reads the separate `h3tab`) so
+      -- the append/head-insert simp below does not duplicate it across branches.
+      simp (config := { zeta := false }) only [hlt, ↓reduceDIte]
+      generalize hsd : h3Seed useH3 data h3tab windowSize pos hlt = sd
+      generalize hash3Single data pos hlt = hsg
+      simp only [headProbeGuarded_eq, guardedSet_eq,
         getElem!_append_right' prev hashTable prevSize (lz77Greedy.hash3 data pos hashSize hlt) hps hh,
         set!_append_right' prev hashTable prevSize (lz77Greedy.hash3 data pos hashSize hlt) pos hps hh,
         set!_append_left prev (hashTable.set! (lz77Greedy.hash3 data pos hashSize hlt) pos)
@@ -406,7 +413,12 @@ private theorem mergedLoop_eq (data : ByteArray)
       have hps' : p'.size = prevSize := by rw [← hp'eq, Array.size_set!]; exact hps
       have hpv' : min chainWinSize data.size ≤ p'.size := by rw [← hp'eq, Array.size_set!]; exact hpv
       rw [chainWalkGuardedPackedU_append data p' t' windowSize pos (min 258 (data.size - pos))
-        niceLen (by omega) hpv' (hashTable[lz77Greedy.hash3 data pos hashSize hlt]!) maxChain 0 0]
+        niceLen (by omega) hpv' (hashTable[lz77Greedy.hash3 data pos hashSize hlt]!) maxChain (sd % 512) (sd / 512)]
+      -- Abstract the (now identical on both sides) main walk result so `split`'s
+      -- normalisation does not carry its many `matchLen`/`matchPos`/interior-insert
+      -- copies (which the split-tier `updateHash3` range multiplied).
+      generalize chainWalkGuardedPackedU data p' windowSize pos (min 258 (data.size - pos)) niceLen
+        (by omega) (hashTable[lz77Greedy.hash3 data pos hashSize hlt]!) maxChain (sd % 512) (sd / 512) = rmain
       split
       · split
         · split
@@ -427,10 +439,8 @@ private theorem mergedLoop_eq (data : ByteArray)
               have hbr := seeded_probe_bridge data p' windowSize (pos + 1)
                 (min 258 (data.size - (pos + 1))) niceLen (by omega) (by omega)
                 (t'[lz77Greedy.hash3 data (pos + 1) hashSize (by omega)]!) lazyDepth
-                (chainWalkGuardedPackedU data p' windowSize pos (min 258 (data.size - pos)) niceLen
-                  (by omega) (hashTable[lz77Greedy.hash3 data pos hashSize hlt]!) maxChain 0 0 % 512)
-                (pos - chainWalkGuardedPackedU data p' windowSize pos (min 258 (data.size - pos)) niceLen
-                  (by omega) (hashTable[lz77Greedy.hash3 data pos hashSize hlt]!) maxChain 0 0 / 512)
+                (rmain % 512)
+                (pos - rmain / 512)
                 (pos + 1)
               rw [hbr.1]
               split
@@ -442,43 +452,43 @@ private theorem mergedLoop_eq (data : ByteArray)
                   · rw [updateHashesMergedGuarded_eq,
                       updateHashesMerged_append data hashSize prevSize t' p' pos 1 _ insertCap hhs hht' hps' hpv',
                       updateHashesGuarded_eq]
-                    exact ih _ (by omega) _ _ _ _ (by rw [updateHashes_size1]; exact hht')
+                    exact ih _ (by omega) _ _ _ _ _ (by rw [updateHashes_size1]; exact hht')
                       (by rw [updateHashes_size2]; exact hps') (by rw [updateHashes_size2]; exact hpv') rfl
                   · rw [updateHashesMergedGuarded_eq,
                       updateHashesMerged_append data hashSize prevSize t' p' pos 1 _ insertCap hhs hht' hps' hpv',
                       updateHashesGuarded_eq]
-                    exact ih _ (by omega) _ _ _ _ (by rw [updateHashes_size1]; exact hht')
+                    exact ih _ (by omega) _ _ _ _ _ (by rw [updateHashes_size1]; exact hht')
                       (by rw [updateHashes_size2]; exact hps') (by rw [updateHashes_size2]; exact hpv') rfl
                 · rw [← hbr.1, hfalse] at hacc; simp at hacc
               · -- reject: the emitted token uses only the `pos` match, not the probe.
                 rw [updateHashesMergedGuarded_eq,
                   updateHashesMerged_append data hashSize prevSize t' p' pos 1 _ insertCap hhs hht' hps' hpv',
                   updateHashesGuarded_eq]
-                exact ih _ (by omega) _ _ _ _ (by rw [updateHashes_size1]; exact hht')
+                exact ih _ (by omega) _ _ _ _ _ (by rw [updateHashes_size1]; exact hht')
                   (by rw [updateHashes_size2]; exact hps') (by rw [updateHashes_size2]; exact hpv') rfl
             · -- goodMatch-F (gated): no probe.
               rw [updateHashesMergedGuarded_eq,
                 updateHashesMerged_append data hashSize prevSize t' p' pos 1 _ insertCap hhs hht' hps' hpv',
                 updateHashesGuarded_eq]
-              exact ih _ (by omega) _ _ _ _ (by rw [updateHashes_size1]; exact hht')
+              exact ih _ (by omega) _ _ _ _ _ (by rw [updateHashes_size1]; exact hht')
                 (by rw [updateHashes_size2]; exact hps') (by rw [updateHashes_size2]; exact hpv') rfl
-          · exact ih _ (by omega) _ _ _ _ hht' hps' hpv' rfl
-        · exact ih _ (by omega) _ _ _ _ hht' hps' hpv' rfl
-      · exact ih _ (by omega) _ _ _ _ hht' hps' hpv' rfl
+          · exact ih _ (by omega) _ _ _ _ _ hht' hps' hpv' rfl
+        · exact ih _ (by omega) _ _ _ _ _ hht' hps' hpv' rfl
+      · exact ih _ (by omega) _ _ _ _ _ hht' hps' hpv' rfl
     · simp only [hlt, ↓reduceDIte]
 
 /-- The merged-array lazy matcher equals the two-array packed lazy matcher. -/
-theorem lz77ChainLazyIterPMerged_eq (data : ByteArray) (maxChain windowSize insertCap goodMatch niceLen lazyDepth : Nat) :
-    lz77ChainLazyIterPMerged data maxChain windowSize insertCap goodMatch niceLen lazyDepth =
-      lz77ChainLazyIterP data maxChain windowSize insertCap goodMatch niceLen lazyDepth := by
+theorem lz77ChainLazyIterPMerged_eq (data : ByteArray) (maxChain windowSize insertCap goodMatch niceLen lazyDepth : Nat) (useH3 : Bool) :
+    lz77ChainLazyIterPMerged data maxChain windowSize insertCap goodMatch niceLen lazyDepth useH3 =
+      lz77ChainLazyIterP data maxChain windowSize insertCap goodMatch niceLen lazyDepth useH3 := by
   unfold lz77ChainLazyIterPMerged lz77ChainLazyIterP
   split
   · rfl
   · dsimp only
     rw [← Array.replicate_append_replicate]
     exact mergedLoop_eq data windowSize 65536 (min chainWinSize data.size) maxChain insertCap
-      goodMatch niceLen lazyDepth (Array.replicate 65536 data.size)
-      (Array.replicate (min chainWinSize data.size) data.size) 0 _
+      goodMatch niceLen lazyDepth useH3 (Array.replicate 65536 data.size)
+      (Array.replicate (min chainWinSize data.size) data.size) (Array.replicate 32768 data.size) 0 _
       (by omega) (by rw [Array.size_replicate]) (by rw [Array.size_replicate])
       (Nat.le_of_eq (by rw [Array.size_replicate]))
 

--- a/Zip/Spec/LZ77MergedCorrect.lean
+++ b/Zip/Spec/LZ77MergedCorrect.lean
@@ -296,6 +296,100 @@ private theorem updateHashesMergedFastU_eq (data : ByteArray) (hashSize prevSize
         exact ih _ (by omega) _ _ hph _ hj1 rfl
     · rw [if_neg (fun hx => hc (hcond.mp hx)), if_neg hc]
 
+/-- `hash3Single` congruence in the position (the bounds proof transports). -/
+private theorem hash3Single_congr (data : ByteArray) {p q : Nat} (e : p = q)
+    (hp : p + 2 < data.size) (hq : q + 2 < data.size) :
+    hash3Single data p hp = hash3Single data q hq := by
+  subst e; rfl
+
+/-- `hash3SingleU` computes exactly `hash3Single`'s bucket whenever the buffer
+    is `USize`-addressable: the hoisted witness makes `hash3Single`'s per-call
+    addressability check always take the wide-load branch (whose body
+    `hash3SingleU` shares), and the trailing `.toUSize` round-trips (a `UInt32`
+    always fits a `USize`). -/
+private theorem hash3SingleU_toNat (data : ByteArray) (p : Nat) (pU : USize)
+    (hpU : pU.toNat = p) (hsz : data.size < USize.size) (h : p + 2 < data.size) :
+    (hash3SingleU data p pU hpU h).toNat = hash3Single data p h := by
+  have hplt : p < USize.size := by omega
+  have hpUe : pU = p.toUSize := by
+    apply USize.toNat_inj.mp; rw [hpU, toUSize_toNat_of_lt hplt]
+  subst hpUe
+  unfold hash3SingleU hash3Single
+  have tail : ∀ w : UInt32,
+      ((((w &&& 0xFFFFFF) * 2654435761) >>> 17).toUSize).toNat
+        = (((w &&& 0xFFFFFF) * 2654435761) >>> 17).toNat := by
+    intro w; rw [UInt32.toNat_toUSize]
+  by_cases h4 : p + 4 ≤ data.size
+  · rw [dif_pos h4, dif_pos h4, dif_pos (toUSize_toNat_of_lt hsz)]
+    exact tail _
+  · rw [dif_neg h4, dif_neg h4]
+    exact tail _
+
+/-- The fused de-boxed walk computes exactly the pair of reference walks: `.1`
+    is `updateHashesMerged` (the hash4 interior insertion) and `.2` is
+    `updateHash3` (the singleton insertion) — one traversal, byte-identical
+    state. Mirrors `updateHashesMergedFastU_eq` with the `h3tab` component
+    riding along (its store aligned by `hash3SingleU_toNat`). -/
+private theorem updateHashesMergedH3FastU_eq (data : ByteArray) (hashSize prevSize : Nat)
+    (c h3tab : Array Nat) (pos j matchLen insertCap : Nat)
+    (hhs : 0 < hashSize) (hph : prevSize + hashSize ≤ c.size)
+    (hpv : min chainWinSize data.size ≤ prevSize) (hh3 : 32768 ≤ h3tab.size)
+    (hsz : data.size < USize.size) (hphlt : prevSize + hashSize < USize.size)
+    (posU prevSizeU hashSizeU rem2U capU jU matchLenU : USize)
+    (hposU : posU.toNat = pos) (hpsU : prevSizeU.toNat = prevSize)
+    (hhsU : hashSizeU.toNat = hashSize) (hrem2U : rem2U.toNat = data.size - pos - 2)
+    (hcapU : capU.toNat = insertCap) (hjU : jU.toNat = j) (hmlU : matchLenU.toNat = matchLen) :
+    updateHashesMergedH3FastU data hashSize prevSize pos c h3tab hhs hph hpv hh3 hsz hphlt
+        posU prevSizeU hashSizeU rem2U capU hposU hpsU hhsU hrem2U jU matchLenU =
+      (updateHashesMerged data hashSize prevSize c pos j matchLen insertCap,
+       updateHash3 data h3tab pos j matchLen insertCap) := by
+  induction hn : matchLen - j using Nat.strongRecOn generalizing j c h3tab jU hph hh3 hjU with
+  | _ n ih =>
+    rw [updateHashesMergedH3FastU, updateHashesMerged, updateHash3]
+    have hUS : USize.size = 2 ^ System.Platform.numBits := rfl
+    have hcond : (jU < matchLenU ∧ jU ≤ capU) ↔ (j < matchLen ∧ j ≤ insertCap) := by
+      rw [USize.lt_iff_toNat_lt, USize.le_iff_toNat_le, hjU, hmlU, hcapU]
+    by_cases hc : j < matchLen ∧ j ≤ insertCap
+    · rw [if_pos (hcond.mpr hc), if_pos hc, if_pos hc]
+      have hmllt := USize.toNat_lt_two_pow_numBits matchLenU
+      have hj1 : (jU + 1).toNat = j + 1 := by
+        rw [USize.toNat_add, USize.toNat_one, hjU]
+        exact Nat.mod_eq_of_lt (by omega)
+      have hdata : (jU < rem2U) ↔ (pos + j + 2 < data.size) := by
+        rw [USize.lt_iff_toNat_lt, hjU, hrem2U]; omega
+      by_cases hd : pos + j + 2 < data.size
+      · rw [dif_pos (hdata.mpr hd), dif_pos hd, dif_pos hd]
+        have e1 : (posU + jU).toNat = pos + j := by
+          rw [USize.toNat_add, hposU, hjU]; exact Nat.mod_eq_of_lt (by omega)
+        have hb3 : lz77Greedy.hash3 data (pos + j) hashSize hd < hashSize := Nat.mod_lt _ hhs
+        have eidx : ∀ (hx : (posU + jU).toNat + 2 < data.size),
+            (prevSizeU + hash3U data ((posU + jU).toNat) (posU + jU) hashSizeU rfl hx).toNat
+              = prevSize + lz77Greedy.hash3 data (pos + j) hashSize hd := by
+          intro hx
+          rw [USize.toNat_add, hpsU, hash3U_toNat data _ hashSize _ _ rfl hhsU hsz hx,
+            hash3_congr data hashSize e1 hx hd]
+          exact Nat.mod_eq_of_lt (by omega)
+        have emask : ((posU + jU) &&& 0x7FFF).toNat = (pos + j) &&& 0x7FFF := by
+          rw [USize.toNat_and,
+            USize.toNat_ofNat_of_lt (Nat.lt_of_lt_of_le (by decide) USize.le_size), e1]
+        -- The singleton bucket: `USize` hash = the `Nat` hash at the aligned position.
+        have eh3 : ∀ (hx : (posU + jU).toNat + 2 < data.size),
+            (hash3SingleU data ((posU + jU).toNat) (posU + jU) rfl hx).toNat
+              = hash3Single data (pos + j) hd := by
+          intro hx
+          rw [hash3SingleU_toNat data _ _ rfl hsz hx, hash3Single_congr data e1 hx hd]
+        have eget : ∀ (a : Array Nat) (i : Nat) (h : i < a.size), a[i]'h = a[i]! :=
+          fun a i h => (getElem!_pos a i h).symm
+        simp only [Array.uget, Array.uset, set_eq_set!, eget, headProbeGuarded_eq,
+          guardedSet_eq, eidx, emask, eh3]
+        simp only [e1]
+        exact ih _ (by omega) _ _ _
+          (by rw [Array.size_set!, Array.size_set!]; exact hph)
+          (by rw [Array.size_set!]; exact hh3) _ hj1 rfl
+      · rw [dif_neg (fun hx => hd (hdata.mp hx)), dif_neg hd, dif_neg hd]
+        exact ih _ (by omega) _ _ _ hph hh3 _ hj1 rfl
+    · rw [if_neg (fun hx => hc (hcond.mp hx)), if_neg hc, if_neg hc]
+
 /-- The guarded merged walk equals the reference merged walk (the de-boxed
     `USize` branch via `updateHashesMergedFastU_eq`, the proven-bounds `Nat`
     branch via `updateHashesMergedFast_eq`; the fallback branch is definitionally
@@ -321,6 +415,36 @@ private theorem updateHashesMergedGuarded_eq (data : ByteArray) (hashSize prevSi
     · exact updateHashesMergedFast_eq data hashSize prevSize c pos j matchLen insertCap
         hg.1 hg.2.1 hg.2.2
   · rfl
+
+/-- The fused split-tier insertion equals the pair of reference walks the loop
+    previously computed separately: `.1` is `updateHashesMerged`, `.2` the
+    `useH3`-gated `updateHash3` — exactly the two `let`s it replaces, so the
+    lockstep loop proof rewrites through this one equation. -/
+private theorem updateHashesMergedH3Guarded_eq (useH3 : Bool) (data : ByteArray)
+    (hashSize prevSize : Nat) (c h3tab : Array Nat) (pos j matchLen insertCap : Nat) :
+    updateHashesMergedH3Guarded useH3 data hashSize prevSize c h3tab pos j matchLen insertCap =
+      (updateHashesMerged data hashSize prevSize c pos j matchLen insertCap,
+       if useH3 then updateHash3 data h3tab pos j matchLen insertCap else h3tab) := by
+  unfold updateHashesMergedH3Guarded
+  by_cases hu3 : useH3
+  · rw [if_pos hu3, if_pos hu3]
+    split
+    · rename_i hg
+      split
+      · rename_i hu
+        have hsz : data.size < USize.size := by
+          rw [← hu.1]; exact USize.toNat_lt_two_pow_numBits _
+        have hphlt : prevSize + hashSize < USize.size := by
+          rw [← hu.2.1]; exact USize.toNat_lt_two_pow_numBits _
+        exact updateHashesMergedH3FastU_eq data hashSize prevSize c h3tab pos j matchLen insertCap
+          hg.1 hg.2.1 hg.2.2.1 hg.2.2.2 hsz hphlt pos.toUSize prevSize.toUSize hashSize.toUSize
+          (data.size - pos - 2).toUSize insertCap.toUSize j.toUSize matchLen.toUSize
+          hu.2.2.1 (toUSize_toNat_of_lt (by omega)) (toUSize_toNat_of_lt (by omega))
+          (toUSize_toNat_of_lt (by omega)) hu.2.2.2.2.2 hu.2.2.2.1 hu.2.2.2.2.1
+      · rw [updateHashesMergedFast_eq data hashSize prevSize c pos j matchLen insertCap
+          hg.1 hg.2.1 hg.2.2.1]
+    · rfl
+  · rw [if_neg hu3, if_neg hu3, updateHashesMergedGuarded_eq]
 
 /-! ## Seeded lookahead probe: byte-identity bridge -/
 
@@ -449,25 +573,25 @@ private theorem mergedLoop_eq (data : ByteArray)
                 rcases hbr.2 with heq | hfalse
                 · rw [heq]
                   split
-                  · rw [updateHashesMergedGuarded_eq,
+                  · rw [updateHashesMergedH3Guarded_eq,
                       updateHashesMerged_append data hashSize prevSize t' p' pos 1 _ insertCap hhs hht' hps' hpv',
                       updateHashesGuarded_eq]
                     exact ih _ (by omega) _ _ _ _ _ (by rw [updateHashes_size1]; exact hht')
                       (by rw [updateHashes_size2]; exact hps') (by rw [updateHashes_size2]; exact hpv') rfl
-                  · rw [updateHashesMergedGuarded_eq,
+                  · rw [updateHashesMergedH3Guarded_eq,
                       updateHashesMerged_append data hashSize prevSize t' p' pos 1 _ insertCap hhs hht' hps' hpv',
                       updateHashesGuarded_eq]
                     exact ih _ (by omega) _ _ _ _ _ (by rw [updateHashes_size1]; exact hht')
                       (by rw [updateHashes_size2]; exact hps') (by rw [updateHashes_size2]; exact hpv') rfl
                 · rw [← hbr.1, hfalse] at hacc; simp at hacc
               · -- reject: the emitted token uses only the `pos` match, not the probe.
-                rw [updateHashesMergedGuarded_eq,
+                rw [updateHashesMergedH3Guarded_eq,
                   updateHashesMerged_append data hashSize prevSize t' p' pos 1 _ insertCap hhs hht' hps' hpv',
                   updateHashesGuarded_eq]
                 exact ih _ (by omega) _ _ _ _ _ (by rw [updateHashes_size1]; exact hht')
                   (by rw [updateHashes_size2]; exact hps') (by rw [updateHashes_size2]; exact hpv') rfl
             · -- goodMatch-F (gated): no probe.
-              rw [updateHashesMergedGuarded_eq,
+              rw [updateHashesMergedH3Guarded_eq,
                 updateHashesMerged_append data hashSize prevSize t' p' pos 1 _ insertCap hhs hht' hps' hpv',
                 updateHashesGuarded_eq]
               exact ih _ (by omega) _ _ _ _ _ (by rw [updateHashes_size1]; exact hht')

--- a/Zip/Spec/LZ77PackedCorrect.lean
+++ b/Zip/Spec/LZ77PackedCorrect.lean
@@ -81,18 +81,24 @@ theorem lz77ChainIterP_eq (data : ByteArray) (maxChain windowSize insertCap nice
 /-- The packed lazy `mainLoop` is the packed image of the boxed one. The gate
     (`matchLen < goodMatch`) is applied identically in both, so the branch tree
     stays in lockstep — one extra split versus the ungated proof. -/
-private theorem mainLoopLazyP_eq (data : ByteArray) (windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth : Nat)
-    (hashTable : Array Nat) (prev : Array Nat) (pos : Nat) (acc : Array LZ77Token) :
-    lz77ChainLazyIterP.mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth hashTable prev pos
+private theorem mainLoopLazyP_eq (data : ByteArray) (windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth : Nat) (useH3 : Bool)
+    (hashTable : Array Nat) (prev h3tab : Array Nat) (pos : Nat) (acc : Array LZ77Token) :
+    lz77ChainLazyIterP.mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth useH3 hashTable prev h3tab pos
         (acc.map packTok) =
-      (lz77ChainLazyIter.mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth hashTable prev pos
+      (lz77ChainLazyIter.mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth useH3 hashTable prev h3tab pos
         acc).map packTok := by
-  induction h : data.size - pos using Nat.strongRecOn generalizing pos acc hashTable prev with
+  induction h : data.size - pos using Nat.strongRecOn generalizing pos acc hashTable prev h3tab with
   | _ n ih =>
     unfold lz77ChainLazyIterP.mainLoop lz77ChainLazyIter.mainLoop
-    simp only [chainWalkGuardedPackedU_eq]
     by_cases hlt : pos + 2 < data.size
-    · simp only [hlt, ↓reduceDIte]
+    · -- Reduce the outer dite with `zeta := false` (so the seed-laden walk is not
+      -- duplicated across the branch tree), abstract the opaque hash3 terms, then
+      -- align the `USize` walk to its `Nat` twin (`chainWalkGuardedPackedU_eq` is
+      -- seed-general, so both sides land on the same packed walk).
+      simp (config := { zeta := false }) only [hlt, ↓reduceDIte]
+      generalize h3Seed useH3 data h3tab windowSize pos hlt = sd
+      generalize hash3Single data pos hlt = hsg
+      simp only [chainWalkGuardedPackedU_eq]
       -- Branch tree: hge / hle / h3lt / gate / deferral / hle2
       split
       · split
@@ -101,27 +107,27 @@ private theorem mainLoopLazyP_eq (data : ByteArray) (windowSize hashSize maxChai
             · split
               · split
                 · -- deferral arm: literal + reference, two pushes
-                  rw [← Array.map_push, ← Array.map_push, ih _ (by omega) _ _ _ _ rfl]
-                · rw [← Array.map_push, ih _ (by omega) _ _ _ _ rfl]
-              · rw [← Array.map_push, ih _ (by omega) _ _ _ _ rfl]
+                  rw [← Array.map_push, ← Array.map_push, ih _ (by omega) _ _ _ _ _ rfl]
+                · rw [← Array.map_push, ih _ (by omega) _ _ _ _ _ rfl]
+              · rw [← Array.map_push, ih _ (by omega) _ _ _ _ _ rfl]
             · -- gated: reference(matchLen)
-              rw [← Array.map_push, ih _ (by omega) _ _ _ _ rfl]
-          · rw [← Array.map_push, ih _ (by omega) _ _ _ _ rfl]
-        · rw [← Array.map_push, ih _ (by omega) _ _ _ _ rfl]
-      · rw [← Array.map_push, ih _ (by omega) _ _ _ _ rfl]
+              rw [← Array.map_push, ih _ (by omega) _ _ _ _ _ rfl]
+          · rw [← Array.map_push, ih _ (by omega) _ _ _ _ _ rfl]
+        · rw [← Array.map_push, ih _ (by omega) _ _ _ _ _ rfl]
+      · rw [← Array.map_push, ih _ (by omega) _ _ _ _ _ rfl]
     · simp only [hlt, ↓reduceDIte]
       exact trailingP_eq data pos acc
 
 /-- `lz77ChainLazyIterP` produces exactly the `packTok` image of
     `lz77ChainLazyIter`. -/
-theorem lz77ChainLazyIterP_eq (data : ByteArray) (maxChain windowSize insertCap goodMatch niceLen lazyDepth : Nat) :
-    lz77ChainLazyIterP data maxChain windowSize insertCap goodMatch niceLen lazyDepth =
-      (lz77ChainLazyIter data maxChain windowSize insertCap goodMatch niceLen lazyDepth).map packTok := by
+theorem lz77ChainLazyIterP_eq (data : ByteArray) (maxChain windowSize insertCap goodMatch niceLen lazyDepth : Nat) (useH3 : Bool) :
+    lz77ChainLazyIterP data maxChain windowSize insertCap goodMatch niceLen lazyDepth useH3 =
+      (lz77ChainLazyIter data maxChain windowSize insertCap goodMatch niceLen lazyDepth useH3).map packTok := by
   unfold lz77ChainLazyIterP lz77ChainLazyIter
   split
   · simpa only [List.map_toArray, List.map_nil] using trailingP_eq data 0 #[]
   · simpa only [List.map_toArray, List.map_nil, Array.emptyWithCapacity_eq] using
-      mainLoopLazyP_eq data windowSize 65536 maxChain insertCap goodMatch niceLen lazyDepth _ _ 0 #[]
+      mainLoopLazyP_eq data windowSize 65536 maxChain insertCap goodMatch niceLen lazyDepth useH3 _ _ _ 0 #[]
 
 /-! ## View direction: the boxed view recovers the boxed matchers
 
@@ -141,15 +147,15 @@ theorem lz77ChainIterP_map (data : ByteArray) (maxChain windowSize insertCap nic
   rw [hcongr, Array.map_id]
 
 /-- The boxed view of the packed lazy matcher is the boxed lazy matcher. -/
-theorem lz77ChainLazyIterP_map (data : ByteArray) (maxChain windowSize insertCap goodMatch niceLen lazyDepth : Nat)
+theorem lz77ChainLazyIterP_map (data : ByteArray) (maxChain windowSize insertCap goodMatch niceLen lazyDepth : Nat) (useH3 : Bool)
     (hw : windowSize > 0) (hws : windowSize ≤ 32768) :
-    (lz77ChainLazyIterP data maxChain windowSize insertCap goodMatch niceLen lazyDepth).map unpackTok =
-      lz77ChainLazyIter data maxChain windowSize insertCap goodMatch niceLen lazyDepth := by
-  have henc := lz77ChainLazyIter_encodable data maxChain windowSize insertCap goodMatch niceLen lazyDepth hw hws
+    (lz77ChainLazyIterP data maxChain windowSize insertCap goodMatch niceLen lazyDepth useH3).map unpackTok =
+      lz77ChainLazyIter data maxChain windowSize insertCap goodMatch niceLen lazyDepth useH3 := by
+  have henc := lz77ChainLazyIter_encodable data maxChain windowSize insertCap goodMatch niceLen lazyDepth useH3 hw hws
   rw [lz77ChainLazyIterP_eq, Array.map_map]
   have hcongr : Array.map (unpackTok ∘ packTok)
-        (lz77ChainLazyIter data maxChain windowSize insertCap goodMatch niceLen lazyDepth) =
-      Array.map id (lz77ChainLazyIter data maxChain windowSize insertCap goodMatch niceLen lazyDepth) :=
+        (lz77ChainLazyIter data maxChain windowSize insertCap goodMatch niceLen lazyDepth useH3) =
+      Array.map id (lz77ChainLazyIter data maxChain windowSize insertCap goodMatch niceLen lazyDepth useH3) :=
     Array.map_congr_left fun t ht => unpackTok_packTok t (henc t (by simpa only [Array.mem_toList_iff] using ht))
   rw [hcongr, Array.map_id]
 
@@ -161,7 +167,7 @@ theorem lzMatchP_eq (data : ByteArray) (level : UInt8) :
   unfold lzMatchP lzMatch
   split
   · rw [lz77ChainLazyIterPMerged_eq]
-    exact lz77ChainLazyIterP_eq data (chainDepth level) 32768 (insertCap level) (goodMatch level) (niceLen level) (lazyDepth level)
+    exact lz77ChainLazyIterP_eq data (chainDepth level) 32768 (insertCap level) (goodMatch level) (niceLen level) (lazyDepth level) (useH3Level level)
   · exact lz77ChainIterP_eq data (chainDepth level) 32768 (insertCap level) (niceLen level)
 
 /-- The boxed view of the packed token stream is exactly `lzMatch`'s stream:
@@ -172,7 +178,7 @@ theorem lzMatchP_map (data : ByteArray) (level : UInt8) :
   unfold lzMatchP lzMatch
   split
   · rw [lz77ChainLazyIterPMerged_eq]
-    exact lz77ChainLazyIterP_map data (chainDepth level) 32768 (insertCap level) (goodMatch level) (niceLen level) (lazyDepth level)
+    exact lz77ChainLazyIterP_map data (chainDepth level) 32768 (insertCap level) (goodMatch level) (niceLen level) (lazyDepth level) (useH3Level level)
       (by omega) (by omega)
   · exact lz77ChainIterP_map data (chainDepth level) 32768 (insertCap level) (niceLen level)
       (by omega) (by omega)

--- a/bench/graphs/canterbury_compress_heatmap.svg
+++ b/bench/graphs/canterbury_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#pae6807e341)">
+   <g clip-path="url(#pf601e60217)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJDElEQVR4nO3YvYpdVQCG4ZzMGU3MGIaAMRgIgpaKlTba23shXoGN1+AdiGAvgoW1jaXYKAQkSIgIUSdm/nJ+LASv4F0ss3meK/g2i73Pe9Zq99eX+ys8X87/nr1gnItlPtv+8nz2hGFWN2/PnjDGiy/NXjDO6ursBWM8W+57ttQz2z/+dfaEYZZ5YgAAEwksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAIDY+sHq8ewNQ1xuz2dPGObO8euzJwxztLs9e8IQq7OT2ROG+e7sp9kThnjthVdmTxhmu9vMnjDEk83p7AnDbPbb2ROGePflu7MnDOMGCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGLro8Pj2RuG2K13sycMc3Tl2uwJ4/z5YPaCIfZnJ7MnDPPevfdnTxjidLPcM3u60Gd78+it2ROGuVxtZk8YYv/LD7MnDOMGCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGLr6wdHszcMcb49nT1hnNWCu/jazdkLhlgt+MwON5vZE4ZY8pndWC/zPfvt8uHsCcNsdpezJwxx98bx7AnDLPcLAgAwicACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACA2Gr746f72SPgP7vd7AXwr6v+fz53fD/4H/EFAQCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgNj6498fzN4wxMnFdvaEYb5/+GT2hGG+/uiD2ROGePX6vdkThnnn8y9mTxjiwzduzZ4wzP0/zmZPGOL6+mD2hGG++ubn2ROGOP3sk9kThnGDBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAALHVZvftfvaIEba7zewJw1xdLbeLD85PZ08Y42A9e8E4Tx/PXjDE9vjO7AnD7Pa72ROGOFwt9z17tl/mb9rhZpnPdeWKGywAgJzAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCIrS+357M3DLHdb2ZPGObG09PZE8Y5eTR7wRD7i4vZE4ZZ3Xt79oQhzrfLfc8uFvpstw5uzZ4wzOH5yewJQ+wf3Z89YRg3WAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABD7B3pwiOznHABHAAAAAElFTkSuQmCC" id="image573336cef9" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJEElEQVR4nO3Yv6ql5R2G4b1m1k5mdCuD4CgKIhhIE7CKjfb2ORCPwMZjyBkEwV4EC2ublMFGQTBDEEQZdXT27Nmz/lgI9sL98ouL6zqC5+Pl+9a93s3hxw+OZ/yxXP08vWCdx6f5bMfrq+kJy2yevTs9YY0/PzW9YJ3NjekFazw53ffsVM/seP9/0xOWOc0TAwAYJLAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGLbe5v70xuWuN5fTU9Y5sU7r05PWObicHd6whKbRw+mJyzz6aPPpycs8dKfnp+esMz+sJuesMRPu8vpCcvsjvvpCUv8/ZmXpycs4wYLACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYtuL8zvTG5Y4bA/TE5a5OLs1PWGdH+5NL1ji+OjB9IRl3njlzekJS1zuTvfMHp7os/3l4m/TE5a53uymJyxx/Oo/0xOWcYMFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAse3tmxfTG5a42l9OT1hnc8JdfOvZ6QVLbE74zM53u+kJS5zymT29Pc337Jvrr6cnLLM7XE9PWOLlp+9MT1jmdL8gAABDBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDENvvP3jtOj4DfHA7TC+BXN/z//MPx/eD/iC8IAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxLbvfHtvesMSDx7vpycs8++vf5qesMxH/3hresISL9x+ZXrCMq//6/3pCUu8/dpz0xOW+fL7R9MTlri9vTk9YZkPP/5iesISl/98d3rCMm6wAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAILbZHT45To9YYX/YTU9Y5sbmdLv45tXl9IQ1bm6nF6zz8P70giX2d16cnrDM4XiYnrDE+eZ037Mnx9P8TTvfneZznZ25wQIAyAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAIDYdn/YTW9YYne4np6wzO0H96cnrPPzd9MLljheP5mesMzmpb9OT+B3ery/nJ6wxPnZrekJy5xf/jA9YYnjt/+dnrCMGywAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCI/QKZEIXgifwRoAAAAABJRU5ErkJggg==" id="imagea05c2d15cd" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m50c57881d9" d="M 0 0 
+       <path id="me27a46d47f" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m50c57881d9" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me27a46d47f" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m50c57881d9" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me27a46d47f" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m50c57881d9" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me27a46d47f" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m50c57881d9" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me27a46d47f" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m50c57881d9" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me27a46d47f" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m50c57881d9" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me27a46d47f" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m50c57881d9" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me27a46d47f" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m50c57881d9" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me27a46d47f" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m50c57881d9" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me27a46d47f" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m50c57881d9" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me27a46d47f" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m50c57881d9" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me27a46d47f" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="m36a26e5866" d="M 0 0 
+       <path id="m0bb0ea8b5b" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m36a26e5866" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0bb0ea8b5b" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m36a26e5866" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0bb0ea8b5b" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m36a26e5866" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0bb0ea8b5b" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m36a26e5866" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0bb0ea8b5b" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m36a26e5866" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0bb0ea8b5b" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m36a26e5866" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0bb0ea8b5b" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m36a26e5866" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0bb0ea8b5b" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m36a26e5866" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0bb0ea8b5b" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1303,7 +1303,7 @@ L 527.435033 49.4355
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_20">
-    <!-- +16 -->
+    <!-- +11 -->
     <g transform="translate(108.442626 68.904519) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-2b" d="M 2944 4013 
@@ -1321,45 +1321,23 @@ L 2419 4013
 L 2944 4013 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-36" d="M 2113 2584 
-Q 1688 2584 1439 2293 
-Q 1191 2003 1191 1497 
-Q 1191 994 1439 701 
-Q 1688 409 2113 409 
-Q 2538 409 2786 701 
-Q 3034 994 3034 1497 
-Q 3034 2003 2786 2293 
-Q 2538 2584 2113 2584 
-z
-M 3366 4563 
-L 3366 3988 
-Q 3128 4100 2886 4159 
-Q 2644 4219 2406 4219 
-Q 1781 4219 1451 3797 
-Q 1122 3375 1075 2522 
-Q 1259 2794 1537 2939 
-Q 1816 3084 2150 3084 
-Q 2853 3084 3261 2657 
-Q 3669 2231 3669 1497 
-Q 3669 778 3244 343 
-Q 2819 -91 2113 -91 
-Q 1303 -91 875 529 
-Q 447 1150 447 2328 
-Q 447 3434 972 4092 
-Q 1497 4750 2381 4750 
-Q 2619 4750 2861 4703 
-Q 3103 4656 3366 4563 
-z
-" transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_21">
-    <!-- +24 -->
+    <!-- +19 -->
     <g transform="translate(147.693424 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_22">
+    <!-- -49 -->
+    <g transform="translate(188.495082 68.904519) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1381,55 +1359,13 @@ L 2253 4666
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_22">
-    <!-- -39 -->
-    <g transform="translate(188.495082 68.904519) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-33" d="M 2597 2516 
-Q 3050 2419 3304 2112 
-Q 3559 1806 3559 1356 
-Q 3559 666 3084 287 
-Q 2609 -91 1734 -91 
-Q 1441 -91 1130 -33 
-Q 819 25 488 141 
-L 488 750 
-Q 750 597 1062 519 
-Q 1375 441 1716 441 
-Q 2309 441 2620 675 
-Q 2931 909 2931 1356 
-Q 2931 1769 2642 2001 
-Q 2353 2234 1838 2234 
-L 1294 2234 
-L 1294 2753 
-L 1863 2753 
-Q 2328 2753 2575 2939 
-Q 2822 3125 2822 3475 
-Q 2822 3834 2567 4026 
-Q 2313 4219 1838 4219 
-Q 1578 4219 1281 4162 
-Q 984 4106 628 3988 
-L 628 4550 
-Q 988 4650 1302 4700 
-Q 1616 4750 1894 4750 
-Q 2613 4750 3031 4423 
-Q 3450 4097 3450 3541 
-Q 3450 3153 3228 2886 
-Q 3006 2619 2597 2516 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_23">
-    <!-- -75 -->
+    <!-- -79 -->
     <g transform="translate(227.74588 68.904519) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-37" d="M 525 4666 
@@ -1445,11 +1381,11 @@ z
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_24">
-    <!-- -87 -->
+    <!-- -89 -->
     <g transform="translate(266.996679 68.904519) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
@@ -1494,55 +1430,88 @@ z
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_25">
-    <!-- -17 -->
+    <!-- -27 -->
     <g transform="translate(306.247477 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_26">
-    <!-- +22 -->
-    <g transform="translate(343.947416 68.904519) scale(0.065 -0.065)">
+    <!-- +7 -->
+    <g transform="translate(346.015229 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_27">
-    <!-- +40 -->
+    <!-- +27 -->
     <g transform="translate(383.198215 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_28">
-    <!-- -10 -->
+    <!-- -13 -->
     <g transform="translate(423.999873 68.904519) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_29">
-    <!-- -33 -->
-    <g transform="translate(463.250671 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
     </g>
    </g>
+   <g id="text_29">
+    <!-- -39 -->
+    <g transform="translate(463.250671 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
    <g id="text_30">
-    <!-- -88 -->
+    <!-- -90 -->
     <g transform="translate(502.50147 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_31">
@@ -1667,6 +1636,38 @@ z
    <g id="text_46">
     <!-- +26 -->
     <g transform="translate(265.44582 139.606222) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
@@ -2181,18 +2182,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="image0bed12608b" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
+iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="imagea1795c90b9" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="m6a1721b66e" d="M 0 0 
+       <path id="mdfff538013" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m6a1721b66e" x="547.779688" y="276.293905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdfff538013" x="547.779688" y="276.293905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
@@ -2215,7 +2216,7 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m6a1721b66e" x="547.779688" y="247.808905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdfff538013" x="547.779688" y="247.808905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
@@ -2229,7 +2230,7 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m6a1721b66e" x="547.779688" y="219.323905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdfff538013" x="547.779688" y="219.323905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
@@ -2243,7 +2244,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m6a1721b66e" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdfff538013" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
@@ -2256,7 +2257,7 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m6a1721b66e" x="547.779688" y="162.353904" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdfff538013" x="547.779688" y="162.353904" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_112">
@@ -2269,7 +2270,7 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m6a1721b66e" x="547.779688" y="133.868904" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdfff538013" x="547.779688" y="133.868904" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
@@ -2282,7 +2283,7 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m6a1721b66e" x="547.779688" y="105.383904" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdfff538013" x="547.779688" y="105.383904" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
@@ -2943,8 +2944,8 @@ z
    </g>
   </g>
   <g id="text_117">
-   <!-- 2026-07-08T21:41:55Z  ·  Linux chungus2 x86_64  ·  commit b17c222c  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(16.990156 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-08T22:12:55Z  ·  Linux chungus2 x86_64  ·  commit 30251fb3  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(17.380078 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -3014,10 +3015,10 @@ z
     <use xlink:href="#DejaVuSans-38" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
     <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
     <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
@@ -3060,109 +3061,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3135.351562 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3198.974609 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3262.597656 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3317.578125 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3381.201172 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3444.824219 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3508.447266 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3563.427734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3595.214844 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3627.001953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3658.789062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3690.576172 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3722.363281 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3750.146484 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3811.669922 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3872.949219 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3936.328125 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3999.804688 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4038.667969 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4099.849609 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4159.029297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4220.552734 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4261.666016 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4295.357422 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4323.140625 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4384.664062 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4445.943359 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4509.322266 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4572.945312 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4606.636719 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4665.816406 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4729.439453 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4761.226562 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4824.849609 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4888.472656 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4920.259766 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4983.882812 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5019.966797 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5058.830078 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5113.810547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5177.433594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5209.220703 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5241.007812 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5272.794922 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5304.582031 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5336.369141 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5375.578125 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5438.957031 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5477.820312 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5539.001953 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5602.380859 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5665.857422 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5729.236328 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5792.712891 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5856.091797 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5895.300781 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5927.087891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6010.876953 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6042.664062 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6140.076172 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6201.599609 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6265.076172 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6292.859375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6354.138672 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6417.517578 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6449.304688 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6501.404297 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6564.783203 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6626.0625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6689.539062 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6741.638672 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6805.017578 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6866.199219 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6905.408203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6939.099609 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6970.886719 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7012 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7073.279297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7112.488281 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7140.271484 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7201.453125 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7233.240234 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7261.023438 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7313.123047 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7344.910156 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7408.386719 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7469.910156 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7509.119141 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7570.642578 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7610.005859 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7707.417969 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7735.201172 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7798.580078 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7826.363281 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7878.462891 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7917.671875 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7945.455078 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3262.744141 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3326.367188 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3389.990234 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3425.195312 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3488.671875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3552.294922 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3584.082031 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3615.869141 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3647.65625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3679.443359 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3711.230469 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3739.013672 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3800.537109 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3861.816406 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3925.195312 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3988.671875 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4027.535156 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4088.716797 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4147.896484 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4209.419922 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4250.533203 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4284.224609 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4312.007812 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4373.53125 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4434.810547 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4498.189453 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4561.8125 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4595.503906 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4654.683594 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4718.306641 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4750.09375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4813.716797 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4877.339844 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4909.126953 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4972.75 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5008.833984 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5047.697266 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5102.677734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5166.300781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5198.087891 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5229.875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5261.662109 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5293.449219 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5325.236328 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5364.445312 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5427.824219 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5466.6875 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5527.869141 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5591.248047 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5654.724609 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5718.103516 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5781.580078 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5844.958984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5884.167969 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5915.955078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5999.744141 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6031.53125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6128.943359 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6190.466797 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6253.943359 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6281.726562 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6343.005859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6406.384766 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6438.171875 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6490.271484 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6553.650391 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6614.929688 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6678.40625 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6730.505859 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6793.884766 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6855.066406 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6894.275391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6927.966797 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6959.753906 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7000.867188 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7062.146484 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7101.355469 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7129.138672 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7190.320312 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7222.107422 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7249.890625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7301.990234 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7333.777344 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7397.253906 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7458.777344 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7497.986328 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7559.509766 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7598.873047 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7696.285156 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7724.068359 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7787.447266 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7815.230469 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7867.330078 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7906.539062 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7934.322266 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pae6807e341">
+  <clipPath id="pf601e60217">
    <rect x="95.67625" y="49.4355" width="431.758783" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_compress_pareto.svg
+++ b/bench/graphs/canterbury_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 79.118387 412.80375 
 L 79.118387 48.323125 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="mead52ac3fa" d="M 0 0 
+       <path id="me5c803b0c3" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mead52ac3fa" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me5c803b0c3" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -161,11 +161,11 @@ z
      <g id="line2d_3">
       <path d="M 166.481434 412.80375 
 L 166.481434 48.323125 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mead52ac3fa" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me5c803b0c3" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -216,11 +216,11 @@ z
      <g id="line2d_5">
       <path d="M 253.844481 412.80375 
 L 253.844481 48.323125 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#mead52ac3fa" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me5c803b0c3" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -237,11 +237,11 @@ L 253.844481 48.323125
      <g id="line2d_7">
       <path d="M 341.207528 412.80375 
 L 341.207528 48.323125 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#mead52ac3fa" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me5c803b0c3" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -279,11 +279,11 @@ z
      <g id="line2d_9">
       <path d="M 428.570575 412.80375 
 L 428.570575 48.323125 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#mead52ac3fa" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me5c803b0c3" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -332,11 +332,11 @@ z
      <g id="line2d_11">
       <path d="M 515.933622 412.80375 
 L 515.933622 48.323125 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#mead52ac3fa" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me5c803b0c3" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -353,11 +353,11 @@ L 515.933622 48.323125
      <g id="line2d_13">
       <path d="M 603.296669 412.80375 
 L 603.296669 48.323125 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mead52ac3fa" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me5c803b0c3" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -854,16 +854,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 347.786382 
 L 637.2 347.786382 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="me3f5b263a9" d="M 0 0 
+       <path id="m1dd6e24117" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#me3f5b263a9" x="49.078125" y="347.786382" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1dd6e24117" x="49.078125" y="347.786382" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -895,11 +895,11 @@ z
      <g id="line2d_17">
       <path d="M 49.078125 238.646289 
 L 637.2 238.646289 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#me3f5b263a9" x="49.078125" y="238.646289" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1dd6e24117" x="49.078125" y="238.646289" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -915,11 +915,11 @@ L 637.2 238.646289
      <g id="line2d_19">
       <path d="M 49.078125 129.506196 
 L 637.2 129.506196 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#me3f5b263a9" x="49.078125" y="129.506196" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1dd6e24117" x="49.078125" y="129.506196" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -935,16 +935,16 @@ L 637.2 129.506196
      <g id="line2d_21">
       <path d="M 49.078125 404.853417 
 L 637.2 404.853417 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="m7d4e1f1ef7" d="M 0 0 
+       <path id="m361227877a" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m7d4e1f1ef7" x="49.078125" y="404.853417" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m361227877a" x="49.078125" y="404.853417" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -952,11 +952,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 391.217592 
 L 637.2 391.217592 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m7d4e1f1ef7" x="49.078125" y="391.217592" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m361227877a" x="49.078125" y="391.217592" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -964,11 +964,11 @@ L 637.2 391.217592
      <g id="line2d_25">
       <path d="M 49.078125 380.640824 
 L 637.2 380.640824 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m7d4e1f1ef7" x="49.078125" y="380.640824" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m361227877a" x="49.078125" y="380.640824" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -976,11 +976,11 @@ L 637.2 380.640824
      <g id="line2d_27">
       <path d="M 49.078125 371.998975 
 L 637.2 371.998975 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m7d4e1f1ef7" x="49.078125" y="371.998975" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m361227877a" x="49.078125" y="371.998975" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -988,11 +988,11 @@ L 637.2 371.998975
      <g id="line2d_29">
       <path d="M 49.078125 364.692396 
 L 637.2 364.692396 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m7d4e1f1ef7" x="49.078125" y="364.692396" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m361227877a" x="49.078125" y="364.692396" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1000,11 +1000,11 @@ L 637.2 364.692396
      <g id="line2d_31">
       <path d="M 49.078125 358.36315 
 L 637.2 358.36315 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m7d4e1f1ef7" x="49.078125" y="358.36315" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m361227877a" x="49.078125" y="358.36315" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1012,11 +1012,11 @@ L 637.2 358.36315
      <g id="line2d_33">
       <path d="M 49.078125 352.780359 
 L 637.2 352.780359 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m7d4e1f1ef7" x="49.078125" y="352.780359" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m361227877a" x="49.078125" y="352.780359" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1024,11 +1024,11 @@ L 637.2 352.780359
      <g id="line2d_35">
       <path d="M 49.078125 314.93194 
 L 637.2 314.93194 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m7d4e1f1ef7" x="49.078125" y="314.93194" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m361227877a" x="49.078125" y="314.93194" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1036,11 +1036,11 @@ L 637.2 314.93194
      <g id="line2d_37">
       <path d="M 49.078125 295.713324 
 L 637.2 295.713324 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m7d4e1f1ef7" x="49.078125" y="295.713324" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m361227877a" x="49.078125" y="295.713324" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1048,11 +1048,11 @@ L 637.2 295.713324
      <g id="line2d_39">
       <path d="M 49.078125 282.077499 
 L 637.2 282.077499 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m7d4e1f1ef7" x="49.078125" y="282.077499" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m361227877a" x="49.078125" y="282.077499" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1060,11 +1060,11 @@ L 637.2 282.077499
      <g id="line2d_41">
       <path d="M 49.078125 271.500731 
 L 637.2 271.500731 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m7d4e1f1ef7" x="49.078125" y="271.500731" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m361227877a" x="49.078125" y="271.500731" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1072,11 +1072,11 @@ L 637.2 271.500731
      <g id="line2d_43">
       <path d="M 49.078125 262.858882 
 L 637.2 262.858882 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m7d4e1f1ef7" x="49.078125" y="262.858882" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m361227877a" x="49.078125" y="262.858882" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1084,11 +1084,11 @@ L 637.2 262.858882
      <g id="line2d_45">
       <path d="M 49.078125 255.552304 
 L 637.2 255.552304 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m7d4e1f1ef7" x="49.078125" y="255.552304" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m361227877a" x="49.078125" y="255.552304" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1096,11 +1096,11 @@ L 637.2 255.552304
      <g id="line2d_47">
       <path d="M 49.078125 249.223057 
 L 637.2 249.223057 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m7d4e1f1ef7" x="49.078125" y="249.223057" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m361227877a" x="49.078125" y="249.223057" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1108,11 +1108,11 @@ L 637.2 249.223057
      <g id="line2d_49">
       <path d="M 49.078125 243.640266 
 L 637.2 243.640266 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m7d4e1f1ef7" x="49.078125" y="243.640266" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m361227877a" x="49.078125" y="243.640266" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1120,11 +1120,11 @@ L 637.2 243.640266
      <g id="line2d_51">
       <path d="M 49.078125 205.791848 
 L 637.2 205.791848 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m7d4e1f1ef7" x="49.078125" y="205.791848" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m361227877a" x="49.078125" y="205.791848" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1132,11 +1132,11 @@ L 637.2 205.791848
      <g id="line2d_53">
       <path d="M 49.078125 186.573231 
 L 637.2 186.573231 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#m7d4e1f1ef7" x="49.078125" y="186.573231" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m361227877a" x="49.078125" y="186.573231" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1144,11 +1144,11 @@ L 637.2 186.573231
      <g id="line2d_55">
       <path d="M 49.078125 172.937406 
 L 637.2 172.937406 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#m7d4e1f1ef7" x="49.078125" y="172.937406" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m361227877a" x="49.078125" y="172.937406" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1156,11 +1156,11 @@ L 637.2 172.937406
      <g id="line2d_57">
       <path d="M 49.078125 162.360638 
 L 637.2 162.360638 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#m7d4e1f1ef7" x="49.078125" y="162.360638" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m361227877a" x="49.078125" y="162.360638" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1168,11 +1168,11 @@ L 637.2 162.360638
      <g id="line2d_59">
       <path d="M 49.078125 153.71879 
 L 637.2 153.71879 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#m7d4e1f1ef7" x="49.078125" y="153.71879" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m361227877a" x="49.078125" y="153.71879" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1180,11 +1180,11 @@ L 637.2 153.71879
      <g id="line2d_61">
       <path d="M 49.078125 146.412211 
 L 637.2 146.412211 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#m7d4e1f1ef7" x="49.078125" y="146.412211" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m361227877a" x="49.078125" y="146.412211" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1192,11 +1192,11 @@ L 637.2 146.412211
      <g id="line2d_63">
       <path d="M 49.078125 140.082964 
 L 637.2 140.082964 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#m7d4e1f1ef7" x="49.078125" y="140.082964" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m361227877a" x="49.078125" y="140.082964" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1204,11 +1204,11 @@ L 637.2 140.082964
      <g id="line2d_65">
       <path d="M 49.078125 134.500173 
 L 637.2 134.500173 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#m7d4e1f1ef7" x="49.078125" y="134.500173" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m361227877a" x="49.078125" y="134.500173" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1216,11 +1216,11 @@ L 637.2 134.500173
      <g id="line2d_67">
       <path d="M 49.078125 96.651755 
 L 637.2 96.651755 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_68">
       <g>
-       <use xlink:href="#m7d4e1f1ef7" x="49.078125" y="96.651755" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m361227877a" x="49.078125" y="96.651755" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1228,11 +1228,11 @@ L 637.2 96.651755
      <g id="line2d_69">
       <path d="M 49.078125 77.433138 
 L 637.2 77.433138 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_70">
       <g>
-       <use xlink:href="#m7d4e1f1ef7" x="49.078125" y="77.433138" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m361227877a" x="49.078125" y="77.433138" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1240,11 +1240,11 @@ L 637.2 77.433138
      <g id="line2d_71">
       <path d="M 49.078125 63.797313 
 L 637.2 63.797313 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_72">
       <g>
-       <use xlink:href="#m7d4e1f1ef7" x="49.078125" y="63.797313" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m361227877a" x="49.078125" y="63.797313" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1252,11 +1252,11 @@ L 637.2 63.797313
      <g id="line2d_73">
       <path d="M 49.078125 53.220545 
 L 637.2 53.220545 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_74">
       <g>
-       <use xlink:href="#m7d4e1f1ef7" x="49.078125" y="53.220545" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m361227877a" x="49.078125" y="53.220545" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1378,7 +1378,7 @@ L 637.2 48.323125
    </g>
    <g id="text_13">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(294.783126 144.17816) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(294.783126 143.992231) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1410,7 +1410,7 @@ z
    </g>
    <g id="text_14">
     <!-- L10 -->
-    <g style="fill: #d62728" transform="translate(104.775489 294.79374) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(104.775489 295.307177) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1732,23 +1732,23 @@ z
    </g>
    <g id="line2d_75">
     <defs>
-     <path id="m9d33523b74" d="M -2.5 2.5 
+     <path id="m40a142740f" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p9ad19b8953)">
-     <use xlink:href="#m9d33523b74" x="355.479835" y="95.382063" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9d33523b74" x="308.273931" y="102.754513" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9d33523b74" x="271.230161" y="116.528062" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9d33523b74" x="217.83458" y="120.013651" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9d33523b74" x="177.077692" y="138.43462" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9d33523b74" x="162.880539" y="157.778627" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9d33523b74" x="160.741445" y="165.196647" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9d33523b74" x="153.966678" y="183.405761" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9d33523b74" x="151.589614" y="194.488118" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p8c12040a6d)">
+     <use xlink:href="#m40a142740f" x="355.479835" y="95.382063" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m40a142740f" x="308.273931" y="102.754513" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m40a142740f" x="271.230161" y="116.528062" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m40a142740f" x="217.83458" y="120.013651" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m40a142740f" x="177.077692" y="138.43462" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m40a142740f" x="162.880539" y="157.778627" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m40a142740f" x="160.741445" y="165.196647" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m40a142740f" x="153.966678" y="183.405761" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m40a142740f" x="151.589614" y="194.488118" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_76">
@@ -1801,7 +1801,7 @@ L 311.2243 102.325849
 L 310.240844 102.469168 
 L 309.257387 102.612055 
 L 308.273931 102.754513 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_77">
     <path d="M 308.273931 102.754513 
@@ -1853,7 +1853,7 @@ L 273.545396 115.775058
 L 272.773651 116.027391 
 L 272.001906 116.278388 
 L 271.230161 116.528062 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_78">
     <path d="M 271.230161 116.528062 
@@ -1905,7 +1905,7 @@ L 221.171803 119.803152
 L 220.059395 119.873422 
 L 218.946988 119.943588 
 L 217.83458 120.013651 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_79">
     <path d="M 217.83458 120.013651 
@@ -1957,7 +1957,7 @@ L 179.624997 137.470928
 L 178.775895 137.79434 
 L 177.926794 138.115561 
 L 177.077692 138.43462 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_80">
     <path d="M 177.077692 138.43462 
@@ -2009,7 +2009,7 @@ L 163.767861 156.775388
 L 163.472087 157.112166 
 L 163.176313 157.446568 
 L 162.880539 157.778627 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_81">
     <path d="M 162.880539 157.778627 
@@ -2061,7 +2061,7 @@ L 160.875139 164.765525
 L 160.830574 164.909668 
 L 160.78601 165.053375 
 L 160.741445 165.196647 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_82">
     <path d="M 160.741445 165.196647 
@@ -2113,7 +2113,7 @@ L 154.390101 182.45125
 L 154.24896 182.771561 
 L 154.107819 183.089721 
 L 153.966678 183.405761 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_83">
     <path d="M 153.966678 183.405761 
@@ -2165,26 +2165,26 @@ L 151.73818 193.866427
 L 151.688658 194.074564 
 L 151.639136 194.281792 
 L 151.589614 194.488118 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_84">
     <defs>
-     <path id="mc30565deca" d="M 0 -2.5 
+     <path id="m5c81e47066" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p9ad19b8953)">
-     <use xlink:href="#mc30565deca" x="531.649087" y="75.963093" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc30565deca" x="283.721324" y="99.020035" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc30565deca" x="218.882044" y="121.069315" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc30565deca" x="187.447228" y="127.10685" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc30565deca" x="176.342474" y="138.36311" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc30565deca" x="163.054314" y="161.312135" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc30565deca" x="162.210539" y="168.753955" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc30565deca" x="159.303811" y="175.753345" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc30565deca" x="157.793928" y="179.494802" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p8c12040a6d)">
+     <use xlink:href="#m5c81e47066" x="531.649087" y="75.963093" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5c81e47066" x="283.721324" y="99.020035" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5c81e47066" x="218.882044" y="121.069315" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5c81e47066" x="187.447228" y="127.10685" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5c81e47066" x="176.342474" y="138.36311" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5c81e47066" x="163.054314" y="161.312135" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5c81e47066" x="162.210539" y="168.753955" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5c81e47066" x="159.303811" y="175.753345" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5c81e47066" x="157.793928" y="179.494802" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_85">
@@ -2237,7 +2237,7 @@ L 299.21681 97.864971
 L 294.051648 98.253128 
 L 288.886486 98.638133 
 L 283.721324 99.020035 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_86">
     <path d="M 283.721324 99.020035 
@@ -2289,7 +2289,7 @@ L 222.934499 119.954333
 L 221.583681 120.328916 
 L 220.232863 120.700561 
 L 218.882044 121.069315 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_87">
     <path d="M 218.882044 121.069315 
@@ -2341,7 +2341,7 @@ L 189.411904 126.751217
 L 188.757012 126.870058 
 L 188.10212 126.988602 
 L 187.447228 127.10685 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_88">
     <path d="M 187.447228 127.10685 
@@ -2393,7 +2393,7 @@ L 177.036521 137.732718
 L 176.805172 137.943781 
 L 176.573823 138.153909 
 L 176.342474 138.36311 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_89">
     <path d="M 176.342474 138.36311 
@@ -2445,7 +2445,7 @@ L 163.884824 160.161325
 L 163.607987 160.548041 
 L 163.33115 160.931628 
 L 163.054314 161.312135 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_90">
     <path d="M 163.054314 161.312135 
@@ -2497,7 +2497,7 @@ L 162.263275 168.321549
 L 162.245696 168.466124 
 L 162.228118 168.610258 
 L 162.210539 168.753955 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_91">
     <path d="M 162.210539 168.753955 
@@ -2549,7 +2549,7 @@ L 159.485481 175.344896
 L 159.424925 175.481437 
 L 159.364368 175.617586 
 L 159.303811 175.753345 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_92">
     <path d="M 159.303811 175.753345 
@@ -2601,30 +2601,30 @@ L 157.888296 179.269417
 L 157.85684 179.344665 
 L 157.825384 179.419793 
 L 157.793928 179.494802 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_93">
     <defs>
-     <path id="mece563f53f" d="M -0 3.535534 
+     <path id="m33358be08b" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p9ad19b8953)">
-     <use xlink:href="#mece563f53f" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mece563f53f" x="203.775848" y="81.750179" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mece563f53f" x="186.982691" y="88.344921" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mece563f53f" x="179.779306" y="91.045312" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mece563f53f" x="157.610419" y="99.395085" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mece563f53f" x="148.722526" y="107.864022" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mece563f53f" x="144.388162" y="121.237794" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mece563f53f" x="127.071247" y="144.560664" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mece563f53f" x="124.491988" y="152.083585" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mece563f53f" x="92.613662" y="207.637263" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mece563f53f" x="87.348715" y="225.457654" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mece563f53f" x="86.053433" y="242.017529" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p8c12040a6d)">
+     <use xlink:href="#m33358be08b" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m33358be08b" x="203.775848" y="81.750179" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m33358be08b" x="186.982691" y="88.344921" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m33358be08b" x="179.779306" y="91.045312" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m33358be08b" x="157.610419" y="99.395085" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m33358be08b" x="148.722526" y="107.864022" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m33358be08b" x="144.388162" y="121.237794" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m33358be08b" x="127.071247" y="144.560664" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m33358be08b" x="124.491988" y="152.083585" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m33358be08b" x="92.613662" y="207.637263" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m33358be08b" x="87.348715" y="225.457654" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m33358be08b" x="86.053433" y="242.017529" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_94">
@@ -2677,7 +2677,7 @@ L 206.762331 80.855075
 L 205.766837 81.155325 
 L 204.771342 81.453685 
 L 203.775848 81.750179 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_95">
     <path d="M 203.775848 81.750179 
@@ -2729,7 +2729,7 @@ L 188.032264 87.958568
 L 187.682406 88.087703 
 L 187.332549 88.216487 
 L 186.982691 88.344921 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_96">
     <path d="M 186.982691 88.344921 
@@ -2781,7 +2781,7 @@ L 180.229518 90.88097
 L 180.079447 90.935814 
 L 179.929376 90.990595 
 L 179.779306 91.045312 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_97">
     <path d="M 179.779306 91.045312 
@@ -2833,7 +2833,7 @@ L 158.995974 98.914174
 L 158.534122 99.075021 
 L 158.07227 99.235323 
 L 157.610419 99.395085 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_98">
     <path d="M 157.610419 99.395085 
@@ -2885,7 +2885,7 @@ L 149.27802 107.37681
 L 149.092855 107.539771 
 L 148.907691 107.702174 
 L 148.722526 107.864022 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_99">
     <path d="M 148.722526 107.864022 
@@ -2937,7 +2937,7 @@ L 144.65906 120.50385
 L 144.568761 120.749763 
 L 144.478462 120.994407 
 L 144.388162 121.237794 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_100">
     <path d="M 144.388162 121.237794 
@@ -2989,7 +2989,7 @@ L 128.153555 143.395158
 L 127.792786 143.786853 
 L 127.432016 144.175338 
 L 127.071247 144.560664 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_101">
     <path d="M 127.071247 144.560664 
@@ -3041,7 +3041,7 @@ L 124.653192 151.646811
 L 124.599457 151.79285 
 L 124.545723 151.93844 
 L 124.491988 152.083585 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_102">
     <path d="M 124.491988 152.083585 
@@ -3093,7 +3093,7 @@ L 94.606058 205.546972
 L 93.941926 206.254028 
 L 93.277794 206.950691 
 L 92.613662 207.637263 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_103">
     <path d="M 92.613662 207.637263 
@@ -3145,7 +3145,7 @@ L 87.677774 224.520091
 L 87.568088 224.834677 
 L 87.458402 225.147189 
 L 87.348715 225.457654 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_104">
     <path d="M 87.348715 225.457654 
@@ -3197,23 +3197,23 @@ L 86.134388 241.135848
 L 86.107403 241.431568 
 L 86.080418 241.725454 
 L 86.053433 242.017529 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_105">
     <defs>
-     <path id="ma38b41dd73" d="M -0 2.5 
+     <path id="m3ddeeba6d8" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p9ad19b8953)">
-     <use xlink:href="#ma38b41dd73" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p8c12040a6d)">
+     <use xlink:href="#m3ddeeba6d8" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_106">
     <defs>
-     <path id="m52a127d546" d="M -0.833333 2.5 
+     <path id="m1969300a46" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -3228,16 +3228,16 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p9ad19b8953)">
-     <use xlink:href="#m52a127d546" x="362.865999" y="115.428618" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m52a127d546" x="278.798176" y="122.858526" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m52a127d546" x="251.17632" y="128.261574" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m52a127d546" x="200.806828" y="131.522849" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m52a127d546" x="169.803221" y="147.931404" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m52a127d546" x="161.916638" y="160.718659" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m52a127d546" x="158.697104" y="167.705569" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m52a127d546" x="154.26679" y="181.026105" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m52a127d546" x="153.096464" y="191.924265" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p8c12040a6d)">
+     <use xlink:href="#m1969300a46" x="362.865999" y="115.428618" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1969300a46" x="278.798176" y="122.858526" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1969300a46" x="251.17632" y="128.261574" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1969300a46" x="200.806828" y="131.522849" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1969300a46" x="169.803221" y="147.931404" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1969300a46" x="161.916638" y="160.718659" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1969300a46" x="158.697104" y="167.705569" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1969300a46" x="154.26679" y="181.026105" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1969300a46" x="153.096464" y="191.924265" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_107">
@@ -3290,7 +3290,7 @@ L 284.052415 122.426763
 L 282.301002 122.571121 
 L 280.549589 122.715042 
 L 278.798176 122.858526 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_108">
     <path d="M 278.798176 122.858526 
@@ -3342,7 +3342,7 @@ L 252.902686 127.94134
 L 252.327231 128.048325 
 L 251.751776 128.155069 
 L 251.17632 128.261574 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_109">
     <path d="M 251.17632 128.261574 
@@ -3394,7 +3394,7 @@ L 203.954921 131.325463
 L 202.905557 131.39135 
 L 201.856192 131.457145 
 L 200.806828 131.522849 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_110">
     <path d="M 200.806828 131.522849 
@@ -3446,7 +3446,7 @@ L 171.740947 147.056528
 L 171.095038 147.349951 
 L 170.44913 147.64157 
 L 169.803221 147.931404 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_111">
     <path d="M 169.803221 147.931404 
@@ -3498,7 +3498,7 @@ L 162.409549 160.012958
 L 162.245246 160.249361 
 L 162.080942 160.484591 
 L 161.916638 160.718659 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_112">
     <path d="M 161.916638 160.718659 
@@ -3550,7 +3550,7 @@ L 158.898325 167.297798
 L 158.831251 167.434112 
 L 158.764178 167.570034 
 L 158.697104 167.705569 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_113">
     <path d="M 158.697104 167.705569 
@@ -3602,7 +3602,7 @@ L 154.543684 180.294711
 L 154.451386 180.539765 
 L 154.359088 180.783558 
 L 154.26679 181.026105 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_114">
     <path d="M 154.26679 181.026105 
@@ -3654,11 +3654,11 @@ L 153.16961 191.311823
 L 153.145228 191.516851 
 L 153.120846 191.720996 
 L 153.096464 191.924265 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_115">
     <defs>
-     <path id="maa6c66c454" d="M -1.25 2.5 
+     <path id="m20421d9ea6" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -3673,16 +3673,16 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p9ad19b8953)">
-     <use xlink:href="#maa6c66c454" x="301.619021" y="150.561849" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#maa6c66c454" x="250.236474" y="156.671134" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#maa6c66c454" x="225.418659" y="160.842551" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#maa6c66c454" x="212.328936" y="161.382211" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#maa6c66c454" x="209.030149" y="166.25091" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#maa6c66c454" x="197.547749" y="171.432451" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#maa6c66c454" x="194.819287" y="175.129495" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#maa6c66c454" x="193.12279" y="181.606362" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#maa6c66c454" x="192.79794" y="189.451167" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p8c12040a6d)">
+     <use xlink:href="#m20421d9ea6" x="301.619021" y="150.561849" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m20421d9ea6" x="250.236474" y="156.671134" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m20421d9ea6" x="225.418659" y="160.842551" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m20421d9ea6" x="212.328936" y="161.382211" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m20421d9ea6" x="209.030149" y="166.25091" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m20421d9ea6" x="197.547749" y="171.432451" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m20421d9ea6" x="194.819287" y="175.129495" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m20421d9ea6" x="193.12279" y="181.606362" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m20421d9ea6" x="192.79794" y="189.451167" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_116">
@@ -3735,7 +3735,7 @@ L 253.447883 156.311526
 L 252.377414 156.431699 
 L 251.306944 156.551567 
 L 250.236474 156.671134 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_117">
     <path d="M 250.236474 156.671134 
@@ -3787,7 +3787,7 @@ L 226.969772 160.592321
 L 226.452735 160.675878 
 L 225.935697 160.759287 
 L 225.418659 160.842551 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_118">
     <path d="M 225.418659 160.842551 
@@ -3839,7 +3839,7 @@ L 213.147044 161.348661
 L 212.874341 161.359847 
 L 212.601639 161.37103 
 L 212.328936 161.382211 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_119">
     <path d="M 212.328936 161.382211 
@@ -3891,7 +3891,7 @@ L 209.236323 165.960837
 L 209.167599 166.057725 
 L 209.098874 166.154416 
 L 209.030149 166.25091 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_120">
     <path d="M 209.030149 166.25091 
@@ -3943,7 +3943,7 @@ L 198.265399 171.124681
 L 198.026182 171.227493 
 L 197.786966 171.330083 
 L 197.547749 171.432451 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_121">
     <path d="M 197.547749 171.432451 
@@ -3995,7 +3995,7 @@ L 194.989815 174.906688
 L 194.932972 174.981074 
 L 194.876129 175.055342 
 L 194.819287 175.129495 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_122">
     <path d="M 194.819287 175.129495 
@@ -4047,7 +4047,7 @@ L 193.228821 181.226479
 L 193.193478 181.353445 
 L 193.158134 181.480072 
 L 193.12279 181.606362 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_123">
     <path d="M 193.12279 181.606362 
@@ -4099,11 +4099,11 @@ L 192.818243 188.997124
 L 192.811475 189.148955 
 L 192.804707 189.300302 
 L 192.79794 189.451167 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_124">
     <defs>
-     <path id="m1d8faa8978" d="M 0 -2.5 
+     <path id="ma42e9d258e" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -4116,16 +4116,16 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p9ad19b8953)">
-     <use xlink:href="#m1d8faa8978" x="206.45578" y="118.584066" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m1d8faa8978" x="206.45578" y="118.258949" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m1d8faa8978" x="206.45578" y="118.759361" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m1d8faa8978" x="206.45578" y="118.234957" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m1d8faa8978" x="171.767499" y="134.097889" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m1d8faa8978" x="163.54283" y="144.663903" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m1d8faa8978" x="160.174881" y="151.505345" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m1d8faa8978" x="154.179217" y="169.303726" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m1d8faa8978" x="152.4406" y="178.584542" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p8c12040a6d)">
+     <use xlink:href="#ma42e9d258e" x="206.45578" y="118.584066" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#ma42e9d258e" x="206.45578" y="118.258949" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#ma42e9d258e" x="206.45578" y="118.759361" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#ma42e9d258e" x="206.45578" y="118.234957" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#ma42e9d258e" x="171.767499" y="134.097889" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#ma42e9d258e" x="163.54283" y="144.663903" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#ma42e9d258e" x="160.174881" y="151.505345" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#ma42e9d258e" x="154.179217" y="169.303726" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#ma42e9d258e" x="152.4406" y="178.584542" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_125">
@@ -4178,7 +4178,7 @@ L 206.45578 118.279335
 L 206.45578 118.27254 
 L 206.45578 118.265745 
 L 206.45578 118.258949 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_126">
     <path d="M 206.45578 118.258949 
@@ -4230,7 +4230,7 @@ L 206.45578 118.728239
 L 206.45578 118.738615 
 L 206.45578 118.748989 
 L 206.45578 118.759361 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_127">
     <path d="M 206.45578 118.759361 
@@ -4282,7 +4282,7 @@ L 206.45578 118.267903
 L 206.45578 118.256924 
 L 206.45578 118.245942 
 L 206.45578 118.234957 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_128">
     <path d="M 206.45578 118.234957 
@@ -4334,7 +4334,7 @@ L 173.935517 133.247721
 L 173.212844 133.532808 
 L 172.490172 133.816191 
 L 171.767499 134.097889 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_129">
     <path d="M 171.767499 134.097889 
@@ -4386,7 +4386,7 @@ L 164.056872 144.068227
 L 163.885524 144.267619 
 L 163.714177 144.466175 
 L 163.54283 144.663903 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_130">
     <path d="M 163.54283 144.663903 
@@ -4438,7 +4438,7 @@ L 160.385378 151.105499
 L 160.315212 151.239156 
 L 160.245047 151.372438 
 L 160.174881 151.505345 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_131">
     <path d="M 160.174881 151.505345 
@@ -4490,7 +4490,7 @@ L 154.553946 168.367127
 L 154.429036 168.681387 
 L 154.304126 168.993578 
 L 154.179217 169.303726 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_132">
     <path d="M 154.179217 169.303726 
@@ -4542,11 +4542,11 @@ L 152.549264 178.054798
 L 152.513043 178.232038 
 L 152.476822 178.408618 
 L 152.4406 178.584542 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_133">
     <defs>
-     <path id="m4b98dc399e" d="M 0 -2.5 
+     <path id="m0f8843e116" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -4555,16 +4555,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p9ad19b8953)">
-     <use xlink:href="#m4b98dc399e" x="610.467188" y="172.829682" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4b98dc399e" x="592.067397" y="173.763838" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4b98dc399e" x="534.807821" y="180.385179" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4b98dc399e" x="327.802209" y="176.172104" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4b98dc399e" x="275.83761" y="186.734601" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4b98dc399e" x="258.25125" y="198.783148" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4b98dc399e" x="256.777056" y="203.737732" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4b98dc399e" x="248.769854" y="217.74136" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4b98dc399e" x="246.264594" y="227.740017" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p8c12040a6d)">
+     <use xlink:href="#m0f8843e116" x="610.467188" y="172.829682" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0f8843e116" x="592.067397" y="173.763838" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0f8843e116" x="534.807821" y="180.385179" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0f8843e116" x="327.802209" y="176.172104" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0f8843e116" x="275.83761" y="186.734601" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0f8843e116" x="258.25125" y="198.783148" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0f8843e116" x="256.777056" y="203.737732" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0f8843e116" x="248.769854" y="217.74136" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0f8843e116" x="246.264594" y="227.740017" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_134">
@@ -4617,7 +4617,7 @@ L 593.217384 173.705989
 L 592.834055 173.72528 
 L 592.450726 173.744563 
 L 592.067397 173.763838 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_135">
     <path d="M 592.067397 173.763838 
@@ -4669,7 +4669,7 @@ L 538.386544 179.997367
 L 537.193636 180.126991 
 L 536.000728 180.25626 
 L 534.807821 180.385179 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_136">
     <path d="M 534.807821 180.385179 
@@ -4721,7 +4721,7 @@ L 340.74006 176.446681
 L 336.427443 176.355332 
 L 332.114826 176.263806 
 L 327.802209 176.172104 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_137">
     <path d="M 327.802209 176.172104 
@@ -4773,7 +4773,7 @@ L 279.085397 186.139102
 L 278.002801 186.338434 
 L 276.920205 186.536931 
 L 275.83761 186.734601 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_138">
     <path d="M 275.83761 186.734601 
@@ -4825,7 +4825,7 @@ L 259.350398 198.113494
 L 258.984015 198.337765 
 L 258.617633 198.560979 
 L 258.25125 198.783148 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_139">
     <path d="M 258.25125 198.783148 
@@ -4877,7 +4877,7 @@ L 256.869193 203.442789
 L 256.838481 203.541307 
 L 256.807768 203.639621 
 L 256.777056 203.737732 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_140">
     <path d="M 256.777056 203.737732 
@@ -4929,7 +4929,7 @@ L 249.270304 216.977455
 L 249.103487 217.23346 
 L 248.93667 217.48809 
 L 248.769854 217.74136 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_141">
     <path d="M 248.769854 217.74136 
@@ -4981,7 +4981,7 @@ L 246.421172 227.173237
 L 246.368979 227.362918 
 L 246.316786 227.551842 
 L 246.264594 227.740017 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="legend_1">
     <g id="patch_7">
@@ -4999,7 +4999,7 @@ z
     </g>
     <g id="line2d_142">
      <defs>
-      <path id="m8cf4c18517" d="M 0 3.5 
+      <path id="ma19fcd5eac" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -5012,7 +5012,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m8cf4c18517" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#ma19fcd5eac" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -5071,7 +5071,7 @@ z
     </g>
     <g id="line2d_143">
      <g>
-      <use xlink:href="#m9d33523b74" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m40a142740f" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -5085,7 +5085,7 @@ z
     </g>
     <g id="line2d_144">
      <g>
-      <use xlink:href="#mc30565deca" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m5c81e47066" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -5130,7 +5130,7 @@ z
     </g>
     <g id="line2d_145">
      <g>
-      <use xlink:href="#mece563f53f" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m33358be08b" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -5173,7 +5173,7 @@ z
     </g>
     <g id="line2d_146">
      <g>
-      <use xlink:href="#ma38b41dd73" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m3ddeeba6d8" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -5189,7 +5189,7 @@ z
     </g>
     <g id="line2d_147">
      <g>
-      <use xlink:href="#m52a127d546" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m1969300a46" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -5243,7 +5243,7 @@ z
     </g>
     <g id="line2d_148">
      <g>
-      <use xlink:href="#maa6c66c454" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m20421d9ea6" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -5308,7 +5308,7 @@ z
     </g>
     <g id="line2d_149">
      <g>
-      <use xlink:href="#m1d8faa8978" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#ma42e9d258e" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -5346,7 +5346,7 @@ z
     </g>
     <g id="line2d_150">
      <g>
-      <use xlink:href="#m4b98dc399e" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m0f8843e116" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -5416,486 +5416,486 @@ z
     </g>
    </g>
    <g id="line2d_151">
-    <g clip-path="url(#p9ad19b8953)">
-     <use xlink:href="#m8cf4c18517" x="289.783126" y="149.17816" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m8cf4c18517" x="223.847406" y="159.268604" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m8cf4c18517" x="212.445767" y="163.194674" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m8cf4c18517" x="181.367844" y="168.38581" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m8cf4c18517" x="165.308999" y="177.369888" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m8cf4c18517" x="153.53933" y="182.984995" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m8cf4c18517" x="148.588101" y="189.525409" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m8cf4c18517" x="145.442461" y="192.752932" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m8cf4c18517" x="115.00257" y="273.691065" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m8cf4c18517" x="99.775489" y="299.79374" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <g clip-path="url(#p8c12040a6d)">
+     <use xlink:href="#ma19fcd5eac" x="289.783126" y="148.992231" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma19fcd5eac" x="223.847406" y="159.16883" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma19fcd5eac" x="212.445767" y="163.265133" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma19fcd5eac" x="181.367844" y="169.605394" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma19fcd5eac" x="165.308999" y="178.516756" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma19fcd5eac" x="157.029538" y="188.373389" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma19fcd5eac" x="152.709397" y="194.486606" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma19fcd5eac" x="149.72506" y="197.352703" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma19fcd5eac" x="115.00257" y="273.867142" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma19fcd5eac" x="99.775489" y="300.307177" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
    <g id="line2d_152">
-    <path d="M 289.783126 149.17816 
-L 288.409466 149.411853 
-L 287.035805 149.644399 
-L 285.662144 149.875809 
-L 284.288483 150.106096 
-L 282.914822 150.335269 
-L 281.541161 150.563339 
-L 280.167501 150.790317 
-L 278.79384 151.016213 
-L 277.420179 151.241038 
-L 276.046518 151.464801 
-L 274.672857 151.687513 
-L 273.299196 151.909184 
-L 271.925536 152.129822 
-L 270.551875 152.349439 
-L 269.178214 152.568042 
-L 267.804553 152.785642 
-L 266.430892 153.002248 
-L 265.057231 153.217868 
-L 263.68357 153.432511 
-L 262.30991 153.646187 
-L 260.936249 153.858905 
-L 259.562588 154.070671 
-L 258.188927 154.281496 
-L 256.815266 154.491387 
-L 255.441605 154.700353 
-L 254.067945 154.908402 
-L 252.694284 155.115542 
-L 251.320623 155.32178 
-L 249.946962 155.527125 
-L 248.573301 155.731584 
-L 247.19964 155.935164 
-L 245.82598 156.137875 
-L 244.452319 156.339722 
-L 243.078658 156.540713 
-L 241.704997 156.740855 
-L 240.331336 156.940156 
-L 238.957675 157.138622 
-L 237.584015 157.336261 
-L 236.210354 157.533079 
-L 234.836693 157.729083 
-L 233.463032 157.92428 
-L 232.089371 158.118676 
-L 230.71571 158.312279 
-L 229.34205 158.505094 
-L 227.968389 158.697127 
-L 226.594728 158.888386 
-L 225.221067 159.078876 
-L 223.847406 159.268604 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 289.783126 148.992231 
+L 288.409466 149.228135 
+L 287.035805 149.462871 
+L 285.662144 149.69645 
+L 284.288483 149.928884 
+L 282.914822 150.160183 
+L 281.541161 150.39036 
+L 280.167501 150.619424 
+L 278.79384 150.847386 
+L 277.420179 151.074257 
+L 276.046518 151.300048 
+L 274.672857 151.524768 
+L 273.299196 151.748427 
+L 271.925536 151.971036 
+L 270.551875 152.192605 
+L 269.178214 152.413142 
+L 267.804553 152.632659 
+L 266.430892 152.851163 
+L 265.057231 153.068665 
+L 263.68357 153.285173 
+L 262.30991 153.500697 
+L 260.936249 153.715245 
+L 259.562588 153.928826 
+L 258.188927 154.141449 
+L 256.815266 154.353123 
+L 255.441605 154.563856 
+L 254.067945 154.773656 
+L 252.694284 154.982531 
+L 251.320623 155.19049 
+L 249.946962 155.39754 
+L 248.573301 155.60369 
+L 247.19964 155.808948 
+L 245.82598 156.01332 
+L 244.452319 156.216815 
+L 243.078658 156.41944 
+L 241.704997 156.621202 
+L 240.331336 156.822109 
+L 238.957675 157.022169 
+L 237.584015 157.221387 
+L 236.210354 157.419772 
+L 234.836693 157.617329 
+L 233.463032 157.814067 
+L 232.089371 158.009991 
+L 230.71571 158.205109 
+L 229.34205 158.399427 
+L 227.968389 158.592952 
+L 226.594728 158.78569 
+L 225.221067 158.977647 
+L 223.847406 159.16883 
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_153">
-    <path d="M 223.847406 159.268604 
-L 223.609872 159.353803 
-L 223.372338 159.43885 
-L 223.134804 159.523744 
-L 222.89727 159.608487 
-L 222.659735 159.693078 
-L 222.422201 159.777519 
-L 222.184667 159.861809 
-L 221.947133 159.94595 
-L 221.709599 160.029941 
-L 221.472065 160.113785 
-L 221.23453 160.19748 
-L 220.996996 160.281027 
-L 220.759462 160.364428 
-L 220.521928 160.447682 
-L 220.284394 160.53079 
-L 220.04686 160.613752 
-L 219.809325 160.69657 
-L 219.571791 160.779243 
-L 219.334257 160.861772 
-L 219.096723 160.944158 
-L 218.859189 161.026401 
-L 218.621655 161.108501 
-L 218.38412 161.19046 
-L 218.146586 161.272277 
-L 217.909052 161.353953 
-L 217.671518 161.435488 
-L 217.433984 161.516884 
-L 217.19645 161.59814 
-L 216.958916 161.679257 
-L 216.721381 161.760235 
-L 216.483847 161.841075 
-L 216.246313 161.921778 
-L 216.008779 162.002343 
-L 215.771245 162.082772 
-L 215.533711 162.163064 
-L 215.296176 162.243221 
-L 215.058642 162.323242 
-L 214.821108 162.403128 
-L 214.583574 162.48288 
-L 214.34604 162.562498 
-L 214.108506 162.641983 
-L 213.870971 162.721334 
-L 213.633437 162.800553 
-L 213.395903 162.87964 
-L 213.158369 162.958595 
-L 212.920835 163.037419 
-L 212.683301 163.116111 
-L 212.445767 163.194674 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 223.847406 159.16883 
+L 223.609872 159.257882 
+L 223.372338 159.346767 
+L 223.134804 159.435486 
+L 222.89727 159.524039 
+L 222.659735 159.612427 
+L 222.422201 159.70065 
+L 222.184667 159.78871 
+L 221.947133 159.876606 
+L 221.709599 159.964339 
+L 221.472065 160.05191 
+L 221.23453 160.13932 
+L 220.996996 160.226569 
+L 220.759462 160.313658 
+L 220.521928 160.400587 
+L 220.284394 160.487357 
+L 220.04686 160.573968 
+L 219.809325 160.660421 
+L 219.571791 160.746717 
+L 219.334257 160.832856 
+L 219.096723 160.918839 
+L 218.859189 161.004666 
+L 218.621655 161.090338 
+L 218.38412 161.175855 
+L 218.146586 161.261219 
+L 217.909052 161.346429 
+L 217.671518 161.431486 
+L 217.433984 161.51639 
+L 217.19645 161.601143 
+L 216.958916 161.685745 
+L 216.721381 161.770196 
+L 216.483847 161.854496 
+L 216.246313 161.938647 
+L 216.008779 162.022649 
+L 215.771245 162.106502 
+L 215.533711 162.190207 
+L 215.296176 162.273765 
+L 215.058642 162.357176 
+L 214.821108 162.44044 
+L 214.583574 162.523558 
+L 214.34604 162.60653 
+L 214.108506 162.689358 
+L 213.870971 162.772041 
+L 213.633437 162.85458 
+L 213.395903 162.936975 
+L 213.158369 163.019228 
+L 212.920835 163.101338 
+L 212.683301 163.183306 
+L 212.445767 163.265133 
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_154">
-    <path d="M 212.445767 163.194674 
-L 211.79831 163.308829 
-L 211.150853 163.422711 
-L 210.503396 163.536319 
-L 209.85594 163.649656 
-L 209.208483 163.762722 
-L 208.561026 163.875519 
-L 207.913569 163.988049 
-L 207.266113 164.100312 
-L 206.618656 164.212309 
-L 205.971199 164.324043 
-L 205.323743 164.435514 
-L 204.676286 164.546723 
-L 204.028829 164.657672 
-L 203.381372 164.768362 
-L 202.733916 164.878794 
-L 202.086459 164.98897 
-L 201.439002 165.09889 
-L 200.791546 165.208555 
-L 200.144089 165.317968 
-L 199.496632 165.427128 
-L 198.849175 165.536038 
-L 198.201719 165.644698 
-L 197.554262 165.753109 
-L 196.906805 165.861273 
-L 196.259348 165.969191 
-L 195.611892 166.076863 
-L 194.964435 166.184292 
-L 194.316978 166.291478 
-L 193.669522 166.398421 
-L 193.022065 166.505124 
-L 192.374608 166.611588 
-L 191.727151 166.717813 
-L 191.079695 166.8238 
-L 190.432238 166.929551 
-L 189.784781 167.035066 
-L 189.137324 167.140347 
-L 188.489868 167.245395 
-L 187.842411 167.35021 
-L 187.194954 167.454794 
-L 186.547498 167.559148 
-L 185.900041 167.663273 
-L 185.252584 167.767169 
-L 184.605127 167.870838 
-L 183.957671 167.974281 
-L 183.310214 168.077499 
-L 182.662757 168.180492 
-L 182.015301 168.283262 
-L 181.367844 168.38581 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 212.445767 163.265133 
+L 211.79831 163.406253 
+L 211.150853 163.546954 
+L 210.503396 163.687239 
+L 209.85594 163.82711 
+L 209.208483 163.96657 
+L 208.561026 164.10562 
+L 207.913569 164.244263 
+L 207.266113 164.382503 
+L 206.618656 164.52034 
+L 205.971199 164.657777 
+L 205.323743 164.794818 
+L 204.676286 164.931463 
+L 204.028829 165.067715 
+L 203.381372 165.203577 
+L 202.733916 165.33905 
+L 202.086459 165.474138 
+L 201.439002 165.608841 
+L 200.791546 165.743163 
+L 200.144089 165.877105 
+L 199.496632 166.01067 
+L 198.849175 166.143859 
+L 198.201719 166.276675 
+L 197.554262 166.40912 
+L 196.906805 166.541196 
+L 196.259348 166.672905 
+L 195.611892 166.804249 
+L 194.964435 166.935231 
+L 194.316978 167.065851 
+L 193.669522 167.196112 
+L 193.022065 167.326016 
+L 192.374608 167.455565 
+L 191.727151 167.584761 
+L 191.079695 167.713606 
+L 190.432238 167.842101 
+L 189.784781 167.97025 
+L 189.137324 168.098052 
+L 188.489868 168.225511 
+L 187.842411 168.352628 
+L 187.194954 168.479405 
+L 186.547498 168.605844 
+L 185.900041 168.731947 
+L 185.252584 168.857715 
+L 184.605127 168.98315 
+L 183.957671 169.108254 
+L 183.310214 169.233028 
+L 182.662757 169.357476 
+L 182.015301 169.481597 
+L 181.367844 169.605394 
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_155">
-    <path d="M 181.367844 168.38581 
-L 181.033285 168.591445 
-L 180.698725 168.796193 
-L 180.364166 169.000059 
-L 180.029607 169.203053 
-L 179.695047 169.405181 
-L 179.360488 169.606451 
-L 179.025929 169.806869 
-L 178.69137 170.006444 
-L 178.35681 170.205182 
-L 178.022251 170.40309 
-L 177.687692 170.600175 
-L 177.353133 170.796444 
-L 177.018573 170.991904 
-L 176.684014 171.186561 
-L 176.349455 171.380422 
-L 176.014895 171.573493 
-L 175.680336 171.765781 
-L 175.345777 171.957292 
-L 175.011218 172.148033 
-L 174.676658 172.338009 
-L 174.342099 172.527226 
-L 174.00754 172.715691 
-L 173.672981 172.90341 
-L 173.338421 173.090388 
-L 173.003862 173.276632 
-L 172.669303 173.462147 
-L 172.334743 173.646938 
-L 172.000184 173.831012 
-L 171.665625 174.014373 
-L 171.331066 174.197028 
-L 170.996506 174.378982 
-L 170.661947 174.56024 
-L 170.327388 174.740808 
-L 169.992829 174.92069 
-L 169.658269 175.099893 
-L 169.32371 175.27842 
-L 168.989151 175.456277 
-L 168.654591 175.63347 
-L 168.320032 175.810002 
-L 167.985473 175.98588 
-L 167.650914 176.161107 
-L 167.316354 176.335689 
-L 166.981795 176.50963 
-L 166.647236 176.682935 
-L 166.312676 176.855609 
-L 165.978117 177.027656 
-L 165.643558 177.199081 
-L 165.308999 177.369888 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 181.367844 169.605394 
+L 181.033285 169.809208 
+L 180.698725 170.012149 
+L 180.364166 170.214225 
+L 180.029607 170.415443 
+L 179.695047 170.61581 
+L 179.360488 170.815334 
+L 179.025929 171.014022 
+L 178.69137 171.21188 
+L 178.35681 171.408916 
+L 178.022251 171.605136 
+L 177.687692 171.800547 
+L 177.353133 171.995156 
+L 177.018573 172.188969 
+L 176.684014 172.381993 
+L 176.349455 172.574234 
+L 176.014895 172.765699 
+L 175.680336 172.956393 
+L 175.345777 173.146323 
+L 175.011218 173.335495 
+L 174.676658 173.523915 
+L 174.342099 173.711589 
+L 174.00754 173.898523 
+L 173.672981 174.084722 
+L 173.338421 174.270193 
+L 173.003862 174.454941 
+L 172.669303 174.638971 
+L 172.334743 174.82229 
+L 172.000184 175.004903 
+L 171.665625 175.186815 
+L 171.331066 175.368031 
+L 170.996506 175.548557 
+L 170.661947 175.728398 
+L 170.327388 175.90756 
+L 169.992829 176.086046 
+L 169.658269 176.263863 
+L 169.32371 176.441016 
+L 168.989151 176.617509 
+L 168.654591 176.793347 
+L 168.320032 176.968535 
+L 167.985473 177.143078 
+L 167.650914 177.316981 
+L 167.316354 177.490248 
+L 166.981795 177.662884 
+L 166.647236 177.834893 
+L 166.312676 178.006281 
+L 165.978117 178.177051 
+L 165.643558 178.347208 
+L 165.308999 178.516756 
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_156">
-    <path d="M 165.308999 177.369888 
-L 165.063797 177.493918 
-L 164.818596 177.617625 
-L 164.573394 177.741009 
-L 164.328193 177.864073 
-L 164.082992 177.986818 
-L 163.83779 178.109246 
-L 163.592589 178.231359 
-L 163.347387 178.353158 
-L 163.102186 178.474645 
-L 162.856984 178.595821 
-L 162.611783 178.716688 
-L 162.366582 178.837248 
-L 162.12138 178.957502 
-L 161.876179 179.077451 
-L 161.630977 179.197098 
-L 161.385776 179.316444 
-L 161.140574 179.43549 
-L 160.895373 179.554237 
-L 160.650172 179.672688 
-L 160.40497 179.790844 
-L 160.159769 179.908705 
-L 159.914567 180.026275 
-L 159.669366 180.143553 
-L 159.424164 180.260542 
-L 159.178963 180.377243 
-L 158.933762 180.493658 
-L 158.68856 180.609787 
-L 158.443359 180.725632 
-L 158.198157 180.841195 
-L 157.952956 180.956477 
-L 157.707754 181.071479 
-L 157.462553 181.186203 
-L 157.217352 181.300649 
-L 156.97215 181.41482 
-L 156.726949 181.528717 
-L 156.481747 181.642341 
-L 156.236546 181.755693 
-L 155.991344 181.868774 
-L 155.746143 181.981587 
-L 155.500942 182.094131 
-L 155.25574 182.206409 
-L 155.010539 182.318422 
-L 154.765337 182.43017 
-L 154.520136 182.541656 
-L 154.274934 182.65288 
-L 154.029733 182.763844 
-L 153.784532 182.874548 
-L 153.53933 182.984995 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 165.308999 178.516756 
+L 165.13651 178.744466 
+L 164.964021 178.971087 
+L 164.791532 179.19663 
+L 164.619044 179.421105 
+L 164.446555 179.644521 
+L 164.274066 179.86689 
+L 164.101577 180.08822 
+L 163.929089 180.308521 
+L 163.7566 180.527803 
+L 163.584111 180.746076 
+L 163.411622 180.963347 
+L 163.239134 181.179628 
+L 163.066645 181.394926 
+L 162.894156 181.60925 
+L 162.721667 181.82261 
+L 162.549178 182.035014 
+L 162.37669 182.24647 
+L 162.204201 182.456987 
+L 162.031712 182.666573 
+L 161.859223 182.875236 
+L 161.686735 183.082985 
+L 161.514246 183.289827 
+L 161.341757 183.495771 
+L 161.169268 183.700824 
+L 160.99678 183.904993 
+L 160.824291 184.108287 
+L 160.651802 184.310712 
+L 160.479313 184.512277 
+L 160.306825 184.712988 
+L 160.134336 184.912853 
+L 159.961847 185.111878 
+L 159.789358 185.310072 
+L 159.61687 185.50744 
+L 159.444381 185.703989 
+L 159.271892 185.899727 
+L 159.099403 186.09466 
+L 158.926914 186.288795 
+L 158.754426 186.482138 
+L 158.581937 186.674695 
+L 158.409448 186.866473 
+L 158.236959 187.057478 
+L 158.064471 187.247717 
+L 157.891982 187.437195 
+L 157.719493 187.625919 
+L 157.547004 187.813894 
+L 157.374516 188.001127 
+L 157.202027 188.187623 
+L 157.029538 188.373389 
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_157">
-    <path d="M 153.53933 182.984995 
-L 153.436179 183.130878 
-L 153.333029 183.276313 
-L 153.229878 183.421303 
-L 153.126728 183.565851 
-L 153.023577 183.709959 
-L 152.920426 183.853631 
-L 152.817276 183.996868 
-L 152.714125 184.139674 
-L 152.610975 184.282051 
-L 152.507824 184.424001 
-L 152.404673 184.565528 
-L 152.301523 184.706633 
-L 152.198372 184.84732 
-L 152.095222 184.98759 
-L 151.992071 185.127447 
-L 151.88892 185.266891 
-L 151.78577 185.405927 
-L 151.682619 185.544557 
-L 151.579468 185.682781 
-L 151.476318 185.820604 
-L 151.373167 185.958028 
-L 151.270017 186.095054 
-L 151.166866 186.231685 
-L 151.063715 186.367924 
-L 150.960565 186.503772 
-L 150.857414 186.639231 
-L 150.754264 186.774305 
-L 150.651113 186.908995 
-L 150.547962 187.043303 
-L 150.444812 187.177232 
-L 150.341661 187.310783 
-L 150.238511 187.443959 
-L 150.13536 187.576762 
-L 150.032209 187.709194 
-L 149.929059 187.841257 
-L 149.825908 187.972953 
-L 149.722758 188.104284 
-L 149.619607 188.235253 
-L 149.516456 188.36586 
-L 149.413306 188.496109 
-L 149.310155 188.626 
-L 149.207004 188.755537 
-L 149.103854 188.88472 
-L 149.000703 189.013553 
-L 148.897553 189.142036 
-L 148.794402 189.270172 
-L 148.691251 189.397962 
-L 148.588101 189.525409 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 157.029538 188.373389 
+L 156.939535 188.509131 
+L 156.849532 188.644485 
+L 156.759529 188.779454 
+L 156.669526 188.914039 
+L 156.579523 189.048244 
+L 156.48952 189.182069 
+L 156.399517 189.315518 
+L 156.309515 189.448592 
+L 156.219512 189.581294 
+L 156.129509 189.713625 
+L 156.039506 189.845588 
+L 155.949503 189.977184 
+L 155.8595 190.108416 
+L 155.769497 190.239286 
+L 155.679494 190.369795 
+L 155.589491 190.499946 
+L 155.499488 190.629741 
+L 155.409485 190.759181 
+L 155.319482 190.888268 
+L 155.229479 191.017005 
+L 155.139476 191.145394 
+L 155.049473 191.273435 
+L 154.95947 191.401131 
+L 154.869467 191.528485 
+L 154.779464 191.655497 
+L 154.689461 191.78217 
+L 154.599459 191.908505 
+L 154.509456 192.034504 
+L 154.419453 192.160169 
+L 154.32945 192.285502 
+L 154.239447 192.410504 
+L 154.149444 192.535178 
+L 154.059441 192.659524 
+L 153.969438 192.783546 
+L 153.879435 192.907243 
+L 153.789432 193.030619 
+L 153.699429 193.153674 
+L 153.609426 193.27641 
+L 153.519423 193.39883 
+L 153.42942 193.520934 
+L 153.339417 193.642724 
+L 153.249414 193.764203 
+L 153.159411 193.885371 
+L 153.069408 194.006229 
+L 152.979406 194.126781 
+L 152.889403 194.247026 
+L 152.7994 194.366968 
+L 152.709397 194.486606 
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_158">
-    <path d="M 148.588101 189.525409 
-L 148.522567 189.59494 
-L 148.457032 189.664369 
-L 148.391498 189.733697 
-L 148.325964 189.802924 
-L 148.26043 189.872049 
-L 148.194896 189.941074 
-L 148.129362 190.009999 
-L 148.063827 190.078823 
-L 147.998293 190.147548 
-L 147.932759 190.216173 
-L 147.867225 190.284699 
-L 147.801691 190.353126 
-L 147.736157 190.421454 
-L 147.670622 190.489684 
-L 147.605088 190.557816 
-L 147.539554 190.62585 
-L 147.47402 190.693787 
-L 147.408486 190.761626 
-L 147.342952 190.829369 
-L 147.277418 190.897015 
-L 147.211883 190.964564 
-L 147.146349 191.032017 
-L 147.080815 191.099375 
-L 147.015281 191.166636 
-L 146.949747 191.233803 
-L 146.884213 191.300874 
-L 146.818678 191.367851 
-L 146.753144 191.434733 
-L 146.68761 191.501521 
-L 146.622076 191.568215 
-L 146.556542 191.634815 
-L 146.491008 191.701322 
-L 146.425473 191.767736 
-L 146.359939 191.834056 
-L 146.294405 191.900284 
-L 146.228871 191.96642 
-L 146.163337 192.032463 
-L 146.097803 192.098415 
-L 146.032268 192.164275 
-L 145.966734 192.230043 
-L 145.9012 192.295721 
-L 145.835666 192.361307 
-L 145.770132 192.426803 
-L 145.704598 192.492209 
-L 145.639063 192.557524 
-L 145.573529 192.622749 
-L 145.507995 192.687885 
-L 145.442461 192.752932 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 152.709397 194.486606 
+L 152.647223 194.548119 
+L 152.585049 194.609552 
+L 152.522876 194.670905 
+L 152.460702 194.732179 
+L 152.398528 194.793374 
+L 152.336355 194.85449 
+L 152.274181 194.915528 
+L 152.212007 194.976487 
+L 152.149834 195.037367 
+L 152.08766 195.09817 
+L 152.025486 195.158894 
+L 151.963313 195.219541 
+L 151.901139 195.280111 
+L 151.838965 195.340603 
+L 151.776792 195.401018 
+L 151.714618 195.461356 
+L 151.652444 195.521617 
+L 151.590271 195.581802 
+L 151.528097 195.64191 
+L 151.465923 195.701943 
+L 151.40375 195.761899 
+L 151.341576 195.82178 
+L 151.279402 195.881585 
+L 151.217229 195.941315 
+L 151.155055 196.000969 
+L 151.092881 196.060549 
+L 151.030708 196.120054 
+L 150.968534 196.179484 
+L 150.90636 196.23884 
+L 150.844187 196.298122 
+L 150.782013 196.357329 
+L 150.719839 196.416463 
+L 150.657665 196.475523 
+L 150.595492 196.534509 
+L 150.533318 196.593422 
+L 150.471144 196.652262 
+L 150.408971 196.711029 
+L 150.346797 196.769724 
+L 150.284623 196.828345 
+L 150.22245 196.886895 
+L 150.160276 196.945372 
+L 150.098102 197.003777 
+L 150.035929 197.06211 
+L 149.973755 197.120371 
+L 149.911581 197.178561 
+L 149.849408 197.23668 
+L 149.787234 197.294727 
+L 149.72506 197.352703 
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_159">
-    <path d="M 145.442461 192.752932 
-L 144.808297 197.014602 
-L 144.174132 200.924511 
-L 143.539968 204.536329 
-L 142.905803 207.892304 
-L 142.271639 211.026298 
-L 141.637475 213.965862 
-L 141.00331 216.733719 
-L 140.369146 219.348827 
-L 139.734981 221.827165 
-L 139.100817 224.182333 
-L 138.466652 226.425996 
-L 137.832488 228.568236 
-L 137.198324 230.617828 
-L 136.564159 232.582454 
-L 135.929995 234.468879 
-L 135.29583 236.283091 
-L 134.661666 238.030416 
-L 134.027502 239.715611 
-L 133.393337 241.342943 
-L 132.759173 242.916254 
-L 132.125008 244.439015 
-L 131.490844 245.914374 
-L 130.85668 247.345194 
-L 130.222515 248.734084 
-L 129.588351 250.083433 
-L 128.954186 251.395429 
-L 128.320022 252.672086 
-L 127.685858 253.915257 
-L 127.051693 255.126653 
-L 126.417529 256.30786 
-L 125.783364 257.460344 
-L 125.1492 258.585471 
-L 124.515036 259.684507 
-L 123.880871 260.758637 
-L 123.246707 261.808964 
-L 122.612542 262.83652 
-L 121.978378 263.842272 
-L 121.344214 264.827125 
-L 120.710049 265.791931 
-L 120.075885 266.73749 
-L 119.44172 267.664554 
-L 118.807556 268.573833 
-L 118.173392 269.465997 
-L 117.539227 270.341677 
-L 116.905063 271.201473 
-L 116.270898 272.04595 
-L 115.636734 272.875645 
-L 115.00257 273.691065 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 149.72506 197.352703 
+L 149.001675 201.16869 
+L 148.27829 204.700218 
+L 147.554905 207.986772 
+L 146.831519 211.060144 
+L 146.108134 213.946313 
+L 145.384749 216.666782 
+L 144.661364 219.239549 
+L 143.937979 221.679829 
+L 143.214593 224.000601 
+L 142.491208 226.213027 
+L 141.767823 228.326773 
+L 141.044438 230.350267 
+L 140.321052 232.290902 
+L 139.597667 234.155198 
+L 138.874282 235.948934 
+L 138.150897 237.677256 
+L 137.427512 239.34477 
+L 136.704126 240.955607 
+L 135.980741 242.513496 
+L 135.257356 244.021805 
+L 134.533971 245.483595 
+L 133.810585 246.901648 
+L 133.0872 248.278506 
+L 132.363815 249.616495 
+L 131.64043 250.917749 
+L 130.917045 252.184233 
+L 130.193659 253.417755 
+L 129.470274 254.619988 
+L 128.746889 255.79248 
+L 128.023504 256.936668 
+L 127.300118 258.053885 
+L 126.576733 259.145374 
+L 125.853348 260.212294 
+L 125.129963 261.255725 
+L 124.406577 262.27668 
+L 123.683192 263.276108 
+L 122.959807 264.254896 
+L 122.236422 265.213881 
+L 121.513037 266.153847 
+L 120.789651 267.075535 
+L 120.066266 267.979642 
+L 119.342881 268.866825 
+L 118.619496 269.737708 
+L 117.89611 270.592878 
+L 117.172725 271.432891 
+L 116.44934 272.258277 
+L 115.725955 273.069536 
+L 115.00257 273.867142 
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_160">
-    <path d="M 115.00257 273.691065 
-L 114.685339 274.410845 
-L 114.368108 275.119857 
-L 114.050877 275.818421 
-L 113.733646 276.506838 
-L 113.416415 277.185399 
-L 113.099184 277.854383 
-L 112.781954 278.514057 
-L 112.464723 279.164675 
-L 112.147492 279.806484 
-L 111.830261 280.439718 
-L 111.51303 281.064603 
-L 111.195799 281.681358 
-L 110.878569 282.29019 
-L 110.561338 282.891301 
-L 110.244107 283.484884 
-L 109.926876 284.071125 
-L 109.609645 284.650205 
-L 109.292414 285.222294 
-L 108.975184 285.787561 
-L 108.657953 286.346167 
-L 108.340722 286.898265 
-L 108.023491 287.444007 
-L 107.70626 287.983537 
-L 107.389029 288.516994 
-L 107.071799 289.044514 
-L 106.754568 289.566228 
-L 106.437337 290.082262 
-L 106.120106 290.592738 
-L 105.802875 291.097775 
-L 105.485644 291.597488 
-L 105.168414 292.091987 
-L 104.851183 292.581381 
-L 104.533952 293.065773 
-L 104.216721 293.545264 
-L 103.89949 294.019954 
-L 103.582259 294.489937 
-L 103.265028 294.955306 
-L 102.947798 295.41615 
-L 102.630567 295.872556 
-L 102.313336 296.32461 
-L 101.996105 296.772393 
-L 101.678874 297.215985 
-L 101.361643 297.655464 
-L 101.044413 298.090906 
-L 100.727182 298.522384 
-L 100.409951 298.949969 
-L 100.09272 299.373732 
-L 99.775489 299.79374 
-" clip-path="url(#p9ad19b8953)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 115.00257 273.867142 
+L 114.685339 274.59897 
+L 114.368108 275.31967 
+L 114.050877 276.029576 
+L 113.733646 276.729006 
+L 113.416415 277.418265 
+L 113.099184 278.097644 
+L 112.781954 278.767423 
+L 112.464723 279.42787 
+L 112.147492 280.07924 
+L 111.830261 280.72178 
+L 111.51303 281.355726 
+L 111.195799 281.981305 
+L 110.878569 282.598736 
+L 110.561338 283.208226 
+L 110.244107 283.809979 
+L 109.926876 284.404188 
+L 109.609645 284.99104 
+L 109.292414 285.570714 
+L 108.975184 286.143385 
+L 108.657953 286.70922 
+L 108.340722 287.268379 
+L 108.023491 287.821019 
+L 107.70626 288.36729 
+L 107.389029 288.907337 
+L 107.071799 289.441299 
+L 106.754568 289.969314 
+L 106.437337 290.491511 
+L 106.120106 291.008018 
+L 105.802875 291.518957 
+L 105.485644 292.024447 
+L 105.168414 292.524603 
+L 104.851183 293.019536 
+L 104.533952 293.509355 
+L 104.216721 293.994164 
+L 103.89949 294.474064 
+L 103.582259 294.949154 
+L 103.265028 295.419529 
+L 102.947798 295.885282 
+L 102.630567 296.346503 
+L 102.313336 296.803279 
+L 101.996105 297.255696 
+L 101.678874 297.703835 
+L 101.361643 298.147776 
+L 101.044413 298.587599 
+L 100.727182 299.023377 
+L 100.409951 299.455186 
+L 100.09272 299.883096 
+L 99.775489 300.307177 
+" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
   </g>
   <g id="text_25">
@@ -6254,8 +6254,8 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-07-08T21:41:55Z  ·  Linux chungus2 x86_64  ·  commit b17c222c  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(43.990156 465.66) scale(0.07 -0.07)">
+   <!-- 2026-07-08T22:12:55Z  ·  Linux chungus2 x86_64  ·  commit 30251fb3  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(44.380078 465.66) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -6414,10 +6414,10 @@ z
     <use xlink:href="#DejaVuSans-38" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
     <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
     <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
@@ -6460,109 +6460,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3135.351562 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3198.974609 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3262.597656 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3317.578125 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3381.201172 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3444.824219 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3508.447266 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3563.427734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3595.214844 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3627.001953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3658.789062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3690.576172 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3722.363281 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3750.146484 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3811.669922 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3872.949219 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3936.328125 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3999.804688 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4038.667969 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4099.849609 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4159.029297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4220.552734 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4261.666016 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4295.357422 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4323.140625 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4384.664062 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4445.943359 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4509.322266 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4572.945312 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4606.636719 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4665.816406 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4729.439453 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4761.226562 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4824.849609 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4888.472656 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4920.259766 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4983.882812 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5019.966797 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5058.830078 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5113.810547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5177.433594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5209.220703 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5241.007812 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5272.794922 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5304.582031 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5336.369141 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5375.578125 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5438.957031 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5477.820312 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5539.001953 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5602.380859 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5665.857422 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5729.236328 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5792.712891 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5856.091797 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5895.300781 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5927.087891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6010.876953 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6042.664062 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6140.076172 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6201.599609 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6265.076172 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6292.859375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6354.138672 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6417.517578 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6449.304688 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6501.404297 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6564.783203 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6626.0625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6689.539062 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6741.638672 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6805.017578 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6866.199219 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6905.408203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6939.099609 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6970.886719 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7012 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7073.279297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7112.488281 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7140.271484 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7201.453125 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7233.240234 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7261.023438 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7313.123047 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7344.910156 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7408.386719 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7469.910156 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7509.119141 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7570.642578 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7610.005859 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7707.417969 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7735.201172 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7798.580078 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7826.363281 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7878.462891 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7917.671875 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7945.455078 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3262.744141 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3326.367188 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3389.990234 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3425.195312 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3488.671875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3552.294922 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3584.082031 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3615.869141 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3647.65625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3679.443359 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3711.230469 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3739.013672 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3800.537109 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3861.816406 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3925.195312 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3988.671875 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4027.535156 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4088.716797 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4147.896484 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4209.419922 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4250.533203 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4284.224609 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4312.007812 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4373.53125 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4434.810547 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4498.189453 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4561.8125 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4595.503906 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4654.683594 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4718.306641 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4750.09375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4813.716797 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4877.339844 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4909.126953 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4972.75 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5008.833984 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5047.697266 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5102.677734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5166.300781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5198.087891 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5229.875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5261.662109 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5293.449219 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5325.236328 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5364.445312 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5427.824219 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5466.6875 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5527.869141 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5591.248047 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5654.724609 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5718.103516 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5781.580078 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5844.958984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5884.167969 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5915.955078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5999.744141 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6031.53125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6128.943359 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6190.466797 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6253.943359 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6281.726562 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6343.005859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6406.384766 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6438.171875 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6490.271484 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6553.650391 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6614.929688 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6678.40625 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6730.505859 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6793.884766 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6855.066406 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6894.275391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6927.966797 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6959.753906 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7000.867188 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7062.146484 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7101.355469 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7129.138672 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7190.320312 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7222.107422 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7249.890625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7301.990234 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7333.777344 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7397.253906 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7458.777344 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7497.986328 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7559.509766 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7598.873047 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7696.285156 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7724.068359 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7787.447266 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7815.230469 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7867.330078 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7906.539062 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7934.322266 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p9ad19b8953">
+  <clipPath id="p8c12040a6d">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_ratio_heatmap.svg
+++ b/bench/graphs/canterbury_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p1d8fbc3c25)">
+   <g clip-path="url(#pd721f650a7)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAI/ElEQVR4nO3Yv4rkWR2H4aqe7qZnxQFl1GVDwUwWAxMnMfZO9goMxdzrUG9AEBFNRDExETMxE1mW3XEcZ5b+U/37eQmzwpGv1Ps8V/A5FHXqrXPc/vnT/XBu3nw6vWCp/bPzOs/hcDj8/Ye/mJ6w1N/+/HZ6wnLf/9kPpicsd/zOd6cnrHW8mF6w3uuPpxesd/NsesFSP//GT6YnLHeG3yQAgC9ODAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApB3vTr/cp0esth+26QlLHc+wWa8urqcnLHW/3U5PWO7qL3+cnrDc6dsvpicsddrupycs9/b0enrCcs/P7Hp4ePZ8esJy5/crCwDwXxBDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpl1dvX01vWO/u8+kFa+3b9IL1nj6bXrDU9fSA/4H99dvpCctd/fvl9ISlrrbT9ITlnp7jfXf7ZnrBUleX53fjeRkCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBA2vG0/XqfHrHavm/TE5bazuw8h8PhcHVxPT1hqcf9ND1huSdvXk5PWO/LX59esNTDdj89YbnPbv8xPWG59+8upycstX3lg+kJy3kZAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSLv/0ye+nNyx3cThOT1jqa+89n56w3ON2mp6w1PWTm+kJy330299NT1jux9/71vSEpU77Nj1huR/94a/TE5Z78cGXpics9dGHL6YnLOdlCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGnHh8df7dMjVrt/vJ2esNTT4830BN7h/nianrDcv+4+nZ6w3Fdv3p+esNS2b9MTlnt198n0hOVe3n08PWGpbz77cHrCcl6GAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkHbctt/s0yOA/0On++kF611eTy/gHW4fP5+esNzNk/emJ/AOXoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQdnm/3U5vWO5xO01PWOry4np6wnJXZ3amh+1+esJ65/hX6cw+p8f9vO66w+FwePPwanrCctdPbqYnLLXv2/SE5c7xugMA+MLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBA2n8ApwuP+NzbRB0AAAAASUVORK5CYII=" id="imagedd3bf0a3cc" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAI7UlEQVR4nO3Yz4plVx2G4XOqq8rqBBsMnT8ER0JmEhw4sScZ505yBQ4l81xH4g0IIqITUZw4EWfiTCSETifpdLdV1af28RLawJKfnPd5ruDbg732u9d+++rT4+7UPHs8vWCp45en9Ty73W73z5//anrCUv/46/PpCct98NmH0xOW2//kp9MT1tqfTS9Y7+nn0wvWu3owvWCpX779yfSE5U7wTQIA+O+JIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCAtP3N4dfH6RGrHXfb9ISl9ifYrBdnl9MTlrrdrqcnLHfxtz9PT1ju8ONH0xOWOmy30xOWe354Oj1huYcndjy8fPBwesJyp/eVBQD4DsQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAEDa+cXzr6c3rHfzYnrBWsdtesF69x9ML1jqcnrA/8Dx6fPpCctdfPtkesJSF9thesJy90/xvLt+Nr1gqYvz0zvx3AwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgbX/YfnucHrHa8bhNT1hqO7Hn2e12u4uzy+kJS90dD9MTlrv37Mn0hPW+/9b0gqVebrfTE5b78vpf0xOWe+fmfHrCUtsP3p2esJybIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAg7fwvX/xxesNyZ7v99ISl3nzt4fSE5e62w/SEpS7vXU1PWO6j3/9hesJyH//svekJSx2O2/SE5X7xp79PT1ju0buvT09Y6qP3H01PWM7NEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANL2L+9+c5wesdrt3fX0hKXu76+mJ/AKt/vD9ITlvrl5PD1huTeu3pmesNR23KYnLPf1zRfTE5Z7cvP59ISlfvTg/ekJy7kZAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQNp+2353nB4B/B863E4vWO/8cnoBr3B992J6wnJX916bnsAruBkCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBA2vn0AKKO2/QCXuHfu9vpCct978SOvLMT/J+9uXsxPWG5b24fT09Y6u2rH05PWO703iQAgO9ADAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApP0HV5aGIrf8pikAAAAASUVORK5CYII=" id="image600a2ba333" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m3bb17d5054" d="M 0 0 
+       <path id="m4e9e360035" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m3bb17d5054" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4e9e360035" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m3bb17d5054" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4e9e360035" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m3bb17d5054" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4e9e360035" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m3bb17d5054" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4e9e360035" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m3bb17d5054" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4e9e360035" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m3bb17d5054" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4e9e360035" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m3bb17d5054" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4e9e360035" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m3bb17d5054" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4e9e360035" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m3bb17d5054" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4e9e360035" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m3bb17d5054" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4e9e360035" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m3bb17d5054" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4e9e360035" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="mcef9e6243a" d="M 0 0 
+       <path id="m825d0082e4" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mcef9e6243a" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m825d0082e4" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#mcef9e6243a" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m825d0082e4" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mcef9e6243a" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m825d0082e4" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#mcef9e6243a" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m825d0082e4" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#mcef9e6243a" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m825d0082e4" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#mcef9e6243a" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m825d0082e4" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mcef9e6243a" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m825d0082e4" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#mcef9e6243a" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m825d0082e4" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1303,29 +1303,8 @@ L 512.247548 49.4355
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_20">
-    <!-- -1 -->
-    <g transform="translate(111.370957 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_21">
-    <!-- -1 -->
-    <g transform="translate(149.241075 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_22">
-    <!-- -1 -->
-    <g transform="translate(187.111194 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_23">
     <!-- +0 -->
-    <g transform="translate(223.430452 68.904519) scale(0.065 -0.065)">
+    <g transform="translate(109.820098 68.904519) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-2b" d="M 2944 4013 
 L 2944 2272 
@@ -1347,11 +1326,32 @@ z
      <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
     </g>
    </g>
-   <g id="text_24">
-    <!-- -1 -->
-    <g transform="translate(262.85143 68.904519) scale(0.065 -0.065)">
+   <g id="text_21">
+    <!-- +0 -->
+    <g transform="translate(147.690216 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_22">
+    <!-- -0 -->
+    <g transform="translate(187.111194 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_23">
+    <!-- +0 -->
+    <g transform="translate(223.430452 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_24">
+    <!-- +0 -->
+    <g transform="translate(261.30057 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_25">
@@ -1362,17 +1362,17 @@ z
     </g>
    </g>
    <g id="text_26">
-    <!-- -1 -->
+    <!-- -0 -->
     <g transform="translate(338.591666 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_27">
-    <!-- -1 -->
+    <!-- -0 -->
     <g transform="translate(376.461784 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_28">
@@ -1383,17 +1383,51 @@ z
     </g>
    </g>
    <g id="text_29">
-    <!-- -0 -->
+    <!-- -3 -->
     <g transform="translate(452.20202 68.904519) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_30">
-    <!-- -0 -->
-    <g transform="translate(490.072138 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(36.083984 0)"/>
+    <!-- +0 -->
+    <g transform="translate(488.521278 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_31">
@@ -1588,40 +1622,6 @@ z
    <g id="text_55">
     <!-- -3 -->
     <g transform="translate(187.111194 174.957073) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-33" d="M 2597 2516 
-Q 3050 2419 3304 2112 
-Q 3559 1806 3559 1356 
-Q 3559 666 3084 287 
-Q 2609 -91 1734 -91 
-Q 1441 -91 1130 -33 
-Q 819 25 488 141 
-L 488 750 
-Q 750 597 1062 519 
-Q 1375 441 1716 441 
-Q 2309 441 2620 675 
-Q 2931 909 2931 1356 
-Q 2931 1769 2642 2001 
-Q 2353 2234 1838 2234 
-L 1294 2234 
-L 1294 2753 
-L 1863 2753 
-Q 2328 2753 2575 2939 
-Q 2822 3125 2822 3475 
-Q 2822 3834 2567 4026 
-Q 2313 4219 1838 4219 
-Q 1578 4219 1281 4162 
-Q 984 4106 628 3988 
-L 628 4550 
-Q 988 4650 1302 4700 
-Q 1616 4750 1894 4750 
-Q 2613 4750 3031 4423 
-Q 3450 4097 3450 3541 
-Q 3450 3153 3228 2886 
-Q 3006 2619 2597 2516 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
     </g>
@@ -2092,18 +2092,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="image51a68da8c7" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
+iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="image8cee542aae" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="m8b04d7bd9b" d="M 0 0 
+       <path id="m7e5077aad9" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m8b04d7bd9b" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7e5077aad9" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
@@ -2129,7 +2129,7 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m8b04d7bd9b" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7e5077aad9" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
@@ -2146,7 +2146,7 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m8b04d7bd9b" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7e5077aad9" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
@@ -2163,7 +2163,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m8b04d7bd9b" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7e5077aad9" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
@@ -2180,7 +2180,7 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m8b04d7bd9b" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7e5077aad9" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_112">
@@ -2196,7 +2196,7 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m8b04d7bd9b" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7e5077aad9" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
@@ -2212,7 +2212,7 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m8b04d7bd9b" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7e5077aad9" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
@@ -2228,7 +2228,7 @@ z
     <g id="ytick_16">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#m8b04d7bd9b" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7e5077aad9" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_115">
@@ -2244,7 +2244,7 @@ z
     <g id="ytick_17">
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m8b04d7bd9b" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7e5077aad9" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_116">
@@ -2882,8 +2882,8 @@ z
    </g>
   </g>
   <g id="text_119">
-   <!-- 2026-07-08T21:41:55Z  ·  Linux chungus2 x86_64  ·  commit b17c222c  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(16.990156 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-08T22:12:55Z  ·  Linux chungus2 x86_64  ·  commit 30251fb3  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(17.380078 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2953,10 +2953,10 @@ z
     <use xlink:href="#DejaVuSans-38" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
     <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
     <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
@@ -2999,109 +2999,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3135.351562 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3198.974609 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3262.597656 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3317.578125 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3381.201172 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3444.824219 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3508.447266 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3563.427734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3595.214844 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3627.001953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3658.789062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3690.576172 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3722.363281 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3750.146484 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3811.669922 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3872.949219 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3936.328125 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3999.804688 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4038.667969 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4099.849609 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4159.029297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4220.552734 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4261.666016 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4295.357422 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4323.140625 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4384.664062 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4445.943359 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4509.322266 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4572.945312 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4606.636719 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4665.816406 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4729.439453 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4761.226562 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4824.849609 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4888.472656 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4920.259766 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4983.882812 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5019.966797 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5058.830078 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5113.810547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5177.433594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5209.220703 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5241.007812 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5272.794922 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5304.582031 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5336.369141 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5375.578125 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5438.957031 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5477.820312 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5539.001953 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5602.380859 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5665.857422 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5729.236328 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5792.712891 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5856.091797 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5895.300781 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5927.087891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6010.876953 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6042.664062 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6140.076172 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6201.599609 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6265.076172 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6292.859375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6354.138672 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6417.517578 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6449.304688 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6501.404297 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6564.783203 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6626.0625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6689.539062 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6741.638672 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6805.017578 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6866.199219 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6905.408203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6939.099609 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6970.886719 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7012 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7073.279297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7112.488281 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7140.271484 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7201.453125 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7233.240234 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7261.023438 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7313.123047 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7344.910156 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7408.386719 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7469.910156 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7509.119141 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7570.642578 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7610.005859 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7707.417969 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7735.201172 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7798.580078 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7826.363281 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7878.462891 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7917.671875 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7945.455078 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3262.744141 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3326.367188 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3389.990234 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3425.195312 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3488.671875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3552.294922 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3584.082031 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3615.869141 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3647.65625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3679.443359 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3711.230469 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3739.013672 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3800.537109 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3861.816406 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3925.195312 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3988.671875 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4027.535156 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4088.716797 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4147.896484 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4209.419922 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4250.533203 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4284.224609 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4312.007812 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4373.53125 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4434.810547 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4498.189453 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4561.8125 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4595.503906 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4654.683594 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4718.306641 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4750.09375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4813.716797 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4877.339844 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4909.126953 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4972.75 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5008.833984 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5047.697266 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5102.677734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5166.300781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5198.087891 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5229.875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5261.662109 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5293.449219 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5325.236328 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5364.445312 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5427.824219 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5466.6875 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5527.869141 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5591.248047 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5654.724609 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5718.103516 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5781.580078 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5844.958984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5884.167969 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5915.955078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5999.744141 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6031.53125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6128.943359 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6190.466797 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6253.943359 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6281.726562 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6343.005859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6406.384766 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6438.171875 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6490.271484 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6553.650391 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6614.929688 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6678.40625 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6730.505859 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6793.884766 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6855.066406 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6894.275391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6927.966797 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6959.753906 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7000.867188 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7062.146484 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7101.355469 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7129.138672 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7190.320312 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7222.107422 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7249.890625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7301.990234 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7333.777344 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7397.253906 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7458.777344 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7497.986328 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7559.509766 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7598.873047 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7696.285156 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7724.068359 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7787.447266 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7815.230469 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7867.330078 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7906.539062 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7934.322266 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p1d8fbc3c25">
+  <clipPath id="pd721f650a7">
    <rect x="95.67625" y="49.4355" width="416.571298" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_summary.svg
+++ b/bench/graphs/canterbury_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="574.419688pt" height="386.202469pt" viewBox="0 0 574.419688 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="573.639844pt" height="386.202469pt" viewBox="0 0 573.639844 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,232 +22,232 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 386.202469 
-L 574.419688 386.202469 
-L 574.419688 0 
+L 573.639844 386.202469 
+L 573.639844 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 189.334844 104.1264 
-L 293.959844 104.1264 
-L 293.959844 74.7432 
-L 189.334844 74.7432 
+    <path d="M 188.944922 104.1264 
+L 293.569922 104.1264 
+L 293.569922 74.7432 
+L 188.944922 74.7432 
 z
-" clip-path="url(#pa6bb1ff674)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2dd898885e)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 293.959844 104.1264 
-L 398.584844 104.1264 
-L 398.584844 74.7432 
-L 293.959844 74.7432 
+    <path d="M 293.569922 104.1264 
+L 398.194922 104.1264 
+L 398.194922 74.7432 
+L 293.569922 74.7432 
 z
-" clip-path="url(#pa6bb1ff674)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2dd898885e)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 398.584844 104.1264 
-L 503.209844 104.1264 
-L 503.209844 74.7432 
-L 398.584844 74.7432 
+    <path d="M 398.194922 104.1264 
+L 502.819922 104.1264 
+L 502.819922 74.7432 
+L 398.194922 74.7432 
 z
-" clip-path="url(#pa6bb1ff674)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2dd898885e)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 189.334844 133.5096 
-L 293.959844 133.5096 
-L 293.959844 104.1264 
-L 189.334844 104.1264 
+    <path d="M 188.944922 133.5096 
+L 293.569922 133.5096 
+L 293.569922 104.1264 
+L 188.944922 104.1264 
 z
-" clip-path="url(#pa6bb1ff674)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2dd898885e)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 293.959844 133.5096 
-L 398.584844 133.5096 
-L 398.584844 104.1264 
-L 293.959844 104.1264 
+    <path d="M 293.569922 133.5096 
+L 398.194922 133.5096 
+L 398.194922 104.1264 
+L 293.569922 104.1264 
 z
-" clip-path="url(#pa6bb1ff674)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2dd898885e)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 398.584844 133.5096 
-L 503.209844 133.5096 
-L 503.209844 104.1264 
-L 398.584844 104.1264 
+    <path d="M 398.194922 133.5096 
+L 502.819922 133.5096 
+L 502.819922 104.1264 
+L 398.194922 104.1264 
 z
-" clip-path="url(#pa6bb1ff674)" style="fill: #fdb768; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2dd898885e)" style="fill: #fdb768; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 189.334844 162.8928 
-L 293.959844 162.8928 
-L 293.959844 133.5096 
-L 189.334844 133.5096 
+    <path d="M 188.944922 162.8928 
+L 293.569922 162.8928 
+L 293.569922 133.5096 
+L 188.944922 133.5096 
 z
-" clip-path="url(#pa6bb1ff674)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2dd898885e)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 293.959844 162.8928 
-L 398.584844 162.8928 
-L 398.584844 133.5096 
-L 293.959844 133.5096 
+    <path d="M 293.569922 162.8928 
+L 398.194922 162.8928 
+L 398.194922 133.5096 
+L 293.569922 133.5096 
 z
-" clip-path="url(#pa6bb1ff674)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2dd898885e)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 398.584844 162.8928 
-L 503.209844 162.8928 
-L 503.209844 133.5096 
-L 398.584844 133.5096 
+    <path d="M 398.194922 162.8928 
+L 502.819922 162.8928 
+L 502.819922 133.5096 
+L 398.194922 133.5096 
 z
-" clip-path="url(#pa6bb1ff674)" style="fill: #bbe278; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2dd898885e)" style="fill: #bbe278; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 189.334844 192.276 
-L 293.959844 192.276 
-L 293.959844 162.8928 
-L 189.334844 162.8928 
+    <path d="M 188.944922 192.276 
+L 293.569922 192.276 
+L 293.569922 162.8928 
+L 188.944922 162.8928 
 z
-" clip-path="url(#pa6bb1ff674)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2dd898885e)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 293.959844 192.276 
-L 398.584844 192.276 
-L 398.584844 162.8928 
-L 293.959844 162.8928 
+    <path d="M 293.569922 192.276 
+L 398.194922 192.276 
+L 398.194922 162.8928 
+L 293.569922 162.8928 
 z
-" clip-path="url(#pa6bb1ff674)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2dd898885e)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 398.584844 192.276 
-L 503.209844 192.276 
-L 503.209844 162.8928 
-L 398.584844 162.8928 
+    <path d="M 398.194922 192.276 
+L 502.819922 192.276 
+L 502.819922 162.8928 
+L 398.194922 162.8928 
 z
-" clip-path="url(#pa6bb1ff674)" style="fill: #fdc776; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2dd898885e)" style="fill: #fdc776; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 189.334844 221.6592 
-L 293.959844 221.6592 
-L 293.959844 192.276 
-L 189.334844 192.276 
+    <path d="M 188.944922 221.6592 
+L 293.569922 221.6592 
+L 293.569922 192.276 
+L 188.944922 192.276 
 z
-" clip-path="url(#pa6bb1ff674)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2dd898885e)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 293.959844 221.6592 
-L 398.584844 221.6592 
-L 398.584844 192.276 
-L 293.959844 192.276 
+    <path d="M 293.569922 221.6592 
+L 398.194922 221.6592 
+L 398.194922 192.276 
+L 293.569922 192.276 
 z
-" clip-path="url(#pa6bb1ff674)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2dd898885e)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 398.584844 221.6592 
-L 503.209844 221.6592 
-L 503.209844 192.276 
-L 398.584844 192.276 
+    <path d="M 398.194922 221.6592 
+L 502.819922 221.6592 
+L 502.819922 192.276 
+L 398.194922 192.276 
 z
-" clip-path="url(#pa6bb1ff674)" style="fill: #addc6f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2dd898885e)" style="fill: #addc6f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 189.334844 251.0424 
-L 293.959844 251.0424 
-L 293.959844 221.6592 
-L 189.334844 221.6592 
+    <path d="M 188.944922 251.0424 
+L 293.569922 251.0424 
+L 293.569922 221.6592 
+L 188.944922 221.6592 
 z
-" clip-path="url(#pa6bb1ff674)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2dd898885e)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 293.959844 251.0424 
-L 398.584844 251.0424 
-L 398.584844 221.6592 
-L 293.959844 221.6592 
+    <path d="M 293.569922 251.0424 
+L 398.194922 251.0424 
+L 398.194922 221.6592 
+L 293.569922 221.6592 
 z
-" clip-path="url(#pa6bb1ff674)" style="fill: #fdbd6d; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2dd898885e)" style="fill: #fdbd6d; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 398.584844 251.0424 
-L 503.209844 251.0424 
-L 503.209844 221.6592 
-L 398.584844 221.6592 
+    <path d="M 398.194922 251.0424 
+L 502.819922 251.0424 
+L 502.819922 221.6592 
+L 398.194922 221.6592 
 z
-" clip-path="url(#pa6bb1ff674)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2dd898885e)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 189.334844 280.4256 
-L 293.959844 280.4256 
-L 293.959844 251.0424 
-L 189.334844 251.0424 
+    <path d="M 188.944922 280.4256 
+L 293.569922 280.4256 
+L 293.569922 251.0424 
+L 188.944922 251.0424 
 z
-" clip-path="url(#pa6bb1ff674)" style="fill: #ebf7a3; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2dd898885e)" style="fill: #f1f9ac; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 293.959844 280.4256 
-L 398.584844 280.4256 
-L 398.584844 251.0424 
-L 293.959844 251.0424 
+    <path d="M 293.569922 280.4256 
+L 398.194922 280.4256 
+L 398.194922 251.0424 
+L 293.569922 251.0424 
 z
-" clip-path="url(#pa6bb1ff674)" style="fill: #fca85e; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2dd898885e)" style="fill: #fb9d59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 398.584844 280.4256 
-L 503.209844 280.4256 
-L 503.209844 251.0424 
-L 398.584844 251.0424 
+    <path d="M 398.194922 280.4256 
+L 502.819922 280.4256 
+L 502.819922 251.0424 
+L 398.194922 251.0424 
 z
-" clip-path="url(#pa6bb1ff674)" style="fill: #fca55d; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2dd898885e)" style="fill: #fca55d; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 189.334844 309.8088 
-L 293.959844 309.8088 
-L 293.959844 280.4256 
-L 189.334844 280.4256 
+    <path d="M 188.944922 309.8088 
+L 293.569922 309.8088 
+L 293.569922 280.4256 
+L 188.944922 280.4256 
 z
-" clip-path="url(#pa6bb1ff674)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2dd898885e)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 293.959844 309.8088 
-L 398.584844 309.8088 
-L 398.584844 280.4256 
-L 293.959844 280.4256 
+    <path d="M 293.569922 309.8088 
+L 398.194922 309.8088 
+L 398.194922 280.4256 
+L 293.569922 280.4256 
 z
-" clip-path="url(#pa6bb1ff674)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2dd898885e)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 398.584844 309.8088 
-L 503.209844 309.8088 
-L 503.209844 280.4256 
-L 398.584844 280.4256 
+    <path d="M 398.194922 309.8088 
+L 502.819922 309.8088 
+L 502.819922 280.4256 
+L 398.194922 280.4256 
 z
-" clip-path="url(#pa6bb1ff674)" style="fill: #ee613e; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2dd898885e)" style="fill: #ee613e; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 189.334844 339.192 
-L 293.959844 339.192 
-L 293.959844 309.8088 
-L 189.334844 309.8088 
+    <path d="M 188.944922 339.192 
+L 293.569922 339.192 
+L 293.569922 309.8088 
+L 188.944922 309.8088 
 z
-" clip-path="url(#pa6bb1ff674)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2dd898885e)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 293.959844 339.192 
-L 398.584844 339.192 
-L 398.584844 309.8088 
-L 293.959844 309.8088 
+    <path d="M 293.569922 339.192 
+L 398.194922 339.192 
+L 398.194922 309.8088 
+L 293.569922 309.8088 
 z
-" clip-path="url(#pa6bb1ff674)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2dd898885e)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 398.584844 339.192 
-L 503.209844 339.192 
-L 503.209844 309.8088 
-L 398.584844 309.8088 
+    <path d="M 398.194922 339.192 
+L 502.819922 339.192 
+L 502.819922 309.8088 
+L 398.194922 309.8088 
 z
-" clip-path="url(#pa6bb1ff674)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2dd898885e)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(122.322109 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(121.932188 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(229.606328 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(229.216406 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(308.178438 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(307.788516 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(406.530156 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(406.140234 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(118.259844 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(117.869922 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.296 -->
-    <g transform="translate(230.196094 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(229.806172 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -946,7 +946,7 @@ z
    </g>
    <g id="text_7">
     <!-- 158 -->
-    <g transform="translate(338.637344 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(338.247422 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -1034,7 +1034,7 @@ z
    </g>
    <g id="text_8">
     <!-- 925 -->
-    <g transform="translate(443.262344 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(442.872422 91.6423) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-39"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
@@ -1042,7 +1042,7 @@ z
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(112.897969 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(112.508047 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1141,7 +1141,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.299 -->
-    <g transform="translate(230.196094 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(229.806172 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1151,7 +1151,7 @@ z
    </g>
    <g id="text_11">
     <!-- 73 -->
-    <g transform="translate(341.182344 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(340.792422 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -1202,7 +1202,7 @@ z
    </g>
    <g id="text_12">
     <!-- 283 -->
-    <g transform="translate(443.262344 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(442.872422 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(127.246094 0)"/>
@@ -1210,7 +1210,7 @@ z
    </g>
    <g id="text_13">
     <!-- zlib -->
-    <g transform="translate(130.161094 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(129.771172 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1234,7 +1234,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.299 -->
-    <g transform="translate(230.196094 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(229.806172 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1244,14 +1244,14 @@ z
    </g>
    <g id="text_15">
     <!-- 55 -->
-    <g transform="translate(341.182344 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(340.792422 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
     <!-- 692 -->
-    <g transform="translate(443.262344 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(442.872422 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-36"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
@@ -1259,7 +1259,7 @@ z
    </g>
    <g id="text_17">
     <!-- Go compress/flate -->
-    <g transform="translate(100.591094 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(100.201172 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -1430,7 +1430,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.299 -->
-    <g transform="translate(230.196094 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(229.806172 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1440,14 +1440,14 @@ z
    </g>
    <g id="text_19">
     <!-- 52 -->
-    <g transform="translate(341.182344 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(340.792422 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
     <!-- 323 -->
-    <g transform="translate(443.262344 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(442.872422 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(127.246094 0)"/>
@@ -1455,7 +1455,7 @@ z
    </g>
    <g id="text_21">
     <!-- miniz_oxide -->
-    <g transform="translate(113.467344 209.06385) scale(0.08 -0.08)">
+    <g transform="translate(113.077422 209.06385) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6e" d="M 3513 2113 
 L 3513 0 
@@ -1514,7 +1514,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.299 -->
-    <g transform="translate(230.196094 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(229.806172 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1524,14 +1524,14 @@ z
    </g>
    <g id="text_23">
     <!-- 51 -->
-    <g transform="translate(341.182344 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(340.792422 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_24">
     <!-- 729 -->
-    <g transform="translate(443.262344 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(442.872422 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-37"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(127.246094 0)"/>
@@ -1539,7 +1539,7 @@ z
    </g>
    <g id="text_25">
     <!-- JS fflate -->
-    <g transform="translate(121.623594 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(121.233672 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1599,7 +1599,7 @@ z
    </g>
    <g id="text_26">
     <!-- 0.307 -->
-    <g transform="translate(230.196094 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(229.806172 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1609,7 +1609,7 @@ z
    </g>
    <g id="text_27">
     <!-- 41 -->
-    <g transform="translate(341.182344 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(340.792422 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1637,14 +1637,14 @@ z
    </g>
    <g id="text_28">
     <!-- 80 -->
-    <g transform="translate(445.807344 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(445.417422 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-38"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_29">
     <!-- lean-zip (native) -->
-    <g transform="translate(99.969219 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(99.579297 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1752,8 +1752,8 @@ z
     </g>
    </g>
    <g id="text_30">
-    <!-- 0.297 -->
-    <g transform="translate(228.995469 267.9415) scale(0.08 -0.08)">
+    <!-- 0.298 -->
+    <g transform="translate(228.605547 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1835,88 +1835,6 @@ Q 1491 2759 1650 2554
 Q 1809 2350 2125 2350 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-37" d="M 428 4666 
-L 3944 4666 
-L 3944 3988 
-L 2125 0 
-L 953 0 
-L 2675 3781 
-L 428 3781 
-L 428 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-Bold-30"/>
-     <use xlink:href="#DejaVuSans-Bold-2e" transform="translate(69.580078 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-32" transform="translate(107.568359 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-39" transform="translate(177.148438 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-37" transform="translate(246.728516 0)"/>
-    </g>
-   </g>
-   <g id="text_31">
-    <!-- 32 -->
-    <g transform="translate(340.706094 267.9415) scale(0.08 -0.08)">
-     <defs>
-      <path id="DejaVuSans-Bold-33" d="M 2981 2516 
-Q 3453 2394 3698 2092 
-Q 3944 1791 3944 1325 
-Q 3944 631 3412 270 
-Q 2881 -91 1863 -91 
-Q 1503 -91 1142 -33 
-Q 781 25 428 141 
-L 428 1069 
-Q 766 900 1098 814 
-Q 1431 728 1753 728 
-Q 2231 728 2486 893 
-Q 2741 1059 2741 1369 
-Q 2741 1688 2480 1852 
-Q 2219 2016 1709 2016 
-L 1228 2016 
-L 1228 2791 
-L 1734 2791 
-Q 2188 2791 2409 2933 
-Q 2631 3075 2631 3366 
-Q 2631 3634 2415 3781 
-Q 2200 3928 1806 3928 
-Q 1516 3928 1219 3862 
-Q 922 3797 628 3669 
-L 628 4550 
-Q 984 4650 1334 4700 
-Q 1684 4750 2022 4750 
-Q 2931 4750 3382 4451 
-Q 3834 4153 3834 3553 
-Q 3834 3144 3618 2883 
-Q 3403 2622 2981 2516 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-Bold-33"/>
-     <use xlink:href="#DejaVuSans-Bold-32" transform="translate(69.580078 0)"/>
-    </g>
-   </g>
-   <g id="text_32">
-    <!-- 248 -->
-    <g transform="translate(442.547969 267.9415) scale(0.08 -0.08)">
-     <defs>
-      <path id="DejaVuSans-Bold-34" d="M 2356 3675 
-L 1038 1722 
-L 2356 1722 
-L 2356 3675 
-z
-M 2156 4666 
-L 3494 4666 
-L 3494 1722 
-L 4159 1722 
-L 4159 850 
-L 3494 850 
-L 3494 0 
-L 2356 0 
-L 2356 850 
-L 288 850 
-L 288 1881 
-L 2156 4666 
-z
-" transform="scale(0.015625)"/>
       <path id="DejaVuSans-Bold-38" d="M 2228 2088 
 Q 1891 2088 1709 1903 
 Q 1528 1719 1528 1375 
@@ -1957,14 +1875,62 @@ Q 1631 3694 1631 3419
 z
 " transform="scale(0.015625)"/>
      </defs>
+     <use xlink:href="#DejaVuSans-Bold-30"/>
+     <use xlink:href="#DejaVuSans-Bold-2e" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-32" transform="translate(107.568359 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-39" transform="translate(177.148438 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-38" transform="translate(246.728516 0)"/>
+    </g>
+   </g>
+   <g id="text_31">
+    <!-- 29 -->
+    <g transform="translate(340.316172 267.9415) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-Bold-32"/>
+     <use xlink:href="#DejaVuSans-Bold-39" transform="translate(69.580078 0)"/>
+    </g>
+   </g>
+   <g id="text_32">
+    <!-- 247 -->
+    <g transform="translate(442.158047 267.9415) scale(0.08 -0.08)">
+     <defs>
+      <path id="DejaVuSans-Bold-34" d="M 2356 3675 
+L 1038 1722 
+L 2356 1722 
+L 2356 3675 
+z
+M 2156 4666 
+L 3494 4666 
+L 3494 1722 
+L 4159 1722 
+L 4159 850 
+L 3494 850 
+L 3494 0 
+L 2356 0 
+L 2356 850 
+L 288 850 
+L 288 1881 
+L 2156 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-37" d="M 428 4666 
+L 3944 4666 
+L 3944 3988 
+L 2125 0 
+L 953 0 
+L 2675 3781 
+L 428 3781 
+L 428 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-Bold-32"/>
      <use xlink:href="#DejaVuSans-Bold-34" transform="translate(69.580078 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-38" transform="translate(139.160156 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-37" transform="translate(139.160156 0)"/>
     </g>
    </g>
    <g id="text_33">
     <!-- OCaml decompress -->
-    <g transform="translate(98.084219 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(97.694297 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -2029,7 +1995,7 @@ z
    </g>
    <g id="text_34">
     <!-- 0.321 -->
-    <g transform="translate(230.196094 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(229.806172 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -2039,14 +2005,14 @@ z
    </g>
    <g id="text_35">
     <!-- 23 -->
-    <g transform="translate(341.182344 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(340.792422 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_36">
     <!-- 117 -->
-    <g transform="translate(443.262344 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(442.872422 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
@@ -2054,7 +2020,7 @@ z
    </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(126.305469 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(125.915547 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -2065,7 +2031,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.279 -->
-    <g transform="translate(230.196094 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(229.806172 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -2075,13 +2041,13 @@ z
    </g>
    <g id="text_39">
     <!-- 0 -->
-    <g transform="translate(343.727344 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(343.337422 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(446.897344 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(446.507422 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2097,7 +2063,7 @@ z
   </g>
   <g id="text_41">
    <!-- canterbury — geomean over files, level 6 -->
-   <g transform="translate(136.718594 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(136.328672 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-62" d="M 2400 722 
 Q 2759 722 2948 984 
@@ -2310,7 +2276,7 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-07-08T21:41:55Z  ·  Linux chungus2 x86_64  ·  commit b17c222c  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-07-08T22:12:55Z  ·  Linux chungus2 x86_64  ·  commit 30251fb3  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2452,10 +2418,10 @@ z
     <use xlink:href="#DejaVuSans-38" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
     <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
     <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
@@ -2498,110 +2464,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3135.351562 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3198.974609 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3262.597656 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3317.578125 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3381.201172 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3444.824219 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3508.447266 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3563.427734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3595.214844 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3627.001953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3658.789062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3690.576172 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3722.363281 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3750.146484 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3811.669922 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3872.949219 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3936.328125 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3999.804688 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4038.667969 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4099.849609 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4159.029297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4220.552734 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4261.666016 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4295.357422 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4323.140625 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4384.664062 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4445.943359 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4509.322266 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4572.945312 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4606.636719 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4665.816406 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4729.439453 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4761.226562 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4824.849609 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4888.472656 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4920.259766 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4983.882812 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5019.966797 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5058.830078 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5113.810547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5177.433594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5209.220703 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5241.007812 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5272.794922 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5304.582031 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5336.369141 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5375.578125 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5438.957031 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5477.820312 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5539.001953 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5602.380859 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5665.857422 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5729.236328 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5792.712891 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5856.091797 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5895.300781 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5927.087891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6010.876953 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6042.664062 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6140.076172 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6201.599609 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6265.076172 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6292.859375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6354.138672 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6417.517578 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6449.304688 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6501.404297 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6564.783203 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6626.0625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6689.539062 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6741.638672 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6805.017578 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6866.199219 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6905.408203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6939.099609 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6970.886719 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7012 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7073.279297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7112.488281 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7140.271484 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7201.453125 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7233.240234 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7261.023438 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7313.123047 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7344.910156 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7408.386719 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7469.910156 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7509.119141 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7570.642578 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7610.005859 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7707.417969 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7735.201172 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7798.580078 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7826.363281 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7878.462891 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7917.671875 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7945.455078 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3262.744141 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3326.367188 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3389.990234 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3425.195312 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3488.671875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3552.294922 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3584.082031 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3615.869141 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3647.65625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3679.443359 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3711.230469 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3739.013672 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3800.537109 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3861.816406 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3925.195312 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3988.671875 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4027.535156 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4088.716797 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4147.896484 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4209.419922 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4250.533203 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4284.224609 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4312.007812 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4373.53125 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4434.810547 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4498.189453 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4561.8125 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4595.503906 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4654.683594 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4718.306641 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4750.09375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4813.716797 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4877.339844 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4909.126953 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4972.75 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5008.833984 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5047.697266 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5102.677734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5166.300781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5198.087891 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5229.875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5261.662109 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5293.449219 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5325.236328 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5364.445312 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5427.824219 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5466.6875 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5527.869141 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5591.248047 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5654.724609 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5718.103516 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5781.580078 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5844.958984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5884.167969 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5915.955078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5999.744141 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6031.53125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6128.943359 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6190.466797 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6253.943359 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6281.726562 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6343.005859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6406.384766 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6438.171875 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6490.271484 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6553.650391 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6614.929688 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6678.40625 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6730.505859 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6793.884766 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6855.066406 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6894.275391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6927.966797 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6959.753906 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7000.867188 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7062.146484 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7101.355469 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7129.138672 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7190.320312 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7222.107422 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7249.890625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7301.990234 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7333.777344 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7397.253906 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7458.777344 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7497.986328 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7559.509766 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7598.873047 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7696.285156 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7724.068359 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7787.447266 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7815.230469 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7867.330078 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7906.539062 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7934.322266 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pa6bb1ff674">
-   <rect x="84.709844" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="p2dd898885e">
+   <rect x="84.319922" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/graphs/silesia_compress_heatmap.svg
+++ b/bench/graphs/silesia_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.34175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p772d83926e)">
+   <g clip-path="url(#p5fc832b6a3)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAqAAAAGaCAYAAADQNfGTAAAJ9UlEQVR4nO3YP27l1R2H4bF9x+MxksWAsBg0TWiiiCIiEoqyjawjVVrWwAboKFkABQ1FikikoaQCiX8SAoEImgyOfX3NItB5v8NPz7OCz9Xx8X3vOTr88N7dvS27fja9YK2j4+kFax320wvW2vr57a+nF6x1/uL0grX+/3R6Ab/Fyen0grW2/vd5/2x6wVIb//YDAOB5I0ABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEjtPtl/Ob1hqdP7u+kJS13tr6cnLPX44rXpCUt98fNX0xOW2h/dTk9Y6k8PX5qesNT+wdn0hKW+efr19ISlLh9eTk9Y6up0Pz1hqaN7z6YnLOUFFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASO0uzy+nNyz1+IXXpycs9d2zL6cnLPXq1bZ/I128/OfpCUudnpxNT1jq9rCfnrDU1s9v85/veNufb3f8ZHrCUmdXV9MTltr2tzsAAM8dAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQGr34OR8esNSP159Oz1hqa2f3+2jl6YnLPXVT59MT1jq6c3V9ISl3nr01vSEpa7v9tMTlvri58+nJyz1xst/mZ6w1Mff/nt6wlJvvrLt8/MCCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJA6uv3XP++mRyx1OEwv4LfY+vkd+w0IY7Z+//z//H3b76cXLLXx0wMA4HkjQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASO0uP/50esNSJ6cn0xOW+u7T76cnLPXuP96cnrDUO//Z9vn97cnF9ISl3v/o8+kJS7399z9OT1jqg8/+Oz1hqT+8+HB6wlI//nIzPWGpvz4+n56wlBdQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgdXRz++Hd9IiVTm6upyesdXI6vWCt/dX0grV2Z9ML1jrZTS9Y6+4wvWCtm43fv6ONv8Ecb/v+3Rxt+/7d3++nJyy18dsHAMDzRoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJDaff/L19Mblnp1dzk9Yan/3T2bnrDUC7eH6QlrPdhNL1jqcG/b5/d0/9P0hKUubqYXrHV7fjE9YanD3bbv3/0ftt0v9x49mV6wlBdQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgNSvp/N/zBRtfskAAAAASUVORK5CYII=" id="image8b03d76803" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="483.84" height="295.2"/>
+iVBORw0KGgoAAAANSUhEUgAAAqAAAAGaCAYAAADQNfGTAAAJ9ElEQVR4nO3YMW5lZx2H4bF9feNx0CiZCCuD0kCDEAUKUoTYButIlZY1sAE6yiyAgiYFBVJoUqYiUhKQokFEZDRMbuxrO4uIvvdvjp5nBb+j75573nNO7v7zp/tHW3b9anrBWien0wvWujtOL1hr6+d3vJ5esNblG9ML1vru5fQCfoiz/fSCtbb++zy/mF6w1MaffgAAPDQCFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACA1O6T4xfTG5ban++mJyx1OF5PT1jq2ZOfTE9Y6vMXX05PWOp4cjs9YalfPH46PWGp42sX0xOW+tfLf05PWOrq8dX0hKUO++P0hKVOHr2anrCUL6AAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBqd3V5Nb1hqWev/2x6wlLPX30xPWGptw/bfkd68tavpicstT+7mJ6w1O3dcXrCUls/v81f3+m2r293+s70hKUuDofpCUtt++kOAMCDI0ABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEjtXju7nN6w1NeHr6YnLLX187t98+n0hKW+/O8n0xOWenlzmJ6w1Htvvjc9Yanr++P0hKU+f/HZ9ISlfvnWr6cnLPXxV3+bnrDUuz/e9vn5AgoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQOrn96wf30yOWurubXsAPsfXzO/UOCGO2fv/5//z/djxOL1hq46cHAMBDI0ABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEjtrj7+dHrDUmf7s+kJSz3/9N/TE5b64/vvTk9Y6g9/3/b5/fadJ9MTlvrwo8+mJyz1+9/9fHrCUn/+xzfTE5b66RuPpycs9fW3N9MTlvrNs8vpCUv5AgoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKRObm7/cj89YqWzm+vpCWud7acXrHU8TC9Ya3cxvWCts930grXu76YXrHWz8fvvZOPfYE63ff/dnGz7/js/HqcnLLXxuw8AgIdGgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkNr97/hiesNST47bbuzr3bavb394OT1hrR9dTC9Y67ttn9/1+W56wlL7b7f9fHj0+tPpBWudbvv5cP7N8+kJa+0vpxcste1fJwAAD44ABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAg9T1Rn3nGMjFSOwAAAABJRU5ErkJggg==" id="image6c52d2c3ec" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="483.84" height="295.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m3981f2f766" d="M 0 0 
+       <path id="m5fba026dfd" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m3981f2f766" x="115.814949" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5fba026dfd" x="115.814949" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m3981f2f766" x="156.092348" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5fba026dfd" x="156.092348" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m3981f2f766" x="196.369746" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5fba026dfd" x="196.369746" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m3981f2f766" x="236.647145" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5fba026dfd" x="236.647145" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m3981f2f766" x="276.924544" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5fba026dfd" x="276.924544" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m3981f2f766" x="317.201942" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5fba026dfd" x="317.201942" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m3981f2f766" x="357.479341" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5fba026dfd" x="357.479341" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m3981f2f766" x="397.756739" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5fba026dfd" x="397.756739" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m3981f2f766" x="438.034138" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5fba026dfd" x="438.034138" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m3981f2f766" x="478.311536" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5fba026dfd" x="478.311536" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m3981f2f766" x="518.588935" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5fba026dfd" x="518.588935" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m3981f2f766" x="558.866334" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5fba026dfd" x="558.866334" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="m62c738e4a4" d="M 0 0 
+       <path id="m60e196f623" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m62c738e4a4" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m60e196f623" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m62c738e4a4" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m60e196f623" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m62c738e4a4" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m60e196f623" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m62c738e4a4" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m60e196f623" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -836,7 +836,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m62c738e4a4" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m60e196f623" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -899,7 +899,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m62c738e4a4" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m60e196f623" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -966,7 +966,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m62c738e4a4" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m60e196f623" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1047,7 +1047,7 @@ z
     <g id="ytick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m62c738e4a4" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m60e196f623" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -1138,7 +1138,7 @@ L 579.005033 49.34175
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_21">
-    <!-- +38 -->
+    <!-- +22 -->
     <g transform="translate(108.955926 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-2b" d="M 2944 4013 
@@ -1156,6 +1156,197 @@ L 2419 4013
 L 2944 4013 
 z
 " transform="scale(0.015625)"/>
+      <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_22">
+    <!-- -20 -->
+    <g transform="translate(150.784184 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_23">
+    <!-- +11 -->
+    <g transform="translate(189.510723 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_24">
+    <!-- -29 -->
+    <g transform="translate(231.338981 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_25">
+    <!-- -7 -->
+    <g transform="translate(273.684192 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_26">
+    <!-- -15 -->
+    <g transform="translate(311.893778 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_27">
+    <!-- +11 -->
+    <g transform="translate(350.620317 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_28">
+    <!-- -30 -->
+    <g transform="translate(392.448575 69.553235) scale(0.065 -0.065)">
+     <defs>
       <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
 Q 3559 1806 3559 1356 
@@ -1188,6 +1379,16 @@ Q 3450 3153 3228 2886
 Q 3006 2619 2597 2516 
 z
 " transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_29">
+    <!-- -8 -->
+    <g transform="translate(434.793786 69.553235) scale(0.065 -0.065)">
+     <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
 Q 1069 1734 1069 1313 
@@ -1228,143 +1429,58 @@ Q 1172 3844 1172 3481
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_22">
-    <!-- -13 -->
-    <g transform="translate(150.784184 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-31" d="M 794 531 
-L 1825 531 
-L 1825 4091 
-L 703 3866 
-L 703 4441 
-L 1819 4666 
-L 2450 4666 
-L 2450 531 
-L 3481 531 
-L 3481 0 
-L 794 0 
-L 794 531 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
     </g>
    </g>
-   <g id="text_23">
-    <!-- +17 -->
-    <g transform="translate(189.510723 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
+   <g id="text_30">
+    <!-- -5 -->
+    <g transform="translate(475.071185 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
     </g>
    </g>
-   <g id="text_24">
+   <g id="text_31">
+    <!-- -32 -->
+    <g transform="translate(513.280771 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_32">
     <!-- -20 -->
-    <g transform="translate(231.338981 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-32" d="M 1228 531 
-L 3431 531 
-L 3431 0 
-L 469 0 
-L 469 531 
-Q 828 903 1448 1529 
-Q 2069 2156 2228 2338 
-Q 2531 2678 2651 2914 
-Q 2772 3150 2772 3378 
-Q 2772 3750 2511 3984 
-Q 2250 4219 1831 4219 
-Q 1534 4219 1204 4116 
-Q 875 4013 500 3803 
-L 500 4441 
-Q 881 4594 1212 4672 
-Q 1544 4750 1819 4750 
-Q 2544 4750 2975 4387 
-Q 3406 4025 3406 3419 
-Q 3406 3131 3298 2873 
-Q 3191 2616 2906 2266 
-Q 2828 2175 2409 1742 
-Q 1991 1309 1228 531 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-30" d="M 2034 4250 
-Q 1547 4250 1301 3770 
-Q 1056 3291 1056 2328 
-Q 1056 1369 1301 889 
-Q 1547 409 2034 409 
-Q 2525 409 2770 889 
-Q 3016 1369 3016 2328 
-Q 3016 3291 2770 3770 
-Q 2525 4250 2034 4250 
-z
-M 2034 4750 
-Q 2819 4750 3233 4129 
-Q 3647 3509 3647 2328 
-Q 3647 1150 3233 529 
-Q 2819 -91 2034 -91 
-Q 1250 -91 836 529 
-Q 422 1150 422 2328 
-Q 422 3509 836 4129 
-Q 1250 4750 2034 4750 
-z
-" transform="scale(0.015625)"/>
-     </defs>
+    <g transform="translate(553.558169 69.553235) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
     </g>
    </g>
-   <g id="text_25">
-    <!-- +2 -->
-    <g transform="translate(272.133333 69.553235) scale(0.065 -0.065)">
+   <g id="text_33">
+    <!-- +7 -->
+    <g transform="translate(111.023738 106.389018) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
     </g>
    </g>
-   <g id="text_26">
-    <!-- +3 -->
-    <g transform="translate(312.410731 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_27">
-    <!-- +21 -->
-    <g transform="translate(350.620317 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_28">
-    <!-- -21 -->
-    <g transform="translate(392.448575 69.553235) scale(0.065 -0.065)">
+   <g id="text_34">
+    <!-- -13 -->
+    <g transform="translate(150.784184 106.389018) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
     </g>
    </g>
-   <g id="text_29">
-    <!-- +6 -->
-    <g transform="translate(433.242927 69.553235) scale(0.065 -0.065)">
+   <g id="text_35">
+    <!-- -5 -->
+    <g transform="translate(193.129395 106.389018) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_36">
+    <!-- -16 -->
+    <g transform="translate(231.338981 106.389018) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -1397,137 +1513,6 @@ Q 3103 4656 3366 4563
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_30">
-    <!-- +9 -->
-    <g transform="translate(473.520325 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-39" d="M 703 97 
-L 703 672 
-Q 941 559 1184 500 
-Q 1428 441 1663 441 
-Q 2288 441 2617 861 
-Q 2947 1281 2994 2138 
-Q 2813 1869 2534 1725 
-Q 2256 1581 1919 1581 
-Q 1219 1581 811 2004 
-Q 403 2428 403 3163 
-Q 403 3881 828 4315 
-Q 1253 4750 1959 4750 
-Q 2769 4750 3195 4129 
-Q 3622 3509 3622 2328 
-Q 3622 1225 3098 567 
-Q 2575 -91 1691 -91 
-Q 1453 -91 1209 -44 
-Q 966 3 703 97 
-z
-M 1959 2075 
-Q 2384 2075 2632 2365 
-Q 2881 2656 2881 3163 
-Q 2881 3666 2632 3958 
-Q 2384 4250 1959 4250 
-Q 1534 4250 1286 3958 
-Q 1038 3666 1038 3163 
-Q 1038 2656 1286 2365 
-Q 1534 2075 1959 2075 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_31">
-    <!-- -41 -->
-    <g transform="translate(513.280771 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-34" d="M 2419 4116 
-L 825 1625 
-L 2419 1625 
-L 2419 4116 
-z
-M 2253 4666 
-L 3047 4666 
-L 3047 1625 
-L 3713 1625 
-L 3713 1100 
-L 3047 1100 
-L 3047 0 
-L 2419 0 
-L 2419 1100 
-L 313 1100 
-L 313 1709 
-L 2253 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_32">
-    <!-- -8 -->
-    <g transform="translate(555.625982 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_33">
-    <!-- +7 -->
-    <g transform="translate(111.023738 106.389018) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_34">
-    <!-- -13 -->
-    <g transform="translate(150.784184 106.389018) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_35">
-    <!-- -5 -->
-    <g transform="translate(193.129395 106.389018) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_36">
-    <!-- -16 -->
-    <g transform="translate(231.338981 106.389018) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
@@ -1550,6 +1535,27 @@ z
    <g id="text_39">
     <!-- -4 -->
     <g transform="translate(354.238989 106.389018) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
     </g>
@@ -2189,18 +2195,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB1ElEQVR4nO2b0a3DMAwD7cSzvM3fmI47gvpxCK6ENABhnkQ5aZH5P/7OAGpdFyEzBiQDnija2qSEghnZhIIZCa3NyWQkmZFOKJhRsDXsOopmJJwjaEPOmxHirE3MWjOqhSBr2EAGMyKtMVpc+ynYwe3viNQVbA0LrZDRFbxGbNbWyM3auG0RGbo1Qp0IZCSMiG2OgtNvbL+Oke6BvddIWaQ1qP3RjGSTLXypwdaIMP2ctWb0olAzKkr4LhLMCPvnOJiRbo6CrTWjF4WCGYHWJtU1TKgZvSZkfNAKZhRsDftFa96MkJCRrf29ausyWrOtWiMjmxDH6FAfDJzzIEKctQc60ToDEqJOBLbfZs04RxQjobWOSFXrjM0IdURqIaG1jkhVPmvGOUqOCPLJMdh+6kRk+zFGMtjKOdK13zbZ2EBGMxLOkSz90YygK9tozSbUa6Qu4RxtRifZ2np0jDY32YiOc44gIQo2aI1ZkB2Rb4SiIyJbtcr0Q0IPdCQyIpCQDnZHpC5uQ27uOtJFBBptH2zlHOnab+uaMSK29htXrW2NKK0hOtlrxLaPjIxys4a99x9dRKgTgUK69gsZ9RxVFWzNyIi6RZIZtbXfE+qI1BU8R5i1D2e5X2tFkZmlAAAAAElFTkSuQmCC" id="imagef0fb3f43fd" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-69.84" width="12.96" height="253.44"/>
+iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB1ElEQVR4nO2b0a3DMAwD7cSzvM3fmI47gvpxCK6ENABhnkQ5aZH5P/7OAGpdFyEzBiQDnija2qSEghnZhIIZCa3NyWQkmZFOKJhRsDXsOopmJJwjaEPOmxHirE3MWjOqhSBr2EAGMyKtMVpc+ynYwe3viNQVbA0LrZDRFbxGbNbWyM3auG0RGbo1Qp0IZCSMiG2OgtNvbL+Oke6BvddIWaQ1qP3RjGSTLXypwdaIMP2ctWb0olAzKkr4LhLMCPvnOJiRbo6CrTWjF4WCGYHWJtU1TKgZvSZkfNAKZhRsDftFa96MkJCRrf29ausyWrOtWiMjmxDH6FAfDJzzIEKctQc60ToDEqJOBLbfZs04RxQjobWOSFXrjM0IdURqIaG1jkhVPmvGOUqOCPLJMdh+6kRk+zFGMtjKOdK13zbZ2EBGMxLOkSz90YygK9tozSbUa6Qu4RxtRifZ2np0jDY32YiOc44gIQo2aI1ZkB2Rb4SiIyJbtcr0Q0IPdCQyIpCQDnZHpC5uQ27uOtJFBBptH2zlHOnab+uaMSK29htXrW2NKK0hOtlrxLaPjIxys4a99x9dRKgTgUK69gsZ9RxVFWzNyIi6RZIZtbXfE+qI1BU8R5i1D2e5X2tFkZmlAAAAAElFTkSuQmCC" id="image833f8e29c7" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-69.84" width="12.96" height="253.44"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_21">
       <defs>
-       <path id="m4092f00be7" d="M 0 0 
+       <path id="m6445d7a25b" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m4092f00be7" x="601.779688" y="322.507463" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6445d7a25b" x="601.779688" y="322.507463" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_117">
@@ -2223,7 +2229,7 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m4092f00be7" x="601.779688" y="280.566603" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6445d7a25b" x="601.779688" y="280.566603" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_118">
@@ -2237,7 +2243,7 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m4092f00be7" x="601.779688" y="238.625742" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6445d7a25b" x="601.779688" y="238.625742" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_119">
@@ -2251,7 +2257,7 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m4092f00be7" x="601.779688" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6445d7a25b" x="601.779688" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_120">
@@ -2264,7 +2270,7 @@ z
     <g id="ytick_13">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m4092f00be7" x="601.779688" y="154.74402" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6445d7a25b" x="601.779688" y="154.74402" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_121">
@@ -2277,7 +2283,7 @@ z
     <g id="ytick_14">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m4092f00be7" x="601.779688" y="112.803159" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6445d7a25b" x="601.779688" y="112.803159" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_122">
@@ -2290,7 +2296,7 @@ z
     <g id="ytick_15">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#m4092f00be7" x="601.779688" y="70.862298" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6445d7a25b" x="601.779688" y="70.862298" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_123">
@@ -2906,8 +2912,8 @@ z
    </g>
   </g>
   <g id="text_126">
-   <!-- 2026-07-08T21:41:55Z  ·  Linux chungus2 x86_64  ·  commit b17c222c  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(43.990156 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-08T22:12:55Z  ·  Linux chungus2 x86_64  ·  commit 30251fb3  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(44.380078 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2999,10 +3005,10 @@ z
     <use xlink:href="#DejaVuSans-38" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
     <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
     <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
@@ -3045,109 +3051,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3135.351562 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3198.974609 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3262.597656 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3317.578125 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3381.201172 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3444.824219 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3508.447266 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3563.427734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3595.214844 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3627.001953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3658.789062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3690.576172 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3722.363281 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3750.146484 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3811.669922 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3872.949219 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3936.328125 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3999.804688 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4038.667969 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4099.849609 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4159.029297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4220.552734 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4261.666016 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4295.357422 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4323.140625 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4384.664062 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4445.943359 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4509.322266 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4572.945312 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4606.636719 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4665.816406 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4729.439453 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4761.226562 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4824.849609 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4888.472656 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4920.259766 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4983.882812 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5019.966797 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5058.830078 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5113.810547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5177.433594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5209.220703 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5241.007812 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5272.794922 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5304.582031 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5336.369141 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5375.578125 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5438.957031 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5477.820312 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5539.001953 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5602.380859 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5665.857422 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5729.236328 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5792.712891 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5856.091797 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5895.300781 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5927.087891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6010.876953 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6042.664062 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6140.076172 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6201.599609 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6265.076172 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6292.859375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6354.138672 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6417.517578 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6449.304688 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6501.404297 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6564.783203 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6626.0625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6689.539062 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6741.638672 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6805.017578 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6866.199219 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6905.408203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6939.099609 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6970.886719 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7012 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7073.279297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7112.488281 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7140.271484 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7201.453125 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7233.240234 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7261.023438 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7313.123047 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7344.910156 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7408.386719 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7469.910156 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7509.119141 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7570.642578 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7610.005859 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7707.417969 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7735.201172 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7798.580078 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7826.363281 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7878.462891 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7917.671875 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7945.455078 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3262.744141 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3326.367188 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3389.990234 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3425.195312 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3488.671875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3552.294922 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3584.082031 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3615.869141 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3647.65625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3679.443359 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3711.230469 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3739.013672 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3800.537109 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3861.816406 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3925.195312 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3988.671875 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4027.535156 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4088.716797 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4147.896484 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4209.419922 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4250.533203 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4284.224609 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4312.007812 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4373.53125 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4434.810547 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4498.189453 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4561.8125 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4595.503906 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4654.683594 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4718.306641 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4750.09375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4813.716797 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4877.339844 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4909.126953 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4972.75 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5008.833984 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5047.697266 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5102.677734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5166.300781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5198.087891 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5229.875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5261.662109 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5293.449219 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5325.236328 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5364.445312 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5427.824219 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5466.6875 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5527.869141 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5591.248047 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5654.724609 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5718.103516 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5781.580078 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5844.958984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5884.167969 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5915.955078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5999.744141 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6031.53125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6128.943359 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6190.466797 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6253.943359 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6281.726562 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6343.005859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6406.384766 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6438.171875 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6490.271484 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6553.650391 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6614.929688 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6678.40625 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6730.505859 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6793.884766 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6855.066406 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6894.275391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6927.966797 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6959.753906 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7000.867188 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7062.146484 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7101.355469 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7129.138672 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7190.320312 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7222.107422 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7249.890625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7301.990234 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7333.777344 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7397.253906 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7458.777344 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7497.986328 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7559.509766 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7598.873047 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7696.285156 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7724.068359 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7787.447266 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7815.230469 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7867.330078 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7906.539062 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7934.322266 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p772d83926e">
+  <clipPath id="p5fc832b6a3">
    <rect x="95.67625" y="49.34175" width="483.328783" height="294.686261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_compress_pareto.svg
+++ b/bench/graphs/silesia_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 61.085542 412.80375 
 L 61.085542 48.323125 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m67f6590966" d="M 0 0 
+       <path id="m7b18aaf7d6" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m67f6590966" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7b18aaf7d6" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -130,11 +130,11 @@ z
      <g id="line2d_3">
       <path d="M 145.270284 412.80375 
 L 145.270284 48.323125 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m67f6590966" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7b18aaf7d6" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -177,11 +177,11 @@ z
      <g id="line2d_5">
       <path d="M 229.455026 412.80375 
 L 229.455026 48.323125 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m67f6590966" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7b18aaf7d6" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -219,11 +219,11 @@ z
      <g id="line2d_7">
       <path d="M 313.639768 412.80375 
 L 313.639768 48.323125 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m67f6590966" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7b18aaf7d6" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -272,11 +272,11 @@ z
      <g id="line2d_9">
       <path d="M 397.82451 412.80375 
 L 397.82451 48.323125 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m67f6590966" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7b18aaf7d6" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -334,11 +334,11 @@ z
      <g id="line2d_11">
       <path d="M 482.009253 412.80375 
 L 482.009253 48.323125 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m67f6590966" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7b18aaf7d6" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -355,11 +355,11 @@ L 482.009253 48.323125
      <g id="line2d_13">
       <path d="M 566.193995 412.80375 
 L 566.193995 48.323125 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m67f6590966" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7b18aaf7d6" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -856,16 +856,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 368.08164 
 L 637.2 368.08164 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="m092d619aa8" d="M 0 0 
+       <path id="mb4e36a9d5f" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m092d619aa8" x="49.078125" y="368.08164" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb4e36a9d5f" x="49.078125" y="368.08164" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -897,11 +897,11 @@ z
      <g id="line2d_17">
       <path d="M 49.078125 243.439835 
 L 637.2 243.439835 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m092d619aa8" x="49.078125" y="243.439835" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb4e36a9d5f" x="49.078125" y="243.439835" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -917,11 +917,11 @@ L 637.2 243.439835
      <g id="line2d_19">
       <path d="M 49.078125 118.798029 
 L 637.2 118.798029 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m092d619aa8" x="49.078125" y="118.798029" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb4e36a9d5f" x="49.078125" y="118.798029" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -937,16 +937,16 @@ L 637.2 118.798029
      <g id="line2d_21">
       <path d="M 49.078125 405.602562 
 L 637.2 405.602562 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="mad631877e0" d="M 0 0 
+       <path id="m82e6c9389b" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#mad631877e0" x="49.078125" y="405.602562" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m82e6c9389b" x="49.078125" y="405.602562" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -954,11 +954,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 395.733268 
 L 637.2 395.733268 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mad631877e0" x="49.078125" y="395.733268" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m82e6c9389b" x="49.078125" y="395.733268" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -966,11 +966,11 @@ L 637.2 395.733268
      <g id="line2d_25">
       <path d="M 49.078125 387.3889 
 L 637.2 387.3889 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mad631877e0" x="49.078125" y="387.3889" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m82e6c9389b" x="49.078125" y="387.3889" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -978,11 +978,11 @@ L 637.2 387.3889
      <g id="line2d_27">
       <path d="M 49.078125 380.160679 
 L 637.2 380.160679 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#mad631877e0" x="49.078125" y="380.160679" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m82e6c9389b" x="49.078125" y="380.160679" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -990,11 +990,11 @@ L 637.2 380.160679
      <g id="line2d_29">
       <path d="M 49.078125 373.784936 
 L 637.2 373.784936 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#mad631877e0" x="49.078125" y="373.784936" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m82e6c9389b" x="49.078125" y="373.784936" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1002,11 +1002,11 @@ L 637.2 373.784936
      <g id="line2d_31">
       <path d="M 49.078125 330.560718 
 L 637.2 330.560718 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#mad631877e0" x="49.078125" y="330.560718" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m82e6c9389b" x="49.078125" y="330.560718" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1014,11 +1014,11 @@ L 637.2 330.560718
      <g id="line2d_33">
       <path d="M 49.078125 308.612385 
 L 637.2 308.612385 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#mad631877e0" x="49.078125" y="308.612385" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m82e6c9389b" x="49.078125" y="308.612385" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1026,11 +1026,11 @@ L 637.2 308.612385
      <g id="line2d_35">
       <path d="M 49.078125 293.039796 
 L 637.2 293.039796 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#mad631877e0" x="49.078125" y="293.039796" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m82e6c9389b" x="49.078125" y="293.039796" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1038,11 +1038,11 @@ L 637.2 293.039796
      <g id="line2d_37">
       <path d="M 49.078125 280.960757 
 L 637.2 280.960757 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#mad631877e0" x="49.078125" y="280.960757" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m82e6c9389b" x="49.078125" y="280.960757" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1050,11 +1050,11 @@ L 637.2 280.960757
      <g id="line2d_39">
       <path d="M 49.078125 271.091463 
 L 637.2 271.091463 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#mad631877e0" x="49.078125" y="271.091463" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m82e6c9389b" x="49.078125" y="271.091463" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1062,11 +1062,11 @@ L 637.2 271.091463
      <g id="line2d_41">
       <path d="M 49.078125 262.747094 
 L 637.2 262.747094 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#mad631877e0" x="49.078125" y="262.747094" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m82e6c9389b" x="49.078125" y="262.747094" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1074,11 +1074,11 @@ L 637.2 262.747094
      <g id="line2d_43">
       <path d="M 49.078125 255.518874 
 L 637.2 255.518874 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#mad631877e0" x="49.078125" y="255.518874" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m82e6c9389b" x="49.078125" y="255.518874" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1086,11 +1086,11 @@ L 637.2 255.518874
      <g id="line2d_45">
       <path d="M 49.078125 249.143131 
 L 637.2 249.143131 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#mad631877e0" x="49.078125" y="249.143131" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m82e6c9389b" x="49.078125" y="249.143131" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1098,11 +1098,11 @@ L 637.2 249.143131
      <g id="line2d_47">
       <path d="M 49.078125 205.918912 
 L 637.2 205.918912 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#mad631877e0" x="49.078125" y="205.918912" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m82e6c9389b" x="49.078125" y="205.918912" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1110,11 +1110,11 @@ L 637.2 205.918912
      <g id="line2d_49">
       <path d="M 49.078125 183.97058 
 L 637.2 183.97058 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#mad631877e0" x="49.078125" y="183.97058" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m82e6c9389b" x="49.078125" y="183.97058" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1122,11 +1122,11 @@ L 637.2 183.97058
      <g id="line2d_51">
       <path d="M 49.078125 168.39799 
 L 637.2 168.39799 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#mad631877e0" x="49.078125" y="168.39799" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m82e6c9389b" x="49.078125" y="168.39799" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1134,11 +1134,11 @@ L 637.2 168.39799
      <g id="line2d_53">
       <path d="M 49.078125 156.318951 
 L 637.2 156.318951 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#mad631877e0" x="49.078125" y="156.318951" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m82e6c9389b" x="49.078125" y="156.318951" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1146,11 +1146,11 @@ L 637.2 156.318951
      <g id="line2d_55">
       <path d="M 49.078125 146.449658 
 L 637.2 146.449658 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#mad631877e0" x="49.078125" y="146.449658" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m82e6c9389b" x="49.078125" y="146.449658" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1158,11 +1158,11 @@ L 637.2 146.449658
      <g id="line2d_57">
       <path d="M 49.078125 138.105289 
 L 637.2 138.105289 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#mad631877e0" x="49.078125" y="138.105289" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m82e6c9389b" x="49.078125" y="138.105289" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1170,11 +1170,11 @@ L 637.2 138.105289
      <g id="line2d_59">
       <path d="M 49.078125 130.877068 
 L 637.2 130.877068 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#mad631877e0" x="49.078125" y="130.877068" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m82e6c9389b" x="49.078125" y="130.877068" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1182,11 +1182,11 @@ L 637.2 130.877068
      <g id="line2d_61">
       <path d="M 49.078125 124.501326 
 L 637.2 124.501326 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#mad631877e0" x="49.078125" y="124.501326" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m82e6c9389b" x="49.078125" y="124.501326" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1194,11 +1194,11 @@ L 637.2 124.501326
      <g id="line2d_63">
       <path d="M 49.078125 81.277107 
 L 637.2 81.277107 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#mad631877e0" x="49.078125" y="81.277107" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m82e6c9389b" x="49.078125" y="81.277107" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1206,11 +1206,11 @@ L 637.2 81.277107
      <g id="line2d_65">
       <path d="M 49.078125 59.328775 
 L 637.2 59.328775 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#mad631877e0" x="49.078125" y="59.328775" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m82e6c9389b" x="49.078125" y="59.328775" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1332,7 +1332,7 @@ L 637.2 48.323125
    </g>
    <g id="text_13">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(324.643112 118.769985) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(324.643112 118.414237) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1364,7 +1364,7 @@ z
    </g>
    <g id="text_14">
     <!-- L10 -->
-    <g style="fill: #d62728" transform="translate(102.814287 308.662731) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(102.814287 308.867065) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1686,23 +1686,23 @@ z
    </g>
    <g id="line2d_67">
     <defs>
-     <path id="m7a66f49d20" d="M -2.5 2.5 
+     <path id="mcd3f418712" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p5ff60b7cdf)">
-     <use xlink:href="#m7a66f49d20" x="377.110281" y="104.685421" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7a66f49d20" x="323.801439" y="110.409833" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7a66f49d20" x="272.665744" y="126.308323" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7a66f49d20" x="235.168828" y="128.026741" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7a66f49d20" x="186.228265" y="149.377587" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7a66f49d20" x="158.303164" y="171.457731" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7a66f49d20" x="149.489547" y="182.192614" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7a66f49d20" x="140.563162" y="202.482797" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7a66f49d20" x="138.984853" y="209.328911" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p5ca6112d80)">
+     <use xlink:href="#mcd3f418712" x="377.110281" y="104.685421" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcd3f418712" x="323.801439" y="110.409833" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcd3f418712" x="272.665744" y="126.308323" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcd3f418712" x="235.168828" y="128.026741" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcd3f418712" x="186.228265" y="149.377587" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcd3f418712" x="158.303164" y="171.457731" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcd3f418712" x="149.489547" y="182.192614" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcd3f418712" x="140.563162" y="202.482797" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcd3f418712" x="138.984853" y="209.328911" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_68">
@@ -1755,7 +1755,7 @@ L 327.133241 110.069256
 L 326.02264 110.18302 
 L 324.91204 110.296545 
 L 323.801439 110.409833 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_69">
     <path d="M 323.801439 110.409833 
@@ -1807,7 +1807,7 @@ L 275.861725 125.44037
 L 274.796398 125.731236 
 L 273.731071 126.020548 
 L 272.665744 126.308323 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_70">
     <path d="M 272.665744 126.308323 
@@ -1859,7 +1859,7 @@ L 237.512385 127.920923
 L 236.7312 127.956219 
 L 235.950014 127.991491 
 L 235.168828 128.026741 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_71">
     <path d="M 235.168828 128.026741 
@@ -1911,7 +1911,7 @@ L 189.28705 148.263499
 L 188.267455 148.637415 
 L 187.24786 149.008766 
 L 186.228265 149.377587 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_72">
     <path d="M 186.228265 149.377587 
@@ -1963,7 +1963,7 @@ L 160.048483 170.312481
 L 159.46671 170.696929 
 L 158.884937 171.078667 
 L 158.303164 171.457731 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_73">
     <path d="M 158.303164 171.457731 
@@ -2015,7 +2015,7 @@ L 150.040398 181.580576
 L 149.856781 181.785359 
 L 149.673164 181.989369 
 L 149.489547 182.192614 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_74">
     <path d="M 149.489547 182.192614 
@@ -2067,7 +2067,7 @@ L 141.121061 201.414753
 L 140.935095 201.773114 
 L 140.749129 202.129119 
 L 140.563162 202.482797 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_75">
     <path d="M 140.563162 202.482797 
@@ -2119,26 +2119,26 @@ L 139.083497 208.925481
 L 139.050616 209.060292 
 L 139.017734 209.194768 
 L 138.984853 209.328911 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_76">
     <defs>
-     <path id="m0d9c3b99f3" d="M 0 -2.5 
+     <path id="m7f0a0c0000" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p5ff60b7cdf)">
-     <use xlink:href="#m0d9c3b99f3" x="610.467187" y="71.939349" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0d9c3b99f3" x="319.880958" y="101.884157" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0d9c3b99f3" x="210.281253" y="129.778154" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0d9c3b99f3" x="196.287076" y="133.586625" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0d9c3b99f3" x="176.054419" y="147.38645" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0d9c3b99f3" x="152.161413" y="174.753272" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0d9c3b99f3" x="146.720208" y="186.587648" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0d9c3b99f3" x="143.994022" y="196.356323" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0d9c3b99f3" x="142.666037" y="200.180971" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p5ca6112d80)">
+     <use xlink:href="#m7f0a0c0000" x="610.467187" y="71.939349" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7f0a0c0000" x="319.880958" y="101.884157" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7f0a0c0000" x="210.281253" y="129.778154" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7f0a0c0000" x="196.287076" y="133.586625" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7f0a0c0000" x="176.054419" y="147.38645" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7f0a0c0000" x="152.161413" y="174.753272" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7f0a0c0000" x="146.720208" y="186.587648" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7f0a0c0000" x="143.994022" y="196.356323" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7f0a0c0000" x="142.666037" y="200.180971" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_77">
@@ -2191,7 +2191,7 @@ L 338.042598 100.427247
 L 331.988718 100.917253 
 L 325.934838 101.402864 
 L 319.880958 101.884157 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_78">
     <path d="M 319.880958 101.884157 
@@ -2243,7 +2243,7 @@ L 217.131235 128.398367
 L 214.847908 128.862215 
 L 212.564581 129.322122 
 L 210.281253 129.778154 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_79">
     <path d="M 210.281253 129.778154 
@@ -2295,7 +2295,7 @@ L 197.161712 133.356286
 L 196.870166 133.433175 
 L 196.578621 133.509954 
 L 196.287076 133.586625 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_80">
     <path d="M 196.287076 133.586625 
@@ -2347,7 +2347,7 @@ L 177.31896 146.619719
 L 176.897447 146.876504 
 L 176.475933 147.132078 
 L 176.054419 147.38645 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_81">
     <path d="M 176.054419 147.38645 
@@ -2399,7 +2399,7 @@ L 153.654726 173.393769
 L 153.156955 173.850741 
 L 152.659184 174.303887 
 L 152.161413 174.753272 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_82">
     <path d="M 152.161413 174.753272 
@@ -2451,7 +2451,7 @@ L 147.060283 185.919158
 L 146.946925 186.142906 
 L 146.833566 186.365734 
 L 146.720208 186.587648 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_83">
     <path d="M 146.720208 186.587648 
@@ -2503,7 +2503,7 @@ L 144.164409 195.794799
 L 144.107613 195.982622 
 L 144.050817 196.169795 
 L 143.994022 196.356323 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_84">
     <path d="M 143.994022 196.356323 
@@ -2555,30 +2555,30 @@ L 142.749036 199.949687
 L 142.72137 200.026891 
 L 142.693704 200.103986 
 L 142.666037 200.180971 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_85">
     <defs>
-     <path id="m32086a8271" d="M -0 3.535534 
+     <path id="m2fa6edb34c" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p5ff60b7cdf)">
-     <use xlink:href="#m32086a8271" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m32086a8271" x="242.839153" y="80.778898" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m32086a8271" x="218.251194" y="86.377096" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m32086a8271" x="197.814984" y="90.309617" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m32086a8271" x="166.378359" y="99.066934" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m32086a8271" x="145.830392" y="110.431955" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m32086a8271" x="134.598477" y="126.026287" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m32086a8271" x="124.077268" y="149.033155" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m32086a8271" x="122.462976" y="157.476606" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m32086a8271" x="81.012077" y="220.06889" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m32086a8271" x="77.44276" y="239.652656" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m32086a8271" x="76.953425" y="252.706566" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p5ca6112d80)">
+     <use xlink:href="#m2fa6edb34c" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2fa6edb34c" x="242.839153" y="80.778898" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2fa6edb34c" x="218.251194" y="86.377096" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2fa6edb34c" x="197.814984" y="90.309617" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2fa6edb34c" x="166.378359" y="99.066934" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2fa6edb34c" x="145.830392" y="110.431955" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2fa6edb34c" x="134.598477" y="126.026287" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2fa6edb34c" x="124.077268" y="149.033155" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2fa6edb34c" x="122.462976" y="157.476606" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2fa6edb34c" x="81.012077" y="220.06889" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2fa6edb34c" x="77.44276" y="239.652656" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2fa6edb34c" x="76.953425" y="252.706566" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_86">
@@ -2631,7 +2631,7 @@ L 245.91379 79.91142
 L 244.888911 80.202126 
 L 243.864032 80.49128 
 L 242.839153 80.778898 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_87">
     <path d="M 242.839153 80.778898 
@@ -2683,7 +2683,7 @@ L 219.787941 86.043669
 L 219.275692 86.155039 
 L 218.763443 86.266182 
 L 218.251194 86.377096 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_88">
     <path d="M 218.251194 86.377096 
@@ -2735,7 +2735,7 @@ L 199.092247 90.072029
 L 198.666492 90.151341 
 L 198.240738 90.230537 
 L 197.814984 90.309617 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_89">
     <path d="M 197.814984 90.309617 
@@ -2787,7 +2787,7 @@ L 168.343148 98.559208
 L 167.688219 98.72898 
 L 167.033289 98.898221 
 L 166.378359 99.066934 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_90">
     <path d="M 166.378359 99.066934 
@@ -2839,7 +2839,7 @@ L 147.11464 109.78743
 L 146.686557 110.003126 
 L 146.258475 110.217965 
 L 145.830392 110.431955 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_91">
     <path d="M 145.830392 110.431955 
@@ -2891,7 +2891,7 @@ L 135.300472 125.172774
 L 135.066474 125.458776 
 L 134.832476 125.743276 
 L 134.598477 126.026287 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_92">
     <path d="M 134.598477 126.026287 
@@ -2943,7 +2943,7 @@ L 124.734843 147.848882
 L 124.515652 148.246526 
 L 124.29646 148.641269 
 L 124.077268 149.033155 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_93">
     <path d="M 124.077268 149.033155 
@@ -2995,7 +2995,7 @@ L 122.56387 156.985769
 L 122.530239 157.149876 
 L 122.496607 157.313488 
 L 122.462976 157.476606 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_94">
     <path d="M 122.462976 157.476606 
@@ -3047,7 +3047,7 @@ L 83.602758 217.699074
 L 82.739198 218.500595 
 L 81.875637 219.290422 
 L 81.012077 220.06889 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_95">
     <path d="M 81.012077 220.06889 
@@ -3099,7 +3099,7 @@ L 77.665842 238.615761
 L 77.591481 238.963605 
 L 77.517121 239.309227 
 L 77.44276 239.652656 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_96">
     <path d="M 77.44276 239.652656 
@@ -3151,23 +3151,23 @@ L 76.984008 251.97672
 L 76.973814 252.221097 
 L 76.96362 252.464376 
 L 76.953425 252.706566 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_97">
     <defs>
-     <path id="m0acbed5808" d="M -0 2.5 
+     <path id="m0b530f356d" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p5ff60b7cdf)">
-     <use xlink:href="#m0acbed5808" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p5ca6112d80)">
+     <use xlink:href="#m0b530f356d" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_98">
     <defs>
-     <path id="mff1feee27e" d="M -0.833333 2.5 
+     <path id="m5253f1838b" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -3182,16 +3182,16 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p5ff60b7cdf)">
-     <use xlink:href="#mff1feee27e" x="432.495268" y="96.067622" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mff1feee27e" x="300.62247" y="112.493412" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mff1feee27e" x="266.967623" y="120.8136" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mff1feee27e" x="226.040946" y="122.099593" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mff1feee27e" x="180.985721" y="141.85872" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mff1feee27e" x="164.441833" y="156.106179" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mff1feee27e" x="157.761315" y="165.23787" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mff1feee27e" x="151.269082" y="178.700983" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mff1feee27e" x="150.327087" y="185.23695" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p5ca6112d80)">
+     <use xlink:href="#m5253f1838b" x="432.495268" y="96.067622" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5253f1838b" x="300.62247" y="112.493412" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5253f1838b" x="266.967623" y="120.8136" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5253f1838b" x="226.040946" y="122.099593" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5253f1838b" x="180.985721" y="141.85872" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5253f1838b" x="164.441833" y="156.106179" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5253f1838b" x="157.761315" y="165.23787" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5253f1838b" x="151.269082" y="178.700983" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5253f1838b" x="150.327087" y="185.23695" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_99">
@@ -3244,7 +3244,7 @@ L 308.86452 111.600609
 L 306.11717 111.899849 
 L 303.36982 112.197444 
 L 300.62247 112.493412 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_100">
     <path d="M 300.62247 112.493412 
@@ -3296,7 +3296,7 @@ L 269.071051 120.329422
 L 268.369908 120.491297 
 L 267.668766 120.652688 
 L 266.967623 120.8136 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_101">
     <path d="M 266.967623 120.8136 
@@ -3348,7 +3348,7 @@ L 228.598863 122.020108
 L 227.746224 122.046616 
 L 226.893585 122.073111 
 L 226.040946 122.099593 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_102">
     <path d="M 226.040946 122.099593 
@@ -3400,7 +3400,7 @@ L 183.801673 140.814056
 L 182.863022 141.164522 
 L 181.924372 141.512734 
 L 180.985721 141.85872 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_103">
     <path d="M 180.985721 141.85872 
@@ -3452,7 +3452,7 @@ L 165.475826 155.317544
 L 165.131161 155.581701 
 L 164.786497 155.844575 
 L 164.441833 156.106179 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_104">
     <path d="M 164.441833 156.106179 
@@ -3504,7 +3504,7 @@ L 158.178848 164.710119
 L 158.03967 164.886608 
 L 157.900493 165.062524 
 L 157.761315 165.23787 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_105">
     <path d="M 157.761315 165.23787 
@@ -3556,7 +3556,7 @@ L 151.674847 177.950842
 L 151.539592 178.202046 
 L 151.404337 178.452089 
 L 151.269082 178.700983 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_106">
     <path d="M 151.269082 178.700983 
@@ -3608,11 +3608,11 @@ L 150.385962 184.850776
 L 150.366337 184.979807 
 L 150.346712 185.108531 
 L 150.327087 185.23695 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_107">
     <defs>
-     <path id="m0c1b2da0ac" d="M -1.25 2.5 
+     <path id="m35056ef38d" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -3627,16 +3627,16 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p5ff60b7cdf)">
-     <use xlink:href="#m0c1b2da0ac" x="345.030867" y="136.859359" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0c1b2da0ac" x="273.364924" y="143.571257" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0c1b2da0ac" x="240.719951" y="149.310846" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0c1b2da0ac" x="221.353978" y="154.160538" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0c1b2da0ac" x="207.129625" y="156.092215" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0c1b2da0ac" x="181.064802" y="166.758473" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0c1b2da0ac" x="179.282169" y="170.289343" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0c1b2da0ac" x="177.719335" y="175.489948" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0c1b2da0ac" x="177.643939" y="181.552088" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p5ca6112d80)">
+     <use xlink:href="#m35056ef38d" x="345.030867" y="136.859359" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m35056ef38d" x="273.364924" y="143.571257" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m35056ef38d" x="240.719951" y="149.310846" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m35056ef38d" x="221.353978" y="154.160538" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m35056ef38d" x="207.129625" y="156.092215" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m35056ef38d" x="181.064802" y="166.758473" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m35056ef38d" x="179.282169" y="170.289343" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m35056ef38d" x="177.719335" y="175.489948" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m35056ef38d" x="177.643939" y="181.552088" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_108">
@@ -3689,7 +3689,7 @@ L 277.844045 143.175283
 L 276.351005 143.307597 
 L 274.857964 143.439587 
 L 273.364924 143.571257 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_109">
     <path d="M 273.364924 143.571257 
@@ -3741,7 +3741,7 @@ L 242.760262 148.96941
 L 242.080158 149.083462 
 L 241.400055 149.197273 
 L 240.719951 149.310846 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_110">
     <path d="M 240.719951 149.310846 
@@ -3793,7 +3793,7 @@ L 222.564351 153.869835
 L 222.160893 153.966909 
 L 221.757435 154.06381 
 L 221.353978 154.160538 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_111">
     <path d="M 221.353978 154.160538 
@@ -3845,7 +3845,7 @@ L 208.018647 155.973483
 L 207.722306 156.013089 
 L 207.425965 156.052666 
 L 207.129625 156.092215 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_112">
     <path d="M 207.129625 156.092215 
@@ -3897,7 +3897,7 @@ L 182.693853 166.149994
 L 182.150836 166.353581 
 L 181.607819 166.556405 
 L 181.064802 166.758473 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_113">
     <path d="M 181.064802 166.758473 
@@ -3949,7 +3949,7 @@ L 179.393584 170.075284
 L 179.356445 170.146731 
 L 179.319307 170.218084 
 L 179.282169 170.289343 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_114">
     <path d="M 179.282169 170.289343 
@@ -4001,7 +4001,7 @@ L 177.817012 175.179146
 L 177.784453 175.282945 
 L 177.751894 175.386546 
 L 177.719335 175.489948 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_115">
     <path d="M 177.719335 175.489948 
@@ -4053,11 +4053,11 @@ L 177.648651 181.192458
 L 177.64708 181.3126 
 L 177.645509 181.432477 
 L 177.643939 181.552088 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_116">
     <defs>
-     <path id="ma109a78523" d="M 0 -2.5 
+     <path id="m4ae4a2483a" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -4070,16 +4070,16 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p5ff60b7cdf)">
-     <use xlink:href="#ma109a78523" x="226.871027" y="113.224491" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#ma109a78523" x="226.871027" y="113.066324" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#ma109a78523" x="226.871027" y="113.178221" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#ma109a78523" x="226.871027" y="113.089884" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#ma109a78523" x="177.768423" y="132.327899" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#ma109a78523" x="160.37503" y="145.652356" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#ma109a78523" x="153.995779" y="152.678629" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#ma109a78523" x="147.106887" y="168.143801" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#ma109a78523" x="145.871703" y="175.118358" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p5ca6112d80)">
+     <use xlink:href="#m4ae4a2483a" x="226.871027" y="113.224491" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m4ae4a2483a" x="226.871027" y="113.066324" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m4ae4a2483a" x="226.871027" y="113.178221" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m4ae4a2483a" x="226.871027" y="113.089884" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m4ae4a2483a" x="177.768423" y="132.327899" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m4ae4a2483a" x="160.37503" y="145.652356" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m4ae4a2483a" x="153.995779" y="152.678629" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m4ae4a2483a" x="147.106887" y="168.143801" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m4ae4a2483a" x="145.871703" y="175.118358" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_117">
@@ -4132,7 +4132,7 @@ L 226.871027 113.076223
 L 226.871027 113.072924 
 L 226.871027 113.069624 
 L 226.871027 113.066324 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_118">
     <path d="M 226.871027 113.066324 
@@ -4184,7 +4184,7 @@ L 226.871027 113.171234
 L 226.871027 113.173563 
 L 226.871027 113.175892 
 L 226.871027 113.178221 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_119">
     <path d="M 226.871027 113.178221 
@@ -4236,7 +4236,7 @@ L 226.871027 113.09541
 L 226.871027 113.093568 
 L 226.871027 113.091726 
 L 226.871027 113.089884 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_120">
     <path d="M 226.871027 113.089884 
@@ -4288,7 +4288,7 @@ L 180.837336 131.306392
 L 179.814365 131.649041 
 L 178.791394 131.989534 
 L 177.768423 132.327899 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_121">
     <path d="M 177.768423 132.327899 
@@ -4340,7 +4340,7 @@ L 161.462117 144.909076
 L 161.099755 145.157972 
 L 160.737393 145.405728 
 L 160.37503 145.652356 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_122">
     <path d="M 160.37503 145.652356 
@@ -4392,7 +4392,7 @@ L 154.394483 152.265218
 L 154.261581 152.403373 
 L 154.12868 152.541176 
 L 153.995779 152.678629 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_123">
     <path d="M 153.995779 152.678629 
@@ -4444,7 +4444,7 @@ L 147.537442 167.296442
 L 147.393924 167.580372 
 L 147.250405 167.862819 
 L 147.106887 168.143801 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_124">
     <path d="M 147.106887 168.143801 
@@ -4496,11 +4496,11 @@ L 145.948902 174.70781
 L 145.923169 174.845005 
 L 145.897436 174.981854 
 L 145.871703 175.118358 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_125">
     <defs>
-     <path id="mbc6e463cf7" d="M 0 -2.5 
+     <path id="mcf2ccd7d9a" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -4509,16 +4509,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p5ff60b7cdf)">
-     <use xlink:href="#mbc6e463cf7" x="585.66883" y="173.051371" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbc6e463cf7" x="527.144592" y="175.326465" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbc6e463cf7" x="457.339427" y="183.688849" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbc6e463cf7" x="292.124837" y="178.486631" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbc6e463cf7" x="243.129344" y="190.369032" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbc6e463cf7" x="213.541392" y="204.43395" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbc6e463cf7" x="204.551957" y="212.140784" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbc6e463cf7" x="195.860087" y="228.582256" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbc6e463cf7" x="194.019853" y="234.294862" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p5ca6112d80)">
+     <use xlink:href="#mcf2ccd7d9a" x="585.66883" y="173.051371" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcf2ccd7d9a" x="527.144592" y="175.326465" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcf2ccd7d9a" x="457.339427" y="183.688849" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcf2ccd7d9a" x="292.124837" y="178.486631" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcf2ccd7d9a" x="243.129344" y="190.369032" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcf2ccd7d9a" x="213.541392" y="204.43395" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcf2ccd7d9a" x="204.551957" y="212.140784" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcf2ccd7d9a" x="195.860087" y="228.582256" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcf2ccd7d9a" x="194.019853" y="234.294862" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_126">
@@ -4571,7 +4571,7 @@ L 530.802357 175.187039
 L 529.583102 175.233554 
 L 528.363847 175.28003 
 L 527.144592 175.326465 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_127">
     <path d="M 527.144592 175.326465 
@@ -4623,7 +4623,7 @@ L 461.70225 183.20239
 L 460.247976 183.36503 
 L 458.793701 183.527182 
 L 457.339427 183.688849 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_128">
     <path d="M 457.339427 183.688849 
@@ -4675,7 +4675,7 @@ L 302.450749 178.826834
 L 299.008779 178.713671 
 L 295.566808 178.60027 
 L 292.124837 178.486631 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_129">
     <path d="M 292.124837 178.486631 
@@ -4727,7 +4727,7 @@ L 246.191563 189.6981
 L 245.170823 189.922669 
 L 244.150084 190.146311 
 L 243.129344 190.369032 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_130">
     <path d="M 243.129344 190.369032 
@@ -4779,7 +4779,7 @@ L 215.390639 203.654226
 L 214.774224 203.915384 
 L 214.157808 204.175288 
 L 213.541392 204.43395 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_131">
     <path d="M 213.541392 204.43395 
@@ -4831,7 +4831,7 @@ L 205.113797 211.689953
 L 204.926517 211.840648 
 L 204.739237 211.990924 
 L 204.551957 212.140784 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_132">
     <path d="M 204.551957 212.140784 
@@ -4883,7 +4883,7 @@ L 196.403329 227.688717
 L 196.222248 227.988205 
 L 196.041168 228.286045 
 L 195.860087 228.582256 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_133">
     <path d="M 195.860087 228.582256 
@@ -4935,7 +4935,7 @@ L 194.134867 233.954953
 L 194.096529 234.068494 
 L 194.058191 234.181796 
 L 194.019853 234.294862 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="legend_1">
     <g id="patch_7">
@@ -4953,7 +4953,7 @@ z
     </g>
     <g id="line2d_134">
      <defs>
-      <path id="m19424b704c" d="M 0 3.5 
+      <path id="m801ab00cd6" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -4966,7 +4966,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m19424b704c" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m801ab00cd6" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -5025,7 +5025,7 @@ z
     </g>
     <g id="line2d_135">
      <g>
-      <use xlink:href="#m7a66f49d20" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mcd3f418712" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -5039,7 +5039,7 @@ z
     </g>
     <g id="line2d_136">
      <g>
-      <use xlink:href="#m0d9c3b99f3" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m7f0a0c0000" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -5084,7 +5084,7 @@ z
     </g>
     <g id="line2d_137">
      <g>
-      <use xlink:href="#m32086a8271" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m2fa6edb34c" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -5127,7 +5127,7 @@ z
     </g>
     <g id="line2d_138">
      <g>
-      <use xlink:href="#m0acbed5808" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m0b530f356d" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -5143,7 +5143,7 @@ z
     </g>
     <g id="line2d_139">
      <g>
-      <use xlink:href="#mff1feee27e" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m5253f1838b" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -5197,7 +5197,7 @@ z
     </g>
     <g id="line2d_140">
      <g>
-      <use xlink:href="#m0c1b2da0ac" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m35056ef38d" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -5262,7 +5262,7 @@ z
     </g>
     <g id="line2d_141">
      <g>
-      <use xlink:href="#ma109a78523" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#m4ae4a2483a" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -5300,7 +5300,7 @@ z
     </g>
     <g id="line2d_142">
      <g>
-      <use xlink:href="#mbc6e463cf7" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mcf2ccd7d9a" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -5370,486 +5370,486 @@ z
     </g>
    </g>
    <g id="line2d_143">
-    <g clip-path="url(#p5ff60b7cdf)">
-     <use xlink:href="#m19424b704c" x="319.643112" y="123.769985" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m19424b704c" x="269.129958" y="139.061591" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m19424b704c" x="247.452898" y="144.36473" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m19424b704c" x="192.820547" y="153.196067" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m19424b704c" x="180.389901" y="164.537964" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m19424b704c" x="156.380826" y="173.075638" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m19424b704c" x="147.895047" y="182.969617" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m19424b704c" x="146.261627" y="187.228053" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m19424b704c" x="119.666036" y="285.720519" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m19424b704c" x="97.814287" y="313.662731" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <g clip-path="url(#p5ca6112d80)">
+     <use xlink:href="#m801ab00cd6" x="319.643112" y="123.414237" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m801ab00cd6" x="269.129958" y="139.002078" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m801ab00cd6" x="247.452898" y="144.112782" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m801ab00cd6" x="192.820547" y="153.120134" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m801ab00cd6" x="180.389901" y="164.441353" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m801ab00cd6" x="149.634124" y="178.135959" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m801ab00cd6" x="141.251771" y="187.434135" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m801ab00cd6" x="139.514773" y="191.335418" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m801ab00cd6" x="119.666036" y="285.286593" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m801ab00cd6" x="97.814287" y="313.867065" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
    <g id="line2d_144">
-    <path d="M 319.643112 123.769985 
-L 318.590755 124.136866 
-L 317.538397 124.501276 
-L 316.48604 124.86325 
-L 315.433682 125.22282 
-L 314.381325 125.580016 
-L 313.328968 125.934871 
-L 312.27661 126.287415 
-L 311.224253 126.637678 
-L 310.171896 126.985689 
-L 309.119538 127.331477 
-L 308.067181 127.67507 
-L 307.014823 128.016496 
-L 305.962466 128.355781 
-L 304.910109 128.692954 
-L 303.857751 129.028039 
-L 302.805394 129.361063 
-L 301.753037 129.69205 
-L 300.700679 130.021026 
-L 299.648322 130.348015 
-L 298.595965 130.67304 
-L 297.543607 130.996126 
-L 296.49125 131.317294 
-L 295.438892 131.636568 
-L 294.386535 131.95397 
-L 293.334178 132.269522 
-L 292.28182 132.583245 
-L 291.229463 132.89516 
-L 290.177106 133.205289 
-L 289.124748 133.51365 
-L 288.072391 133.820265 
-L 287.020033 134.125153 
-L 285.967676 134.428333 
-L 284.915319 134.729825 
-L 283.862961 135.029647 
-L 282.810604 135.327817 
-L 281.758247 135.624354 
-L 280.705889 135.919275 
-L 279.653532 136.212598 
-L 278.601175 136.50434 
-L 277.548817 136.794519 
-L 276.49646 137.08315 
-L 275.444102 137.37025 
-L 274.391745 137.655835 
-L 273.339388 137.939922 
-L 272.28703 138.222526 
-L 271.234673 138.503662 
-L 270.182316 138.783345 
-L 269.129958 139.061591 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 319.643112 123.414237 
+L 318.590755 123.78927 
+L 317.538397 124.161723 
+L 316.48604 124.53163 
+L 315.433682 124.899027 
+L 314.381325 125.263947 
+L 313.328968 125.626423 
+L 312.27661 125.986489 
+L 311.224253 126.344175 
+L 310.171896 126.699513 
+L 309.119538 127.052533 
+L 308.067181 127.403267 
+L 307.014823 127.751742 
+L 305.962466 128.097989 
+L 304.910109 128.442034 
+L 303.857751 128.783907 
+L 302.805394 129.123635 
+L 301.753037 129.461243 
+L 300.700679 129.796759 
+L 299.648322 130.130208 
+L 298.595965 130.461616 
+L 297.543607 130.791007 
+L 296.49125 131.118405 
+L 295.438892 131.443836 
+L 294.386535 131.767322 
+L 293.334178 132.088886 
+L 292.28182 132.408551 
+L 291.229463 132.726339 
+L 290.177106 133.042273 
+L 289.124748 133.356373 
+L 288.072391 133.668662 
+L 287.020033 133.979159 
+L 285.967676 134.287885 
+L 284.915319 134.59486 
+L 283.862961 134.900105 
+L 282.810604 135.203637 
+L 281.758247 135.505478 
+L 280.705889 135.805644 
+L 279.653532 136.104155 
+L 278.601175 136.401029 
+L 277.548817 136.696284 
+L 276.49646 136.989937 
+L 275.444102 137.282006 
+L 274.391745 137.572507 
+L 273.339388 137.861458 
+L 272.28703 138.148874 
+L 271.234673 138.434772 
+L 270.182316 138.719168 
+L 269.129958 139.002078 
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_145">
-    <path d="M 269.129958 139.061591 
-L 268.678353 139.177542 
-L 268.226747 139.293245 
-L 267.775142 139.408701 
-L 267.323537 139.523911 
-L 266.871931 139.638877 
-L 266.420326 139.753599 
-L 265.96872 139.868079 
-L 265.517115 139.982316 
-L 265.065509 140.096314 
-L 264.613904 140.210072 
-L 264.162299 140.323591 
-L 263.710693 140.436872 
-L 263.259088 140.549917 
-L 262.807482 140.662727 
-L 262.355877 140.775302 
-L 261.904271 140.887643 
-L 261.452666 140.999751 
-L 261.001061 141.111628 
-L 260.549455 141.223274 
-L 260.09785 141.334691 
-L 259.646244 141.445878 
-L 259.194639 141.556838 
-L 258.743034 141.66757 
-L 258.291428 141.778077 
-L 257.839823 141.888358 
-L 257.388217 141.998415 
-L 256.936612 142.108249 
-L 256.485006 142.217861 
-L 256.033401 142.327251 
-L 255.581796 142.43642 
-L 255.13019 142.54537 
-L 254.678585 142.6541 
-L 254.226979 142.762613 
-L 253.775374 142.870909 
-L 253.323769 142.978988 
-L 252.872163 143.086852 
-L 252.420558 143.194502 
-L 251.968952 143.301938 
-L 251.517347 143.409161 
-L 251.065741 143.516172 
-L 250.614136 143.622972 
-L 250.162531 143.729562 
-L 249.710925 143.835942 
-L 249.25932 143.942114 
-L 248.807714 144.048078 
-L 248.356109 144.153834 
-L 247.904503 144.259385 
-L 247.452898 144.36473 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 269.129958 139.002078 
+L 268.678353 139.113624 
+L 268.226747 139.224941 
+L 267.775142 139.33603 
+L 267.323537 139.44689 
+L 266.871931 139.557525 
+L 266.420326 139.667933 
+L 265.96872 139.778117 
+L 265.517115 139.888077 
+L 265.065509 139.997814 
+L 264.613904 140.10733 
+L 264.162299 140.216624 
+L 263.710693 140.325697 
+L 263.259088 140.434552 
+L 262.807482 140.543188 
+L 262.355877 140.651606 
+L 261.904271 140.759808 
+L 261.452666 140.867794 
+L 261.001061 140.975565 
+L 260.549455 141.083121 
+L 260.09785 141.190465 
+L 259.646244 141.297596 
+L 259.194639 141.404515 
+L 258.743034 141.511224 
+L 258.291428 141.617722 
+L 257.839823 141.724012 
+L 257.388217 141.830093 
+L 256.936612 141.935967 
+L 256.485006 142.041634 
+L 256.033401 142.147095 
+L 255.581796 142.252352 
+L 255.13019 142.357404 
+L 254.678585 142.462252 
+L 254.226979 142.566898 
+L 253.775374 142.671342 
+L 253.323769 142.775584 
+L 252.872163 142.879627 
+L 252.420558 142.983469 
+L 251.968952 143.087113 
+L 251.517347 143.190559 
+L 251.065741 143.293808 
+L 250.614136 143.39686 
+L 250.162531 143.499716 
+L 249.710925 143.602377 
+L 249.25932 143.704844 
+L 248.807714 143.807117 
+L 248.356109 143.909197 
+L 247.904503 144.011085 
+L 247.452898 144.112782 
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_146">
-    <path d="M 247.452898 144.36473 
-L 246.314724 144.564207 
-L 245.17655 144.762952 
-L 244.038376 144.96097 
-L 242.900202 145.158266 
-L 241.762028 145.354845 
-L 240.623854 145.550714 
-L 239.48568 145.745876 
-L 238.347506 145.940337 
-L 237.209332 146.134101 
-L 236.071158 146.327175 
-L 234.932984 146.519563 
-L 233.79481 146.711269 
-L 232.656636 146.902299 
-L 231.518462 147.092657 
-L 230.380288 147.282347 
-L 229.242114 147.471376 
-L 228.10394 147.659746 
-L 226.965766 147.847464 
-L 225.827592 148.034533 
-L 224.689418 148.220957 
-L 223.551244 148.406742 
-L 222.41307 148.591891 
-L 221.274896 148.776409 
-L 220.136722 148.9603 
-L 218.998548 149.143568 
-L 217.860374 149.326219 
-L 216.7222 149.508255 
-L 215.584026 149.689681 
-L 214.445852 149.8705 
-L 213.307678 150.050718 
-L 212.169505 150.230338 
-L 211.031331 150.409364 
-L 209.893157 150.587799 
-L 208.754983 150.765649 
-L 207.616809 150.942916 
-L 206.478635 151.119604 
-L 205.340461 151.295718 
-L 204.202287 151.47126 
-L 203.064113 151.646235 
-L 201.925939 151.820646 
-L 200.787765 151.994497 
-L 199.649591 152.167792 
-L 198.511417 152.340533 
-L 197.373243 152.512725 
-L 196.235069 152.684371 
-L 195.096895 152.855475 
-L 193.958721 153.026039 
-L 192.820547 153.196067 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 247.452898 144.112782 
+L 246.314724 144.316567 
+L 245.17655 144.519588 
+L 244.038376 144.72185 
+L 242.900202 144.923359 
+L 241.762028 145.12412 
+L 240.623854 145.32414 
+L 239.48568 145.523424 
+L 238.347506 145.721976 
+L 237.209332 145.919803 
+L 236.071158 146.11691 
+L 234.932984 146.313301 
+L 233.79481 146.508983 
+L 232.656636 146.70396 
+L 231.518462 146.898237 
+L 230.380288 147.091819 
+L 229.242114 147.284711 
+L 228.10394 147.476918 
+L 226.965766 147.668446 
+L 225.827592 147.859298 
+L 224.689418 148.049479 
+L 223.551244 148.238995 
+L 222.41307 148.42785 
+L 221.274896 148.616048 
+L 220.136722 148.803594 
+L 218.998548 148.990492 
+L 217.860374 149.176747 
+L 216.7222 149.362364 
+L 215.584026 149.547346 
+L 214.445852 149.731698 
+L 213.307678 149.915425 
+L 212.169505 150.09853 
+L 211.031331 150.281018 
+L 209.893157 150.462893 
+L 208.754983 150.644158 
+L 207.616809 150.824819 
+L 206.478635 151.004879 
+L 205.340461 151.184342 
+L 204.202287 151.363211 
+L 203.064113 151.541492 
+L 201.925939 151.719187 
+L 200.787765 151.896302 
+L 199.649591 152.072838 
+L 198.511417 152.2488 
+L 197.373243 152.424193 
+L 196.235069 152.599019 
+L 195.096895 152.773282 
+L 193.958721 152.946986 
+L 192.820547 153.120134 
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_147">
-    <path d="M 192.820547 153.196067 
-L 192.561575 153.458299 
-L 192.302603 153.719265 
-L 192.043631 153.97898 
-L 191.78466 154.237455 
-L 191.525688 154.494701 
-L 191.266716 154.750731 
-L 191.007744 155.005555 
-L 190.748773 155.259185 
-L 190.489801 155.511633 
-L 190.230829 155.762909 
-L 189.971857 156.013023 
-L 189.712885 156.261987 
-L 189.453914 156.509812 
-L 189.194942 156.756507 
-L 188.93597 157.002083 
-L 188.676998 157.24655 
-L 188.418027 157.489917 
-L 188.159055 157.732196 
-L 187.900083 157.973395 
-L 187.641111 158.213523 
-L 187.382139 158.452592 
-L 187.123168 158.690609 
-L 186.864196 158.927584 
-L 186.605224 159.163527 
-L 186.346252 159.398445 
-L 186.087281 159.632348 
-L 185.828309 159.865245 
-L 185.569337 160.097144 
-L 185.310365 160.328054 
-L 185.051393 160.557983 
-L 184.792422 160.78694 
-L 184.53345 161.014932 
-L 184.274478 161.241968 
-L 184.015506 161.468056 
-L 183.756535 161.693204 
-L 183.497563 161.917418 
-L 183.238591 162.140708 
-L 182.979619 162.363081 
-L 182.720647 162.584544 
-L 182.461676 162.805104 
-L 182.202704 163.02477 
-L 181.943732 163.243548 
-L 181.68476 163.461445 
-L 181.425789 163.678468 
-L 181.166817 163.894625 
-L 180.907845 164.109922 
-L 180.648873 164.324366 
-L 180.389901 164.537964 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 192.820547 153.120134 
+L 192.561575 153.381837 
+L 192.302603 153.64228 
+L 192.043631 153.901477 
+L 191.78466 154.159438 
+L 191.525688 154.416175 
+L 191.266716 154.671701 
+L 191.007744 154.926026 
+L 190.748773 155.179162 
+L 190.489801 155.43112 
+L 190.230829 155.68191 
+L 189.971857 155.931544 
+L 189.712885 156.180032 
+L 189.453914 156.427384 
+L 189.194942 156.673611 
+L 188.93597 156.918724 
+L 188.676998 157.162731 
+L 188.418027 157.405643 
+L 188.159055 157.64747 
+L 187.900083 157.888222 
+L 187.641111 158.127908 
+L 187.382139 158.366537 
+L 187.123168 158.604119 
+L 186.864196 158.840662 
+L 186.605224 159.076176 
+L 186.346252 159.31067 
+L 186.087281 159.544153 
+L 185.828309 159.776633 
+L 185.569337 160.008119 
+L 185.310365 160.238619 
+L 185.051393 160.468142 
+L 184.792422 160.696695 
+L 184.53345 160.924288 
+L 184.274478 161.150927 
+L 184.015506 161.376622 
+L 183.756535 161.60138 
+L 183.497563 161.825208 
+L 183.238591 162.048115 
+L 182.979619 162.270107 
+L 182.720647 162.491193 
+L 182.461676 162.71138 
+L 182.202704 162.930674 
+L 181.943732 163.149084 
+L 181.68476 163.366616 
+L 181.425789 163.583277 
+L 181.166817 163.799075 
+L 180.907845 164.014015 
+L 180.648873 164.228106 
+L 180.389901 164.441353 
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_148">
-    <path d="M 180.389901 164.537964 
-L 179.889712 164.730285 
-L 179.389523 164.921924 
-L 178.889334 165.112888 
-L 178.389145 165.30318 
-L 177.888956 165.492806 
-L 177.388767 165.681769 
-L 176.888578 165.870076 
-L 176.388389 166.057729 
-L 175.8882 166.244734 
-L 175.388011 166.431096 
-L 174.887822 166.616818 
-L 174.387633 166.801905 
-L 173.887443 166.986361 
-L 173.387254 167.170191 
-L 172.887065 167.353399 
-L 172.386876 167.535988 
-L 171.886687 167.717964 
-L 171.386498 167.89933 
-L 170.886309 168.080091 
-L 170.38612 168.26025 
-L 169.885931 168.439811 
-L 169.385742 168.618779 
-L 168.885553 168.797157 
-L 168.385364 168.974949 
-L 167.885175 169.152159 
-L 167.384985 169.328791 
-L 166.884796 169.504848 
-L 166.384607 169.680334 
-L 165.884418 169.855254 
-L 165.384229 170.02961 
-L 164.88404 170.203406 
-L 164.383851 170.376646 
-L 163.883662 170.549334 
-L 163.383473 170.721472 
-L 162.883284 170.893064 
-L 162.383095 171.064115 
-L 161.882906 171.234626 
-L 161.382717 171.404602 
-L 160.882527 171.574046 
-L 160.382338 171.742962 
-L 159.882149 171.911352 
-L 159.38196 172.079219 
-L 158.881771 172.246568 
-L 158.381582 172.413401 
-L 157.881393 172.579721 
-L 157.381204 172.745532 
-L 156.881015 172.910836 
-L 156.380826 173.075638 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 180.389901 164.441353 
+L 179.749156 164.765023 
+L 179.108411 165.08677 
+L 178.467665 165.406615 
+L 177.82692 165.724581 
+L 177.186175 166.040691 
+L 176.545429 166.354965 
+L 175.904684 166.667426 
+L 175.263939 166.978093 
+L 174.623193 167.286987 
+L 173.982448 167.594128 
+L 173.341702 167.899537 
+L 172.700957 168.203232 
+L 172.060212 168.505233 
+L 171.419466 168.805558 
+L 170.778721 169.104226 
+L 170.137976 169.401256 
+L 169.49723 169.696664 
+L 168.856485 169.990469 
+L 168.215739 170.282688 
+L 167.574994 170.573338 
+L 166.934249 170.862436 
+L 166.293503 171.149998 
+L 165.652758 171.43604 
+L 165.012013 171.720579 
+L 164.371267 172.00363 
+L 163.730522 172.285209 
+L 163.089777 172.56533 
+L 162.449031 172.844009 
+L 161.808286 173.121261 
+L 161.16754 173.3971 
+L 160.526795 173.671541 
+L 159.88605 173.944597 
+L 159.245304 174.216283 
+L 158.604559 174.486612 
+L 157.963814 174.755598 
+L 157.323068 175.023254 
+L 156.682323 175.289592 
+L 156.041577 175.554627 
+L 155.400832 175.81837 
+L 154.760087 176.080835 
+L 154.119341 176.342033 
+L 153.478596 176.601977 
+L 152.837851 176.860678 
+L 152.197105 177.118149 
+L 151.55636 177.374402 
+L 150.915614 177.629446 
+L 150.274869 177.883295 
+L 149.634124 178.135959 
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_149">
-    <path d="M 156.380826 173.075638 
-L 156.204039 173.301331 
-L 156.027252 173.526087 
-L 155.850465 173.749913 
-L 155.673678 173.972818 
-L 155.496891 174.194809 
-L 155.320103 174.415893 
-L 155.143316 174.636078 
-L 154.966529 174.85537 
-L 154.789742 175.073778 
-L 154.612955 175.291309 
-L 154.436168 175.507968 
-L 154.259381 175.723764 
-L 154.082594 175.938703 
-L 153.905807 176.152792 
-L 153.72902 176.366038 
-L 153.552233 176.578447 
-L 153.375446 176.790025 
-L 153.198659 177.00078 
-L 153.021872 177.210718 
-L 152.845085 177.419844 
-L 152.668298 177.628166 
-L 152.491511 177.835689 
-L 152.314724 178.042419 
-L 152.137937 178.248363 
-L 151.96115 178.453526 
-L 151.784362 178.657915 
-L 151.607575 178.861535 
-L 151.430788 179.064392 
-L 151.254001 179.266491 
-L 151.077214 179.467839 
-L 150.900427 179.66844 
-L 150.72364 179.868301 
-L 150.546853 180.067427 
-L 150.370066 180.265823 
-L 150.193279 180.463494 
-L 150.016492 180.660446 
-L 149.839705 180.856684 
-L 149.662918 181.052214 
-L 149.486131 181.247039 
-L 149.309344 181.441166 
-L 149.132557 181.634599 
-L 148.95577 181.827344 
-L 148.778983 182.019404 
-L 148.602196 182.210786 
-L 148.425408 182.401493 
-L 148.248621 182.591531 
-L 148.071834 182.780904 
-L 147.895047 182.969617 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 149.634124 178.135959 
+L 149.459491 178.346892 
+L 149.284859 178.557005 
+L 149.110227 178.766307 
+L 148.935594 178.974802 
+L 148.760962 179.182497 
+L 148.58633 179.389398 
+L 148.411697 179.595512 
+L 148.237065 179.800844 
+L 148.062433 180.005399 
+L 147.8878 180.209185 
+L 147.713168 180.412206 
+L 147.538535 180.614469 
+L 147.363903 180.815979 
+L 147.189271 181.016741 
+L 147.014638 181.216762 
+L 146.840006 181.416046 
+L 146.665374 181.6146 
+L 146.490741 181.812427 
+L 146.316109 182.009535 
+L 146.141477 182.205927 
+L 145.966844 182.401609 
+L 145.792212 182.596586 
+L 145.61758 182.790864 
+L 145.442947 182.984447 
+L 145.268315 183.17734 
+L 145.093683 183.369548 
+L 144.91905 183.561076 
+L 144.744418 183.751929 
+L 144.569785 183.942111 
+L 144.395153 184.131627 
+L 144.220521 184.320483 
+L 144.045888 184.508681 
+L 143.871256 184.696228 
+L 143.696624 184.883127 
+L 143.521991 185.069383 
+L 143.347359 185.255 
+L 143.172727 185.439983 
+L 142.998094 185.624336 
+L 142.823462 185.808063 
+L 142.64883 185.991169 
+L 142.474197 186.173657 
+L 142.299565 186.355532 
+L 142.124933 186.536799 
+L 141.9503 186.71746 
+L 141.775668 186.89752 
+L 141.601035 187.076984 
+L 141.426403 187.255854 
+L 141.251771 187.434135 
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_150">
-    <path d="M 147.895047 182.969617 
-L 147.861018 183.061839 
-L 147.826988 183.153904 
-L 147.792959 183.245812 
-L 147.758929 183.337565 
-L 147.724899 183.429163 
-L 147.69087 183.520605 
-L 147.65684 183.611894 
-L 147.622811 183.703029 
-L 147.588781 183.794011 
-L 147.554751 183.88484 
-L 147.520722 183.975517 
-L 147.486692 184.066042 
-L 147.452663 184.156416 
-L 147.418633 184.24664 
-L 147.384604 184.336713 
-L 147.350574 184.426637 
-L 147.316544 184.516412 
-L 147.282515 184.606038 
-L 147.248485 184.695516 
-L 147.214456 184.784846 
-L 147.180426 184.874029 
-L 147.146396 184.963065 
-L 147.112367 185.051955 
-L 147.078337 185.1407 
-L 147.044308 185.229299 
-L 147.010278 185.317753 
-L 146.976249 185.406063 
-L 146.942219 185.49423 
-L 146.908189 185.582253 
-L 146.87416 185.670132 
-L 146.84013 185.75787 
-L 146.806101 185.845466 
-L 146.772071 185.93292 
-L 146.738041 186.020233 
-L 146.704012 186.107405 
-L 146.669982 186.194437 
-L 146.635953 186.28133 
-L 146.601923 186.368083 
-L 146.567893 186.454697 
-L 146.533864 186.541173 
-L 146.499834 186.627511 
-L 146.465805 186.713712 
-L 146.431775 186.799776 
-L 146.397746 186.885703 
-L 146.363716 186.971493 
-L 146.329686 187.057148 
-L 146.295657 187.142668 
-L 146.261627 187.228053 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 141.251771 187.434135 
+L 141.215583 187.518347 
+L 141.179396 187.602428 
+L 141.143208 187.686378 
+L 141.107021 187.770199 
+L 141.070833 187.85389 
+L 141.034646 187.937451 
+L 140.998459 188.020884 
+L 140.962271 188.104189 
+L 140.926084 188.187365 
+L 140.889896 188.270414 
+L 140.853709 188.353336 
+L 140.817521 188.436131 
+L 140.781334 188.518799 
+L 140.745146 188.601341 
+L 140.708959 188.683758 
+L 140.672772 188.766049 
+L 140.636584 188.848216 
+L 140.600397 188.930258 
+L 140.564209 189.012176 
+L 140.528022 189.09397 
+L 140.491834 189.17564 
+L 140.455647 189.257188 
+L 140.419459 189.338613 
+L 140.383272 189.419915 
+L 140.347084 189.501096 
+L 140.310897 189.582155 
+L 140.27471 189.663093 
+L 140.238522 189.74391 
+L 140.202335 189.824606 
+L 140.166147 189.905183 
+L 140.12996 189.98564 
+L 140.093772 190.065977 
+L 140.057585 190.146195 
+L 140.021397 190.226295 
+L 139.98521 190.306276 
+L 139.949022 190.386139 
+L 139.912835 190.465884 
+L 139.876648 190.545513 
+L 139.84046 190.625024 
+L 139.804273 190.704419 
+L 139.768085 190.783697 
+L 139.731898 190.862859 
+L 139.69571 190.941906 
+L 139.659523 191.020838 
+L 139.623335 191.099654 
+L 139.587148 191.178356 
+L 139.55096 191.256944 
+L 139.514773 191.335418 
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_151">
-    <path d="M 146.261627 187.228053 
-L 145.707552 192.764146 
-L 145.153478 197.786216 
-L 144.599403 202.381661 
-L 144.045328 206.617323 
-L 143.491253 210.545469 
-L 142.937178 214.207746 
-L 142.383103 217.637873 
-L 141.829029 220.863535 
-L 141.274954 223.907744 
-L 140.720879 226.789831 
-L 140.166804 229.526193 
-L 139.612729 232.130862 
-L 139.058654 234.615933 
-L 138.50458 236.991909 
-L 137.950505 239.267967 
-L 137.39643 241.452173 
-L 136.842355 243.551653 
-L 136.28828 245.572735 
-L 135.734206 247.521066 
-L 135.180131 249.4017 
-L 134.626056 251.219185 
-L 134.071981 252.977624 
-L 133.517906 254.680733 
-L 132.963831 256.331889 
-L 132.409757 257.934167 
-L 131.855682 259.490378 
-L 131.301607 261.003097 
-L 130.747532 262.474689 
-L 130.193457 263.907331 
-L 129.639382 265.303033 
-L 129.085308 266.663651 
-L 128.531233 267.990906 
-L 127.977158 269.286396 
-L 127.423083 270.551604 
-L 126.869008 271.787915 
-L 126.314933 272.996619 
-L 125.760859 274.178922 
-L 125.206784 275.335953 
-L 124.652709 276.468769 
-L 124.098634 277.578364 
-L 123.544559 278.66567 
-L 122.990485 279.731566 
-L 122.43641 280.776878 
-L 121.882335 281.802385 
-L 121.32826 282.808826 
-L 120.774185 283.796895 
-L 120.22011 284.767251 
-L 119.666036 285.720519 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 139.514773 191.335418 
+L 139.101258 196.363735 
+L 138.687742 200.964409 
+L 138.274227 205.204512 
+L 137.860712 209.136478 
+L 137.447196 212.802074 
+L 137.033681 216.235113 
+L 136.620165 219.46335 
+L 136.20665 222.509852 
+L 135.793135 225.393994 
+L 135.379619 228.132209 
+L 134.966104 230.738556 
+L 134.552589 233.225155 
+L 134.139073 235.602528 
+L 133.725558 237.879867 
+L 133.312043 240.065252 
+L 132.898527 242.165823 
+L 132.485012 244.187916 
+L 132.071496 246.137185 
+L 131.657981 248.018694 
+L 131.244466 249.836996 
+L 130.83095 251.5962 
+L 130.417435 253.300026 
+L 130.00392 254.951856 
+L 129.590404 256.554769 
+L 129.176889 258.111578 
+L 128.763374 259.624863 
+L 128.349858 261.096991 
+L 127.936343 262.530141 
+L 127.522827 263.926325 
+L 127.109312 265.287401 
+L 126.695797 266.615091 
+L 126.282281 267.910996 
+L 125.868766 269.1766 
+L 125.455251 270.413288 
+L 125.041735 271.622354 
+L 124.62822 272.805002 
+L 124.214705 273.962364 
+L 123.801189 275.095498 
+L 123.387674 276.205397 
+L 122.974158 277.292996 
+L 122.560643 278.359172 
+L 122.147128 279.404754 
+L 121.733612 280.430522 
+L 121.320097 281.437213 
+L 120.906582 282.425523 
+L 120.493066 283.396113 
+L 120.079551 284.349605 
+L 119.666036 285.286593 
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_152">
-    <path d="M 119.666036 285.720519 
-L 119.210791 286.477146 
-L 118.755546 287.223343 
-L 118.300301 287.959393 
-L 117.845056 288.685569 
-L 117.389812 289.402132 
-L 116.934567 290.109334 
-L 116.479322 290.807415 
-L 116.024077 291.496608 
-L 115.568833 292.177136 
-L 115.113588 292.849215 
-L 114.658343 293.513052 
-L 114.203098 294.168847 
-L 113.747854 294.816792 
-L 113.292609 295.457072 
-L 112.837364 296.089868 
-L 112.382119 296.715351 
-L 111.926875 297.33369 
-L 111.47163 297.945045 
-L 111.016385 298.549572 
-L 110.56114 299.147423 
-L 110.105895 299.738743 
-L 109.650651 300.323673 
-L 109.195406 300.90235 
-L 108.740161 301.474906 
-L 108.284916 302.04147 
-L 107.829672 302.602165 
-L 107.374427 303.157111 
-L 106.919182 303.706426 
-L 106.463937 304.250223 
-L 106.008693 304.788611 
-L 105.553448 305.321697 
-L 105.098203 305.849584 
-L 104.642958 306.372374 
-L 104.187713 306.890162 
-L 103.732469 307.403044 
-L 103.277224 307.911113 
-L 102.821979 308.414457 
-L 102.366734 308.913163 
-L 101.91149 309.407318 
-L 101.456245 309.897001 
-L 101.001 310.382295 
-L 100.545755 310.863277 
-L 100.090511 311.340022 
-L 99.635266 311.812606 
-L 99.180021 312.281099 
-L 98.724776 312.745572 
-L 98.269531 313.206094 
-L 97.814287 313.662731 
-" clip-path="url(#p5ff60b7cdf)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 119.666036 285.286593 
+L 119.210791 286.065317 
+L 118.755546 286.832998 
+L 118.300301 287.589943 
+L 117.845056 288.33645 
+L 117.389812 289.072801 
+L 116.934567 289.79927 
+L 116.479322 290.516119 
+L 116.024077 291.223598 
+L 115.568833 291.92195 
+L 115.113588 292.611407 
+L 114.658343 293.292193 
+L 114.203098 293.964524 
+L 113.747854 294.628606 
+L 113.292609 295.28464 
+L 112.837364 295.932818 
+L 112.382119 296.573326 
+L 111.926875 297.206344 
+L 111.47163 297.832046 
+L 111.016385 298.450597 
+L 110.56114 299.06216 
+L 110.105895 299.66689 
+L 109.650651 300.26494 
+L 109.195406 300.856454 
+L 108.740161 301.441574 
+L 108.284916 302.020438 
+L 107.829672 302.593176 
+L 107.374427 303.159918 
+L 106.919182 303.720788 
+L 106.463937 304.275906 
+L 106.008693 304.825389 
+L 105.553448 305.36935 
+L 105.098203 305.907899 
+L 104.642958 306.441143 
+L 104.187713 306.969185 
+L 103.732469 307.492126 
+L 103.277224 308.010064 
+L 102.821979 308.523092 
+L 102.366734 309.031304 
+L 101.91149 309.534789 
+L 101.456245 310.033634 
+L 101.001 310.527924 
+L 100.545755 311.017741 
+L 100.090511 311.503166 
+L 99.635266 311.984276 
+L 99.180021 312.461148 
+L 98.724776 312.933856 
+L 98.269531 313.402471 
+L 97.814287 313.867065 
+" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
   </g>
   <g id="text_25">
@@ -6166,8 +6166,8 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-07-08T21:41:55Z  ·  Linux chungus2 x86_64  ·  commit b17c222c  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(43.990156 465.66) scale(0.07 -0.07)">
+   <!-- 2026-07-08T22:12:55Z  ·  Linux chungus2 x86_64  ·  commit 30251fb3  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(44.380078 465.66) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -6326,10 +6326,10 @@ z
     <use xlink:href="#DejaVuSans-38" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
     <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
     <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
@@ -6372,109 +6372,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3135.351562 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3198.974609 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3262.597656 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3317.578125 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3381.201172 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3444.824219 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3508.447266 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3563.427734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3595.214844 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3627.001953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3658.789062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3690.576172 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3722.363281 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3750.146484 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3811.669922 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3872.949219 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3936.328125 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3999.804688 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4038.667969 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4099.849609 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4159.029297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4220.552734 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4261.666016 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4295.357422 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4323.140625 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4384.664062 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4445.943359 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4509.322266 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4572.945312 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4606.636719 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4665.816406 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4729.439453 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4761.226562 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4824.849609 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4888.472656 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4920.259766 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4983.882812 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5019.966797 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5058.830078 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5113.810547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5177.433594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5209.220703 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5241.007812 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5272.794922 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5304.582031 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5336.369141 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5375.578125 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5438.957031 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5477.820312 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5539.001953 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5602.380859 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5665.857422 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5729.236328 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5792.712891 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5856.091797 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5895.300781 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5927.087891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6010.876953 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6042.664062 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6140.076172 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6201.599609 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6265.076172 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6292.859375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6354.138672 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6417.517578 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6449.304688 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6501.404297 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6564.783203 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6626.0625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6689.539062 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6741.638672 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6805.017578 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6866.199219 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6905.408203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6939.099609 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6970.886719 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7012 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7073.279297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7112.488281 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7140.271484 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7201.453125 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7233.240234 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7261.023438 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7313.123047 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7344.910156 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7408.386719 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7469.910156 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7509.119141 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7570.642578 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7610.005859 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7707.417969 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7735.201172 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7798.580078 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7826.363281 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7878.462891 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7917.671875 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7945.455078 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3262.744141 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3326.367188 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3389.990234 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3425.195312 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3488.671875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3552.294922 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3584.082031 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3615.869141 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3647.65625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3679.443359 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3711.230469 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3739.013672 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3800.537109 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3861.816406 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3925.195312 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3988.671875 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4027.535156 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4088.716797 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4147.896484 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4209.419922 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4250.533203 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4284.224609 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4312.007812 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4373.53125 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4434.810547 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4498.189453 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4561.8125 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4595.503906 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4654.683594 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4718.306641 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4750.09375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4813.716797 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4877.339844 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4909.126953 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4972.75 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5008.833984 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5047.697266 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5102.677734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5166.300781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5198.087891 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5229.875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5261.662109 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5293.449219 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5325.236328 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5364.445312 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5427.824219 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5466.6875 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5527.869141 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5591.248047 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5654.724609 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5718.103516 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5781.580078 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5844.958984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5884.167969 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5915.955078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5999.744141 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6031.53125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6128.943359 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6190.466797 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6253.943359 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6281.726562 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6343.005859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6406.384766 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6438.171875 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6490.271484 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6553.650391 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6614.929688 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6678.40625 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6730.505859 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6793.884766 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6855.066406 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6894.275391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6927.966797 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6959.753906 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7000.867188 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7062.146484 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7101.355469 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7129.138672 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7190.320312 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7222.107422 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7249.890625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7301.990234 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7333.777344 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7397.253906 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7458.777344 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7497.986328 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7559.509766 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7598.873047 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7696.285156 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7724.068359 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7787.447266 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7815.230469 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7867.330078 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7906.539062 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7934.322266 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p5ff60b7cdf">
+  <clipPath id="p5ca6112d80">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_decode_density.svg
+++ b/bench/graphs/silesia_decode_density.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 82.373685 412.80375 
 L 82.373685 47.3475 
-" clip-path="url(#pf5e1538b81)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pead9396e02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m706dd6b66d" d="M 0 0 
+       <path id="mf60d624f33" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m706dd6b66d" x="82.373685" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf60d624f33" x="82.373685" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -111,11 +111,11 @@ z
      <g id="line2d_3">
       <path d="M 165.44644 412.80375 
 L 165.44644 47.3475 
-" clip-path="url(#pf5e1538b81)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pead9396e02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m706dd6b66d" x="165.44644" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf60d624f33" x="165.44644" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -157,11 +157,11 @@ z
      <g id="line2d_5">
       <path d="M 248.519195 412.80375 
 L 248.519195 47.3475 
-" clip-path="url(#pf5e1538b81)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pead9396e02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m706dd6b66d" x="248.519195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf60d624f33" x="248.519195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -211,11 +211,11 @@ z
      <g id="line2d_7">
       <path d="M 331.59195 412.80375 
 L 331.59195 47.3475 
-" clip-path="url(#pf5e1538b81)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pead9396e02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m706dd6b66d" x="331.59195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf60d624f33" x="331.59195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -252,11 +252,11 @@ z
      <g id="line2d_9">
       <path d="M 414.664704 412.80375 
 L 414.664704 47.3475 
-" clip-path="url(#pf5e1538b81)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pead9396e02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m706dd6b66d" x="414.664704" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf60d624f33" x="414.664704" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -299,11 +299,11 @@ z
      <g id="line2d_11">
       <path d="M 497.737459 412.80375 
 L 497.737459 47.3475 
-" clip-path="url(#pf5e1538b81)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pead9396e02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m706dd6b66d" x="497.737459" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf60d624f33" x="497.737459" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -351,11 +351,11 @@ z
      <g id="line2d_13">
       <path d="M 580.810214 412.80375 
 L 580.810214 47.3475 
-" clip-path="url(#pf5e1538b81)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pead9396e02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m706dd6b66d" x="580.810214" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf60d624f33" x="580.810214" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -897,16 +897,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 391.33747 
 L 637.2 391.33747 
-" clip-path="url(#pf5e1538b81)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pead9396e02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="ma50e1efcd9" d="M 0 0 
+       <path id="m14036431f3" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#ma50e1efcd9" x="49.078125" y="391.33747" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m14036431f3" x="49.078125" y="391.33747" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -922,11 +922,11 @@ L -3.5 0
      <g id="line2d_17">
       <path d="M 49.078125 263.934445 
 L 637.2 263.934445 
-" clip-path="url(#pf5e1538b81)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pead9396e02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#ma50e1efcd9" x="49.078125" y="263.934445" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m14036431f3" x="49.078125" y="263.934445" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -942,11 +942,11 @@ L 637.2 263.934445
      <g id="line2d_19">
       <path d="M 49.078125 136.53142 
 L 637.2 136.53142 
-" clip-path="url(#pf5e1538b81)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pead9396e02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#ma50e1efcd9" x="49.078125" y="136.53142" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m14036431f3" x="49.078125" y="136.53142" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -962,16 +962,16 @@ L 637.2 136.53142
      <g id="line2d_21">
       <path d="M 49.078125 411.072449 
 L 637.2 411.072449 
-" clip-path="url(#pf5e1538b81)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pead9396e02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="mf79f956769" d="M 0 0 
+       <path id="m3f0d699ef5" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#mf79f956769" x="49.078125" y="411.072449" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3f0d699ef5" x="49.078125" y="411.072449" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -979,11 +979,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 403.684099 
 L 637.2 403.684099 
-" clip-path="url(#pf5e1538b81)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pead9396e02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mf79f956769" x="49.078125" y="403.684099" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3f0d699ef5" x="49.078125" y="403.684099" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -991,11 +991,11 @@ L 637.2 403.684099
      <g id="line2d_25">
       <path d="M 49.078125 397.167113 
 L 637.2 397.167113 
-" clip-path="url(#pf5e1538b81)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pead9396e02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mf79f956769" x="49.078125" y="397.167113" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3f0d699ef5" x="49.078125" y="397.167113" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1003,11 +1003,11 @@ L 637.2 397.167113
      <g id="line2d_27">
       <path d="M 49.078125 352.985338 
 L 637.2 352.985338 
-" clip-path="url(#pf5e1538b81)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pead9396e02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#mf79f956769" x="49.078125" y="352.985338" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3f0d699ef5" x="49.078125" y="352.985338" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1015,11 +1015,11 @@ L 637.2 352.985338
      <g id="line2d_29">
       <path d="M 49.078125 330.550779 
 L 637.2 330.550779 
-" clip-path="url(#pf5e1538b81)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pead9396e02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#mf79f956769" x="49.078125" y="330.550779" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3f0d699ef5" x="49.078125" y="330.550779" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1027,11 +1027,11 @@ L 637.2 330.550779
      <g id="line2d_31">
       <path d="M 49.078125 314.633206 
 L 637.2 314.633206 
-" clip-path="url(#pf5e1538b81)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pead9396e02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#mf79f956769" x="49.078125" y="314.633206" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3f0d699ef5" x="49.078125" y="314.633206" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1039,11 +1039,11 @@ L 637.2 314.633206
      <g id="line2d_33">
       <path d="M 49.078125 302.286577 
 L 637.2 302.286577 
-" clip-path="url(#pf5e1538b81)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pead9396e02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#mf79f956769" x="49.078125" y="302.286577" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3f0d699ef5" x="49.078125" y="302.286577" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1051,11 +1051,11 @@ L 637.2 302.286577
      <g id="line2d_35">
       <path d="M 49.078125 292.198647 
 L 637.2 292.198647 
-" clip-path="url(#pf5e1538b81)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pead9396e02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#mf79f956769" x="49.078125" y="292.198647" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3f0d699ef5" x="49.078125" y="292.198647" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1063,11 +1063,11 @@ L 637.2 292.198647
      <g id="line2d_37">
       <path d="M 49.078125 283.669424 
 L 637.2 283.669424 
-" clip-path="url(#pf5e1538b81)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pead9396e02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#mf79f956769" x="49.078125" y="283.669424" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3f0d699ef5" x="49.078125" y="283.669424" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1075,11 +1075,11 @@ L 637.2 283.669424
      <g id="line2d_39">
       <path d="M 49.078125 276.281074 
 L 637.2 276.281074 
-" clip-path="url(#pf5e1538b81)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pead9396e02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#mf79f956769" x="49.078125" y="276.281074" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3f0d699ef5" x="49.078125" y="276.281074" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1087,11 +1087,11 @@ L 637.2 276.281074
      <g id="line2d_41">
       <path d="M 49.078125 269.764088 
 L 637.2 269.764088 
-" clip-path="url(#pf5e1538b81)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pead9396e02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#mf79f956769" x="49.078125" y="269.764088" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3f0d699ef5" x="49.078125" y="269.764088" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1099,11 +1099,11 @@ L 637.2 269.764088
      <g id="line2d_43">
       <path d="M 49.078125 225.582313 
 L 637.2 225.582313 
-" clip-path="url(#pf5e1538b81)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pead9396e02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#mf79f956769" x="49.078125" y="225.582313" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3f0d699ef5" x="49.078125" y="225.582313" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1111,11 +1111,11 @@ L 637.2 225.582313
      <g id="line2d_45">
       <path d="M 49.078125 203.147754 
 L 637.2 203.147754 
-" clip-path="url(#pf5e1538b81)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pead9396e02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#mf79f956769" x="49.078125" y="203.147754" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3f0d699ef5" x="49.078125" y="203.147754" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1123,11 +1123,11 @@ L 637.2 203.147754
      <g id="line2d_47">
       <path d="M 49.078125 187.230181 
 L 637.2 187.230181 
-" clip-path="url(#pf5e1538b81)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pead9396e02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#mf79f956769" x="49.078125" y="187.230181" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3f0d699ef5" x="49.078125" y="187.230181" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1135,11 +1135,11 @@ L 637.2 187.230181
      <g id="line2d_49">
       <path d="M 49.078125 174.883552 
 L 637.2 174.883552 
-" clip-path="url(#pf5e1538b81)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pead9396e02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#mf79f956769" x="49.078125" y="174.883552" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3f0d699ef5" x="49.078125" y="174.883552" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1147,11 +1147,11 @@ L 637.2 174.883552
      <g id="line2d_51">
       <path d="M 49.078125 164.795622 
 L 637.2 164.795622 
-" clip-path="url(#pf5e1538b81)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pead9396e02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#mf79f956769" x="49.078125" y="164.795622" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3f0d699ef5" x="49.078125" y="164.795622" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1159,11 +1159,11 @@ L 637.2 164.795622
      <g id="line2d_53">
       <path d="M 49.078125 156.266399 
 L 637.2 156.266399 
-" clip-path="url(#pf5e1538b81)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pead9396e02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#mf79f956769" x="49.078125" y="156.266399" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3f0d699ef5" x="49.078125" y="156.266399" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1171,11 +1171,11 @@ L 637.2 156.266399
      <g id="line2d_55">
       <path d="M 49.078125 148.878049 
 L 637.2 148.878049 
-" clip-path="url(#pf5e1538b81)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pead9396e02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#mf79f956769" x="49.078125" y="148.878049" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3f0d699ef5" x="49.078125" y="148.878049" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1183,11 +1183,11 @@ L 637.2 148.878049
      <g id="line2d_57">
       <path d="M 49.078125 142.361063 
 L 637.2 142.361063 
-" clip-path="url(#pf5e1538b81)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pead9396e02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#mf79f956769" x="49.078125" y="142.361063" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3f0d699ef5" x="49.078125" y="142.361063" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1195,11 +1195,11 @@ L 637.2 142.361063
      <g id="line2d_59">
       <path d="M 49.078125 98.179288 
 L 637.2 98.179288 
-" clip-path="url(#pf5e1538b81)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pead9396e02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#mf79f956769" x="49.078125" y="98.179288" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3f0d699ef5" x="49.078125" y="98.179288" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1207,11 +1207,11 @@ L 637.2 98.179288
      <g id="line2d_61">
       <path d="M 49.078125 75.744729 
 L 637.2 75.744729 
-" clip-path="url(#pf5e1538b81)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pead9396e02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#mf79f956769" x="49.078125" y="75.744729" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3f0d699ef5" x="49.078125" y="75.744729" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1219,11 +1219,11 @@ L 637.2 75.744729
      <g id="line2d_63">
       <path d="M 49.078125 59.827156 
 L 637.2 59.827156 
-" clip-path="url(#pf5e1538b81)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pead9396e02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#mf79f956769" x="49.078125" y="59.827156" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3f0d699ef5" x="49.078125" y="59.827156" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1231,11 +1231,11 @@ L 637.2 59.827156
      <g id="line2d_65">
       <path d="M 49.078125 47.480527 
 L 637.2 47.480527 
-" clip-path="url(#pf5e1538b81)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pead9396e02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#mf79f956769" x="49.078125" y="47.480527" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3f0d699ef5" x="49.078125" y="47.480527" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1398,7 +1398,7 @@ z
    <g id="line2d_67">
     <path d="M 49.078125 63.959148 
 L 637.2 63.959148 
-" clip-path="url(#pf5e1538b81)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
+" clip-path="url(#pead9396e02)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
    </g>
    <g id="patch_3">
     <path d="M 49.078125 412.80375 
@@ -1762,78 +1762,78 @@ z
    </g>
    <g id="line2d_68">
     <defs>
-     <path id="m3bcb55bba5" d="M -2.5 2.5 
+     <path id="m96af1c15e7" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pf5e1538b81)">
-     <use xlink:href="#m3bcb55bba5" x="75.810937" y="263.190298" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3bcb55bba5" x="105.634056" y="267.887378" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3bcb55bba5" x="204.490635" y="300.240046" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3bcb55bba5" x="234.479899" y="306.367428" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3bcb55bba5" x="242.537956" y="316.909198" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3bcb55bba5" x="300.771958" y="297.352079" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3bcb55bba5" x="303.26414" y="310.698625" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3bcb55bba5" x="304.261013" y="317.548512" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3bcb55bba5" x="313.897453" y="317.953886" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3bcb55bba5" x="414.166268" y="334.149272" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3bcb55bba5" x="587.289889" y="327.780982" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3bcb55bba5" x="610.467187" y="318.981257" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pead9396e02)">
+     <use xlink:href="#m96af1c15e7" x="75.810937" y="263.190298" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m96af1c15e7" x="105.634056" y="267.887378" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m96af1c15e7" x="204.490635" y="300.240046" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m96af1c15e7" x="234.479899" y="306.367428" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m96af1c15e7" x="242.537956" y="316.909198" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m96af1c15e7" x="300.771958" y="297.352079" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m96af1c15e7" x="303.26414" y="310.698625" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m96af1c15e7" x="304.261013" y="317.548512" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m96af1c15e7" x="313.897453" y="317.953886" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m96af1c15e7" x="414.166268" y="334.149272" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m96af1c15e7" x="587.289889" y="327.780982" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m96af1c15e7" x="610.467187" y="318.981257" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_69">
     <defs>
-     <path id="mf8935de0f8" d="M 0 -2.5 
+     <path id="mf976e4499d" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pf5e1538b81)">
-     <use xlink:href="#mf8935de0f8" x="75.810937" y="260.629553" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf8935de0f8" x="105.634056" y="253.888028" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf8935de0f8" x="204.490635" y="301.454063" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf8935de0f8" x="234.479899" y="296.198152" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf8935de0f8" x="242.537956" y="306.497434" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf8935de0f8" x="300.771958" y="285.157082" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf8935de0f8" x="303.26414" y="299.127298" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf8935de0f8" x="304.261013" y="312.289143" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf8935de0f8" x="313.897453" y="305.55147" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf8935de0f8" x="414.166268" y="323.799851" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf8935de0f8" x="587.289889" y="327.192921" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf8935de0f8" x="610.467187" y="316.49707" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pead9396e02)">
+     <use xlink:href="#mf976e4499d" x="75.810937" y="260.629553" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf976e4499d" x="105.634056" y="253.888028" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf976e4499d" x="204.490635" y="301.454063" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf976e4499d" x="234.479899" y="296.198152" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf976e4499d" x="242.537956" y="306.497434" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf976e4499d" x="300.771958" y="285.157082" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf976e4499d" x="303.26414" y="299.127298" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf976e4499d" x="304.261013" y="312.289143" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf976e4499d" x="313.897453" y="305.55147" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf976e4499d" x="414.166268" y="323.799851" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf976e4499d" x="587.289889" y="327.192921" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf976e4499d" x="610.467187" y="316.49707" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_70">
     <defs>
-     <path id="ma69b435af8" d="M -0 3.535534 
+     <path id="m6f9479ee88" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pf5e1538b81)">
-     <use xlink:href="#ma69b435af8" x="75.810937" y="229.675972" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma69b435af8" x="105.634056" y="230.807252" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma69b435af8" x="204.490635" y="262.817606" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma69b435af8" x="234.479899" y="260.308889" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma69b435af8" x="242.537956" y="274.651617" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma69b435af8" x="300.771958" y="258.820574" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma69b435af8" x="303.26414" y="270.569757" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma69b435af8" x="304.261013" y="279.042037" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma69b435af8" x="313.897453" y="275.908162" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma69b435af8" x="414.166268" y="294.938772" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma69b435af8" x="587.289889" y="301.872049" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma69b435af8" x="610.467187" y="298.545064" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pead9396e02)">
+     <use xlink:href="#m6f9479ee88" x="75.810937" y="229.675972" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6f9479ee88" x="105.634056" y="230.807252" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6f9479ee88" x="204.490635" y="262.817606" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6f9479ee88" x="234.479899" y="260.308889" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6f9479ee88" x="242.537956" y="274.651617" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6f9479ee88" x="300.771958" y="258.820574" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6f9479ee88" x="303.26414" y="270.569757" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6f9479ee88" x="304.261013" y="279.042037" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6f9479ee88" x="313.897453" y="275.908162" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6f9479ee88" x="414.166268" y="294.938772" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6f9479ee88" x="587.289889" y="301.872049" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6f9479ee88" x="610.467187" y="298.545064" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_71">
     <defs>
-     <path id="m33c2642395" d="M -0.833333 2.5 
+     <path id="m0c0c4e7e0d" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -1848,24 +1848,24 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pf5e1538b81)">
-     <use xlink:href="#m33c2642395" x="75.810937" y="286.028664" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m33c2642395" x="105.634056" y="293.887771" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m33c2642395" x="204.490635" y="326.335201" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m33c2642395" x="234.479899" y="337.903307" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m33c2642395" x="242.537956" y="341.092058" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m33c2642395" x="300.771958" y="336.485034" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m33c2642395" x="303.26414" y="344.754119" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m33c2642395" x="304.261013" y="344.606502" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m33c2642395" x="313.897453" y="351.527394" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m33c2642395" x="414.166268" y="363.295034" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m33c2642395" x="587.289889" y="368.159128" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m33c2642395" x="610.467187" y="356.976913" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pead9396e02)">
+     <use xlink:href="#m0c0c4e7e0d" x="75.810937" y="286.028664" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0c0c4e7e0d" x="105.634056" y="293.887771" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0c0c4e7e0d" x="204.490635" y="326.335201" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0c0c4e7e0d" x="234.479899" y="337.903307" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0c0c4e7e0d" x="242.537956" y="341.092058" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0c0c4e7e0d" x="300.771958" y="336.485034" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0c0c4e7e0d" x="303.26414" y="344.754119" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0c0c4e7e0d" x="304.261013" y="344.606502" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0c0c4e7e0d" x="313.897453" y="351.527394" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0c0c4e7e0d" x="414.166268" y="363.295034" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0c0c4e7e0d" x="587.289889" y="368.159128" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0c0c4e7e0d" x="610.467187" y="356.976913" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_72">
     <defs>
-     <path id="m5a300280aa" d="M -1.25 2.5 
+     <path id="mef5ffc0799" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -1880,24 +1880,24 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pf5e1538b81)">
-     <use xlink:href="#m5a300280aa" x="75.810937" y="327.723121" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5a300280aa" x="105.634056" y="342.646685" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5a300280aa" x="204.490635" y="362.850184" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5a300280aa" x="234.479899" y="371.338643" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5a300280aa" x="242.537956" y="367.245927" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5a300280aa" x="300.771958" y="360.026985" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5a300280aa" x="303.26414" y="374.683393" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5a300280aa" x="304.261013" y="357.457726" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5a300280aa" x="313.897453" y="374.58929" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5a300280aa" x="414.166268" y="385.027438" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5a300280aa" x="587.289889" y="394.333029" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5a300280aa" x="610.467187" y="391.249012" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pead9396e02)">
+     <use xlink:href="#mef5ffc0799" x="75.810937" y="327.723121" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mef5ffc0799" x="105.634056" y="342.646685" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mef5ffc0799" x="204.490635" y="362.850184" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mef5ffc0799" x="234.479899" y="371.338643" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mef5ffc0799" x="242.537956" y="367.245927" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mef5ffc0799" x="300.771958" y="360.026985" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mef5ffc0799" x="303.26414" y="374.683393" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mef5ffc0799" x="304.261013" y="357.457726" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mef5ffc0799" x="313.897453" y="374.58929" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mef5ffc0799" x="414.166268" y="385.027438" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mef5ffc0799" x="587.289889" y="394.333029" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mef5ffc0799" x="610.467187" y="391.249012" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_73">
     <defs>
-     <path id="m9ea72bf2ee" d="M 0 -2.5 
+     <path id="m03241c48d0" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -1910,24 +1910,24 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#pf5e1538b81)">
-     <use xlink:href="#m9ea72bf2ee" x="75.810937" y="273.778134" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m9ea72bf2ee" x="105.634056" y="286.227815" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m9ea72bf2ee" x="204.490635" y="319.608779" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m9ea72bf2ee" x="234.479899" y="321.188418" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m9ea72bf2ee" x="242.537956" y="325.921453" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m9ea72bf2ee" x="300.771958" y="333.05015" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m9ea72bf2ee" x="303.26414" y="336.951003" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m9ea72bf2ee" x="304.261013" y="345.759761" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m9ea72bf2ee" x="313.897453" y="336.754653" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m9ea72bf2ee" x="414.166268" y="357.454726" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m9ea72bf2ee" x="587.289889" y="366.280671" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m9ea72bf2ee" x="610.467187" y="360.878702" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#pead9396e02)">
+     <use xlink:href="#m03241c48d0" x="75.810937" y="273.778134" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m03241c48d0" x="105.634056" y="286.227815" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m03241c48d0" x="204.490635" y="319.608779" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m03241c48d0" x="234.479899" y="321.188418" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m03241c48d0" x="242.537956" y="325.921453" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m03241c48d0" x="300.771958" y="333.05015" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m03241c48d0" x="303.26414" y="336.951003" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m03241c48d0" x="304.261013" y="345.759761" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m03241c48d0" x="313.897453" y="336.754653" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m03241c48d0" x="414.166268" y="357.454726" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m03241c48d0" x="587.289889" y="366.280671" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m03241c48d0" x="610.467187" y="360.878702" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_74">
     <defs>
-     <path id="ma69330c2da" d="M 0 -2.5 
+     <path id="m716a489fbc" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -1936,19 +1936,19 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pf5e1538b81)">
-     <use xlink:href="#ma69330c2da" x="75.810937" y="347.176172" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma69330c2da" x="105.634056" y="348.704001" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma69330c2da" x="204.490635" y="367.31757" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma69330c2da" x="234.479899" y="373.033423" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma69330c2da" x="242.537956" y="380.00037" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma69330c2da" x="300.771958" y="370.53122" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma69330c2da" x="303.26414" y="375.375651" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma69330c2da" x="304.261013" y="383.030012" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma69330c2da" x="313.897453" y="385.215351" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma69330c2da" x="414.166268" y="391.648192" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma69330c2da" x="587.289889" y="396.192102" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma69330c2da" x="610.467187" y="383.710333" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pead9396e02)">
+     <use xlink:href="#m716a489fbc" x="75.810937" y="347.176172" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m716a489fbc" x="105.634056" y="348.704001" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m716a489fbc" x="204.490635" y="367.31757" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m716a489fbc" x="234.479899" y="373.033423" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m716a489fbc" x="242.537956" y="380.00037" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m716a489fbc" x="300.771958" y="370.53122" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m716a489fbc" x="303.26414" y="375.375651" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m716a489fbc" x="304.261013" y="383.030012" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m716a489fbc" x="313.897453" y="385.215351" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m716a489fbc" x="414.166268" y="391.648192" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m716a489fbc" x="587.289889" y="396.192102" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m716a489fbc" x="610.467187" y="383.710333" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="legend_1">
@@ -1967,7 +1967,7 @@ z
     </g>
     <g id="line2d_75">
      <defs>
-      <path id="m4b17eca917" d="M 0 3.5 
+      <path id="me4a11aaffc" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -1980,7 +1980,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m4b17eca917" x="434.04625" y="211.758125" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#me4a11aaffc" x="434.04625" y="211.758125" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_15">
@@ -2039,7 +2039,7 @@ z
     </g>
     <g id="line2d_76">
      <g>
-      <use xlink:href="#m3bcb55bba5" x="434.04625" y="223.500625" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m96af1c15e7" x="434.04625" y="223.500625" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_16">
@@ -2053,7 +2053,7 @@ z
     </g>
     <g id="line2d_77">
      <g>
-      <use xlink:href="#mf8935de0f8" x="434.04625" y="235.243125" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mf976e4499d" x="434.04625" y="235.243125" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -2098,7 +2098,7 @@ z
     </g>
     <g id="line2d_78">
      <g>
-      <use xlink:href="#ma69b435af8" x="434.04625" y="247.208125" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m6f9479ee88" x="434.04625" y="247.208125" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -2118,7 +2118,7 @@ z
     </g>
     <g id="line2d_79">
      <g>
-      <use xlink:href="#m33c2642395" x="537.72375" y="211.758125" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m0c0c4e7e0d" x="537.72375" y="211.758125" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -2145,7 +2145,7 @@ z
     </g>
     <g id="line2d_80">
      <g>
-      <use xlink:href="#m5a300280aa" x="537.72375" y="223.500625" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mef5ffc0799" x="537.72375" y="223.500625" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -2210,7 +2210,7 @@ z
     </g>
     <g id="line2d_81">
      <g>
-      <use xlink:href="#m9ea72bf2ee" x="537.72375" y="235.243125" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#m03241c48d0" x="537.72375" y="235.243125" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_21">
@@ -2248,7 +2248,7 @@ z
     </g>
     <g id="line2d_82">
      <g>
-      <use xlink:href="#ma69330c2da" x="537.72375" y="246.985625" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m716a489fbc" x="537.72375" y="246.985625" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -2318,19 +2318,19 @@ z
     </g>
    </g>
    <g id="line2d_83">
-    <g clip-path="url(#pf5e1538b81)">
-     <use xlink:href="#m4b17eca917" x="75.810937" y="272.143954" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m4b17eca917" x="105.634056" y="288.399073" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m4b17eca917" x="204.490635" y="322.103822" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m4b17eca917" x="234.479899" y="324.29343" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m4b17eca917" x="242.537956" y="324.418753" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m4b17eca917" x="300.771958" y="312.453798" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m4b17eca917" x="303.26414" y="333.249253" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m4b17eca917" x="304.261013" y="351.748791" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m4b17eca917" x="313.897453" y="337.048403" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m4b17eca917" x="414.166268" y="356.441315" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m4b17eca917" x="587.289889" y="359.296601" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m4b17eca917" x="610.467187" y="343.193293" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <g clip-path="url(#pead9396e02)">
+     <use xlink:href="#me4a11aaffc" x="75.810937" y="272.143954" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#me4a11aaffc" x="105.634056" y="288.399073" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#me4a11aaffc" x="204.490635" y="322.103822" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#me4a11aaffc" x="234.479899" y="324.29343" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#me4a11aaffc" x="242.537956" y="324.418753" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#me4a11aaffc" x="300.771958" y="312.453798" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#me4a11aaffc" x="303.26414" y="333.249253" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#me4a11aaffc" x="304.261013" y="351.748791" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#me4a11aaffc" x="313.897453" y="337.048403" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#me4a11aaffc" x="414.166268" y="356.441315" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#me4a11aaffc" x="587.289889" y="359.296601" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#me4a11aaffc" x="610.467187" y="343.193293" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
   </g>
@@ -3154,7 +3154,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="pf5e1538b81">
+  <clipPath id="pead9396e02">
    <rect x="49.078125" y="47.3475" width="588.121875" height="365.45625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_decode_ranking.svg
+++ b/bench/graphs/silesia_decode_ranking.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 292.269187 308.04375 
 L 292.269187 56.7075 
-" clip-path="url(#p4566bc2936)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb8387c6509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="mabb5f6361d" d="M 0 0 
+       <path id="mf9f4403cc9" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mabb5f6361d" x="292.269187" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf9f4403cc9" x="292.269187" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -136,11 +136,11 @@ z
      <g id="line2d_3">
       <path d="M 449.991563 308.04375 
 L 449.991563 56.7075 
-" clip-path="url(#p4566bc2936)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb8387c6509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mabb5f6361d" x="449.991563" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf9f4403cc9" x="449.991563" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -177,16 +177,16 @@ z
      <g id="line2d_5">
       <path d="M 182.025977 308.04375 
 L 182.025977 56.7075 
-" clip-path="url(#p4566bc2936)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb8387c6509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <defs>
-       <path id="maed5668f49" d="M 0 0 
+       <path id="mb1df935b97" d="M 0 0 
 L 0 2 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#maed5668f49" x="182.025977" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb1df935b97" x="182.025977" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -194,11 +194,11 @@ L 0 2
      <g id="line2d_7">
       <path d="M 209.799509 308.04375 
 L 209.799509 56.7075 
-" clip-path="url(#p4566bc2936)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb8387c6509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#maed5668f49" x="209.799509" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb1df935b97" x="209.799509" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -206,11 +206,11 @@ L 209.799509 56.7075
      <g id="line2d_9">
       <path d="M 229.505143 308.04375 
 L 229.505143 56.7075 
-" clip-path="url(#p4566bc2936)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb8387c6509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#maed5668f49" x="229.505143" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb1df935b97" x="229.505143" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -218,11 +218,11 @@ L 229.505143 56.7075
      <g id="line2d_11">
       <path d="M 244.790021 308.04375 
 L 244.790021 56.7075 
-" clip-path="url(#p4566bc2936)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb8387c6509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#maed5668f49" x="244.790021" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb1df935b97" x="244.790021" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -230,11 +230,11 @@ L 244.790021 56.7075
      <g id="line2d_13">
       <path d="M 257.278675 308.04375 
 L 257.278675 56.7075 
-" clip-path="url(#p4566bc2936)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb8387c6509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#maed5668f49" x="257.278675" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb1df935b97" x="257.278675" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -242,11 +242,11 @@ L 257.278675 56.7075
      <g id="line2d_15">
       <path d="M 267.837682 308.04375 
 L 267.837682 56.7075 
-" clip-path="url(#p4566bc2936)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb8387c6509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <g>
-       <use xlink:href="#maed5668f49" x="267.837682" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb1df935b97" x="267.837682" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -254,11 +254,11 @@ L 267.837682 56.7075
      <g id="line2d_17">
       <path d="M 276.984309 308.04375 
 L 276.984309 56.7075 
-" clip-path="url(#p4566bc2936)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb8387c6509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#maed5668f49" x="276.984309" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb1df935b97" x="276.984309" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -266,11 +266,11 @@ L 276.984309 56.7075
      <g id="line2d_19">
       <path d="M 285.052207 308.04375 
 L 285.052207 56.7075 
-" clip-path="url(#p4566bc2936)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb8387c6509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#maed5668f49" x="285.052207" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb1df935b97" x="285.052207" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -278,11 +278,11 @@ L 285.052207 56.7075
      <g id="line2d_21">
       <path d="M 339.748353 308.04375 
 L 339.748353 56.7075 
-" clip-path="url(#p4566bc2936)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb8387c6509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#maed5668f49" x="339.748353" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb1df935b97" x="339.748353" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -290,11 +290,11 @@ L 339.748353 56.7075
      <g id="line2d_23">
       <path d="M 367.521885 308.04375 
 L 367.521885 56.7075 
-" clip-path="url(#p4566bc2936)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb8387c6509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#maed5668f49" x="367.521885" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb1df935b97" x="367.521885" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -302,11 +302,11 @@ L 367.521885 56.7075
      <g id="line2d_25">
       <path d="M 387.227519 308.04375 
 L 387.227519 56.7075 
-" clip-path="url(#p4566bc2936)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb8387c6509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#maed5668f49" x="387.227519" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb1df935b97" x="387.227519" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -314,11 +314,11 @@ L 387.227519 56.7075
      <g id="line2d_27">
       <path d="M 402.512397 308.04375 
 L 402.512397 56.7075 
-" clip-path="url(#p4566bc2936)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb8387c6509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#maed5668f49" x="402.512397" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb1df935b97" x="402.512397" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -326,11 +326,11 @@ L 402.512397 56.7075
      <g id="line2d_29">
       <path d="M 415.001051 308.04375 
 L 415.001051 56.7075 
-" clip-path="url(#p4566bc2936)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb8387c6509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#maed5668f49" x="415.001051" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb1df935b97" x="415.001051" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -338,11 +338,11 @@ L 415.001051 56.7075
      <g id="line2d_31">
       <path d="M 425.560057 308.04375 
 L 425.560057 56.7075 
-" clip-path="url(#p4566bc2936)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb8387c6509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#maed5668f49" x="425.560057" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb1df935b97" x="425.560057" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -350,11 +350,11 @@ L 425.560057 56.7075
      <g id="line2d_33">
       <path d="M 434.706685 308.04375 
 L 434.706685 56.7075 
-" clip-path="url(#p4566bc2936)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb8387c6509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#maed5668f49" x="434.706685" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb1df935b97" x="434.706685" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -362,11 +362,11 @@ L 434.706685 56.7075
      <g id="line2d_35">
       <path d="M 442.774583 308.04375 
 L 442.774583 56.7075 
-" clip-path="url(#p4566bc2936)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb8387c6509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#maed5668f49" x="442.774583" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb1df935b97" x="442.774583" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -374,11 +374,11 @@ L 442.774583 56.7075
      <g id="line2d_37">
       <path d="M 497.470729 308.04375 
 L 497.470729 56.7075 
-" clip-path="url(#p4566bc2936)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb8387c6509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#maed5668f49" x="497.470729" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb1df935b97" x="497.470729" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -386,11 +386,11 @@ L 497.470729 56.7075
      <g id="line2d_39">
       <path d="M 525.24426 308.04375 
 L 525.24426 56.7075 
-" clip-path="url(#p4566bc2936)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb8387c6509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#maed5668f49" x="525.24426" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb1df935b97" x="525.24426" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -398,11 +398,11 @@ L 525.24426 56.7075
      <g id="line2d_41">
       <path d="M 544.949895 308.04375 
 L 544.949895 56.7075 
-" clip-path="url(#p4566bc2936)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb8387c6509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#maed5668f49" x="544.949895" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb1df935b97" x="544.949895" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -410,11 +410,11 @@ L 544.949895 56.7075
      <g id="line2d_43">
       <path d="M 560.234772 308.04375 
 L 560.234772 56.7075 
-" clip-path="url(#p4566bc2936)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb8387c6509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#maed5668f49" x="560.234772" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb1df935b97" x="560.234772" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1016,12 +1016,12 @@ z
     <g id="ytick_1">
      <g id="line2d_45">
       <defs>
-       <path id="m742b7edf21" d="M 0 0 
+       <path id="m8eb4b6b303" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m742b7edf21" x="139.360469" y="296.619375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8eb4b6b303" x="139.360469" y="296.619375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -1093,7 +1093,7 @@ z
     <g id="ytick_2">
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m742b7edf21" x="139.360469" y="263.978304" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8eb4b6b303" x="139.360469" y="263.978304" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -1160,7 +1160,7 @@ z
     <g id="ytick_3">
      <g id="line2d_47">
       <g>
-       <use xlink:href="#m742b7edf21" x="139.360469" y="231.337232" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8eb4b6b303" x="139.360469" y="231.337232" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -1216,7 +1216,7 @@ z
     <g id="ytick_4">
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m742b7edf21" x="139.360469" y="198.696161" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8eb4b6b303" x="139.360469" y="198.696161" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -1263,7 +1263,7 @@ z
     <g id="ytick_5">
      <g id="line2d_49">
       <g>
-       <use xlink:href="#m742b7edf21" x="139.360469" y="166.055089" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8eb4b6b303" x="139.360469" y="166.055089" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -1376,7 +1376,7 @@ z
     <g id="ytick_6">
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m742b7edf21" x="139.360469" y="133.414018" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8eb4b6b303" x="139.360469" y="133.414018" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -1392,7 +1392,7 @@ z
     <g id="ytick_7">
      <g id="line2d_51">
       <g>
-       <use xlink:href="#m742b7edf21" x="139.360469" y="100.772946" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8eb4b6b303" x="139.360469" y="100.772946" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -1439,7 +1439,7 @@ z
     <g id="ytick_8">
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m742b7edf21" x="139.360469" y="68.131875" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8eb4b6b303" x="139.360469" y="68.131875" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -1462,47 +1462,47 @@ z
    <g id="LineCollection_1">
     <path d="M 139.360469 296.619375 
 L 154.645346 296.619375 
-" clip-path="url(#p4566bc2936)" style="fill: none; stroke: #17becf; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#pb8387c6509)" style="fill: none; stroke: #17becf; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_2">
     <path d="M 139.360469 263.978304 
 L 161.142927 263.978304 
-" clip-path="url(#p4566bc2936)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#pb8387c6509)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_3">
     <path d="M 139.360469 231.337232 
 L 200.65327 231.337232 
-" clip-path="url(#p4566bc2936)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#pb8387c6509)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_4">
     <path d="M 139.360469 198.696161 
 L 208.426981 198.696161 
-" clip-path="url(#p4566bc2936)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#pb8387c6509)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_5">
     <path d="M 139.360469 166.055089 
 L 212.673671 166.055089 
-" clip-path="url(#p4566bc2936)" style="fill: none; stroke: #d62728; stroke-opacity: 0.9; stroke-width: 2.4"/>
+" clip-path="url(#pb8387c6509)" style="fill: none; stroke: #d62728; stroke-opacity: 0.9; stroke-width: 2.4"/>
    </g>
    <g id="LineCollection_6">
     <path d="M 139.360469 133.414018 
 L 239.878265 133.414018 
-" clip-path="url(#p4566bc2936)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#pb8387c6509)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_7">
     <path d="M 139.360469 100.772946 
 L 248.943982 100.772946 
-" clip-path="url(#p4566bc2936)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#pb8387c6509)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_8">
     <path d="M 139.360469 68.131875 
 L 284.774562 68.131875 
-" clip-path="url(#p4566bc2936)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#pb8387c6509)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="line2d_53">
     <path d="M 542.152339 308.04375 
 L 542.152339 56.7075 
-" clip-path="url(#p4566bc2936)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
+" clip-path="url(#pb8387c6509)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
    </g>
    <g id="patch_3">
     <path d="M 139.360469 308.04375 
@@ -1888,7 +1888,7 @@ z
    </g>
    <g id="line2d_54">
     <defs>
-     <path id="mb0400895ba" d="M 0 3 
+     <path id="m946a711b4c" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1900,13 +1900,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #17becf"/>
     </defs>
-    <g clip-path="url(#p4566bc2936)">
-     <use xlink:href="#mb0400895ba" x="154.645346" y="296.619375" style="fill: #17becf; stroke: #17becf"/>
+    <g clip-path="url(#pb8387c6509)">
+     <use xlink:href="#m946a711b4c" x="154.645346" y="296.619375" style="fill: #17becf; stroke: #17becf"/>
     </g>
    </g>
    <g id="line2d_55">
     <defs>
-     <path id="m9fc9284000" d="M 0 3 
+     <path id="m02d906a529" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1918,13 +1918,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #e377c2"/>
     </defs>
-    <g clip-path="url(#p4566bc2936)">
-     <use xlink:href="#m9fc9284000" x="161.142927" y="263.978304" style="fill: #e377c2; stroke: #e377c2"/>
+    <g clip-path="url(#pb8387c6509)">
+     <use xlink:href="#m02d906a529" x="161.142927" y="263.978304" style="fill: #e377c2; stroke: #e377c2"/>
     </g>
    </g>
    <g id="line2d_56">
     <defs>
-     <path id="m75502bbca1" d="M 0 3 
+     <path id="me45a5a9a61" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1936,13 +1936,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #8c564b"/>
     </defs>
-    <g clip-path="url(#p4566bc2936)">
-     <use xlink:href="#m75502bbca1" x="200.65327" y="231.337232" style="fill: #8c564b; stroke: #8c564b"/>
+    <g clip-path="url(#pb8387c6509)">
+     <use xlink:href="#me45a5a9a61" x="200.65327" y="231.337232" style="fill: #8c564b; stroke: #8c564b"/>
     </g>
    </g>
    <g id="line2d_57">
     <defs>
-     <path id="m2be234e50e" d="M 0 3 
+     <path id="m5c773b735c" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1954,13 +1954,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #bcbd22"/>
     </defs>
-    <g clip-path="url(#p4566bc2936)">
-     <use xlink:href="#m2be234e50e" x="208.426981" y="198.696161" style="fill: #bcbd22; stroke: #bcbd22"/>
+    <g clip-path="url(#pb8387c6509)">
+     <use xlink:href="#m5c773b735c" x="208.426981" y="198.696161" style="fill: #bcbd22; stroke: #bcbd22"/>
     </g>
    </g>
    <g id="line2d_58">
     <defs>
-     <path id="m8444fc7558" d="M 0 5 
+     <path id="mbc09d81826" d="M 0 5 
 C 1.326016 5 2.597899 4.473168 3.535534 3.535534 
 C 4.473168 2.597899 5 1.326016 5 0 
 C 5 -1.326016 4.473168 -2.597899 3.535534 -3.535534 
@@ -1972,13 +1972,13 @@ C -2.597899 4.473168 -1.326016 5 0 5
 z
 " style="stroke: #d62728"/>
     </defs>
-    <g clip-path="url(#p4566bc2936)">
-     <use xlink:href="#m8444fc7558" x="212.673671" y="166.055089" style="fill: #d62728; stroke: #d62728"/>
+    <g clip-path="url(#pb8387c6509)">
+     <use xlink:href="#mbc09d81826" x="212.673671" y="166.055089" style="fill: #d62728; stroke: #d62728"/>
     </g>
    </g>
    <g id="line2d_59">
     <defs>
-     <path id="maa98235848" d="M 0 3 
+     <path id="m360148a81c" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1990,13 +1990,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #1f77b4"/>
     </defs>
-    <g clip-path="url(#p4566bc2936)">
-     <use xlink:href="#maa98235848" x="239.878265" y="133.414018" style="fill: #1f77b4; stroke: #1f77b4"/>
+    <g clip-path="url(#pb8387c6509)">
+     <use xlink:href="#m360148a81c" x="239.878265" y="133.414018" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_60">
     <defs>
-     <path id="m99636e9711" d="M 0 3 
+     <path id="m24e46c7d43" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -2008,13 +2008,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #2ca02c"/>
     </defs>
-    <g clip-path="url(#p4566bc2936)">
-     <use xlink:href="#m99636e9711" x="248.943982" y="100.772946" style="fill: #2ca02c; stroke: #2ca02c"/>
+    <g clip-path="url(#pb8387c6509)">
+     <use xlink:href="#m24e46c7d43" x="248.943982" y="100.772946" style="fill: #2ca02c; stroke: #2ca02c"/>
     </g>
    </g>
    <g id="line2d_61">
     <defs>
-     <path id="mb725ac9293" d="M 0 3 
+     <path id="m092fafc338" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -2026,8 +2026,8 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #9467bd"/>
     </defs>
-    <g clip-path="url(#p4566bc2936)">
-     <use xlink:href="#mb725ac9293" x="284.774562" y="68.131875" style="fill: #9467bd; stroke: #9467bd"/>
+    <g clip-path="url(#pb8387c6509)">
+     <use xlink:href="#m092fafc338" x="284.774562" y="68.131875" style="fill: #9467bd; stroke: #9467bd"/>
     </g>
    </g>
   </g>
@@ -2967,7 +2967,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p4566bc2936">
+  <clipPath id="pb8387c6509">
    <rect x="139.360469" y="56.7075" width="425.839531" height="251.33625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_ratio_heatmap.svg
+++ b/bench/graphs/silesia_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.34175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p0d2b978fae)">
+   <g clip-path="url(#pc0cea4624c)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAosAAAGaCAYAAABniAm0AAAJ/UlEQVR4nO3Yu45eVx2H4ZnM+IDHmbEtSCLCQcIRIIVAiUJBlQpBwTVwBTRUVIg7oOIG6FBE6SZlpHAMoQCiJARxkDXE2DGWsccz83EFb4HC0h99ep4r+El7a+13r93z2z/e7Gyhk5/cmp6wxIVXXpqesMzuM5+cnrDE5s3fTk9YYvfLL05PWGLz8P70hGWOv/fq9IQlnvnhN6cnLLF749npCWucPJxesMz5z7fzvH9qegAAAP+/xCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAGn3XyevbqZHrHDwz+PpCUt8cHhlesIy/z59MD1hiU9/eDI9YYkPP/Hc9IQlzjfn0xOWub5/Y3rCGnfen16wxP3r2/m8nv7TH6cnLLP5/FenJyzhZhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgLR/cOf29IY1rlybXrDEZnMyPWGZT732y+kJa7zyjekFSxx98PfpCWucn04vWOdgS8+PS1enFyxx+I/t/D7f/ezN6QnLXP/LW9MTlnCzCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAAKTdJ2e3NtMjVtg7fm96whK3n744PWGZB0/uTU9Y4uaf701PWOL0S1+bnrDEw9P70xOWOdq7Nj1hic27v5iesMSjz700PWGJy2+9MT1hmcdfeXl6whJuFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIC0+7N3v7uZHrHCjcsH0xOWePvenekJy3znR7+enrDEb37wrekJSxxdOpqesMT3X//V9IRlvv785ekJS3z75svTE5Z47a9vTE9Y4uqF7XwPd3Z2dn76zt3pCUu4WQQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAADS7pOzW5vpESvcfXw8PWGJg/3D6QnLvH3vd9MTlnjh2ovTE5bYbM6nJyxx9XR7/6H/dr6d5+LzBy9MT1ji0dnD6QlLbOvZsbOzs7P31P70hCW291QEAOAjE4sAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA2t/b3Z/esMTH925MT1hj7+L0gmWOLh1NT1jiYP9wesISZ5vT6QlLnF/Y3n/o5zZXpifwX9jW7/PJ5tH0hGXuPz6enrDE9p6KAAB8ZGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIC0/+js4fSGJS5vaQe//+AP0xOWOT0/mZ6wxvE70wuWuH90OD1hicOLN6YnLHNy9mh6whIfu/3e9IQlHj/7mekJSxz8/s3pCcs8/sIXpycssZ1FBQDA/4RYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAg/Qdg9JyFmQO2bgAAAABJRU5ErkJggg==" id="image07a5053975" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="468.72" height="295.2"/>
+iVBORw0KGgoAAAANSUhEUgAAAosAAAGaCAYAAABniAm0AAAJ9ElEQVR4nO3YvY5dVx2H4RnPjG08E49tQYgICAlHNCFQolBQpUJQcA1cAQ0VFeIOqLgBOhRRukmJFL4JFRHhQ3zIGmLsDMbY45k5XMFboLD0R0fPcwW/o7O19rvX7uX97292ttDZD+5NT1ji4I3Xpicss/viJ6YnLLH51a+nJyyx+/lXpycssXlyOj1hmZNvvTk9YYkXv/vV6QlL7N75+PSENc6eTC9Y5vIn23neX5keAADA/y+xCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA2v3n2Zub6RErHP7jZHrCEu/fvDE9YZl/nz+enrDEpz44m56wxAcfe2l6whKXm8vpCcvc3r8zPWGNB3+cXrDE6e3t/L9e+MNvpycss/nsF6cnLOFmEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAtH/44P70hjVu3JpesMRmczY9YZlPvvWz6QlrvPGV6QVLHL//t+kJa1yeTy9Y53BLz49rR9MLlrj59+18Pz/89N3pCcvc/vM70xOWcLMIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAApN3nF/c20yNW2Dv5/fSEJe6/cHV6wjKPnz+anrDE3T89mp6wxPnnvjQ9YYkn56fTE5Y53rs1PWGJzXs/nZ6wxNPPvDY9YYnr77w9PWGZZ194fXrCEm4WAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgLT7o/e+uZkescKd64fTE5Z499GD6QnLfON7v5iesMQvv/O16QlLHF87np6wxLd//PPpCct8+eXr0xOW+Prd16cnLPHWX96enrDE0cF2Poc7Ozs7P/zdw+kJS7hZBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAANLu84t7m+kRKzx8djI9YYnD/ZvTE5Z599Fvpics8cqtV6cnLLHZXE5PWOLofHu/of96uZ3n4suHr0xPWOLpxZPpCUts69mxs7Ozs3dlf3rCEtt7KgIA8KGJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACDt7+3uT29Y4qN7d6YnrLF3dXrBMsfXjqcnLHG4f3N6whIXm/PpCUtcHmzvN/RLmxvTE/gvbOv7+WzzdHrCMqfPTqYnLLG9pyIAAB+aWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIO1PD1jl4eXp9IQlDs6vTk9Y5nD/5vSEJc4un05PWOLsYjt/19HBrekJy/zr4vH0hCW29ey4srud9zkf2T+anrDMxeZ8esIS2/kkAgDwPyEWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBI/wHC8pgry+eQtQAAAABJRU5ErkJggg==" id="imaged01622bea7" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="468.72" height="295.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m5fc6ff1d3c" d="M 0 0 
+       <path id="m90f0714b7c" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m5fc6ff1d3c" x="115.182137" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m90f0714b7c" x="115.182137" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m5fc6ff1d3c" x="154.193912" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m90f0714b7c" x="154.193912" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m5fc6ff1d3c" x="193.205687" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m90f0714b7c" x="193.205687" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m5fc6ff1d3c" x="232.217462" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m90f0714b7c" x="232.217462" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m5fc6ff1d3c" x="271.229237" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m90f0714b7c" x="271.229237" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m5fc6ff1d3c" x="310.241012" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m90f0714b7c" x="310.241012" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m5fc6ff1d3c" x="349.252787" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m90f0714b7c" x="349.252787" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m5fc6ff1d3c" x="388.264562" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m90f0714b7c" x="388.264562" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m5fc6ff1d3c" x="427.276336" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m90f0714b7c" x="427.276336" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m5fc6ff1d3c" x="466.288111" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m90f0714b7c" x="466.288111" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m5fc6ff1d3c" x="505.299886" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m90f0714b7c" x="505.299886" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m5fc6ff1d3c" x="544.311661" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m90f0714b7c" x="544.311661" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="mc594308882" d="M 0 0 
+       <path id="mc39904a297" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mc594308882" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc39904a297" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mc594308882" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc39904a297" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#mc594308882" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc39904a297" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#mc594308882" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc39904a297" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -836,7 +836,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#mc594308882" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc39904a297" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -899,7 +899,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mc594308882" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc39904a297" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -966,7 +966,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#mc594308882" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc39904a297" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1047,7 +1047,7 @@ z
     <g id="ytick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#mc594308882" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc39904a297" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -1138,47 +1138,9 @@ L 563.817548 49.34175
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_21">
-    <!-- -1 -->
+    <!-- -0 -->
     <g transform="translate(111.941786 69.553235) scale(0.065 -0.065)">
      <defs>
-      <path id="DejaVuSans-31" d="M 794 531 
-L 1825 531 
-L 1825 4091 
-L 703 3866 
-L 703 4441 
-L 1819 4666 
-L 2450 4666 
-L 2450 531 
-L 3481 531 
-L 3481 0 
-L 794 0 
-L 794 531 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_22">
-    <!-- +0 -->
-    <g transform="translate(149.402701 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-2b" d="M 2944 4013 
-L 2944 2272 
-L 4684 2272 
-L 4684 1741 
-L 2944 1741 
-L 2944 0 
-L 2419 0 
-L 2419 1741 
-L 678 1741 
-L 678 2272 
-L 2419 2272 
-L 2419 4013 
-L 2944 4013 
-z
-" transform="scale(0.015625)"/>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
 Q 1056 3291 1056 2328 
@@ -1201,13 +1163,43 @@ Q 1250 4750 2034 4750
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_22">
+    <!-- -1 -->
+    <g transform="translate(150.953561 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_23">
-    <!-- -2 -->
+    <!-- -1 -->
     <g transform="translate(189.965336 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_24">
+    <!-- -2 -->
+    <g transform="translate(228.97711 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-32" d="M 1228 531 
 L 3431 531 
@@ -1238,52 +1230,11 @@ z
      <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
     </g>
    </g>
-   <g id="text_24">
-    <!-- -3 -->
-    <g transform="translate(228.97711 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-33" d="M 2597 2516 
-Q 3050 2419 3304 2112 
-Q 3559 1806 3559 1356 
-Q 3559 666 3084 287 
-Q 2609 -91 1734 -91 
-Q 1441 -91 1130 -33 
-Q 819 25 488 141 
-L 488 750 
-Q 750 597 1062 519 
-Q 1375 441 1716 441 
-Q 2309 441 2620 675 
-Q 2931 909 2931 1356 
-Q 2931 1769 2642 2001 
-Q 2353 2234 1838 2234 
-L 1294 2234 
-L 1294 2753 
-L 1863 2753 
-Q 2328 2753 2575 2939 
-Q 2822 3125 2822 3475 
-Q 2822 3834 2567 4026 
-Q 2313 4219 1838 4219 
-Q 1578 4219 1281 4162 
-Q 984 4106 628 3988 
-L 628 4550 
-Q 988 4650 1302 4700 
-Q 1616 4750 1894 4750 
-Q 2613 4750 3031 4423 
-Q 3450 4097 3450 3541 
-Q 3450 3153 3228 2886 
-Q 3006 2619 2597 2516 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
    <g id="text_25">
-    <!-- +2 -->
-    <g transform="translate(266.438026 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+    <!-- -0 -->
+    <g transform="translate(267.988885 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_26">
@@ -1294,10 +1245,27 @@ z
     </g>
    </g>
    <g id="text_27">
-    <!-- -0 -->
-    <g transform="translate(346.012435 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(36.083984 0)"/>
+    <!-- +0 -->
+    <g transform="translate(344.461576 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-2b" d="M 2944 4013 
+L 2944 2272 
+L 4684 2272 
+L 4684 1741 
+L 2944 1741 
+L 2944 0 
+L 2419 0 
+L 2419 1741 
+L 678 1741 
+L 678 2272 
+L 2419 2272 
+L 2419 4013 
+L 2944 4013 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_28">
@@ -1308,45 +1276,24 @@ z
     </g>
    </g>
    <g id="text_29">
-    <!-- +3 -->
+    <!-- +0 -->
     <g transform="translate(422.485125 69.553235) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_30">
-    <!-- -1 -->
+    <!-- -0 -->
     <g transform="translate(463.04776 69.553235) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_31">
-    <!-- +4 -->
-    <g transform="translate(500.508675 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-34" d="M 2419 4116 
-L 825 1625 
-L 2419 1625 
-L 2419 4116 
-z
-M 2253 4666 
-L 3047 4666 
-L 3047 1625 
-L 3713 1625 
-L 3713 1100 
-L 3047 1100 
-L 3047 0 
-L 2419 0 
-L 2419 1100 
-L 313 1100 
-L 313 1709 
-L 2253 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
+    <!-- -0 -->
+    <g transform="translate(502.059535 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_32">
@@ -1464,6 +1411,40 @@ z
    <g id="text_48">
     <!-- -3 -->
     <g transform="translate(228.97711 143.2248) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
     </g>
@@ -1561,6 +1542,27 @@ z
    <g id="text_58">
     <!-- -4 -->
     <g transform="translate(150.953561 180.060583) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
     </g>
@@ -2060,18 +2062,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABEAAAFUCAYAAADCj9eRAAAB2ElEQVR4nO2aQY7EIAwEIeFP+6X9/33C3MPcKKSS1TygZRftNlLS2//fbJtn9KvvajAi17ZCM7Uzeg+TEyJhsh4TE8D25ZhYRMJkPSYmmZ0zIhfQEMPkJq74JpgQlUBMABkIrOV2KLMRItXMhrQjqcQUSszsbGuomFSbHULEAlblE0klor1zMaG0XwnDBDAsBVY0O4CIBizlE4ntEbCijK3mE8vKUPkEEIF8YslYje2RZFP5BJkdCxOonf1i6jEhRICOyjEBzFaPiWd2iChoYbKKhMkqgmSsh4kkHkU+6UyeACJEJaLZ6QQTzy7WtGPyicX2Kp/c+yKaATTliSWoTXsnPllEEtTLGX37f+7WRpuPQ4RhomlntCdMTohATIDbKceEaGfOD1BJZueIiImJZQBNTCxgw2Q91N7Zf7RBsxMmR0TqMdmvxPRmI0TmDJNVJExWkTBZRcJkFSnFZH6Q5aVhQrQzkYUOVEIxIXxSjAnRDjQ7mndsZud9VEwsPtFcsWjvaNZofHKoEpFPELCPJmORdqblMWxiYjEbw+QJk/dR+SQD+BbROFbEJAP4Q4RgQpiNCupKIhAT4gewakws7YTJIREoY4FPeNWYaNoJk18iQNqXY1LKJ1/07Ct/l+QCQgAAAABJRU5ErkJggg==" id="image35f557e1a5" transform="scale(1 -1) translate(0 -244.8)" x="573.84" y="-74.16" width="12.24" height="244.8"/>
+iVBORw0KGgoAAAANSUhEUgAAABEAAAFUCAYAAADCj9eRAAAB2ElEQVR4nO2aQY7EIAwEIeFP+6X9/33C3MPcKKSS1TygZRftNlLS2//fbJtn9KvvajAi17ZCM7Uzeg+TEyJhsh4TE8D25ZhYRMJkPSYmmZ0zIhfQEMPkJq74JpgQlUBMABkIrOV2KLMRItXMhrQjqcQUSszsbGuomFSbHULEAlblE0klor1zMaG0XwnDBDAsBVY0O4CIBizlE4ntEbCijK3mE8vKUPkEEIF8YslYje2RZFP5BJkdCxOonf1i6jEhRICOyjEBzFaPiWd2iChoYbKKhMkqgmSsh4kkHkU+6UyeACJEJaLZ6QQTzy7WtGPyicX2Kp/c+yKaATTliSWoTXsnPllEEtTLGX37f+7WRpuPQ4RhomlntCdMTohATIDbKceEaGfOD1BJZueIiImJZQBNTCxgw2Q91N7Zf7RBsxMmR0TqMdmvxPRmI0TmDJNVJExWkTBZRcJkFSnFZH6Q5aVhQrQzkYUOVEIxIXxSjAnRDjQ7mndsZud9VEwsPtFcsWjvaNZofHKoEpFPELCPJmORdqblMWxiYjEbw+QJk/dR+SQD+BbROFbEJAP4Q4RgQpiNCupKIhAT4gewakws7YTJIREoY4FPeNWYaNoJk18iQNqXY1LKJ1/07Ct/l+QCQgAAAABJRU5ErkJggg==" id="image9781825cce" transform="scale(1 -1) translate(0 -244.8)" x="573.84" y="-74.16" width="12.24" height="244.8"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_21">
       <defs>
-       <path id="mc3dc5f1adf" d="M 0 0 
+       <path id="m3320da5097" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mc3dc5f1adf" x="585.876562" y="282.022672" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3320da5097" x="585.876562" y="282.022672" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_117">
@@ -2097,7 +2099,7 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#mc3dc5f1adf" x="585.876562" y="239.353777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3320da5097" x="585.876562" y="239.353777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_118">
@@ -2114,7 +2116,7 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#mc3dc5f1adf" x="585.876562" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3320da5097" x="585.876562" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_119">
@@ -2130,7 +2132,7 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mc3dc5f1adf" x="585.876562" y="154.015985" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3320da5097" x="585.876562" y="154.015985" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_120">
@@ -2146,7 +2148,7 @@ z
     <g id="ytick_13">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#mc3dc5f1adf" x="585.876562" y="111.347089" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3320da5097" x="585.876562" y="111.347089" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_121">
@@ -2739,8 +2741,8 @@ z
    </g>
   </g>
   <g id="text_124">
-   <!-- 2026-07-08T21:41:55Z  ·  Linux chungus2 x86_64  ·  commit b17c222c  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(43.990156 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-08T22:12:55Z  ·  Linux chungus2 x86_64  ·  commit 30251fb3  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(44.380078 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -2871,10 +2873,10 @@ z
     <use xlink:href="#DejaVuSans-38" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
     <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
     <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
@@ -2917,109 +2919,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3135.351562 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3198.974609 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3262.597656 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3317.578125 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3381.201172 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3444.824219 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3508.447266 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3563.427734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3595.214844 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3627.001953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3658.789062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3690.576172 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3722.363281 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3750.146484 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3811.669922 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3872.949219 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3936.328125 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3999.804688 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4038.667969 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4099.849609 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4159.029297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4220.552734 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4261.666016 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4295.357422 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4323.140625 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4384.664062 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4445.943359 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4509.322266 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4572.945312 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4606.636719 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4665.816406 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4729.439453 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4761.226562 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4824.849609 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4888.472656 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4920.259766 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4983.882812 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5019.966797 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5058.830078 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5113.810547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5177.433594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5209.220703 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5241.007812 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5272.794922 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5304.582031 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5336.369141 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5375.578125 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5438.957031 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5477.820312 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5539.001953 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5602.380859 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5665.857422 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5729.236328 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5792.712891 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5856.091797 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5895.300781 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5927.087891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6010.876953 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6042.664062 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6140.076172 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6201.599609 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6265.076172 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6292.859375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6354.138672 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6417.517578 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6449.304688 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6501.404297 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6564.783203 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6626.0625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6689.539062 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6741.638672 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6805.017578 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6866.199219 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6905.408203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6939.099609 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6970.886719 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7012 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7073.279297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7112.488281 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7140.271484 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7201.453125 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7233.240234 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7261.023438 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7313.123047 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7344.910156 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7408.386719 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7469.910156 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7509.119141 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7570.642578 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7610.005859 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7707.417969 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7735.201172 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7798.580078 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7826.363281 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7878.462891 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7917.671875 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7945.455078 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3262.744141 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3326.367188 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3389.990234 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3425.195312 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3488.671875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3552.294922 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3584.082031 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3615.869141 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3647.65625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3679.443359 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3711.230469 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3739.013672 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3800.537109 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3861.816406 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3925.195312 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3988.671875 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4027.535156 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4088.716797 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4147.896484 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4209.419922 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4250.533203 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4284.224609 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4312.007812 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4373.53125 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4434.810547 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4498.189453 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4561.8125 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4595.503906 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4654.683594 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4718.306641 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4750.09375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4813.716797 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4877.339844 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4909.126953 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4972.75 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5008.833984 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5047.697266 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5102.677734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5166.300781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5198.087891 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5229.875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5261.662109 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5293.449219 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5325.236328 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5364.445312 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5427.824219 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5466.6875 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5527.869141 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5591.248047 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5654.724609 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5718.103516 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5781.580078 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5844.958984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5884.167969 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5915.955078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5999.744141 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6031.53125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6128.943359 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6190.466797 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6253.943359 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6281.726562 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6343.005859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6406.384766 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6438.171875 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6490.271484 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6553.650391 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6614.929688 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6678.40625 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6730.505859 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6793.884766 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6855.066406 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6894.275391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6927.966797 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6959.753906 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7000.867188 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7062.146484 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7101.355469 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7129.138672 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7190.320312 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7222.107422 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7249.890625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7301.990234 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7333.777344 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7397.253906 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7458.777344 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7497.986328 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7559.509766 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7598.873047 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7696.285156 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7724.068359 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7787.447266 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7815.230469 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7867.330078 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7906.539062 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7934.322266 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p0d2b978fae">
+  <clipPath id="pc0cea4624c">
    <rect x="95.67625" y="49.34175" width="468.141298" height="294.686261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_summary.svg
+++ b/bench/graphs/silesia_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="574.419688pt" height="386.202469pt" viewBox="0 0 574.419688 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="573.639844pt" height="386.202469pt" viewBox="0 0 573.639844 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,232 +22,232 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 386.202469 
-L 574.419688 386.202469 
-L 574.419688 0 
+L 573.639844 386.202469 
+L 573.639844 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 189.334844 104.1264 
-L 293.959844 104.1264 
-L 293.959844 74.7432 
-L 189.334844 74.7432 
+    <path d="M 188.944922 104.1264 
+L 293.569922 104.1264 
+L 293.569922 74.7432 
+L 188.944922 74.7432 
 z
-" clip-path="url(#pd7bf6d5294)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p696bf80384)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 293.959844 104.1264 
-L 398.584844 104.1264 
-L 398.584844 74.7432 
-L 293.959844 74.7432 
+    <path d="M 293.569922 104.1264 
+L 398.194922 104.1264 
+L 398.194922 74.7432 
+L 293.569922 74.7432 
 z
-" clip-path="url(#pd7bf6d5294)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p696bf80384)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 398.584844 104.1264 
-L 503.209844 104.1264 
-L 503.209844 74.7432 
-L 398.584844 74.7432 
+    <path d="M 398.194922 104.1264 
+L 502.819922 104.1264 
+L 502.819922 74.7432 
+L 398.194922 74.7432 
 z
-" clip-path="url(#pd7bf6d5294)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p696bf80384)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 189.334844 133.5096 
-L 293.959844 133.5096 
-L 293.959844 104.1264 
-L 189.334844 104.1264 
+    <path d="M 188.944922 133.5096 
+L 293.569922 133.5096 
+L 293.569922 104.1264 
+L 188.944922 104.1264 
 z
-" clip-path="url(#pd7bf6d5294)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p696bf80384)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 293.959844 133.5096 
-L 398.584844 133.5096 
-L 398.584844 104.1264 
-L 293.959844 104.1264 
+    <path d="M 293.569922 133.5096 
+L 398.194922 133.5096 
+L 398.194922 104.1264 
+L 293.569922 104.1264 
 z
-" clip-path="url(#pd7bf6d5294)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p696bf80384)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 398.584844 133.5096 
-L 503.209844 133.5096 
-L 503.209844 104.1264 
-L 398.584844 104.1264 
+    <path d="M 398.194922 133.5096 
+L 502.819922 133.5096 
+L 502.819922 104.1264 
+L 398.194922 104.1264 
 z
-" clip-path="url(#pd7bf6d5294)" style="fill: #fece7c; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p696bf80384)" style="fill: #fece7c; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 189.334844 162.8928 
-L 293.959844 162.8928 
-L 293.959844 133.5096 
-L 189.334844 133.5096 
+    <path d="M 188.944922 162.8928 
+L 293.569922 162.8928 
+L 293.569922 133.5096 
+L 188.944922 133.5096 
 z
-" clip-path="url(#pd7bf6d5294)" style="fill: #fee08b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p696bf80384)" style="fill: #fee08b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 293.959844 162.8928 
-L 398.584844 162.8928 
-L 398.584844 133.5096 
-L 293.959844 133.5096 
+    <path d="M 293.569922 162.8928 
+L 398.194922 162.8928 
+L 398.194922 133.5096 
+L 293.569922 133.5096 
 z
-" clip-path="url(#pd7bf6d5294)" style="fill: #feefa3; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p696bf80384)" style="fill: #feefa3; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 398.584844 162.8928 
-L 503.209844 162.8928 
-L 503.209844 133.5096 
-L 398.584844 133.5096 
+    <path d="M 398.194922 162.8928 
+L 502.819922 162.8928 
+L 502.819922 133.5096 
+L 398.194922 133.5096 
 z
-" clip-path="url(#pd7bf6d5294)" style="fill: #fdbf6f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p696bf80384)" style="fill: #fdbf6f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 189.334844 192.276 
-L 293.959844 192.276 
-L 293.959844 162.8928 
-L 189.334844 162.8928 
+    <path d="M 188.944922 192.276 
+L 293.569922 192.276 
+L 293.569922 162.8928 
+L 188.944922 162.8928 
 z
-" clip-path="url(#pd7bf6d5294)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p696bf80384)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 293.959844 192.276 
-L 398.584844 192.276 
-L 398.584844 162.8928 
-L 293.959844 162.8928 
+    <path d="M 293.569922 192.276 
+L 398.194922 192.276 
+L 398.194922 162.8928 
+L 293.569922 162.8928 
 z
-" clip-path="url(#pd7bf6d5294)" style="fill: #fede89; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p696bf80384)" style="fill: #fede89; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 398.584844 192.276 
-L 503.209844 192.276 
-L 503.209844 162.8928 
-L 398.584844 162.8928 
+    <path d="M 398.194922 192.276 
+L 502.819922 192.276 
+L 502.819922 162.8928 
+L 398.194922 162.8928 
 z
-" clip-path="url(#pd7bf6d5294)" style="fill: #f7814c; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p696bf80384)" style="fill: #f7814c; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 189.334844 221.6592 
-L 293.959844 221.6592 
-L 293.959844 192.276 
-L 189.334844 192.276 
+    <path d="M 188.944922 221.6592 
+L 293.569922 221.6592 
+L 293.569922 192.276 
+L 188.944922 192.276 
 z
-" clip-path="url(#pd7bf6d5294)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p696bf80384)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 293.959844 221.6592 
-L 398.584844 221.6592 
-L 398.584844 192.276 
-L 293.959844 192.276 
+    <path d="M 293.569922 221.6592 
+L 398.194922 221.6592 
+L 398.194922 192.276 
+L 293.569922 192.276 
 z
-" clip-path="url(#pd7bf6d5294)" style="fill: #fed27f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p696bf80384)" style="fill: #fed27f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 398.584844 221.6592 
-L 503.209844 221.6592 
-L 503.209844 192.276 
-L 398.584844 192.276 
+    <path d="M 398.194922 221.6592 
+L 502.819922 221.6592 
+L 502.819922 192.276 
+L 398.194922 192.276 
 z
-" clip-path="url(#pd7bf6d5294)" style="fill: #fffcba; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p696bf80384)" style="fill: #fffcba; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 189.334844 251.0424 
-L 293.959844 251.0424 
-L 293.959844 221.6592 
-L 189.334844 221.6592 
+    <path d="M 188.944922 251.0424 
+L 293.569922 251.0424 
+L 293.569922 221.6592 
+L 188.944922 221.6592 
 z
-" clip-path="url(#pd7bf6d5294)" style="fill: #feec9f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p696bf80384)" style="fill: #fff3ac; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 293.959844 251.0424 
-L 398.584844 251.0424 
-L 398.584844 221.6592 
-L 293.959844 221.6592 
+    <path d="M 293.569922 251.0424 
+L 398.194922 251.0424 
+L 398.194922 221.6592 
+L 293.569922 221.6592 
 z
-" clip-path="url(#pd7bf6d5294)" style="fill: #fed07e; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p696bf80384)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 398.584844 251.0424 
-L 503.209844 251.0424 
-L 503.209844 221.6592 
-L 398.584844 221.6592 
+    <path d="M 398.194922 251.0424 
+L 502.819922 251.0424 
+L 502.819922 221.6592 
+L 398.194922 221.6592 
 z
-" clip-path="url(#pd7bf6d5294)" style="fill: #fec877; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p696bf80384)" style="fill: #e8f59f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 189.334844 280.4256 
-L 293.959844 280.4256 
-L 293.959844 251.0424 
-L 189.334844 251.0424 
+    <path d="M 188.944922 280.4256 
+L 293.569922 280.4256 
+L 293.569922 251.0424 
+L 188.944922 251.0424 
 z
-" clip-path="url(#pd7bf6d5294)" style="fill: #fff3ac; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p696bf80384)" style="fill: #fff7b2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 293.959844 280.4256 
-L 398.584844 280.4256 
-L 398.584844 251.0424 
-L 293.959844 251.0424 
+    <path d="M 293.569922 280.4256 
+L 398.194922 280.4256 
+L 398.194922 251.0424 
+L 293.569922 251.0424 
 z
-" clip-path="url(#pd7bf6d5294)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p696bf80384)" style="fill: #fdc776; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 398.584844 280.4256 
-L 503.209844 280.4256 
-L 503.209844 251.0424 
-L 398.584844 251.0424 
+    <path d="M 398.194922 280.4256 
+L 502.819922 280.4256 
+L 502.819922 251.0424 
+L 398.194922 251.0424 
 z
-" clip-path="url(#pd7bf6d5294)" style="fill: #e8f59f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p696bf80384)" style="fill: #fec877; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 189.334844 309.8088 
-L 293.959844 309.8088 
-L 293.959844 280.4256 
-L 189.334844 280.4256 
+    <path d="M 188.944922 309.8088 
+L 293.569922 309.8088 
+L 293.569922 280.4256 
+L 188.944922 280.4256 
 z
-" clip-path="url(#pd7bf6d5294)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p696bf80384)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 293.959844 309.8088 
-L 398.584844 309.8088 
-L 398.584844 280.4256 
-L 293.959844 280.4256 
+    <path d="M 293.569922 309.8088 
+L 398.194922 309.8088 
+L 398.194922 280.4256 
+L 293.569922 280.4256 
 z
-" clip-path="url(#pd7bf6d5294)" style="fill: #fa9b58; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p696bf80384)" style="fill: #fa9b58; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 398.584844 309.8088 
-L 503.209844 309.8088 
-L 503.209844 280.4256 
-L 398.584844 280.4256 
+    <path d="M 398.194922 309.8088 
+L 502.819922 309.8088 
+L 502.819922 280.4256 
+L 398.194922 280.4256 
 z
-" clip-path="url(#pd7bf6d5294)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p696bf80384)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 189.334844 339.192 
-L 293.959844 339.192 
-L 293.959844 309.8088 
-L 189.334844 309.8088 
+    <path d="M 188.944922 339.192 
+L 293.569922 339.192 
+L 293.569922 309.8088 
+L 188.944922 309.8088 
 z
-" clip-path="url(#pd7bf6d5294)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p696bf80384)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 293.959844 339.192 
-L 398.584844 339.192 
-L 398.584844 309.8088 
-L 293.959844 309.8088 
+    <path d="M 293.569922 339.192 
+L 398.194922 339.192 
+L 398.194922 309.8088 
+L 293.569922 309.8088 
 z
-" clip-path="url(#pd7bf6d5294)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p696bf80384)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 398.584844 339.192 
-L 503.209844 339.192 
-L 503.209844 309.8088 
-L 398.584844 309.8088 
+    <path d="M 398.194922 339.192 
+L 502.819922 339.192 
+L 502.819922 309.8088 
+L 398.194922 309.8088 
 z
-" clip-path="url(#pd7bf6d5294)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p696bf80384)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(122.322109 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(121.932188 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(229.606328 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(229.216406 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(308.178438 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(307.788516 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(406.530156 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(406.140234 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(118.259844 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(117.869922 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.320 -->
-    <g transform="translate(230.196094 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(229.806172 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -918,7 +918,7 @@ z
    </g>
    <g id="text_7">
     <!-- 117 -->
-    <g transform="translate(338.637344 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(338.247422 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -952,7 +952,7 @@ z
    </g>
    <g id="text_8">
     <!-- 852 -->
-    <g transform="translate(443.262344 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(442.872422 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -1026,7 +1026,7 @@ z
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(112.897969 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(112.508047 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1125,7 +1125,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.324 -->
-    <g transform="translate(230.196094 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(229.806172 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1156,7 +1156,7 @@ z
    </g>
    <g id="text_11">
     <!-- 61 -->
-    <g transform="translate(341.182344 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(340.792422 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -1195,7 +1195,7 @@ z
    </g>
    <g id="text_12">
     <!-- 312 -->
-    <g transform="translate(443.262344 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(442.872422 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
@@ -1203,7 +1203,7 @@ z
    </g>
    <g id="text_13">
     <!-- Go compress/flate -->
-    <g transform="translate(100.591094 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(100.201172 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -1374,7 +1374,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.325 -->
-    <g transform="translate(230.196094 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(229.806172 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1384,14 +1384,14 @@ z
    </g>
    <g id="text_15">
     <!-- 50 -->
-    <g transform="translate(341.182344 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(340.792422 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
     <!-- 275 -->
-    <g transform="translate(443.262344 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(442.872422 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
@@ -1399,7 +1399,7 @@ z
    </g>
    <g id="text_17">
     <!-- JS fflate -->
-    <g transform="translate(121.623594 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(121.233672 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1459,7 +1459,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.329 -->
-    <g transform="translate(230.196094 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(229.806172 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-39" d="M 703 97 
 L 703 672 
@@ -1501,14 +1501,14 @@ z
    </g>
    <g id="text_19">
     <!-- 41 -->
-    <g transform="translate(341.182344 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(340.792422 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
     <!-- 160 -->
-    <g transform="translate(443.262344 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(442.872422 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -1516,7 +1516,7 @@ z
    </g>
    <g id="text_21">
     <!-- zlib -->
-    <g transform="translate(130.161094 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(129.771172 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1540,7 +1540,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.323 -->
-    <g transform="translate(230.196094 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(229.806172 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1550,22 +1550,106 @@ z
    </g>
    <g id="text_23">
     <!-- 38 -->
-    <g transform="translate(341.182344 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(340.792422 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_24">
     <!-- 448 -->
-    <g transform="translate(443.262344 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(442.872422 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_25">
+    <!-- miniz_oxide -->
+    <g transform="translate(113.077422 238.44705) scale(0.08 -0.08)">
+     <defs>
+      <path id="DejaVuSans-6e" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-5f" d="M 3263 -1063 
+L 3263 -1509 
+L -63 -1509 
+L -63 -1063 
+L 3263 -1063 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-78" d="M 3513 3500 
+L 2247 1797 
+L 3578 0 
+L 2900 0 
+L 1881 1375 
+L 863 0 
+L 184 0 
+L 1544 1831 
+L 300 3500 
+L 978 3500 
+L 1906 2253 
+L 2834 3500 
+L 3513 3500 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-6d"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(97.412109 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(125.195312 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(188.574219 0)"/>
+     <use xlink:href="#DejaVuSans-7a" transform="translate(216.357422 0)"/>
+     <use xlink:href="#DejaVuSans-5f" transform="translate(268.847656 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(318.847656 0)"/>
+     <use xlink:href="#DejaVuSans-78" transform="translate(376.904297 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(436.083984 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(463.867188 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(527.34375 0)"/>
+    </g>
+   </g>
+   <g id="text_26">
+    <!-- 0.322 -->
+    <g transform="translate(229.806172 238.5583) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-30"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(159.033203 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(222.65625 0)"/>
+    </g>
+   </g>
+   <g id="text_27">
+    <!-- 36 -->
+    <g transform="translate(340.792422 238.5583) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-33"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
+    </g>
+   </g>
+   <g id="text_28">
+    <!-- 527 -->
+    <g transform="translate(442.872422 238.5583) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-35"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
+    </g>
+   </g>
+   <g id="text_29">
     <!-- lean-zip (native) -->
-    <g transform="translate(99.969219 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(99.579297 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1672,9 +1756,9 @@ z
      <use xlink:href="#DejaVuSans-Bold-29" transform="translate(880.615234 0)"/>
     </g>
    </g>
-   <g id="text_26">
-    <!-- 0.323 -->
-    <g transform="translate(228.995469 238.5583) scale(0.08 -0.08)">
+   <g id="text_30">
+    <!-- 0.321 -->
+    <g transform="translate(228.605547 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1758,36 +1842,38 @@ Q 3472 2313 2841 1759
 L 1844 884 
 z
 " transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-31" d="M 750 831 
+L 1813 831 
+L 1813 3847 
+L 722 3622 
+L 722 4441 
+L 1806 4666 
+L 2950 4666 
+L 2950 831 
+L 4013 831 
+L 4013 0 
+L 750 0 
+L 750 831 
+z
+" transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-Bold-30"/>
      <use xlink:href="#DejaVuSans-Bold-2e" transform="translate(69.580078 0)"/>
      <use xlink:href="#DejaVuSans-Bold-33" transform="translate(107.568359 0)"/>
      <use xlink:href="#DejaVuSans-Bold-32" transform="translate(177.148438 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-33" transform="translate(246.728516 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-31" transform="translate(246.728516 0)"/>
     </g>
    </g>
-   <g id="text_27">
-    <!-- 37 -->
-    <g transform="translate(340.706094 238.5583) scale(0.08 -0.08)">
-     <defs>
-      <path id="DejaVuSans-Bold-37" d="M 428 4666 
-L 3944 4666 
-L 3944 3988 
-L 2125 0 
-L 953 0 
-L 2675 3781 
-L 428 3781 
-L 428 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
+   <g id="text_31">
+    <!-- 33 -->
+    <g transform="translate(340.316172 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-Bold-33"/>
-     <use xlink:href="#DejaVuSans-Bold-37" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-33" transform="translate(69.580078 0)"/>
     </g>
    </g>
-   <g id="text_28">
-    <!-- 295 -->
-    <g transform="translate(442.547969 238.5583) scale(0.08 -0.08)">
+   <g id="text_32">
+    <!-- 297 -->
+    <g transform="translate(442.158047 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-39" d="M 641 103 
 L 641 966 
@@ -1819,124 +1905,25 @@ Q 1491 2759 1650 2554
 Q 1809 2350 2125 2350 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-35" d="M 678 4666 
-L 3669 4666 
-L 3669 3781 
-L 1638 3781 
-L 1638 3059 
-Q 1775 3097 1914 3117 
-Q 2053 3138 2203 3138 
-Q 3056 3138 3531 2711 
-Q 4006 2284 4006 1522 
-Q 4006 766 3489 337 
-Q 2972 -91 2053 -91 
-Q 1656 -91 1267 -14 
-Q 878 63 494 219 
-L 494 1166 
-Q 875 947 1217 837 
-Q 1559 728 1863 728 
-Q 2300 728 2551 942 
-Q 2803 1156 2803 1522 
-Q 2803 1891 2551 2103 
-Q 2300 2316 1863 2316 
-Q 1603 2316 1309 2248 
-Q 1016 2181 678 2041 
-L 678 4666 
+      <path id="DejaVuSans-Bold-37" d="M 428 4666 
+L 3944 4666 
+L 3944 3988 
+L 2125 0 
+L 953 0 
+L 2675 3781 
+L 428 3781 
+L 428 4666 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-Bold-32"/>
      <use xlink:href="#DejaVuSans-Bold-39" transform="translate(69.580078 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-35" transform="translate(139.160156 0)"/>
-    </g>
-   </g>
-   <g id="text_29">
-    <!-- miniz_oxide -->
-    <g transform="translate(113.467344 267.83025) scale(0.08 -0.08)">
-     <defs>
-      <path id="DejaVuSans-6e" d="M 3513 2113 
-L 3513 0 
-L 2938 0 
-L 2938 2094 
-Q 2938 2591 2744 2837 
-Q 2550 3084 2163 3084 
-Q 1697 3084 1428 2787 
-Q 1159 2491 1159 1978 
-L 1159 0 
-L 581 0 
-L 581 3500 
-L 1159 3500 
-L 1159 2956 
-Q 1366 3272 1645 3428 
-Q 1925 3584 2291 3584 
-Q 2894 3584 3203 3211 
-Q 3513 2838 3513 2113 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-5f" d="M 3263 -1063 
-L 3263 -1509 
-L -63 -1509 
-L -63 -1063 
-L 3263 -1063 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-78" d="M 3513 3500 
-L 2247 1797 
-L 3578 0 
-L 2900 0 
-L 1881 1375 
-L 863 0 
-L 184 0 
-L 1544 1831 
-L 300 3500 
-L 978 3500 
-L 1906 2253 
-L 2834 3500 
-L 3513 3500 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-6d"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(97.412109 0)"/>
-     <use xlink:href="#DejaVuSans-6e" transform="translate(125.195312 0)"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(188.574219 0)"/>
-     <use xlink:href="#DejaVuSans-7a" transform="translate(216.357422 0)"/>
-     <use xlink:href="#DejaVuSans-5f" transform="translate(268.847656 0)"/>
-     <use xlink:href="#DejaVuSans-6f" transform="translate(318.847656 0)"/>
-     <use xlink:href="#DejaVuSans-78" transform="translate(376.904297 0)"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(436.083984 0)"/>
-     <use xlink:href="#DejaVuSans-64" transform="translate(463.867188 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(527.34375 0)"/>
-    </g>
-   </g>
-   <g id="text_30">
-    <!-- 0.322 -->
-    <g transform="translate(230.196094 267.9415) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-30"/>
-     <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(159.033203 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(222.65625 0)"/>
-    </g>
-   </g>
-   <g id="text_31">
-    <!-- 36 -->
-    <g transform="translate(341.182344 267.9415) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-33"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
-    </g>
-   </g>
-   <g id="text_32">
-    <!-- 527 -->
-    <g transform="translate(443.262344 267.9415) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-37" transform="translate(139.160156 0)"/>
     </g>
    </g>
    <g id="text_33">
     <!-- OCaml decompress -->
-    <g transform="translate(98.084219 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(97.694297 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -2001,7 +1988,7 @@ z
    </g>
    <g id="text_34">
     <!-- 0.336 -->
-    <g transform="translate(230.196094 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(229.806172 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -2011,21 +1998,21 @@ z
    </g>
    <g id="text_35">
     <!-- 21 -->
-    <g transform="translate(341.182344 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(340.792422 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_36">
     <!-- 69 -->
-    <g transform="translate(445.807344 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(445.417422 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-36"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(126.305469 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(125.915547 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -2036,7 +2023,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.303 -->
-    <g transform="translate(230.196094 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(229.806172 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -2046,13 +2033,13 @@ z
    </g>
    <g id="text_39">
     <!-- 1 -->
-    <g transform="translate(343.727344 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(343.337422 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(446.897344 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(446.507422 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2068,7 +2055,7 @@ z
   </g>
   <g id="text_41">
    <!-- silesia — geomean over files, level 6 -->
-   <g transform="translate(153.811563 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(153.421641 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-2014" d="M 344 2156 
 L 6056 2156 
@@ -2212,7 +2199,7 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-07-08T21:41:55Z  ·  Linux chungus2 x86_64  ·  commit b17c222c  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-07-08T22:12:55Z  ·  Linux chungus2 x86_64  ·  commit 30251fb3  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2354,10 +2341,10 @@ z
     <use xlink:href="#DejaVuSans-38" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
     <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
     <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
@@ -2400,110 +2387,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3135.351562 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3198.974609 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3262.597656 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3317.578125 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3381.201172 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3444.824219 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3508.447266 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3563.427734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3595.214844 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3627.001953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3658.789062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3690.576172 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3722.363281 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3750.146484 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3811.669922 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3872.949219 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3936.328125 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3999.804688 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4038.667969 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4099.849609 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4159.029297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4220.552734 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4261.666016 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4295.357422 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4323.140625 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4384.664062 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4445.943359 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4509.322266 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4572.945312 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4606.636719 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4665.816406 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4729.439453 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4761.226562 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4824.849609 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4888.472656 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4920.259766 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4983.882812 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5019.966797 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5058.830078 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5113.810547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5177.433594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5209.220703 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5241.007812 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5272.794922 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5304.582031 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5336.369141 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5375.578125 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5438.957031 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5477.820312 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5539.001953 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5602.380859 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5665.857422 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5729.236328 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5792.712891 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5856.091797 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5895.300781 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5927.087891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6010.876953 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6042.664062 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6140.076172 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6201.599609 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6265.076172 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6292.859375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6354.138672 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6417.517578 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6449.304688 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6501.404297 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6564.783203 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6626.0625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6689.539062 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6741.638672 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6805.017578 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6866.199219 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6905.408203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6939.099609 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6970.886719 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7012 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7073.279297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7112.488281 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7140.271484 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7201.453125 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7233.240234 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7261.023438 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7313.123047 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7344.910156 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7408.386719 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7469.910156 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7509.119141 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7570.642578 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7610.005859 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7707.417969 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7735.201172 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7798.580078 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7826.363281 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7878.462891 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7917.671875 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7945.455078 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3262.744141 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3326.367188 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3389.990234 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3425.195312 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3488.671875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3552.294922 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3584.082031 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3615.869141 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3647.65625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3679.443359 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3711.230469 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3739.013672 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3800.537109 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3861.816406 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3925.195312 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3988.671875 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4027.535156 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4088.716797 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4147.896484 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4209.419922 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4250.533203 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4284.224609 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4312.007812 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4373.53125 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4434.810547 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4498.189453 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4561.8125 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4595.503906 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4654.683594 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4718.306641 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4750.09375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4813.716797 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4877.339844 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4909.126953 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4972.75 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5008.833984 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5047.697266 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5102.677734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5166.300781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5198.087891 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5229.875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5261.662109 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5293.449219 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5325.236328 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5364.445312 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5427.824219 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5466.6875 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5527.869141 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5591.248047 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5654.724609 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5718.103516 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5781.580078 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5844.958984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5884.167969 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5915.955078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5999.744141 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6031.53125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6128.943359 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6190.466797 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6253.943359 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6281.726562 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6343.005859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6406.384766 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6438.171875 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6490.271484 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6553.650391 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6614.929688 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6678.40625 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6730.505859 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6793.884766 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6855.066406 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6894.275391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6927.966797 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6959.753906 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7000.867188 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7062.146484 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7101.355469 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7129.138672 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7190.320312 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7222.107422 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7249.890625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7301.990234 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7333.777344 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7397.253906 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7458.777344 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7497.986328 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7559.509766 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7598.873047 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7696.285156 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7724.068359 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7787.447266 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7815.230469 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7867.330078 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7906.539062 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7934.322266 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pd7bf6d5294">
-   <rect x="84.709844" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="p696bf80384">
+   <rect x="84.319922" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/results/latest.json
+++ b/bench/results/latest.json
@@ -1,8 +1,8 @@
 {
  "meta": {
-  "date": "2026-07-08T21:41:55Z",
+  "date": "2026-07-08T22:12:55Z",
   "machine": "Linux chungus2 x86_64",
-  "git_commit": "b17c222c",
+  "git_commit": "30251fb3",
   "toolchain": "leanprover/lean4:v4.30.0-rc2",
   "note": "compress_mbps/decompress_mbps are a median-of-5 snapshot on the machine above; ratio is deterministic"
  },
@@ -14,8 +14,8 @@
    "level": 1,
    "out_size": 60455,
    "ratio": 0.3975,
-   "compress_mbps": 73.36,
-   "decompress_mbps": 214.85
+   "compress_mbps": 73.47,
+   "decompress_mbps": 213.85
   },
   {
    "compressor": "native",
@@ -24,8 +24,8 @@
    "level": 2,
    "out_size": 56316,
    "ratio": 0.3703,
-   "compress_mbps": 53.94,
-   "decompress_mbps": 245.86
+   "compress_mbps": 54.11,
+   "decompress_mbps": 244.38
   },
   {
    "compressor": "native",
@@ -34,8 +34,8 @@
    "level": 3,
    "out_size": 55646,
    "ratio": 0.3659,
-   "compress_mbps": 47.79,
-   "decompress_mbps": 269.89
+   "compress_mbps": 46.97,
+   "decompress_mbps": 268.94
   },
   {
    "compressor": "native",
@@ -44,8 +44,8 @@
    "level": 4,
    "out_size": 54357,
    "ratio": 0.3574,
-   "compress_mbps": 37.84,
-   "decompress_mbps": 272.09
+   "compress_mbps": 37.96,
+   "decompress_mbps": 271.87
   },
   {
    "compressor": "native",
@@ -54,38 +54,38 @@
    "level": 5,
    "out_size": 54078,
    "ratio": 0.3556,
-   "compress_mbps": 30.65,
-   "decompress_mbps": 271.89
+   "compress_mbps": 30.6,
+   "decompress_mbps": 271.94
   },
   {
    "compressor": "native",
    "pattern": "canterbury/alice29.txt",
    "size": 152089,
    "level": 6,
-   "out_size": 54013,
-   "ratio": 0.3551,
-   "compress_mbps": 29.55,
-   "decompress_mbps": 279.77
+   "out_size": 54469,
+   "ratio": 0.3581,
+   "compress_mbps": 28.42,
+   "decompress_mbps": 279.7
   },
   {
    "compressor": "native",
    "pattern": "canterbury/alice29.txt",
    "size": 152089,
    "level": 7,
-   "out_size": 53772,
-   "ratio": 0.3536,
-   "compress_mbps": 24.53,
-   "decompress_mbps": 279.88
+   "out_size": 54234,
+   "ratio": 0.3566,
+   "compress_mbps": 23.66,
+   "decompress_mbps": 280.92
   },
   {
    "compressor": "native",
    "pattern": "canterbury/alice29.txt",
    "size": 152089,
    "level": 8,
-   "out_size": 53753,
-   "ratio": 0.3534,
-   "compress_mbps": 23.56,
-   "decompress_mbps": 281.47
+   "out_size": 54216,
+   "ratio": 0.3565,
+   "compress_mbps": 22.48,
+   "decompress_mbps": 281.26
   },
   {
    "compressor": "native",
@@ -94,8 +94,8 @@
    "level": 9,
    "out_size": 52732,
    "ratio": 0.3467,
-   "compress_mbps": 4.31,
-   "decompress_mbps": 281.59
+   "compress_mbps": 4.32,
+   "decompress_mbps": 281.82
   },
   {
    "compressor": "native",
@@ -104,7 +104,7 @@
    "level": 10,
    "out_size": 52078,
    "ratio": 0.3424,
-   "compress_mbps": 2.43,
+   "compress_mbps": 2.41,
    "decompress_mbps": null
   },
   {
@@ -114,8 +114,8 @@
    "level": 1,
    "out_size": 53135,
    "ratio": 0.4245,
-   "compress_mbps": 65.51,
-   "decompress_mbps": 207.86
+   "compress_mbps": 66.05,
+   "decompress_mbps": 207.2
   },
   {
    "compressor": "native",
@@ -124,8 +124,8 @@
    "level": 2,
    "out_size": 50187,
    "ratio": 0.4009,
-   "compress_mbps": 48.89,
-   "decompress_mbps": 226.61
+   "compress_mbps": 49.42,
+   "decompress_mbps": 225.34
   },
   {
    "compressor": "native",
@@ -134,8 +134,8 @@
    "level": 3,
    "out_size": 49810,
    "ratio": 0.3979,
-   "compress_mbps": 44.13,
-   "decompress_mbps": 247.72
+   "compress_mbps": 44.29,
+   "decompress_mbps": 247.81
   },
   {
    "compressor": "native",
@@ -144,8 +144,8 @@
    "level": 4,
    "out_size": 48687,
    "ratio": 0.3889,
-   "compress_mbps": 35.66,
-   "decompress_mbps": 251.14
+   "compress_mbps": 35.15,
+   "decompress_mbps": 251.56
   },
   {
    "compressor": "native",
@@ -154,38 +154,38 @@
    "level": 5,
    "out_size": 48586,
    "ratio": 0.3881,
-   "compress_mbps": 30.77,
-   "decompress_mbps": 250.39
+   "compress_mbps": 30.54,
+   "decompress_mbps": 251.42
   },
   {
    "compressor": "native",
    "pattern": "canterbury/asyoulik.txt",
    "size": 125179,
    "level": 6,
-   "out_size": 48373,
-   "ratio": 0.3864,
-   "compress_mbps": 28.34,
-   "decompress_mbps": 254.23
+   "out_size": 48910,
+   "ratio": 0.3907,
+   "compress_mbps": 27.15,
+   "decompress_mbps": 255.6
   },
   {
    "compressor": "native",
    "pattern": "canterbury/asyoulik.txt",
    "size": 125179,
    "level": 7,
-   "out_size": 48287,
-   "ratio": 0.3857,
-   "compress_mbps": 25.66,
-   "decompress_mbps": 255.41
+   "out_size": 48843,
+   "ratio": 0.3902,
+   "compress_mbps": 24.19,
+   "decompress_mbps": 255.96
   },
   {
    "compressor": "native",
    "pattern": "canterbury/asyoulik.txt",
    "size": 125179,
    "level": 8,
-   "out_size": 48284,
-   "ratio": 0.3857,
-   "compress_mbps": 25.34,
-   "decompress_mbps": 256.14
+   "out_size": 48839,
+   "ratio": 0.3902,
+   "compress_mbps": 24.03,
+   "decompress_mbps": 256.11
   },
   {
    "compressor": "native",
@@ -194,8 +194,8 @@
    "level": 9,
    "out_size": 47433,
    "ratio": 0.3789,
-   "compress_mbps": 4.69,
-   "decompress_mbps": 253.99
+   "compress_mbps": 4.67,
+   "decompress_mbps": 256.83
   },
   {
    "compressor": "native",
@@ -204,7 +204,7 @@
    "level": 10,
    "out_size": 46866,
    "ratio": 0.3744,
-   "compress_mbps": 2.84,
+   "compress_mbps": 2.8,
    "decompress_mbps": null
   },
   {
@@ -214,8 +214,8 @@
    "level": 1,
    "out_size": 8476,
    "ratio": 0.3445,
-   "compress_mbps": 65.35,
-   "decompress_mbps": 272.1
+   "compress_mbps": 65.41,
+   "decompress_mbps": 272.52
   },
   {
    "compressor": "native",
@@ -224,8 +224,8 @@
    "level": 2,
    "out_size": 8271,
    "ratio": 0.3362,
-   "compress_mbps": 55.0,
-   "decompress_mbps": 282.32
+   "compress_mbps": 55.18,
+   "decompress_mbps": 284.2
   },
   {
    "compressor": "native",
@@ -234,8 +234,8 @@
    "level": 3,
    "out_size": 8159,
    "ratio": 0.3316,
-   "compress_mbps": 53.27,
-   "decompress_mbps": 287.59
+   "compress_mbps": 53.12,
+   "decompress_mbps": 285.38
   },
   {
    "compressor": "native",
@@ -244,8 +244,8 @@
    "level": 4,
    "out_size": 7948,
    "ratio": 0.3231,
-   "compress_mbps": 50.05,
-   "decompress_mbps": 295.37
+   "compress_mbps": 48.32,
+   "decompress_mbps": 294.67
   },
   {
    "compressor": "native",
@@ -254,38 +254,38 @@
    "level": 5,
    "out_size": 7899,
    "ratio": 0.3211,
-   "compress_mbps": 42.6,
-   "decompress_mbps": 303.12
+   "compress_mbps": 41.25,
+   "decompress_mbps": 300.91
   },
   {
    "compressor": "native",
    "pattern": "canterbury/cp.html",
    "size": 24603,
    "level": 6,
-   "out_size": 7912,
-   "ratio": 0.3216,
-   "compress_mbps": 41.97,
-   "decompress_mbps": 301.6
+   "out_size": 7950,
+   "ratio": 0.3231,
+   "compress_mbps": 35.0,
+   "decompress_mbps": 299.04
   },
   {
    "compressor": "native",
    "pattern": "canterbury/cp.html",
    "size": 24603,
    "level": 7,
-   "out_size": 7897,
-   "ratio": 0.321,
-   "compress_mbps": 37.73,
-   "decompress_mbps": 306.48
+   "out_size": 7934,
+   "ratio": 0.3225,
+   "compress_mbps": 31.87,
+   "decompress_mbps": 305.18
   },
   {
    "compressor": "native",
    "pattern": "canterbury/cp.html",
    "size": 24603,
    "level": 8,
-   "out_size": 7897,
-   "ratio": 0.321,
-   "compress_mbps": 37.79,
-   "decompress_mbps": 307.17
+   "out_size": 7934,
+   "ratio": 0.3225,
+   "compress_mbps": 31.76,
+   "decompress_mbps": 304.07
   },
   {
    "compressor": "native",
@@ -294,8 +294,8 @@
    "level": 9,
    "out_size": 7803,
    "ratio": 0.3172,
-   "compress_mbps": 5.02,
-   "decompress_mbps": 305.88
+   "compress_mbps": 4.98,
+   "decompress_mbps": 306.75
   },
   {
    "compressor": "native",
@@ -304,7 +304,7 @@
    "level": 10,
    "out_size": 7737,
    "ratio": 0.3145,
-   "compress_mbps": 2.99,
+   "compress_mbps": 2.93,
    "decompress_mbps": null
   },
   {
@@ -314,8 +314,8 @@
    "level": 1,
    "out_size": 3509,
    "ratio": 0.3147,
-   "compress_mbps": 48.96,
-   "decompress_mbps": 186.64
+   "compress_mbps": 49.39,
+   "decompress_mbps": 186.84
   },
   {
    "compressor": "native",
@@ -324,8 +324,8 @@
    "level": 2,
    "out_size": 3269,
    "ratio": 0.2932,
-   "compress_mbps": 43.94,
-   "decompress_mbps": 188.52
+   "compress_mbps": 43.58,
+   "decompress_mbps": 188.28
   },
   {
    "compressor": "native",
@@ -334,8 +334,8 @@
    "level": 3,
    "out_size": 3209,
    "ratio": 0.2878,
-   "compress_mbps": 42.78,
-   "decompress_mbps": 192.66
+   "compress_mbps": 42.35,
+   "decompress_mbps": 192.51
   },
   {
    "compressor": "native",
@@ -344,8 +344,8 @@
    "level": 4,
    "out_size": 3128,
    "ratio": 0.2805,
-   "compress_mbps": 42.45,
-   "decompress_mbps": 196.82
+   "compress_mbps": 39.79,
+   "decompress_mbps": 197.21
   },
   {
    "compressor": "native",
@@ -354,38 +354,38 @@
    "level": 5,
    "out_size": 3112,
    "ratio": 0.2791,
-   "compress_mbps": 37.95,
-   "decompress_mbps": 197.2
+   "compress_mbps": 35.71,
+   "decompress_mbps": 197.3
   },
   {
    "compressor": "native",
    "pattern": "canterbury/fields.c",
    "size": 11150,
    "level": 6,
-   "out_size": 3120,
-   "ratio": 0.2798,
-   "compress_mbps": 38.34,
-   "decompress_mbps": 198.37
+   "out_size": 3122,
+   "ratio": 0.28,
+   "compress_mbps": 32.32,
+   "decompress_mbps": 197.97
   },
   {
    "compressor": "native",
    "pattern": "canterbury/fields.c",
    "size": 11150,
    "level": 7,
-   "out_size": 3112,
-   "ratio": 0.2791,
-   "compress_mbps": 35.6,
-   "decompress_mbps": 198.26
+   "out_size": 3117,
+   "ratio": 0.2796,
+   "compress_mbps": 30.34,
+   "decompress_mbps": 197.86
   },
   {
    "compressor": "native",
    "pattern": "canterbury/fields.c",
    "size": 11150,
    "level": 8,
-   "out_size": 3112,
-   "ratio": 0.2791,
-   "compress_mbps": 35.57,
-   "decompress_mbps": 198.67
+   "out_size": 3117,
+   "ratio": 0.2796,
+   "compress_mbps": 30.2,
+   "decompress_mbps": 197.83
   },
   {
    "compressor": "native",
@@ -394,8 +394,8 @@
    "level": 9,
    "out_size": 3056,
    "ratio": 0.2741,
-   "compress_mbps": 5.54,
-   "decompress_mbps": 198.66
+   "compress_mbps": 5.48,
+   "decompress_mbps": 198.13
   },
   {
    "compressor": "native",
@@ -404,7 +404,7 @@
    "level": 10,
    "out_size": 3031,
    "ratio": 0.2718,
-   "compress_mbps": 3.11,
+   "compress_mbps": 3.07,
    "decompress_mbps": null
   },
   {
@@ -414,8 +414,8 @@
    "level": 1,
    "out_size": 1283,
    "ratio": 0.3448,
-   "compress_mbps": 24.96,
-   "decompress_mbps": 84.91
+   "compress_mbps": 24.98,
+   "decompress_mbps": 84.73
   },
   {
    "compressor": "native",
@@ -424,8 +424,8 @@
    "level": 2,
    "out_size": 1225,
    "ratio": 0.3292,
-   "compress_mbps": 23.99,
-   "decompress_mbps": 86.0
+   "compress_mbps": 23.77,
+   "decompress_mbps": 85.62
   },
   {
    "compressor": "native",
@@ -434,8 +434,8 @@
    "level": 3,
    "out_size": 1222,
    "ratio": 0.3284,
-   "compress_mbps": 23.67,
-   "decompress_mbps": 85.96
+   "compress_mbps": 23.45,
+   "decompress_mbps": 85.71
   },
   {
    "compressor": "native",
@@ -444,8 +444,8 @@
    "level": 4,
    "out_size": 1213,
    "ratio": 0.326,
-   "compress_mbps": 23.9,
-   "decompress_mbps": 86.17
+   "compress_mbps": 21.78,
+   "decompress_mbps": 85.82
   },
   {
    "compressor": "native",
@@ -454,38 +454,38 @@
    "level": 5,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 23.23,
-   "decompress_mbps": 86.56
+   "compress_mbps": 21.21,
+   "decompress_mbps": 86.43
   },
   {
    "compressor": "native",
    "pattern": "canterbury/grammar.lsp",
    "size": 3721,
    "level": 6,
-   "out_size": 1209,
-   "ratio": 0.3249,
-   "compress_mbps": 22.84,
-   "decompress_mbps": 86.62
+   "out_size": 1219,
+   "ratio": 0.3276,
+   "compress_mbps": 19.47,
+   "decompress_mbps": 86.68
   },
   {
    "compressor": "native",
    "pattern": "canterbury/grammar.lsp",
    "size": 3721,
    "level": 7,
-   "out_size": 1209,
-   "ratio": 0.3249,
-   "compress_mbps": 22.67,
-   "decompress_mbps": 86.75
+   "out_size": 1219,
+   "ratio": 0.3276,
+   "compress_mbps": 19.26,
+   "decompress_mbps": 86.73
   },
   {
    "compressor": "native",
    "pattern": "canterbury/grammar.lsp",
    "size": 3721,
    "level": 8,
-   "out_size": 1209,
-   "ratio": 0.3249,
-   "compress_mbps": 22.62,
-   "decompress_mbps": 86.7
+   "out_size": 1219,
+   "ratio": 0.3276,
+   "compress_mbps": 19.29,
+   "decompress_mbps": 86.71
   },
   {
    "compressor": "native",
@@ -494,8 +494,8 @@
    "level": 9,
    "out_size": 1205,
    "ratio": 0.3238,
-   "compress_mbps": 5.05,
-   "decompress_mbps": 86.49
+   "compress_mbps": 4.95,
+   "decompress_mbps": 86.69
   },
   {
    "compressor": "native",
@@ -504,7 +504,7 @@
    "level": 10,
    "out_size": 1191,
    "ratio": 0.3201,
-   "compress_mbps": 3.02,
+   "compress_mbps": 2.96,
    "decompress_mbps": null
   },
   {
@@ -514,8 +514,8 @@
    "level": 1,
    "out_size": 251793,
    "ratio": 0.2445,
-   "compress_mbps": 143.62,
-   "decompress_mbps": 396.59
+   "compress_mbps": 143.5,
+   "decompress_mbps": 396.3
   },
   {
    "compressor": "native",
@@ -524,8 +524,8 @@
    "level": 2,
    "out_size": 242565,
    "ratio": 0.2356,
-   "compress_mbps": 108.65,
-   "decompress_mbps": 428.96
+   "compress_mbps": 108.74,
+   "decompress_mbps": 426.25
   },
   {
    "compressor": "native",
@@ -534,8 +534,8 @@
    "level": 3,
    "out_size": 242532,
    "ratio": 0.2355,
-   "compress_mbps": 90.94,
-   "decompress_mbps": 454.73
+   "compress_mbps": 89.75,
+   "decompress_mbps": 452.86
   },
   {
    "compressor": "native",
@@ -544,8 +544,8 @@
    "level": 4,
    "out_size": 239953,
    "ratio": 0.233,
-   "compress_mbps": 95.98,
-   "decompress_mbps": 482.68
+   "compress_mbps": 96.89,
+   "decompress_mbps": 482.5
   },
   {
    "compressor": "native",
@@ -554,38 +554,38 @@
    "level": 5,
    "out_size": 218565,
    "ratio": 0.2123,
-   "compress_mbps": 53.29,
-   "decompress_mbps": 466.02
+   "compress_mbps": 54.14,
+   "decompress_mbps": 465.58
   },
   {
    "compressor": "native",
    "pattern": "canterbury/kennedy.xls",
    "size": 1029744,
    "level": 6,
-   "out_size": 202718,
-   "ratio": 0.1969,
-   "compress_mbps": 41.62,
-   "decompress_mbps": 484.78
+   "out_size": 201821,
+   "ratio": 0.196,
+   "compress_mbps": 36.35,
+   "decompress_mbps": 482.06
   },
   {
    "compressor": "native",
    "pattern": "canterbury/kennedy.xls",
    "size": 1029744,
    "level": 7,
-   "out_size": 201435,
-   "ratio": 0.1956,
-   "compress_mbps": 30.31,
-   "decompress_mbps": 490.42
+   "out_size": 201362,
+   "ratio": 0.1955,
+   "compress_mbps": 28.18,
+   "decompress_mbps": 487.25
   },
   {
    "compressor": "native",
    "pattern": "canterbury/kennedy.xls",
    "size": 1029744,
    "level": 8,
-   "out_size": 200825,
-   "ratio": 0.195,
-   "compress_mbps": 22.38,
-   "decompress_mbps": 496.91
+   "out_size": 200869,
+   "ratio": 0.1951,
+   "compress_mbps": 21.27,
+   "decompress_mbps": 497.79
   },
   {
    "compressor": "native",
@@ -594,8 +594,8 @@
    "level": 9,
    "out_size": 182511,
    "ratio": 0.1772,
-   "compress_mbps": 3.45,
-   "decompress_mbps": 497.51
+   "compress_mbps": 3.47,
+   "decompress_mbps": 498.44
   },
   {
    "compressor": "native",
@@ -604,7 +604,7 @@
    "level": 10,
    "out_size": 178069,
    "ratio": 0.1729,
-   "compress_mbps": 1.47,
+   "compress_mbps": 1.46,
    "decompress_mbps": null
   },
   {
@@ -614,8 +614,8 @@
    "level": 1,
    "out_size": 160674,
    "ratio": 0.3765,
-   "compress_mbps": 79.06,
-   "decompress_mbps": 224.13
+   "compress_mbps": 78.84,
+   "decompress_mbps": 223.97
   },
   {
    "compressor": "native",
@@ -624,8 +624,8 @@
    "level": 2,
    "out_size": 149787,
    "ratio": 0.351,
-   "compress_mbps": 56.61,
-   "decompress_mbps": 242.59
+   "compress_mbps": 56.78,
+   "decompress_mbps": 242.81
   },
   {
    "compressor": "native",
@@ -634,8 +634,8 @@
    "level": 3,
    "out_size": 148055,
    "ratio": 0.3469,
-   "compress_mbps": 49.74,
-   "decompress_mbps": 270.37
+   "compress_mbps": 50.12,
+   "decompress_mbps": 270.54
   },
   {
    "compressor": "native",
@@ -644,8 +644,8 @@
    "level": 4,
    "out_size": 144750,
    "ratio": 0.3392,
-   "compress_mbps": 41.12,
-   "decompress_mbps": 273.1
+   "compress_mbps": 41.25,
+   "decompress_mbps": 272.36
   },
   {
    "compressor": "native",
@@ -654,38 +654,38 @@
    "level": 5,
    "out_size": 144408,
    "ratio": 0.3384,
-   "compress_mbps": 33.32,
-   "decompress_mbps": 273.04
+   "compress_mbps": 33.43,
+   "decompress_mbps": 273.23
   },
   {
    "compressor": "native",
    "pattern": "canterbury/lcet10.txt",
    "size": 426754,
    "level": 6,
-   "out_size": 144071,
-   "ratio": 0.3376,
-   "compress_mbps": 32.07,
-   "decompress_mbps": 278.79
+   "out_size": 144583,
+   "ratio": 0.3388,
+   "compress_mbps": 28.08,
+   "decompress_mbps": 279.29
   },
   {
    "compressor": "native",
    "pattern": "canterbury/lcet10.txt",
    "size": 426754,
    "level": 7,
-   "out_size": 143631,
-   "ratio": 0.3366,
-   "compress_mbps": 26.74,
-   "decompress_mbps": 278.62
+   "out_size": 144099,
+   "ratio": 0.3377,
+   "compress_mbps": 24.24,
+   "decompress_mbps": 280.8
   },
   {
    "compressor": "native",
    "pattern": "canterbury/lcet10.txt",
    "size": 426754,
    "level": 8,
-   "out_size": 143573,
-   "ratio": 0.3364,
-   "compress_mbps": 25.4,
-   "decompress_mbps": 279.84
+   "out_size": 144045,
+   "ratio": 0.3375,
+   "compress_mbps": 23.38,
+   "decompress_mbps": 279.83
   },
   {
    "compressor": "native",
@@ -694,8 +694,8 @@
    "level": 9,
    "out_size": 140323,
    "ratio": 0.3288,
-   "compress_mbps": 4.27,
-   "decompress_mbps": 280.11
+   "compress_mbps": 4.26,
+   "decompress_mbps": 279.36
   },
   {
    "compressor": "native",
@@ -704,7 +704,7 @@
    "level": 10,
    "out_size": 138833,
    "ratio": 0.3253,
-   "compress_mbps": 2.53,
+   "compress_mbps": 2.51,
    "decompress_mbps": null
   },
   {
@@ -714,8 +714,8 @@
    "level": 1,
    "out_size": 212588,
    "ratio": 0.4412,
-   "compress_mbps": 66.44,
-   "decompress_mbps": 192.88
+   "compress_mbps": 67.15,
+   "decompress_mbps": 193.51
   },
   {
    "compressor": "native",
@@ -724,8 +724,8 @@
    "level": 2,
    "out_size": 199981,
    "ratio": 0.415,
-   "compress_mbps": 47.91,
-   "decompress_mbps": 216.35
+   "compress_mbps": 48.43,
+   "decompress_mbps": 216.53
   },
   {
    "compressor": "native",
@@ -734,8 +734,8 @@
    "level": 3,
    "out_size": 198551,
    "ratio": 0.4121,
-   "compress_mbps": 42.28,
-   "decompress_mbps": 237.61
+   "compress_mbps": 42.98,
+   "decompress_mbps": 237.73
   },
   {
    "compressor": "native",
@@ -744,8 +744,8 @@
    "level": 4,
    "out_size": 193783,
    "ratio": 0.4022,
-   "compress_mbps": 31.92,
-   "decompress_mbps": 241.87
+   "compress_mbps": 31.86,
+   "decompress_mbps": 241.2
   },
   {
    "compressor": "native",
@@ -754,38 +754,38 @@
    "level": 5,
    "out_size": 193223,
    "ratio": 0.401,
-   "compress_mbps": 26.79,
-   "decompress_mbps": 238.11
+   "compress_mbps": 26.69,
+   "decompress_mbps": 237.49
   },
   {
    "compressor": "native",
    "pattern": "canterbury/plrabn12.txt",
    "size": 481861,
    "level": 6,
-   "out_size": 193415,
-   "ratio": 0.4014,
-   "compress_mbps": 27.04,
-   "decompress_mbps": 241.93
+   "out_size": 195104,
+   "ratio": 0.4049,
+   "compress_mbps": 24.57,
+   "decompress_mbps": 241.6
   },
   {
    "compressor": "native",
    "pattern": "canterbury/plrabn12.txt",
    "size": 481861,
    "level": 7,
-   "out_size": 192664,
-   "ratio": 0.3998,
-   "compress_mbps": 22.31,
-   "decompress_mbps": 242.64
+   "out_size": 194378,
+   "ratio": 0.4034,
+   "compress_mbps": 20.65,
+   "decompress_mbps": 241.96
   },
   {
    "compressor": "native",
    "pattern": "canterbury/plrabn12.txt",
    "size": 481861,
    "level": 8,
-   "out_size": 192638,
-   "ratio": 0.3998,
-   "compress_mbps": 21.62,
-   "decompress_mbps": 242.37
+   "out_size": 194355,
+   "ratio": 0.4033,
+   "compress_mbps": 20.17,
+   "decompress_mbps": 242.05
   },
   {
    "compressor": "native",
@@ -794,8 +794,8 @@
    "level": 9,
    "out_size": 189368,
    "ratio": 0.393,
-   "compress_mbps": 4.04,
-   "decompress_mbps": 242.09
+   "compress_mbps": 4.05,
+   "decompress_mbps": 242.23
   },
   {
    "compressor": "native",
@@ -804,7 +804,7 @@
    "level": 10,
    "out_size": 186146,
    "ratio": 0.3863,
-   "compress_mbps": 2.46,
+   "compress_mbps": 2.44,
    "decompress_mbps": null
   },
   {
@@ -814,8 +814,8 @@
    "level": 1,
    "out_size": 60161,
    "ratio": 0.1172,
-   "compress_mbps": 230.09,
-   "decompress_mbps": 589.85
+   "compress_mbps": 231.73,
+   "decompress_mbps": 586.9
   },
   {
    "compressor": "native",
@@ -824,8 +824,8 @@
    "level": 2,
    "out_size": 58873,
    "ratio": 0.1147,
-   "compress_mbps": 171.55,
-   "decompress_mbps": 614.48
+   "compress_mbps": 171.49,
+   "decompress_mbps": 615.62
   },
   {
    "compressor": "native",
@@ -834,8 +834,8 @@
    "level": 3,
    "out_size": 58327,
    "ratio": 0.1137,
-   "compress_mbps": 149.2,
-   "decompress_mbps": 645.07
+   "compress_mbps": 149.46,
+   "decompress_mbps": 641.62
   },
   {
    "compressor": "native",
@@ -844,8 +844,8 @@
    "level": 4,
    "out_size": 55586,
    "ratio": 0.1083,
-   "compress_mbps": 120.91,
-   "decompress_mbps": 664.38
+   "compress_mbps": 121.58,
+   "decompress_mbps": 663.36
   },
   {
    "compressor": "native",
@@ -854,38 +854,38 @@
    "level": 5,
    "out_size": 55097,
    "ratio": 0.1074,
-   "compress_mbps": 89.96,
-   "decompress_mbps": 687.13
+   "compress_mbps": 90.77,
+   "decompress_mbps": 684.29
   },
   {
    "compressor": "native",
    "pattern": "canterbury/ptt5",
    "size": 513216,
    "level": 6,
-   "out_size": 55199,
-   "ratio": 0.1076,
-   "compress_mbps": 69.56,
-   "decompress_mbps": 708.05
+   "out_size": 55495,
+   "ratio": 0.1081,
+   "compress_mbps": 66.85,
+   "decompress_mbps": 709.57
   },
   {
    "compressor": "native",
    "pattern": "canterbury/ptt5",
    "size": 513216,
    "level": 7,
-   "out_size": 54313,
-   "ratio": 0.1058,
-   "compress_mbps": 54.67,
-   "decompress_mbps": 723.5
+   "out_size": 54556,
+   "ratio": 0.1063,
+   "compress_mbps": 50.45,
+   "decompress_mbps": 723.25
   },
   {
    "compressor": "native",
    "pattern": "canterbury/ptt5",
    "size": 513216,
    "level": 8,
-   "out_size": 53095,
-   "ratio": 0.1035,
-   "compress_mbps": 43.97,
-   "decompress_mbps": 748.02
+   "out_size": 53384,
+   "ratio": 0.104,
+   "compress_mbps": 42.73,
+   "decompress_mbps": 749.59
   },
   {
    "compressor": "native",
@@ -894,8 +894,8 @@
    "level": 9,
    "out_size": 52603,
    "ratio": 0.1025,
-   "compress_mbps": 5.81,
-   "decompress_mbps": 761.53
+   "compress_mbps": 5.85,
+   "decompress_mbps": 760.53
   },
   {
    "compressor": "native",
@@ -904,7 +904,7 @@
    "level": 10,
    "out_size": 52236,
    "ratio": 0.1018,
-   "compress_mbps": 3.8,
+   "compress_mbps": 3.77,
    "decompress_mbps": null
   },
   {
@@ -914,8 +914,8 @@
    "level": 1,
    "out_size": 14249,
    "ratio": 0.3726,
-   "compress_mbps": 59.35,
-   "decompress_mbps": 241.26
+   "compress_mbps": 59.36,
+   "decompress_mbps": 239.63
   },
   {
    "compressor": "native",
@@ -924,8 +924,8 @@
    "level": 2,
    "out_size": 13825,
    "ratio": 0.3615,
-   "compress_mbps": 51.79,
-   "decompress_mbps": 248.29
+   "compress_mbps": 51.85,
+   "decompress_mbps": 248.35
   },
   {
    "compressor": "native",
@@ -934,8 +934,8 @@
    "level": 3,
    "out_size": 13751,
    "ratio": 0.3596,
-   "compress_mbps": 49.9,
-   "decompress_mbps": 248.96
+   "compress_mbps": 49.71,
+   "decompress_mbps": 250.26
   },
   {
    "compressor": "native",
@@ -944,8 +944,8 @@
    "level": 4,
    "out_size": 13290,
    "ratio": 0.3475,
-   "compress_mbps": 45.86,
-   "decompress_mbps": 256.7
+   "compress_mbps": 45.19,
+   "decompress_mbps": 256.39
   },
   {
    "compressor": "native",
@@ -954,38 +954,38 @@
    "level": 5,
    "out_size": 13244,
    "ratio": 0.3463,
-   "compress_mbps": 39.73,
-   "decompress_mbps": 268.75
+   "compress_mbps": 38.87,
+   "decompress_mbps": 264.09
   },
   {
    "compressor": "native",
    "pattern": "canterbury/sum",
    "size": 38240,
    "level": 6,
-   "out_size": 12946,
-   "ratio": 0.3385,
-   "compress_mbps": 22.04,
-   "decompress_mbps": 271.96
+   "out_size": 12653,
+   "ratio": 0.3309,
+   "compress_mbps": 20.12,
+   "decompress_mbps": 267.6
   },
   {
    "compressor": "native",
    "pattern": "canterbury/sum",
    "size": 38240,
    "level": 7,
-   "out_size": 12930,
-   "ratio": 0.3381,
-   "compress_mbps": 19.66,
-   "decompress_mbps": 274.29
+   "out_size": 12635,
+   "ratio": 0.3304,
+   "compress_mbps": 18.3,
+   "decompress_mbps": 269.94
   },
   {
    "compressor": "native",
    "pattern": "canterbury/sum",
    "size": 38240,
    "level": 8,
-   "out_size": 12922,
-   "ratio": 0.3379,
-   "compress_mbps": 17.97,
-   "decompress_mbps": 274.98
+   "out_size": 12632,
+   "ratio": 0.3303,
+   "compress_mbps": 16.67,
+   "decompress_mbps": 272.46
   },
   {
    "compressor": "native",
@@ -995,7 +995,7 @@
    "out_size": 12427,
    "ratio": 0.325,
    "compress_mbps": 5.43,
-   "decompress_mbps": 275.89
+   "decompress_mbps": 274.58
   },
   {
    "compressor": "native",
@@ -1004,7 +1004,7 @@
    "level": 10,
    "out_size": 12273,
    "ratio": 0.3209,
-   "compress_mbps": 3.1,
+   "compress_mbps": 3.08,
    "decompress_mbps": null
   },
   {
@@ -1014,8 +1014,8 @@
    "level": 1,
    "out_size": 1800,
    "ratio": 0.4258,
-   "compress_mbps": 26.32,
-   "decompress_mbps": 91.8
+   "compress_mbps": 26.55,
+   "decompress_mbps": 91.55
   },
   {
    "compressor": "native",
@@ -1024,8 +1024,8 @@
    "level": 2,
    "out_size": 1750,
    "ratio": 0.414,
-   "compress_mbps": 25.0,
-   "decompress_mbps": 92.0
+   "compress_mbps": 25.2,
+   "decompress_mbps": 91.41
   },
   {
    "compressor": "native",
@@ -1034,8 +1034,8 @@
    "level": 3,
    "out_size": 1742,
    "ratio": 0.4121,
-   "compress_mbps": 24.84,
-   "decompress_mbps": 91.98
+   "compress_mbps": 25.11,
+   "decompress_mbps": 91.39
   },
   {
    "compressor": "native",
@@ -1044,8 +1044,8 @@
    "level": 4,
    "out_size": 1726,
    "ratio": 0.4083,
-   "compress_mbps": 25.2,
-   "decompress_mbps": 93.12
+   "compress_mbps": 23.25,
+   "decompress_mbps": 93.02
   },
   {
    "compressor": "native",
@@ -1054,38 +1054,38 @@
    "level": 5,
    "out_size": 1722,
    "ratio": 0.4074,
-   "compress_mbps": 24.9,
-   "decompress_mbps": 93.28
+   "compress_mbps": 23.09,
+   "decompress_mbps": 92.97
   },
   {
    "compressor": "native",
    "pattern": "canterbury/xargs.1",
    "size": 4227,
    "level": 6,
-   "out_size": 1722,
-   "ratio": 0.4074,
-   "compress_mbps": 23.92,
-   "decompress_mbps": 93.35
+   "out_size": 1734,
+   "ratio": 0.4102,
+   "compress_mbps": 20.35,
+   "decompress_mbps": 93.07
   },
   {
    "compressor": "native",
    "pattern": "canterbury/xargs.1",
    "size": 4227,
    "level": 7,
-   "out_size": 1722,
-   "ratio": 0.4074,
-   "compress_mbps": 23.97,
-   "decompress_mbps": 93.41
+   "out_size": 1734,
+   "ratio": 0.4102,
+   "compress_mbps": 20.34,
+   "decompress_mbps": 93.15
   },
   {
    "compressor": "native",
    "pattern": "canterbury/xargs.1",
    "size": 4227,
    "level": 8,
-   "out_size": 1722,
-   "ratio": 0.4074,
-   "compress_mbps": 23.95,
-   "decompress_mbps": 93.42
+   "out_size": 1734,
+   "ratio": 0.4102,
+   "compress_mbps": 20.33,
+   "decompress_mbps": 93.01
   },
   {
    "compressor": "native",
@@ -1094,8 +1094,8 @@
    "level": 9,
    "out_size": 1708,
    "ratio": 0.4041,
-   "compress_mbps": 5.51,
-   "decompress_mbps": 93.57
+   "compress_mbps": 5.44,
+   "decompress_mbps": 93.25
   },
   {
    "compressor": "native",
@@ -1104,7 +1104,7 @@
    "level": 10,
    "out_size": 1693,
    "ratio": 0.4005,
-   "compress_mbps": 3.29,
+   "compress_mbps": 3.27,
    "decompress_mbps": null
   },
   {
@@ -4414,8 +4414,8 @@
    "level": 1,
    "out_size": 4259644,
    "ratio": 0.4179,
-   "compress_mbps": 69.75,
-   "decompress_mbps": 196.01
+   "compress_mbps": 69.73,
+   "decompress_mbps": 197.11
   },
   {
    "compressor": "native",
@@ -4424,8 +4424,8 @@
    "level": 2,
    "out_size": 3977395,
    "ratio": 0.3902,
-   "compress_mbps": 49.97,
-   "decompress_mbps": 216.73
+   "compress_mbps": 50.12,
+   "decompress_mbps": 217.46
   },
   {
    "compressor": "native",
@@ -4434,8 +4434,8 @@
    "level": 3,
    "out_size": 3945296,
    "ratio": 0.3871,
-   "compress_mbps": 44.14,
-   "decompress_mbps": 240.23
+   "compress_mbps": 44.43,
+   "decompress_mbps": 240.37
   },
   {
    "compressor": "native",
@@ -4444,8 +4444,8 @@
    "level": 4,
    "out_size": 3851998,
    "ratio": 0.3779,
-   "compress_mbps": 34.57,
-   "decompress_mbps": 240.46
+   "compress_mbps": 34.24,
+   "decompress_mbps": 238.41
   },
   {
    "compressor": "native",
@@ -4454,38 +4454,38 @@
    "level": 5,
    "out_size": 3840481,
    "ratio": 0.3768,
-   "compress_mbps": 28.99,
-   "decompress_mbps": 239.27
+   "compress_mbps": 28.84,
+   "decompress_mbps": 235.83
   },
   {
    "compressor": "native",
    "pattern": "silesia/dickens",
    "size": 10192446,
    "level": 6,
-   "out_size": 3847942,
-   "ratio": 0.3775,
-   "compress_mbps": 29.2,
-   "decompress_mbps": 242.87
+   "out_size": 3868436,
+   "ratio": 0.3795,
+   "compress_mbps": 25.89,
+   "decompress_mbps": 240.89
   },
   {
    "compressor": "native",
    "pattern": "silesia/dickens",
    "size": 10192446,
    "level": 7,
-   "out_size": 3834801,
-   "ratio": 0.3762,
-   "compress_mbps": 24.17,
-   "decompress_mbps": 243.5
+   "out_size": 3855625,
+   "ratio": 0.3783,
+   "compress_mbps": 21.87,
+   "decompress_mbps": 241.66
   },
   {
    "compressor": "native",
    "pattern": "silesia/dickens",
    "size": 10192446,
    "level": 8,
-   "out_size": 3833946,
-   "ratio": 0.3762,
-   "compress_mbps": 23.34,
-   "decompress_mbps": 244.88
+   "out_size": 3854820,
+   "ratio": 0.3782,
+   "compress_mbps": 21.11,
+   "decompress_mbps": 242.44
   },
   {
    "compressor": "native",
@@ -4494,8 +4494,8 @@
    "level": 9,
    "out_size": 3766619,
    "ratio": 0.3696,
-   "compress_mbps": 4.16,
-   "decompress_mbps": 254.77
+   "compress_mbps": 4.19,
+   "decompress_mbps": 254.78
   },
   {
    "compressor": "native",
@@ -4504,7 +4504,7 @@
    "level": 10,
    "out_size": 3711208,
    "ratio": 0.3641,
-   "compress_mbps": 2.48,
+   "compress_mbps": 2.45,
    "decompress_mbps": null
   },
   {
@@ -4514,8 +4514,8 @@
    "level": 1,
    "out_size": 21267086,
    "ratio": 0.4152,
-   "compress_mbps": 85.71,
-   "decompress_mbps": 213.41
+   "compress_mbps": 85.97,
+   "decompress_mbps": 213.55
   },
   {
    "compressor": "native",
@@ -4524,8 +4524,8 @@
    "level": 2,
    "out_size": 20802983,
    "ratio": 0.4061,
-   "compress_mbps": 68.35,
-   "decompress_mbps": 226.45
+   "compress_mbps": 68.83,
+   "decompress_mbps": 228.08
   },
   {
    "compressor": "native",
@@ -4534,8 +4534,8 @@
    "level": 3,
    "out_size": 20665485,
    "ratio": 0.4035,
-   "compress_mbps": 63.53,
-   "decompress_mbps": 235.02
+   "compress_mbps": 64.15,
+   "decompress_mbps": 235.0
   },
   {
    "compressor": "native",
@@ -4544,8 +4544,8 @@
    "level": 4,
    "out_size": 20356893,
    "ratio": 0.3974,
-   "compress_mbps": 54.43,
-   "decompress_mbps": 245.49
+   "compress_mbps": 53.87,
+   "decompress_mbps": 245.63
   },
   {
    "compressor": "native",
@@ -4554,38 +4554,38 @@
    "level": 5,
    "out_size": 20209289,
    "ratio": 0.3946,
-   "compress_mbps": 41.23,
-   "decompress_mbps": 247.69
+   "compress_mbps": 41.27,
+   "decompress_mbps": 246.85
   },
   {
    "compressor": "native",
    "pattern": "silesia/mozilla",
    "size": 51220480,
    "level": 6,
-   "out_size": 19175370,
-   "ratio": 0.3744,
-   "compress_mbps": 29.74,
-   "decompress_mbps": 256.92
+   "out_size": 18835212,
+   "ratio": 0.3677,
+   "compress_mbps": 27.39,
+   "decompress_mbps": 255.05
   },
   {
    "compressor": "native",
    "pattern": "silesia/mozilla",
    "size": 51220480,
    "level": 7,
-   "out_size": 19128614,
-   "ratio": 0.3735,
-   "compress_mbps": 23.68,
-   "decompress_mbps": 258.69
+   "out_size": 18790897,
+   "ratio": 0.3669,
+   "compress_mbps": 22.36,
+   "decompress_mbps": 259.56
   },
   {
    "compressor": "native",
    "pattern": "silesia/mozilla",
    "size": 51220480,
    "level": 8,
-   "out_size": 19118971,
-   "ratio": 0.3733,
-   "compress_mbps": 20.36,
-   "decompress_mbps": 258.52
+   "out_size": 18777212,
+   "ratio": 0.3666,
+   "compress_mbps": 19.22,
+   "decompress_mbps": 260.1
   },
   {
    "compressor": "native",
@@ -4594,8 +4594,8 @@
    "level": 9,
    "out_size": 18688252,
    "ratio": 0.3649,
-   "compress_mbps": 4.41,
-   "decompress_mbps": 260.56
+   "compress_mbps": 4.45,
+   "decompress_mbps": 254.54
   },
   {
    "compressor": "native",
@@ -4604,7 +4604,7 @@
    "level": 10,
    "out_size": 18541040,
    "ratio": 0.362,
-   "compress_mbps": 2.36,
+   "compress_mbps": 2.33,
    "decompress_mbps": null
   },
   {
@@ -4614,8 +4614,8 @@
    "level": 1,
    "out_size": 3864163,
    "ratio": 0.3876,
-   "compress_mbps": 86.1,
-   "decompress_mbps": 242.61
+   "compress_mbps": 85.71,
+   "decompress_mbps": 243.11
   },
   {
    "compressor": "native",
@@ -4624,8 +4624,8 @@
    "level": 2,
    "out_size": 3734957,
    "ratio": 0.3746,
-   "compress_mbps": 66.02,
-   "decompress_mbps": 248.15
+   "compress_mbps": 66.0,
+   "decompress_mbps": 250.72
   },
   {
    "compressor": "native",
@@ -4634,8 +4634,8 @@
    "level": 3,
    "out_size": 3708443,
    "ratio": 0.3719,
-   "compress_mbps": 56.28,
-   "decompress_mbps": 264.0
+   "compress_mbps": 55.72,
+   "decompress_mbps": 263.48
   },
   {
    "compressor": "native",
@@ -4644,8 +4644,8 @@
    "level": 4,
    "out_size": 3683603,
    "ratio": 0.3694,
-   "compress_mbps": 41.15,
-   "decompress_mbps": 249.92
+   "compress_mbps": 41.4,
+   "decompress_mbps": 248.05
   },
   {
    "compressor": "native",
@@ -4655,37 +4655,37 @@
    "out_size": 3677014,
    "ratio": 0.3688,
    "compress_mbps": 33.15,
-   "decompress_mbps": 241.95
+   "decompress_mbps": 241.18
   },
   {
    "compressor": "native",
    "pattern": "silesia/mr",
    "size": 9970564,
    "level": 6,
-   "out_size": 3588296,
-   "ratio": 0.3599,
-   "compress_mbps": 30.77,
-   "decompress_mbps": 249.94
+   "out_size": 3642579,
+   "ratio": 0.3653,
+   "compress_mbps": 29.15,
+   "decompress_mbps": 248.42
   },
   {
    "compressor": "native",
    "pattern": "silesia/mr",
    "size": 9970564,
    "level": 7,
-   "out_size": 3581081,
-   "ratio": 0.3592,
-   "compress_mbps": 25.19,
-   "decompress_mbps": 251.64
+   "out_size": 3636175,
+   "ratio": 0.3647,
+   "compress_mbps": 23.67,
+   "decompress_mbps": 250.97
   },
   {
    "compressor": "native",
    "pattern": "silesia/mr",
    "size": 9970564,
    "level": 8,
-   "out_size": 3581042,
-   "ratio": 0.3592,
-   "compress_mbps": 23.54,
-   "decompress_mbps": 258.41
+   "out_size": 3634763,
+   "ratio": 0.3645,
+   "compress_mbps": 22.2,
+   "decompress_mbps": 256.51
   },
   {
    "compressor": "native",
@@ -4694,8 +4694,8 @@
    "level": 9,
    "out_size": 3581643,
    "ratio": 0.3592,
-   "compress_mbps": 4.83,
-   "decompress_mbps": 268.25
+   "compress_mbps": 4.85,
+   "decompress_mbps": 268.26
   },
   {
    "compressor": "native",
@@ -4704,7 +4704,7 @@
    "level": 10,
    "out_size": 3513006,
    "ratio": 0.3523,
-   "compress_mbps": 2.96,
+   "compress_mbps": 2.95,
    "decompress_mbps": null
   },
   {
@@ -4714,8 +4714,8 @@
    "level": 1,
    "out_size": 3785443,
    "ratio": 0.1128,
-   "compress_mbps": 262.19,
-   "decompress_mbps": 676.78
+   "compress_mbps": 267.43,
+   "decompress_mbps": 677.75
   },
   {
    "compressor": "native",
@@ -4724,8 +4724,8 @@
    "level": 2,
    "out_size": 3761560,
    "ratio": 0.1121,
-   "compress_mbps": 166.31,
-   "decompress_mbps": 752.3
+   "compress_mbps": 166.07,
+   "decompress_mbps": 728.16
   },
   {
    "compressor": "native",
@@ -4734,8 +4734,8 @@
    "level": 3,
    "out_size": 3606997,
    "ratio": 0.1075,
-   "compress_mbps": 142.89,
-   "decompress_mbps": 833.8
+   "compress_mbps": 145.87,
+   "decompress_mbps": 835.85
   },
   {
    "compressor": "native",
@@ -4744,8 +4744,8 @@
    "level": 4,
    "out_size": 3201209,
    "ratio": 0.0954,
-   "compress_mbps": 135.92,
-   "decompress_mbps": 849.82
+   "compress_mbps": 138.39,
+   "decompress_mbps": 848.64
   },
   {
    "compressor": "native",
@@ -4754,38 +4754,38 @@
    "level": 5,
    "out_size": 3091564,
    "ratio": 0.0921,
-   "compress_mbps": 94.19,
-   "decompress_mbps": 923.95
+   "compress_mbps": 95.18,
+   "decompress_mbps": 923.71
   },
   {
    "compressor": "native",
    "pattern": "silesia/nci",
    "size": 33553445,
    "level": 6,
-   "out_size": 3112786,
-   "ratio": 0.0928,
-   "compress_mbps": 91.9,
-   "decompress_mbps": 907.05
+   "out_size": 3146242,
+   "ratio": 0.0938,
+   "compress_mbps": 80.85,
+   "decompress_mbps": 974.08
   },
   {
    "compressor": "native",
    "pattern": "silesia/nci",
    "size": 33553445,
    "level": 7,
-   "out_size": 3062338,
-   "ratio": 0.0913,
-   "compress_mbps": 67.77,
-   "decompress_mbps": 991.7
+   "out_size": 3095094,
+   "ratio": 0.0922,
+   "compress_mbps": 61.36,
+   "decompress_mbps": 987.0
   },
   {
    "compressor": "native",
    "pattern": "silesia/nci",
    "size": 33553445,
    "level": 8,
-   "out_size": 3045373,
-   "ratio": 0.0908,
-   "compress_mbps": 55.62,
-   "decompress_mbps": 995.47
+   "out_size": 3078031,
+   "ratio": 0.0917,
+   "compress_mbps": 51.02,
+   "decompress_mbps": 997.8
   },
   {
    "compressor": "native",
@@ -4794,8 +4794,8 @@
    "level": 9,
    "out_size": 3031645,
    "ratio": 0.0904,
-   "compress_mbps": 3.56,
-   "decompress_mbps": 1014.58
+   "compress_mbps": 3.6,
+   "decompress_mbps": 989.94
   },
   {
    "compressor": "native",
@@ -4804,7 +4804,7 @@
    "level": 10,
    "out_size": 2902212,
    "ratio": 0.0865,
-   "compress_mbps": 2.03,
+   "compress_mbps": 2.02,
    "decompress_mbps": null
   },
   {
@@ -4814,8 +4814,8 @@
    "level": 1,
    "out_size": 3357083,
    "ratio": 0.5457,
-   "compress_mbps": 60.55,
-   "decompress_mbps": 148.57
+   "compress_mbps": 60.54,
+   "decompress_mbps": 148.6
   },
   {
    "compressor": "native",
@@ -4824,8 +4824,8 @@
    "level": 2,
    "out_size": 3285077,
    "ratio": 0.534,
-   "compress_mbps": 49.75,
-   "decompress_mbps": 148.58
+   "compress_mbps": 49.37,
+   "decompress_mbps": 149.32
   },
   {
    "compressor": "native",
@@ -4834,8 +4834,8 @@
    "level": 3,
    "out_size": 3272746,
    "ratio": 0.532,
-   "compress_mbps": 47.34,
-   "decompress_mbps": 158.19
+   "compress_mbps": 47.24,
+   "decompress_mbps": 154.94
   },
   {
    "compressor": "native",
@@ -4844,8 +4844,8 @@
    "level": 4,
    "out_size": 3228052,
    "ratio": 0.5247,
-   "compress_mbps": 40.8,
-   "decompress_mbps": 165.48
+   "compress_mbps": 40.59,
+   "decompress_mbps": 165.74
   },
   {
    "compressor": "native",
@@ -4854,38 +4854,38 @@
    "level": 5,
    "out_size": 3223415,
    "ratio": 0.5239,
-   "compress_mbps": 36.76,
-   "decompress_mbps": 171.47
+   "compress_mbps": 36.52,
+   "decompress_mbps": 169.38
   },
   {
    "compressor": "native",
    "pattern": "silesia/ooffice",
    "size": 6152192,
    "level": 6,
-   "out_size": 3159592,
-   "ratio": 0.5136,
-   "compress_mbps": 26.91,
-   "decompress_mbps": 173.78
+   "out_size": 3082738,
+   "ratio": 0.5011,
+   "compress_mbps": 24.6,
+   "decompress_mbps": 172.93
   },
   {
    "compressor": "native",
    "pattern": "silesia/ooffice",
    "size": 6152192,
    "level": 7,
-   "out_size": 3156403,
-   "ratio": 0.5131,
-   "compress_mbps": 24.68,
-   "decompress_mbps": 173.93
+   "out_size": 3079404,
+   "ratio": 0.5005,
+   "compress_mbps": 22.9,
+   "decompress_mbps": 173.97
   },
   {
    "compressor": "native",
    "pattern": "silesia/ooffice",
    "size": 6152192,
    "level": 8,
-   "out_size": 3155458,
-   "ratio": 0.5129,
-   "compress_mbps": 23.54,
-   "decompress_mbps": 174.11
+   "out_size": 3078530,
+   "ratio": 0.5004,
+   "compress_mbps": 22.04,
+   "decompress_mbps": 173.17
   },
   {
    "compressor": "native",
@@ -4895,7 +4895,7 @@
    "out_size": 3049028,
    "ratio": 0.4956,
    "compress_mbps": 5.21,
-   "decompress_mbps": 178.34
+   "decompress_mbps": 177.54
   },
   {
    "compressor": "native",
@@ -4904,7 +4904,7 @@
    "level": 10,
    "out_size": 3022127,
    "ratio": 0.4912,
-   "compress_mbps": 3.24,
+   "compress_mbps": 3.22,
    "decompress_mbps": null
   },
   {
@@ -4914,8 +4914,8 @@
    "level": 1,
    "out_size": 3838828,
    "ratio": 0.3806,
-   "compress_mbps": 98.0,
-   "decompress_mbps": 265.65
+   "compress_mbps": 98.2,
+   "decompress_mbps": 266.26
   },
   {
    "compressor": "native",
@@ -4924,8 +4924,8 @@
    "level": 2,
    "out_size": 3792520,
    "ratio": 0.376,
-   "compress_mbps": 72.91,
-   "decompress_mbps": 274.45
+   "compress_mbps": 73.32,
+   "decompress_mbps": 274.61
   },
   {
    "compressor": "native",
@@ -4934,8 +4934,8 @@
    "level": 3,
    "out_size": 3783171,
    "ratio": 0.3751,
-   "compress_mbps": 70.01,
-   "decompress_mbps": 251.81
+   "compress_mbps": 68.29,
+   "decompress_mbps": 278.95
   },
   {
    "compressor": "native",
@@ -4944,8 +4944,8 @@
    "level": 4,
    "out_size": 3648458,
    "ratio": 0.3617,
-   "compress_mbps": 68.22,
-   "decompress_mbps": 277.36
+   "compress_mbps": 68.76,
+   "decompress_mbps": 277.17
   },
   {
    "compressor": "native",
@@ -4954,38 +4954,38 @@
    "level": 5,
    "out_size": 3648472,
    "ratio": 0.3617,
-   "compress_mbps": 63.07,
-   "decompress_mbps": 279.29
+   "compress_mbps": 63.35,
+   "decompress_mbps": 277.3
   },
   {
    "compressor": "native",
    "pattern": "silesia/osdb",
    "size": 10085684,
    "level": 6,
-   "out_size": 3648595,
-   "ratio": 0.3618,
-   "compress_mbps": 50.83,
-   "decompress_mbps": 287.32
+   "out_size": 3659614,
+   "ratio": 0.3629,
+   "compress_mbps": 42.03,
+   "decompress_mbps": 287.25
   },
   {
    "compressor": "native",
    "pattern": "silesia/osdb",
    "size": 10085684,
    "level": 7,
-   "out_size": 3648160,
-   "ratio": 0.3617,
-   "compress_mbps": 50.63,
-   "decompress_mbps": 293.09
+   "out_size": 3659139,
+   "ratio": 0.3628,
+   "compress_mbps": 41.76,
+   "decompress_mbps": 292.2
   },
   {
    "compressor": "native",
    "pattern": "silesia/osdb",
    "size": 10085684,
    "level": 8,
-   "out_size": 3648156,
-   "ratio": 0.3617,
-   "compress_mbps": 50.41,
-   "decompress_mbps": 293.06
+   "out_size": 3659136,
+   "ratio": 0.3628,
+   "compress_mbps": 41.64,
+   "decompress_mbps": 291.96
   },
   {
    "compressor": "native",
@@ -4994,8 +4994,8 @@
    "level": 9,
    "out_size": 3648156,
    "ratio": 0.3617,
-   "compress_mbps": 6.12,
-   "decompress_mbps": 307.78
+   "compress_mbps": 6.11,
+   "decompress_mbps": 305.09
   },
   {
    "compressor": "native",
@@ -5004,7 +5004,7 @@
    "level": 10,
    "out_size": 3647385,
    "ratio": 0.3616,
-   "compress_mbps": 3.49,
+   "compress_mbps": 3.42,
    "decompress_mbps": null
   },
   {
@@ -5014,8 +5014,8 @@
    "level": 1,
    "out_size": 2254442,
    "ratio": 0.3402,
-   "compress_mbps": 89.19,
-   "decompress_mbps": 248.19
+   "compress_mbps": 90.01,
+   "decompress_mbps": 247.27
   },
   {
    "compressor": "native",
@@ -5024,8 +5024,8 @@
    "level": 2,
    "out_size": 2044843,
    "ratio": 0.3086,
-   "compress_mbps": 60.87,
-   "decompress_mbps": 268.11
+   "compress_mbps": 60.56,
+   "decompress_mbps": 265.13
   },
   {
    "compressor": "native",
@@ -5034,8 +5034,8 @@
    "level": 3,
    "out_size": 1992105,
    "ratio": 0.3006,
-   "compress_mbps": 48.01,
-   "decompress_mbps": 297.87
+   "compress_mbps": 50.11,
+   "decompress_mbps": 297.13
   },
   {
    "compressor": "native",
@@ -5044,8 +5044,8 @@
    "level": 4,
    "out_size": 1890729,
    "ratio": 0.2853,
-   "compress_mbps": 35.31,
-   "decompress_mbps": 293.59
+   "compress_mbps": 35.47,
+   "decompress_mbps": 295.97
   },
   {
    "compressor": "native",
@@ -5054,37 +5054,37 @@
    "level": 5,
    "out_size": 1858234,
    "ratio": 0.2804,
-   "compress_mbps": 22.63,
-   "decompress_mbps": 291.8
+   "compress_mbps": 22.76,
+   "decompress_mbps": 295.85
   },
   {
    "compressor": "native",
    "pattern": "silesia/reymont",
    "size": 6627202,
    "level": 6,
-   "out_size": 1856238,
-   "ratio": 0.2801,
-   "compress_mbps": 27.71,
-   "decompress_mbps": 299.45
+   "out_size": 1860657,
+   "ratio": 0.2808,
+   "compress_mbps": 25.3,
+   "decompress_mbps": 305.59
   },
   {
    "compressor": "native",
    "pattern": "silesia/reymont",
    "size": 6627202,
    "level": 7,
-   "out_size": 1823963,
-   "ratio": 0.2752,
-   "compress_mbps": 17.25,
-   "decompress_mbps": 306.1
+   "out_size": 1830058,
+   "ratio": 0.2761,
+   "compress_mbps": 15.98,
+   "decompress_mbps": 309.73
   },
   {
    "compressor": "native",
    "pattern": "silesia/reymont",
    "size": 6627202,
    "level": 8,
-   "out_size": 1820116,
-   "ratio": 0.2746,
-   "compress_mbps": 14.86,
+   "out_size": 1826296,
+   "ratio": 0.2756,
+   "compress_mbps": 13.99,
    "decompress_mbps": 312.52
   },
   {
@@ -5094,8 +5094,8 @@
    "level": 9,
    "out_size": 1773469,
    "ratio": 0.2676,
-   "compress_mbps": 2.96,
-   "decompress_mbps": 327.64
+   "compress_mbps": 2.97,
+   "decompress_mbps": 326.46
   },
   {
    "compressor": "native",
@@ -5104,7 +5104,7 @@
    "level": 10,
    "out_size": 1718509,
    "ratio": 0.2593,
-   "compress_mbps": 1.59,
+   "compress_mbps": 1.6,
    "decompress_mbps": null
   },
   {
@@ -5114,8 +5114,8 @@
    "level": 1,
    "out_size": 6406301,
    "ratio": 0.2965,
-   "compress_mbps": 118.66,
-   "decompress_mbps": 339.02
+   "compress_mbps": 120.17,
+   "decompress_mbps": 340.41
   },
   {
    "compressor": "native",
@@ -5124,8 +5124,8 @@
    "level": 2,
    "out_size": 6102377,
    "ratio": 0.2824,
-   "compress_mbps": 89.14,
-   "decompress_mbps": 360.08
+   "compress_mbps": 89.66,
+   "decompress_mbps": 360.09
   },
   {
    "compressor": "native",
@@ -5134,8 +5134,8 @@
    "level": 3,
    "out_size": 6022184,
    "ratio": 0.2787,
-   "compress_mbps": 80.78,
-   "decompress_mbps": 375.15
+   "compress_mbps": 80.38,
+   "decompress_mbps": 376.32
   },
   {
    "compressor": "native",
@@ -5144,8 +5144,8 @@
    "level": 4,
    "out_size": 5880892,
    "ratio": 0.2722,
-   "compress_mbps": 68.29,
-   "decompress_mbps": 392.07
+   "compress_mbps": 68.95,
+   "decompress_mbps": 394.04
   },
   {
    "compressor": "native",
@@ -5154,38 +5154,38 @@
    "level": 5,
    "out_size": 5834363,
    "ratio": 0.27,
-   "compress_mbps": 53.5,
-   "decompress_mbps": 400.85
+   "compress_mbps": 53.58,
+   "decompress_mbps": 401.86
   },
   {
    "compressor": "native",
    "pattern": "silesia/samba",
    "size": 21606400,
    "level": 6,
-   "out_size": 5409868,
-   "ratio": 0.2504,
-   "compress_mbps": 44.53,
-   "decompress_mbps": 405.84
+   "out_size": 5406915,
+   "ratio": 0.2502,
+   "compress_mbps": 39.85,
+   "decompress_mbps": 408.23
   },
   {
    "compressor": "native",
    "pattern": "silesia/samba",
    "size": 21606400,
    "level": 7,
-   "out_size": 5393825,
-   "ratio": 0.2496,
-   "compress_mbps": 37.8,
-   "decompress_mbps": 405.24
+   "out_size": 5389990,
+   "ratio": 0.2495,
+   "compress_mbps": 33.79,
+   "decompress_mbps": 408.46
   },
   {
    "compressor": "native",
    "pattern": "silesia/samba",
    "size": 21606400,
    "level": 8,
-   "out_size": 5390050,
-   "ratio": 0.2495,
-   "compress_mbps": 35.06,
-   "decompress_mbps": 408.52
+   "out_size": 5387415,
+   "ratio": 0.2493,
+   "compress_mbps": 31.72,
+   "decompress_mbps": 410.13
   },
   {
    "compressor": "native",
@@ -5194,8 +5194,8 @@
    "level": 9,
    "out_size": 5236015,
    "ratio": 0.2423,
-   "compress_mbps": 4.78,
-   "decompress_mbps": 410.47
+   "compress_mbps": 4.92,
+   "decompress_mbps": 411.94
   },
   {
    "compressor": "native",
@@ -5214,8 +5214,8 @@
    "level": 1,
    "out_size": 5612204,
    "ratio": 0.7739,
-   "compress_mbps": 50.36,
-   "decompress_mbps": 147.51
+   "compress_mbps": 50.51,
+   "decompress_mbps": 148.41
   },
   {
    "compressor": "native",
@@ -5224,8 +5224,8 @@
    "level": 2,
    "out_size": 5533875,
    "ratio": 0.7631,
-   "compress_mbps": 41.78,
-   "decompress_mbps": 152.66
+   "compress_mbps": 41.64,
+   "decompress_mbps": 155.13
   },
   {
    "compressor": "native",
@@ -5234,8 +5234,8 @@
    "level": 3,
    "out_size": 5522436,
    "ratio": 0.7615,
-   "compress_mbps": 39.32,
-   "decompress_mbps": 156.5
+   "compress_mbps": 39.15,
+   "decompress_mbps": 157.31
   },
   {
    "compressor": "native",
@@ -5244,8 +5244,8 @@
    "level": 4,
    "out_size": 5494383,
    "ratio": 0.7576,
-   "compress_mbps": 34.03,
-   "decompress_mbps": 163.09
+   "compress_mbps": 33.71,
+   "decompress_mbps": 163.75
   },
   {
    "compressor": "native",
@@ -5254,38 +5254,38 @@
    "level": 5,
    "out_size": 5489807,
    "ratio": 0.757,
-   "compress_mbps": 31.91,
-   "decompress_mbps": 160.41
+   "compress_mbps": 31.94,
+   "decompress_mbps": 160.52
   },
   {
    "compressor": "native",
    "pattern": "silesia/sao",
    "size": 7251944,
    "level": 6,
-   "out_size": 5470520,
-   "ratio": 0.7544,
-   "compress_mbps": 24.42,
-   "decompress_mbps": 164.06
+   "out_size": 5336745,
+   "ratio": 0.7359,
+   "compress_mbps": 21.26,
+   "decompress_mbps": 164.47
   },
   {
    "compressor": "native",
    "pattern": "silesia/sao",
    "size": 7251944,
    "level": 7,
-   "out_size": 5463682,
-   "ratio": 0.7534,
-   "compress_mbps": 23.17,
-   "decompress_mbps": 161.72
+   "out_size": 5331731,
+   "ratio": 0.7352,
+   "compress_mbps": 20.38,
+   "decompress_mbps": 163.56
   },
   {
    "compressor": "native",
    "pattern": "silesia/sao",
    "size": 7251944,
    "level": 8,
-   "out_size": 5463761,
-   "ratio": 0.7534,
-   "compress_mbps": 22.87,
-   "decompress_mbps": 161.78
+   "out_size": 5330972,
+   "ratio": 0.7351,
+   "compress_mbps": 20.02,
+   "decompress_mbps": 164.65
   },
   {
    "compressor": "native",
@@ -5294,8 +5294,8 @@
    "level": 9,
    "out_size": 5284606,
    "ratio": 0.7287,
-   "compress_mbps": 5.3,
-   "decompress_mbps": 162.8
+   "compress_mbps": 5.41,
+   "decompress_mbps": 161.89
   },
   {
    "compressor": "native",
@@ -5304,7 +5304,7 @@
    "level": 10,
    "out_size": 5262387,
    "ratio": 0.7257,
-   "compress_mbps": 3.71,
+   "compress_mbps": 3.8,
    "decompress_mbps": null
   },
   {
@@ -5314,8 +5314,8 @@
    "level": 1,
    "out_size": 13727247,
    "ratio": 0.3311,
-   "compress_mbps": 88.29,
-   "decompress_mbps": 252.25
+   "compress_mbps": 89.34,
+   "decompress_mbps": 252.77
   },
   {
    "compressor": "native",
@@ -5324,8 +5324,8 @@
    "level": 2,
    "out_size": 12940398,
    "ratio": 0.3121,
-   "compress_mbps": 65.85,
-   "decompress_mbps": 274.23
+   "compress_mbps": 66.56,
+   "decompress_mbps": 274.44
   },
   {
    "compressor": "native",
@@ -5334,8 +5334,8 @@
    "level": 3,
    "out_size": 12703756,
    "ratio": 0.3064,
-   "compress_mbps": 60.34,
-   "decompress_mbps": 293.83
+   "compress_mbps": 60.96,
+   "decompress_mbps": 296.03
   },
   {
    "compressor": "native",
@@ -5344,8 +5344,8 @@
    "level": 4,
    "out_size": 12177338,
    "ratio": 0.2937,
-   "compress_mbps": 49.33,
-   "decompress_mbps": 298.42
+   "compress_mbps": 49.72,
+   "decompress_mbps": 299.28
   },
   {
    "compressor": "native",
@@ -5354,38 +5354,38 @@
    "level": 5,
    "out_size": 12051075,
    "ratio": 0.2907,
-   "compress_mbps": 38.05,
-   "decompress_mbps": 302.5
+   "compress_mbps": 38.36,
+   "decompress_mbps": 302.76
   },
   {
    "compressor": "native",
    "pattern": "silesia/webster",
    "size": 41458703,
    "level": 6,
-   "out_size": 12103573,
-   "ratio": 0.2919,
-   "compress_mbps": 39.53,
-   "decompress_mbps": 310.05
+   "out_size": 12178598,
+   "ratio": 0.2938,
+   "compress_mbps": 34.7,
+   "decompress_mbps": 311.04
   },
   {
    "compressor": "native",
    "pattern": "silesia/webster",
    "size": 41458703,
    "level": 7,
-   "out_size": 12027976,
-   "ratio": 0.2901,
-   "compress_mbps": 31.22,
-   "decompress_mbps": 298.48
+   "out_size": 12104809,
+   "ratio": 0.292,
+   "compress_mbps": 27.72,
+   "decompress_mbps": 312.69
   },
   {
    "compressor": "native",
    "pattern": "silesia/webster",
    "size": 41458703,
    "level": 8,
-   "out_size": 12019953,
-   "ratio": 0.2899,
-   "compress_mbps": 29.09,
-   "decompress_mbps": 307.73
+   "out_size": 12096772,
+   "ratio": 0.2918,
+   "compress_mbps": 26.29,
+   "decompress_mbps": 313.38
   },
   {
    "compressor": "native",
@@ -5395,7 +5395,7 @@
    "out_size": 11806641,
    "ratio": 0.2848,
    "compress_mbps": 3.95,
-   "decompress_mbps": 313.49
+   "decompress_mbps": 313.55
   },
   {
    "compressor": "native",
@@ -5404,7 +5404,7 @@
    "level": 10,
    "out_size": 11636945,
    "ratio": 0.2807,
-   "compress_mbps": 2.05,
+   "compress_mbps": 2.02,
    "decompress_mbps": null
   },
   {
@@ -5414,8 +5414,8 @@
    "level": 1,
    "out_size": 6438176,
    "ratio": 0.7597,
-   "compress_mbps": 45.07,
-   "decompress_mbps": 144.31
+   "compress_mbps": 45.59,
+   "decompress_mbps": 143.3
   },
   {
    "compressor": "native",
@@ -5424,8 +5424,8 @@
    "level": 2,
    "out_size": 6392101,
    "ratio": 0.7543,
-   "compress_mbps": 43.45,
-   "decompress_mbps": 147.17
+   "compress_mbps": 43.25,
+   "decompress_mbps": 145.14
   },
   {
    "compressor": "native",
@@ -5434,8 +5434,8 @@
    "level": 3,
    "out_size": 6392124,
    "ratio": 0.7543,
-   "compress_mbps": 43.51,
-   "decompress_mbps": 149.1
+   "compress_mbps": 43.61,
+   "decompress_mbps": 147.81
   },
   {
    "compressor": "native",
@@ -5444,8 +5444,8 @@
    "level": 4,
    "out_size": 6360604,
    "ratio": 0.7506,
-   "compress_mbps": 40.85,
-   "decompress_mbps": 133.57
+   "compress_mbps": 40.32,
+   "decompress_mbps": 132.69
   },
   {
    "compressor": "native",
@@ -5454,38 +5454,38 @@
    "level": 5,
    "out_size": 6360567,
    "ratio": 0.7506,
-   "compress_mbps": 40.55,
-   "decompress_mbps": 135.72
+   "compress_mbps": 40.37,
+   "decompress_mbps": 134.58
   },
   {
    "compressor": "native",
    "pattern": "silesia/x-ray",
    "size": 8474240,
    "level": 6,
-   "out_size": 6271790,
-   "ratio": 0.7401,
-   "compress_mbps": 20.41,
-   "decompress_mbps": 137.13
+   "out_size": 6036620,
+   "ratio": 0.7123,
+   "compress_mbps": 23.76,
+   "decompress_mbps": 136.42
   },
   {
    "compressor": "native",
    "pattern": "silesia/x-ray",
    "size": 8474240,
    "level": 7,
-   "out_size": 6271785,
-   "ratio": 0.7401,
-   "compress_mbps": 20.32,
-   "decompress_mbps": 137.49
+   "out_size": 6036614,
+   "ratio": 0.7123,
+   "compress_mbps": 23.63,
+   "decompress_mbps": 136.25
   },
   {
    "compressor": "native",
    "pattern": "silesia/x-ray",
    "size": 8474240,
    "level": 8,
-   "out_size": 6271785,
-   "ratio": 0.7401,
-   "compress_mbps": 20.39,
-   "decompress_mbps": 136.98
+   "out_size": 6036614,
+   "ratio": 0.7123,
+   "compress_mbps": 23.76,
+   "decompress_mbps": 136.38
   },
   {
    "compressor": "native",
@@ -5494,8 +5494,8 @@
    "level": 9,
    "out_size": 5952975,
    "ratio": 0.7025,
-   "compress_mbps": 6.27,
-   "decompress_mbps": 140.45
+   "compress_mbps": 6.3,
+   "decompress_mbps": 140.0
   },
   {
    "compressor": "native",
@@ -5504,7 +5504,7 @@
    "level": 10,
    "out_size": 5849157,
    "ratio": 0.6902,
-   "compress_mbps": 4.48,
+   "compress_mbps": 4.49,
    "decompress_mbps": null
   },
   {
@@ -5514,8 +5514,8 @@
    "level": 1,
    "out_size": 858525,
    "ratio": 0.1606,
-   "compress_mbps": 195.56,
-   "decompress_mbps": 470.47
+   "compress_mbps": 197.71,
+   "decompress_mbps": 506.67
   },
   {
    "compressor": "native",
@@ -5524,8 +5524,8 @@
    "level": 2,
    "out_size": 846807,
    "ratio": 0.1584,
-   "compress_mbps": 126.91,
-   "decompress_mbps": 574.86
+   "compress_mbps": 127.36,
+   "decompress_mbps": 569.2
   },
   {
    "compressor": "native",
@@ -5534,8 +5534,8 @@
    "level": 3,
    "out_size": 806798,
    "ratio": 0.1509,
-   "compress_mbps": 115.49,
-   "decompress_mbps": 636.64
+   "compress_mbps": 116.64,
+   "decompress_mbps": 631.34
   },
   {
    "compressor": "native",
@@ -5544,8 +5544,8 @@
    "level": 4,
    "out_size": 717301,
    "ratio": 0.1342,
-   "compress_mbps": 100.72,
-   "decompress_mbps": 627.76
+   "compress_mbps": 101.78,
+   "decompress_mbps": 624.61
   },
   {
    "compressor": "native",
@@ -5554,38 +5554,38 @@
    "level": 5,
    "out_size": 701552,
    "ratio": 0.1312,
-   "compress_mbps": 76.54,
-   "decompress_mbps": 681.08
+   "compress_mbps": 76.96,
+   "decompress_mbps": 608.18
   },
   {
    "compressor": "native",
    "pattern": "silesia/xml",
    "size": 5345280,
    "level": 6,
-   "out_size": 678560,
-   "ratio": 0.1269,
-   "compress_mbps": 72.84,
-   "decompress_mbps": 732.69
+   "out_size": 680793,
+   "ratio": 0.1274,
+   "compress_mbps": 63.44,
+   "decompress_mbps": 733.73
   },
   {
    "compressor": "native",
    "pattern": "silesia/xml",
    "size": 5345280,
    "level": 7,
-   "out_size": 663724,
-   "ratio": 0.1242,
-   "compress_mbps": 56.7,
-   "decompress_mbps": 740.83
+   "out_size": 666035,
+   "ratio": 0.1246,
+   "compress_mbps": 50.37,
+   "decompress_mbps": 732.63
   },
   {
    "compressor": "native",
    "pattern": "silesia/xml",
    "size": 5345280,
    "level": 8,
-   "out_size": 660492,
-   "ratio": 0.1236,
-   "compress_mbps": 49.47,
-   "decompress_mbps": 746.99
+   "out_size": 662896,
+   "ratio": 0.124,
+   "compress_mbps": 44.37,
+   "decompress_mbps": 752.55
   },
   {
    "compressor": "native",
@@ -5594,8 +5594,8 @@
    "level": 9,
    "out_size": 659422,
    "ratio": 0.1234,
-   "compress_mbps": 4.55,
-   "decompress_mbps": 650.17
+   "compress_mbps": 4.59,
+   "decompress_mbps": 642.57
   },
   {
    "compressor": "native",
@@ -5604,7 +5604,7 @@
    "level": 10,
    "out_size": 643101,
    "ratio": 0.1203,
-   "compress_mbps": 3.05,
+   "compress_mbps": 3.04,
    "decompress_mbps": null
   },
   {


### PR DESCRIPTION
This PR adds libdeflate's hash3-singleton to the split-tier lazy matcher (levels 6-8): a 32768-entry most-recent-position table keyed by the 15-bit 3-byte hash, maintained fused inside the USize insertion loop (one extra proven-bounds `uset` per inserted position, sharing the hash4 wide load), and consulted once per match-search position — a verified in-window length-3 candidate within `TOO_FAR = 4096` seeds the chain walk, restoring the length-3 matches a hash4-keyed chain cannot see. The lazy `pos+1` probe stays unseeded (a length-3 seed there is output-neutral: deferral acceptance requires strict improvement over a match that is already ≥ 3). Levels outside 6-8 are proven byte-identical (`useH3 = false` collapses the dispatcher to the existing loop); L9/L10 keep their own cache-build singleton.

This reopens #2742's plan item 1, which was measured and rejected on *unweighted geomean* — but the gain is concentrated exactly where the corpus bytes are: on weighted Silesia the L6 ratio moves 0.32236 → 0.31959 (−0.28 pp; x-ray −235 KB closing most of its gap to the hash3-capable codecs, mozilla −340 KB, sao −134 KB, ooffice −77 KB now *beating* miniz_oxide; match-dense text pays back tens of KB), and the same at L7/L8. The mixing-frontier test is decisive: the new L6 point (ratio 0.3196 at ~34 MB/s weighted) sits at a ratio today's frontier only reaches at ~14 MB/s via an L8↔L9 blend — far outside the hull — and it pulls the achievable frontier at miniz_oxide L6's ratio (0.3213) from ~28 to ~36 MB/s, putting that reference point inside our hull for the first time. Speed cost where gated on is file-dependent (mozilla −6%, dickens −11%, xml −14%, x-ray +34% — the length-3 references shrink its token stream), a price the frontier judgment already absorbs; gated-off levels are a measured wash.

The probe-seeded walk carries new obligations (`hash3Probe_spec`, `h3Seed_spec`, seed-general packed-walk decode lemmas) threaded through the boxed/packed/merged lockstep proofs; the emitted length-3 references are re-verified at emission as always, `lake exe test` (roundtrip + FFI conformance) is green, and there is no `sorry`. The production implementation reproduces the certified bench spike's out-bytes exactly on all 36 Silesia file×level rows.

🤖 Prepared with Claude Code