### PR TITLE
perf: re-grid L6/L7 for the hash3-singleton cost structure

### DIFF
--- a/Zip/Native/DeflateDynamic.lean
+++ b/Zip/Native/DeflateDynamic.lean
@@ -570,8 +570,12 @@ attribute [irreducible] symbolBitCount fixedBlockBytes dynBlockBytes dynBlockByt
     drops back to 64 on purpose**: the split tier starts there, and at equal
     cycles the observation-divergence split + a shallow chain beats a deep
     chain without the split — the block-split, not the chain, is L6's budget.
-    L7/L8 deepen the chain again within the split tier (256/512); past that
-    the chain saturates.
+    **L7 also sits at 64 since the post-singleton re-grid** (the hash3
+    singleton, gate-sweep over chain × gate × probe depth): with length-3
+    coverage paying the ratio bill, (chain 64, gate off, probe /2) lands at
+    0.3196 weighted-Silesia ratio — beyond what the old chain-256 L7 reached —
+    so the deep-chain point fell inside the new frontier and L7 adopts the old
+    L6 config wholesale. L8 keeps 512; past that the chain saturates.
 
     Level 1 is the `deflate_fast` corner (#2726): depth `4` is exactly zlib
     `-1`'s `max_chain`. A tokens-held-constant attribution on Silesia (see
@@ -592,8 +596,7 @@ def chainDepth (level : UInt8) : Nat :=
   else if level ≤ 3 then 32
   else if level ≤ 4 then 64
   else if level ≤ 5 then 128
-  else if level ≤ 6 then 64
-  else if level ≤ 7 then 256
+  else if level ≤ 7 then 64
   else if level ≤ 8 then 512
   else 1024
 
@@ -618,12 +621,16 @@ def insertCap (level : UInt8) : Nat :=
     long first match is rarely improved by deferral. Lower → more gating (faster,
     slightly worse ratio). `259 > 258` disables gating.
 
-    Only L4 keeps the gate (#2737 `mid-sweep`): disabling it gains ~16bp of
+    Only L4 keeps the full gate (#2737 `mid-sweep`): disabling it gains ~16bp of
     Silesia geomean ratio at *any* chain depth — more ratio per cycle than
     deepening the chain — so every level from 5 up spends its first budget
-    increment here. -/
+    increment here. **Exception: L6 gates at 64 since the hash3-singleton
+    re-grid** — with the singleton paying the ratio bill, (gate 64, ld/8)
+    buys +8% weighted speed for +0.09pp, the point that strictly dominates
+    miniz_oxide L6; L7 keeps the gate off and the old L6 ratio point. -/
 def goodMatch (level : UInt8) : Nat :=
   if level ≤ 4 then 8
+  else if level == 6 then 64
   else 259
 
 /-- Per-level `niceLen` cutoff (libdeflate `nice_match_length`, `deflate_compress.c`):
@@ -639,9 +646,11 @@ def goodMatch (level : UInt8) : Nat :=
     with the lazy gate on, every `niceLen` value times identically (the gate
     already skips the probes the cutoff would save) and lower cutoffs only
     cost ratio (nl30 +11bp, nl65 +3.5bp corpus-total), so the early-out is a
-    pure loss there. L5/L6 (gate off) sit at the measured knee `65` (nl30
+    pure loss there. L5–L7 sit at the measured knee `65` (nl30
     gains ~3% speed for +10bp — a poor trade; nl130/258 return ≤1bp for the
-    speed given up); L7's chain-256 walk earns `130`; L8 (the max split tier)
+    speed given up; since the post-singleton re-grid L7 runs the old L6
+    config, chain 64, so the old chain-256 `130` knee no longer applies);
+    L8 (the max split tier)
     disables the cutoff — nl130 times within 1% but emits more bytes, and L8's
     cadence guard promises old-L8 ratio parity. `258` (the max match length,
     ≥ every `maxLen`) disables the cutoff: the walk then stops only on the
@@ -653,8 +662,7 @@ def niceLen (level : UInt8) : Nat :=
   else if level ≤ 2 then 10
   else if level ≤ 3 then 14
   else if level ≤ 4 then 258
-  else if level ≤ 6 then 65
-  else if level ≤ 7 then 130
+  else if level ≤ 7 then 65
   else 258
 
 /-- Lazy lookahead probe depth (libdeflate `deflate_compress.c`): the second
@@ -666,12 +674,18 @@ def niceLen (level : UInt8) : Nat :=
     slack. The probe still runs — it is shallower, not skipped — so the ratio cost
     stays in the noise while the second walk's cycles roughly halve.
 
+    **L6 probes at `/8` since the post-singleton re-grid**: paired with the
+    `goodMatch = 64` gate it buys +8% weighted-Silesia speed for +0.09pp on a
+    tier where the hash3 singleton already banked −0.28pp — the resulting
+    (0.3205, ~36.5 MB/s) point strictly dominates miniz_oxide L6. L7 (the old
+    L6 config) stays at `/2`.
+
     Only levels ≥ 4 (the lazy `deflate_slow` tier) consult this; the greedy
     matcher (1–3) has no lookahead. Depth is a pure heuristic — the chain is
     re-verified at emission (`chainWalk_spec` holds for any fuel) — so any value
     keeps the encoder contracts. -/
 def lazyDepth (level : UInt8) : Nat :=
-  chainDepth level / 2
+  if level == 6 then chainDepth level / 8 else chainDepth level / 2
 
 /-- Enable the hash3 length-3 singleton at the split tier (levels 6–8). Our
     lazy matcher walks hash4-keyed chains only, so length-3 matches are invisible
@@ -1810,8 +1824,10 @@ def incompressiblePrescan (data : ByteArray) : Bool := Id.run do
       * **L5** — single-block, chain 128, gate off: 29.7 @ 0.3304 (dominates
         the old L7 = single-block chain 256: gate-off buys more ratio per
         cycle than chain depth).
-      * **L6** — split, chain 64, gate off: 20.1 @ 0.3245.
-      * **L7** — split, chain 256, gate off: 17.1 @ 0.3232.
+      * **L6** — split, chain 64, gate off: 20.1 @ 0.3245. (Since the
+        post-singleton re-grid: gate 64, probe /8 — 0.3205 @ ~36.5 weighted.)
+      * **L7** — split, chain 256, gate off: 17.1 @ 0.3232. (Since the
+        post-singleton re-grid: the old L6 config — 0.3196 @ ~33.7 weighted.)
       * **L8** — split + emitted fixed-cadence candidate, chain 512: 11.4 @
         0.3228 — the old L8's exact geomean ratio, ~20% faster.
 

--- a/bench/ZipGateSweep.lean
+++ b/bench/ZipGateSweep.lean
@@ -1,0 +1,98 @@
+import Zip
+
+/-! # gate-sweep — intermediate lazy-gate (`goodMatch`) + probe-depth sweep at the split tier
+
+The #2737 `mid-sweep` grid only ever tried `goodMatch ∈ {8, 259}` (full gating
+vs. disabled). This sweep probes the *intermediate* gate values at the L6 split
+config: with the gate at `g`, a first match of length ≥ `g` skips the lazy
+`pos+1` lookahead walk entirely — on match-rich files that deletes a large
+fraction of the second chain walks for a ratio cost that shrinks as `g` grows.
+Also grids the lazy probe depth (`lazyDepth`, production `chain/2`; #2781
+suggests `/4`) and deeper chains re-paired with a gate.
+
+Ratio rows go through the *exact* production L6–L8 dispatch (sized prep,
+base-vs-obs-split arbitration — the same code `deflateRaw` runs), so `out`
+is byte-for-byte what the shipped encoder would emit at that config.
+
+    <file>,<label>,<inBytes>,<outBytes>
+
+`--time` interleaves configs round-robin over the files (3 reps) and prints
+per-config corpus MB/s. Pin it (`bench/pin_core.sh`) on a quiet machine.
+
+Usage: lake -d bench exe gate-sweep [--time] <file> [<file> ...]
+-/
+
+open Zip.Native.Deflate
+
+namespace ZipGateSweep
+
+structure Cfg where
+  label : String
+  chain : Nat
+  gm : Nat
+  nl : Nat
+  lazyD : Nat
+  h3 : Bool := false
+
+/-- The grid: production L6 first (the certification row — must reproduce the
+    shipped L6 bytes), then gate values, probe depths, and deeper chains. -/
+def cfgs : List Cfg := [
+  ⟨"h3-prod-c64-gm259-ld32",  64, 259, 65, 32, true⟩,
+  ⟨"noh3-c64-gm259-ld32",     64, 259, 65, 32, false⟩,
+  ⟨"h3-ld16",                 64, 259, 65, 16, true⟩,
+  ⟨"h3-gm64",                 64,  64, 65, 32, true⟩,
+  ⟨"h3-gm64-ld16",            64,  64, 65, 16, true⟩,
+  ⟨"h3-gm32-ld16",            64,  32, 65, 16, true⟩,
+  ⟨"h3-c48-gm259-ld24",       48, 259, 65, 24, true⟩,
+  ⟨"h3-c48-gm64-ld16",        48,  64, 65, 16, true⟩,
+  ⟨"h3-c96-gm259-ld48",       96, 259, 65, 48, true⟩,
+  ⟨"h3-ld8",                  64, 259, 65,  8, true⟩,
+  ⟨"h3-gm64-ld8",             64,  64, 65,  8, true⟩ ]
+
+/-- One config through the exact production split-tier dispatch (the L6–L7
+    arm of `deflateRaw`: sized preps, obs-split arbitration, winner emitted). -/
+def runCfg (cfg : Cfg) (data : ByteArray) : Nat :=
+  let ptokens := lz77ChainLazyIterPMerged data cfg.chain 32768 1000000000 cfg.gm cfg.nl cfg.lazyD cfg.h3
+  let cuts := chooseSplitsHeuristicP ptokens data.size
+  let withObs : Nat × (Unit → ByteArray) :=
+    if cuts.isEmpty then deflateRawBasePPrep data ptokens
+    else
+      let obsFreqs := deflateObsSplitSizedFreqsP data ptokens cuts
+      let basePrep := deflateRawBasePPrepF data ptokens obsFreqs.2
+      if basePrep.1 < obsFreqs.1.1 then basePrep else obsFreqs.1
+  (withObs.2 ()).size
+
+def timeMain (paths : List String) : IO Unit := do
+  let mut files : List ByteArray := []
+  for path in paths do
+    files := files ++ [← IO.FS.readBinFile path]
+  let total := files.foldl (fun a f => a + f.size) 0
+  IO.println s!"corpus: {paths.length} files, {total} bytes"
+  for rep in [0:3] do
+    for cfg in cfgs do
+      let t0 ← IO.monoNanosNow
+      let mut sink := 0
+      for f in files do
+        sink := sink + runCfg cfg f
+      let t1 ← IO.monoNanosNow
+      let mbps := total.toFloat / 1048576.0 / ((t1 - t0).toFloat / 1.0e9)
+      IO.println s!"rep {rep} {cfg.label}: {mbps} MB/s (out {sink})"
+      (← IO.getStdout).flush
+
+def ratioMain (paths : List String) : IO Unit := do
+  for path in paths do
+    let data ← IO.FS.readBinFile path
+    let name := (path.splitOn "/").getLastD path
+    for cfg in cfgs do
+      IO.println s!"{name},{cfg.label},{data.size},{runCfg cfg data}"
+      (← IO.getStdout).flush
+    (← IO.getStderr).putStr "."
+  IO.eprintln " done"
+
+end ZipGateSweep
+
+def main (args : List String) : IO Unit := do
+  if args.head? == some "--time" then
+    ZipGateSweep.timeMain args.tail
+  else
+    ZipGateSweep.ratioMain args

--- a/bench/graphs/canterbury_compress_heatmap.svg
+++ b/bench/graphs/canterbury_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#pf601e60217)">
+   <g clip-path="url(#p67c96c403e)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJEElEQVR4nO3Yv6ql5R2G4b1m1k5mdCuD4CgKIhhIE7CKjfb2ORCPwMZjyBkEwV4EC2ublMFGQTBDEEQZdXT27Nmz/lgI9sL98ouL6zqC5+Pl+9a93s3hxw+OZ/yxXP08vWCdx6f5bMfrq+kJy2yevTs9YY0/PzW9YJ3NjekFazw53ffsVM/seP9/0xOWOc0TAwAYJLAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGLbe5v70xuWuN5fTU9Y5sU7r05PWObicHd6whKbRw+mJyzz6aPPpycs8dKfnp+esMz+sJuesMRPu8vpCcvsjvvpCUv8/ZmXpycs4wYLACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYtuL8zvTG5Y4bA/TE5a5OLs1PWGdH+5NL1ji+OjB9IRl3njlzekJS1zuTvfMHp7os/3l4m/TE5a53uymJyxx/Oo/0xOWcYMFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAse3tmxfTG5a42l9OT1hnc8JdfOvZ6QVLbE74zM53u+kJS5zymT29Pc337Jvrr6cnLLM7XE9PWOLlp+9MT1jmdL8gAABDBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDENvvP3jtOj4DfHA7TC+BXN/z//MPx/eD/iC8IAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxLbvfHtvesMSDx7vpycs8++vf5qesMxH/3hresISL9x+ZXrCMq//6/3pCUu8/dpz0xOW+fL7R9MTlri9vTk9YZkPP/5iesISl/98d3rCMm6wAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAILbZHT45To9YYX/YTU9Y5sbmdLv45tXl9IQ1bm6nF6zz8P70giX2d16cnrDM4XiYnrDE+eZ037Mnx9P8TTvfneZznZ25wQIAyAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAIDYdn/YTW9YYne4np6wzO0H96cnrPPzd9MLljheP5mesMzmpb9OT+B3ery/nJ6wxPnZrekJy5xf/jA9YYnjt/+dnrCMGywAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCI/QKZEIXgifwRoAAAAABJRU5ErkJggg==" id="imagea05c2d15cd" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJGElEQVR4nO3YwYqdZx3H8ZzkTJvYMQbRGAyUQrspFFy1m3bfvRfiFbjxGrwDKXQvggvXblyKGwulJUggVNKYTmamM2fOcSF4Bd+Hf3P4fK7g9/Lwvud7ns3+P58fbvF6uTybXrDO98f5bIery+kJy2zuP5yesMabP5pesM7m9vSCNa6P9z071jM7PP/X9IRljvPEAAAGCSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgNj2yeb59IYlrm4upycs8+jBO9MTljndP5yesMTm4uX0hGX+evHP6QlL/PKNn09PWOZmv5uesMR3u/PpCcvsDjfTE5b48MePpycs4wYLACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYtvTkwfTG5bYb/fTE5Y5vXV3esI6L55ML1jicPFyesIyH7398fSEJc53x3tmr4702d47/WB6wjJXm930hCUOX/99esIybrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgtr1353R6wxKXN+fTE9bZHHEX370/vWCJzRGf2cluNz1hiWM+s7e2x/mePbt6Oj1hmd3+anrCEo/fejA9YZnj/YIAAAwRWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABDb3Pzjd4fpEfB/+/30Avif2/5/vnZ8P/gB8QUBAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACA2PY33zyZ3rDEy+9vpics87en301PWOZPv/5kesISv7j39vSEZX71h8+mJyzx6bs/nZ6wzJffXkxPWOLe9s70hGX++Ocvpicscf77305PWMYNFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQ2u/1fDtMjVrjZ76YnLHN7c7xdfOfyfHrCGne20wvWefV8esESNw8eTU9YZn/YT09Y4mRzvO/Z9eE4f9NOdsf5XLduucECAMgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACA2PZidza9YYnd/mp6wjI/OTufnrDO2b+nFyxxuLqenrDM5vH70xOWuD7ib8jZ9YvpCUv87M1H0xOWOXn1YnrCEodnX01PWMYNFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMT+C8VmiOrLMfHaAAAAAElFTkSuQmCC" id="imagedddf3eaf16" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="me27a46d47f" d="M 0 0 
+       <path id="m5f96e629e9" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#me27a46d47f" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5f96e629e9" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#me27a46d47f" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5f96e629e9" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#me27a46d47f" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5f96e629e9" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#me27a46d47f" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5f96e629e9" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#me27a46d47f" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5f96e629e9" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#me27a46d47f" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5f96e629e9" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#me27a46d47f" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5f96e629e9" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#me27a46d47f" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5f96e629e9" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#me27a46d47f" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5f96e629e9" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#me27a46d47f" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5f96e629e9" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#me27a46d47f" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5f96e629e9" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="m0bb0ea8b5b" d="M 0 0 
+       <path id="m7c1124f498" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m0bb0ea8b5b" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7c1124f498" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m0bb0ea8b5b" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7c1124f498" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m0bb0ea8b5b" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7c1124f498" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m0bb0ea8b5b" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7c1124f498" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m0bb0ea8b5b" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7c1124f498" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m0bb0ea8b5b" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7c1124f498" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m0bb0ea8b5b" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7c1124f498" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m0bb0ea8b5b" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7c1124f498" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1303,7 +1303,7 @@ L 527.435033 49.4355
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_20">
-    <!-- +11 -->
+    <!-- +23 -->
     <g transform="translate(108.442626 68.904519) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-2b" d="M 2944 4013 
@@ -1321,22 +1321,54 @@ L 2419 4013
 L 2944 4013 
 z
 " transform="scale(0.015625)"/>
+      <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_21">
-    <!-- +19 -->
+    <!-- +31 -->
     <g transform="translate(147.693424 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_22">
-    <!-- -49 -->
+    <!-- -47 -->
     <g transform="translate(188.495082 68.904519) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
@@ -1358,16 +1390,6 @@ L 313 1709
 L 2253 4666 
 z
 " transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_23">
-    <!-- -79 -->
-    <g transform="translate(227.74588 68.904519) scale(0.065 -0.065)">
-     <defs>
       <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
 L 3525 4397 
@@ -1380,13 +1402,13 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
     </g>
    </g>
-   <g id="text_24">
-    <!-- -89 -->
-    <g transform="translate(266.996679 68.904519) scale(0.065 -0.065)">
+   <g id="text_23">
+    <!-- -78 -->
+    <g transform="translate(227.74588 68.904519) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -1429,81 +1451,55 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_24">
+    <!-- -89 -->
+    <g transform="translate(266.996679 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_25">
-    <!-- -27 -->
+    <!-- -22 -->
     <g transform="translate(306.247477 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_26">
-    <!-- +7 -->
-    <g transform="translate(346.015229 68.904519) scale(0.065 -0.065)">
+    <!-- +18 -->
+    <g transform="translate(343.947416 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_27">
-    <!-- +27 -->
+    <!-- +43 -->
     <g transform="translate(383.198215 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_28">
-    <!-- -13 -->
-    <g transform="translate(423.999873 68.904519) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-33" d="M 2597 2516 
-Q 3050 2419 3304 2112 
-Q 3559 1806 3559 1356 
-Q 3559 666 3084 287 
-Q 2609 -91 1734 -91 
-Q 1441 -91 1130 -33 
-Q 819 25 488 141 
-L 488 750 
-Q 750 597 1062 519 
-Q 1375 441 1716 441 
-Q 2309 441 2620 675 
-Q 2931 909 2931 1356 
-Q 2931 1769 2642 2001 
-Q 2353 2234 1838 2234 
-L 1294 2234 
-L 1294 2753 
-L 1863 2753 
-Q 2328 2753 2575 2939 
-Q 2822 3125 2822 3475 
-Q 2822 3834 2567 4026 
-Q 2313 4219 1838 4219 
-Q 1578 4219 1281 4162 
-Q 984 4106 628 3988 
-L 628 4550 
-Q 988 4650 1302 4700 
-Q 1616 4750 1894 4750 
-Q 2613 4750 3031 4423 
-Q 3450 4097 3450 3541 
-Q 3450 3153 3228 2886 
-Q 3006 2619 2597 2516 
-z
-" transform="scale(0.015625)"/>
-     </defs>
+    <!-- -5 -->
+    <g transform="translate(426.067685 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_29">
-    <!-- -39 -->
+    <!-- -37 -->
     <g transform="translate(463.250671 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_30">
@@ -2182,18 +2178,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="imagea1795c90b9" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
+iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="image45032a71e2" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="mdfff538013" d="M 0 0 
+       <path id="m1840cbef8e" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mdfff538013" x="547.779688" y="276.293905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1840cbef8e" x="547.779688" y="276.293905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
@@ -2216,7 +2212,7 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#mdfff538013" x="547.779688" y="247.808905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1840cbef8e" x="547.779688" y="247.808905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
@@ -2230,7 +2226,7 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#mdfff538013" x="547.779688" y="219.323905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1840cbef8e" x="547.779688" y="219.323905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
@@ -2244,7 +2240,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#mdfff538013" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1840cbef8e" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
@@ -2257,7 +2253,7 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mdfff538013" x="547.779688" y="162.353904" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1840cbef8e" x="547.779688" y="162.353904" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_112">
@@ -2270,7 +2266,7 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#mdfff538013" x="547.779688" y="133.868904" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1840cbef8e" x="547.779688" y="133.868904" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
@@ -2283,7 +2279,7 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mdfff538013" x="547.779688" y="105.383904" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1840cbef8e" x="547.779688" y="105.383904" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
@@ -2944,8 +2940,8 @@ z
    </g>
   </g>
   <g id="text_117">
-   <!-- 2026-07-08T22:12:55Z  ·  Linux chungus2 x86_64  ·  commit 30251fb3  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(17.380078 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-08T22:38:10Z  ·  Linux chungus2 x86_64  ·  commit f6be9ada  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(17.622344 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -3017,11 +3013,11 @@ z
     <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3061,109 +3057,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3262.744141 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3326.367188 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3389.990234 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3425.195312 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3488.671875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3552.294922 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3584.082031 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3615.869141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3647.65625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3679.443359 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3711.230469 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3739.013672 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3800.537109 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3861.816406 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3925.195312 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3988.671875 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4027.535156 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4088.716797 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4147.896484 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4209.419922 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4250.533203 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4284.224609 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4312.007812 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4373.53125 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4434.810547 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4498.189453 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4561.8125 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4595.503906 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4654.683594 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4718.306641 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4750.09375 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4813.716797 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4877.339844 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4909.126953 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4972.75 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5008.833984 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5047.697266 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5102.677734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5166.300781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5198.087891 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5229.875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5261.662109 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5293.449219 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5325.236328 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5364.445312 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5427.824219 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5466.6875 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5527.869141 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5591.248047 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5654.724609 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5718.103516 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5781.580078 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5844.958984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5884.167969 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5915.955078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5999.744141 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6031.53125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6128.943359 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6190.466797 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6253.943359 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6281.726562 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6343.005859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6406.384766 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6438.171875 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6490.271484 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6553.650391 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6614.929688 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6678.40625 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6730.505859 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6793.884766 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6855.066406 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6894.275391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6927.966797 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6959.753906 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7000.867188 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7062.146484 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7101.355469 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7129.138672 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7190.320312 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7222.107422 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7249.890625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7301.990234 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7333.777344 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7397.253906 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7458.777344 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7497.986328 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7559.509766 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7598.873047 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7696.285156 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7724.068359 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7787.447266 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7815.230469 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7867.330078 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7906.539062 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7934.322266 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3107.080078 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3170.703125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3234.179688 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3295.703125 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3359.326172 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3420.605469 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3484.082031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3545.361328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3577.148438 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3608.935547 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3640.722656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3672.509766 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3704.296875 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3732.080078 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3793.603516 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3854.882812 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3918.261719 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3981.738281 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4020.601562 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4081.783203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4140.962891 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4202.486328 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4243.599609 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4277.291016 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4305.074219 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4366.597656 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4427.876953 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4491.255859 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4554.878906 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4588.570312 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4647.75 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4711.373047 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4743.160156 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4806.783203 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4870.40625 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4902.193359 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4965.816406 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5001.900391 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5040.763672 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5095.744141 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5159.367188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5191.154297 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5222.941406 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5254.728516 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5286.515625 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5318.302734 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5357.511719 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5420.890625 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5459.753906 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5520.935547 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5584.314453 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5647.791016 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5711.169922 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5774.646484 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5838.025391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5877.234375 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5909.021484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5992.810547 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6024.597656 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6122.009766 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6183.533203 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6247.009766 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6274.792969 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6336.072266 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6399.451172 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6431.238281 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6483.337891 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6546.716797 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6607.996094 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6671.472656 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6723.572266 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6786.951172 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6848.132812 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6887.341797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6921.033203 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6952.820312 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6993.933594 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7055.212891 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7094.421875 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7122.205078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7183.386719 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7215.173828 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7242.957031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7295.056641 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7326.84375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7390.320312 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7451.84375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7491.052734 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7552.576172 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7591.939453 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7689.351562 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7717.134766 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7780.513672 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7808.296875 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7860.396484 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7899.605469 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7927.388672 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pf601e60217">
+  <clipPath id="p67c96c403e">
    <rect x="95.67625" y="49.4355" width="431.758783" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_compress_pareto.svg
+++ b/bench/graphs/canterbury_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 79.118387 412.80375 
 L 79.118387 48.323125 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="me5c803b0c3" d="M 0 0 
+       <path id="m315f0f6b65" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#me5c803b0c3" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m315f0f6b65" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -161,11 +161,11 @@ z
      <g id="line2d_3">
       <path d="M 166.481434 412.80375 
 L 166.481434 48.323125 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#me5c803b0c3" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m315f0f6b65" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -216,11 +216,11 @@ z
      <g id="line2d_5">
       <path d="M 253.844481 412.80375 
 L 253.844481 48.323125 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#me5c803b0c3" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m315f0f6b65" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -237,11 +237,11 @@ L 253.844481 48.323125
      <g id="line2d_7">
       <path d="M 341.207528 412.80375 
 L 341.207528 48.323125 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#me5c803b0c3" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m315f0f6b65" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -279,11 +279,11 @@ z
      <g id="line2d_9">
       <path d="M 428.570575 412.80375 
 L 428.570575 48.323125 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#me5c803b0c3" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m315f0f6b65" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -332,11 +332,11 @@ z
      <g id="line2d_11">
       <path d="M 515.933622 412.80375 
 L 515.933622 48.323125 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#me5c803b0c3" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m315f0f6b65" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -353,11 +353,11 @@ L 515.933622 48.323125
      <g id="line2d_13">
       <path d="M 603.296669 412.80375 
 L 603.296669 48.323125 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#me5c803b0c3" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m315f0f6b65" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -854,16 +854,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 347.786382 
 L 637.2 347.786382 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="m1dd6e24117" d="M 0 0 
+       <path id="mbe9e66397f" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m1dd6e24117" x="49.078125" y="347.786382" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbe9e66397f" x="49.078125" y="347.786382" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -895,11 +895,11 @@ z
      <g id="line2d_17">
       <path d="M 49.078125 238.646289 
 L 637.2 238.646289 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m1dd6e24117" x="49.078125" y="238.646289" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbe9e66397f" x="49.078125" y="238.646289" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -915,11 +915,11 @@ L 637.2 238.646289
      <g id="line2d_19">
       <path d="M 49.078125 129.506196 
 L 637.2 129.506196 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m1dd6e24117" x="49.078125" y="129.506196" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbe9e66397f" x="49.078125" y="129.506196" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -935,16 +935,16 @@ L 637.2 129.506196
      <g id="line2d_21">
       <path d="M 49.078125 404.853417 
 L 637.2 404.853417 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="m361227877a" d="M 0 0 
+       <path id="md960c07558" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m361227877a" x="49.078125" y="404.853417" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md960c07558" x="49.078125" y="404.853417" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -952,11 +952,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 391.217592 
 L 637.2 391.217592 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m361227877a" x="49.078125" y="391.217592" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md960c07558" x="49.078125" y="391.217592" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -964,11 +964,11 @@ L 637.2 391.217592
      <g id="line2d_25">
       <path d="M 49.078125 380.640824 
 L 637.2 380.640824 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m361227877a" x="49.078125" y="380.640824" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md960c07558" x="49.078125" y="380.640824" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -976,11 +976,11 @@ L 637.2 380.640824
      <g id="line2d_27">
       <path d="M 49.078125 371.998975 
 L 637.2 371.998975 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m361227877a" x="49.078125" y="371.998975" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md960c07558" x="49.078125" y="371.998975" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -988,11 +988,11 @@ L 637.2 371.998975
      <g id="line2d_29">
       <path d="M 49.078125 364.692396 
 L 637.2 364.692396 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m361227877a" x="49.078125" y="364.692396" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md960c07558" x="49.078125" y="364.692396" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1000,11 +1000,11 @@ L 637.2 364.692396
      <g id="line2d_31">
       <path d="M 49.078125 358.36315 
 L 637.2 358.36315 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m361227877a" x="49.078125" y="358.36315" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md960c07558" x="49.078125" y="358.36315" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1012,11 +1012,11 @@ L 637.2 358.36315
      <g id="line2d_33">
       <path d="M 49.078125 352.780359 
 L 637.2 352.780359 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m361227877a" x="49.078125" y="352.780359" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md960c07558" x="49.078125" y="352.780359" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1024,11 +1024,11 @@ L 637.2 352.780359
      <g id="line2d_35">
       <path d="M 49.078125 314.93194 
 L 637.2 314.93194 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m361227877a" x="49.078125" y="314.93194" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md960c07558" x="49.078125" y="314.93194" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1036,11 +1036,11 @@ L 637.2 314.93194
      <g id="line2d_37">
       <path d="M 49.078125 295.713324 
 L 637.2 295.713324 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m361227877a" x="49.078125" y="295.713324" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md960c07558" x="49.078125" y="295.713324" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1048,11 +1048,11 @@ L 637.2 295.713324
      <g id="line2d_39">
       <path d="M 49.078125 282.077499 
 L 637.2 282.077499 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m361227877a" x="49.078125" y="282.077499" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md960c07558" x="49.078125" y="282.077499" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1060,11 +1060,11 @@ L 637.2 282.077499
      <g id="line2d_41">
       <path d="M 49.078125 271.500731 
 L 637.2 271.500731 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m361227877a" x="49.078125" y="271.500731" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md960c07558" x="49.078125" y="271.500731" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1072,11 +1072,11 @@ L 637.2 271.500731
      <g id="line2d_43">
       <path d="M 49.078125 262.858882 
 L 637.2 262.858882 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m361227877a" x="49.078125" y="262.858882" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md960c07558" x="49.078125" y="262.858882" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1084,11 +1084,11 @@ L 637.2 262.858882
      <g id="line2d_45">
       <path d="M 49.078125 255.552304 
 L 637.2 255.552304 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m361227877a" x="49.078125" y="255.552304" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md960c07558" x="49.078125" y="255.552304" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1096,11 +1096,11 @@ L 637.2 255.552304
      <g id="line2d_47">
       <path d="M 49.078125 249.223057 
 L 637.2 249.223057 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m361227877a" x="49.078125" y="249.223057" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md960c07558" x="49.078125" y="249.223057" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1108,11 +1108,11 @@ L 637.2 249.223057
      <g id="line2d_49">
       <path d="M 49.078125 243.640266 
 L 637.2 243.640266 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m361227877a" x="49.078125" y="243.640266" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md960c07558" x="49.078125" y="243.640266" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1120,11 +1120,11 @@ L 637.2 243.640266
      <g id="line2d_51">
       <path d="M 49.078125 205.791848 
 L 637.2 205.791848 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m361227877a" x="49.078125" y="205.791848" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md960c07558" x="49.078125" y="205.791848" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1132,11 +1132,11 @@ L 637.2 205.791848
      <g id="line2d_53">
       <path d="M 49.078125 186.573231 
 L 637.2 186.573231 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#m361227877a" x="49.078125" y="186.573231" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md960c07558" x="49.078125" y="186.573231" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1144,11 +1144,11 @@ L 637.2 186.573231
      <g id="line2d_55">
       <path d="M 49.078125 172.937406 
 L 637.2 172.937406 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#m361227877a" x="49.078125" y="172.937406" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md960c07558" x="49.078125" y="172.937406" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1156,11 +1156,11 @@ L 637.2 172.937406
      <g id="line2d_57">
       <path d="M 49.078125 162.360638 
 L 637.2 162.360638 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#m361227877a" x="49.078125" y="162.360638" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md960c07558" x="49.078125" y="162.360638" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1168,11 +1168,11 @@ L 637.2 162.360638
      <g id="line2d_59">
       <path d="M 49.078125 153.71879 
 L 637.2 153.71879 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#m361227877a" x="49.078125" y="153.71879" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md960c07558" x="49.078125" y="153.71879" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1180,11 +1180,11 @@ L 637.2 153.71879
      <g id="line2d_61">
       <path d="M 49.078125 146.412211 
 L 637.2 146.412211 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#m361227877a" x="49.078125" y="146.412211" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md960c07558" x="49.078125" y="146.412211" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1192,11 +1192,11 @@ L 637.2 146.412211
      <g id="line2d_63">
       <path d="M 49.078125 140.082964 
 L 637.2 140.082964 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#m361227877a" x="49.078125" y="140.082964" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md960c07558" x="49.078125" y="140.082964" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1204,11 +1204,11 @@ L 637.2 140.082964
      <g id="line2d_65">
       <path d="M 49.078125 134.500173 
 L 637.2 134.500173 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#m361227877a" x="49.078125" y="134.500173" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md960c07558" x="49.078125" y="134.500173" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1216,11 +1216,11 @@ L 637.2 134.500173
      <g id="line2d_67">
       <path d="M 49.078125 96.651755 
 L 637.2 96.651755 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_68">
       <g>
-       <use xlink:href="#m361227877a" x="49.078125" y="96.651755" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md960c07558" x="49.078125" y="96.651755" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1228,11 +1228,11 @@ L 637.2 96.651755
      <g id="line2d_69">
       <path d="M 49.078125 77.433138 
 L 637.2 77.433138 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_70">
       <g>
-       <use xlink:href="#m361227877a" x="49.078125" y="77.433138" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md960c07558" x="49.078125" y="77.433138" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1240,11 +1240,11 @@ L 637.2 77.433138
      <g id="line2d_71">
       <path d="M 49.078125 63.797313 
 L 637.2 63.797313 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_72">
       <g>
-       <use xlink:href="#m361227877a" x="49.078125" y="63.797313" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md960c07558" x="49.078125" y="63.797313" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1252,11 +1252,11 @@ L 637.2 63.797313
      <g id="line2d_73">
       <path d="M 49.078125 53.220545 
 L 637.2 53.220545 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_74">
       <g>
-       <use xlink:href="#m361227877a" x="49.078125" y="53.220545" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md960c07558" x="49.078125" y="53.220545" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1378,7 +1378,7 @@ L 637.2 48.323125
    </g>
    <g id="text_13">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(294.783126 143.992231) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(294.783126 144.052867) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1410,7 +1410,7 @@ z
    </g>
    <g id="text_14">
     <!-- L10 -->
-    <g style="fill: #d62728" transform="translate(104.775489 295.307177) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(104.775489 294.729413) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1732,23 +1732,23 @@ z
    </g>
    <g id="line2d_75">
     <defs>
-     <path id="m40a142740f" d="M -2.5 2.5 
+     <path id="m2845fccc9c" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p8c12040a6d)">
-     <use xlink:href="#m40a142740f" x="355.479835" y="95.382063" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m40a142740f" x="308.273931" y="102.754513" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m40a142740f" x="271.230161" y="116.528062" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m40a142740f" x="217.83458" y="120.013651" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m40a142740f" x="177.077692" y="138.43462" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m40a142740f" x="162.880539" y="157.778627" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m40a142740f" x="160.741445" y="165.196647" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m40a142740f" x="153.966678" y="183.405761" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m40a142740f" x="151.589614" y="194.488118" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p61f30a6cbc)">
+     <use xlink:href="#m2845fccc9c" x="355.479835" y="95.382063" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2845fccc9c" x="308.273931" y="102.754513" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2845fccc9c" x="271.230161" y="116.528062" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2845fccc9c" x="217.83458" y="120.013651" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2845fccc9c" x="177.077692" y="138.43462" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2845fccc9c" x="162.880539" y="157.778627" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2845fccc9c" x="160.741445" y="165.196647" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2845fccc9c" x="153.966678" y="183.405761" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2845fccc9c" x="151.589614" y="194.488118" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_76">
@@ -1801,7 +1801,7 @@ L 311.2243 102.325849
 L 310.240844 102.469168 
 L 309.257387 102.612055 
 L 308.273931 102.754513 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_77">
     <path d="M 308.273931 102.754513 
@@ -1853,7 +1853,7 @@ L 273.545396 115.775058
 L 272.773651 116.027391 
 L 272.001906 116.278388 
 L 271.230161 116.528062 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_78">
     <path d="M 271.230161 116.528062 
@@ -1905,7 +1905,7 @@ L 221.171803 119.803152
 L 220.059395 119.873422 
 L 218.946988 119.943588 
 L 217.83458 120.013651 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_79">
     <path d="M 217.83458 120.013651 
@@ -1957,7 +1957,7 @@ L 179.624997 137.470928
 L 178.775895 137.79434 
 L 177.926794 138.115561 
 L 177.077692 138.43462 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_80">
     <path d="M 177.077692 138.43462 
@@ -2009,7 +2009,7 @@ L 163.767861 156.775388
 L 163.472087 157.112166 
 L 163.176313 157.446568 
 L 162.880539 157.778627 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_81">
     <path d="M 162.880539 157.778627 
@@ -2061,7 +2061,7 @@ L 160.875139 164.765525
 L 160.830574 164.909668 
 L 160.78601 165.053375 
 L 160.741445 165.196647 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_82">
     <path d="M 160.741445 165.196647 
@@ -2113,7 +2113,7 @@ L 154.390101 182.45125
 L 154.24896 182.771561 
 L 154.107819 183.089721 
 L 153.966678 183.405761 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_83">
     <path d="M 153.966678 183.405761 
@@ -2165,26 +2165,26 @@ L 151.73818 193.866427
 L 151.688658 194.074564 
 L 151.639136 194.281792 
 L 151.589614 194.488118 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_84">
     <defs>
-     <path id="m5c81e47066" d="M 0 -2.5 
+     <path id="mf1ab5fe0cf" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p8c12040a6d)">
-     <use xlink:href="#m5c81e47066" x="531.649087" y="75.963093" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5c81e47066" x="283.721324" y="99.020035" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5c81e47066" x="218.882044" y="121.069315" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5c81e47066" x="187.447228" y="127.10685" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5c81e47066" x="176.342474" y="138.36311" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5c81e47066" x="163.054314" y="161.312135" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5c81e47066" x="162.210539" y="168.753955" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5c81e47066" x="159.303811" y="175.753345" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5c81e47066" x="157.793928" y="179.494802" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p61f30a6cbc)">
+     <use xlink:href="#mf1ab5fe0cf" x="531.649087" y="75.963093" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf1ab5fe0cf" x="283.721324" y="99.020035" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf1ab5fe0cf" x="218.882044" y="121.069315" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf1ab5fe0cf" x="187.447228" y="127.10685" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf1ab5fe0cf" x="176.342474" y="138.36311" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf1ab5fe0cf" x="163.054314" y="161.312135" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf1ab5fe0cf" x="162.210539" y="168.753955" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf1ab5fe0cf" x="159.303811" y="175.753345" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf1ab5fe0cf" x="157.793928" y="179.494802" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_85">
@@ -2237,7 +2237,7 @@ L 299.21681 97.864971
 L 294.051648 98.253128 
 L 288.886486 98.638133 
 L 283.721324 99.020035 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_86">
     <path d="M 283.721324 99.020035 
@@ -2289,7 +2289,7 @@ L 222.934499 119.954333
 L 221.583681 120.328916 
 L 220.232863 120.700561 
 L 218.882044 121.069315 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_87">
     <path d="M 218.882044 121.069315 
@@ -2341,7 +2341,7 @@ L 189.411904 126.751217
 L 188.757012 126.870058 
 L 188.10212 126.988602 
 L 187.447228 127.10685 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_88">
     <path d="M 187.447228 127.10685 
@@ -2393,7 +2393,7 @@ L 177.036521 137.732718
 L 176.805172 137.943781 
 L 176.573823 138.153909 
 L 176.342474 138.36311 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_89">
     <path d="M 176.342474 138.36311 
@@ -2445,7 +2445,7 @@ L 163.884824 160.161325
 L 163.607987 160.548041 
 L 163.33115 160.931628 
 L 163.054314 161.312135 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_90">
     <path d="M 163.054314 161.312135 
@@ -2497,7 +2497,7 @@ L 162.263275 168.321549
 L 162.245696 168.466124 
 L 162.228118 168.610258 
 L 162.210539 168.753955 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_91">
     <path d="M 162.210539 168.753955 
@@ -2549,7 +2549,7 @@ L 159.485481 175.344896
 L 159.424925 175.481437 
 L 159.364368 175.617586 
 L 159.303811 175.753345 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_92">
     <path d="M 159.303811 175.753345 
@@ -2601,30 +2601,30 @@ L 157.888296 179.269417
 L 157.85684 179.344665 
 L 157.825384 179.419793 
 L 157.793928 179.494802 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_93">
     <defs>
-     <path id="m33358be08b" d="M -0 3.535534 
+     <path id="mec2de86622" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p8c12040a6d)">
-     <use xlink:href="#m33358be08b" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m33358be08b" x="203.775848" y="81.750179" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m33358be08b" x="186.982691" y="88.344921" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m33358be08b" x="179.779306" y="91.045312" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m33358be08b" x="157.610419" y="99.395085" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m33358be08b" x="148.722526" y="107.864022" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m33358be08b" x="144.388162" y="121.237794" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m33358be08b" x="127.071247" y="144.560664" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m33358be08b" x="124.491988" y="152.083585" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m33358be08b" x="92.613662" y="207.637263" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m33358be08b" x="87.348715" y="225.457654" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m33358be08b" x="86.053433" y="242.017529" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p61f30a6cbc)">
+     <use xlink:href="#mec2de86622" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mec2de86622" x="203.775848" y="81.750179" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mec2de86622" x="186.982691" y="88.344921" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mec2de86622" x="179.779306" y="91.045312" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mec2de86622" x="157.610419" y="99.395085" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mec2de86622" x="148.722526" y="107.864022" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mec2de86622" x="144.388162" y="121.237794" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mec2de86622" x="127.071247" y="144.560664" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mec2de86622" x="124.491988" y="152.083585" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mec2de86622" x="92.613662" y="207.637263" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mec2de86622" x="87.348715" y="225.457654" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mec2de86622" x="86.053433" y="242.017529" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_94">
@@ -2677,7 +2677,7 @@ L 206.762331 80.855075
 L 205.766837 81.155325 
 L 204.771342 81.453685 
 L 203.775848 81.750179 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_95">
     <path d="M 203.775848 81.750179 
@@ -2729,7 +2729,7 @@ L 188.032264 87.958568
 L 187.682406 88.087703 
 L 187.332549 88.216487 
 L 186.982691 88.344921 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_96">
     <path d="M 186.982691 88.344921 
@@ -2781,7 +2781,7 @@ L 180.229518 90.88097
 L 180.079447 90.935814 
 L 179.929376 90.990595 
 L 179.779306 91.045312 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_97">
     <path d="M 179.779306 91.045312 
@@ -2833,7 +2833,7 @@ L 158.995974 98.914174
 L 158.534122 99.075021 
 L 158.07227 99.235323 
 L 157.610419 99.395085 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_98">
     <path d="M 157.610419 99.395085 
@@ -2885,7 +2885,7 @@ L 149.27802 107.37681
 L 149.092855 107.539771 
 L 148.907691 107.702174 
 L 148.722526 107.864022 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_99">
     <path d="M 148.722526 107.864022 
@@ -2937,7 +2937,7 @@ L 144.65906 120.50385
 L 144.568761 120.749763 
 L 144.478462 120.994407 
 L 144.388162 121.237794 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_100">
     <path d="M 144.388162 121.237794 
@@ -2989,7 +2989,7 @@ L 128.153555 143.395158
 L 127.792786 143.786853 
 L 127.432016 144.175338 
 L 127.071247 144.560664 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_101">
     <path d="M 127.071247 144.560664 
@@ -3041,7 +3041,7 @@ L 124.653192 151.646811
 L 124.599457 151.79285 
 L 124.545723 151.93844 
 L 124.491988 152.083585 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_102">
     <path d="M 124.491988 152.083585 
@@ -3093,7 +3093,7 @@ L 94.606058 205.546972
 L 93.941926 206.254028 
 L 93.277794 206.950691 
 L 92.613662 207.637263 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_103">
     <path d="M 92.613662 207.637263 
@@ -3145,7 +3145,7 @@ L 87.677774 224.520091
 L 87.568088 224.834677 
 L 87.458402 225.147189 
 L 87.348715 225.457654 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_104">
     <path d="M 87.348715 225.457654 
@@ -3197,23 +3197,23 @@ L 86.134388 241.135848
 L 86.107403 241.431568 
 L 86.080418 241.725454 
 L 86.053433 242.017529 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_105">
     <defs>
-     <path id="m3ddeeba6d8" d="M -0 2.5 
+     <path id="me1d9b0f7ca" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p8c12040a6d)">
-     <use xlink:href="#m3ddeeba6d8" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p61f30a6cbc)">
+     <use xlink:href="#me1d9b0f7ca" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_106">
     <defs>
-     <path id="m1969300a46" d="M -0.833333 2.5 
+     <path id="mca87767e6e" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -3228,16 +3228,16 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p8c12040a6d)">
-     <use xlink:href="#m1969300a46" x="362.865999" y="115.428618" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1969300a46" x="278.798176" y="122.858526" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1969300a46" x="251.17632" y="128.261574" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1969300a46" x="200.806828" y="131.522849" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1969300a46" x="169.803221" y="147.931404" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1969300a46" x="161.916638" y="160.718659" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1969300a46" x="158.697104" y="167.705569" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1969300a46" x="154.26679" y="181.026105" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1969300a46" x="153.096464" y="191.924265" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p61f30a6cbc)">
+     <use xlink:href="#mca87767e6e" x="362.865999" y="115.428618" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mca87767e6e" x="278.798176" y="122.858526" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mca87767e6e" x="251.17632" y="128.261574" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mca87767e6e" x="200.806828" y="131.522849" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mca87767e6e" x="169.803221" y="147.931404" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mca87767e6e" x="161.916638" y="160.718659" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mca87767e6e" x="158.697104" y="167.705569" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mca87767e6e" x="154.26679" y="181.026105" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mca87767e6e" x="153.096464" y="191.924265" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_107">
@@ -3290,7 +3290,7 @@ L 284.052415 122.426763
 L 282.301002 122.571121 
 L 280.549589 122.715042 
 L 278.798176 122.858526 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_108">
     <path d="M 278.798176 122.858526 
@@ -3342,7 +3342,7 @@ L 252.902686 127.94134
 L 252.327231 128.048325 
 L 251.751776 128.155069 
 L 251.17632 128.261574 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_109">
     <path d="M 251.17632 128.261574 
@@ -3394,7 +3394,7 @@ L 203.954921 131.325463
 L 202.905557 131.39135 
 L 201.856192 131.457145 
 L 200.806828 131.522849 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_110">
     <path d="M 200.806828 131.522849 
@@ -3446,7 +3446,7 @@ L 171.740947 147.056528
 L 171.095038 147.349951 
 L 170.44913 147.64157 
 L 169.803221 147.931404 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_111">
     <path d="M 169.803221 147.931404 
@@ -3498,7 +3498,7 @@ L 162.409549 160.012958
 L 162.245246 160.249361 
 L 162.080942 160.484591 
 L 161.916638 160.718659 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_112">
     <path d="M 161.916638 160.718659 
@@ -3550,7 +3550,7 @@ L 158.898325 167.297798
 L 158.831251 167.434112 
 L 158.764178 167.570034 
 L 158.697104 167.705569 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_113">
     <path d="M 158.697104 167.705569 
@@ -3602,7 +3602,7 @@ L 154.543684 180.294711
 L 154.451386 180.539765 
 L 154.359088 180.783558 
 L 154.26679 181.026105 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_114">
     <path d="M 154.26679 181.026105 
@@ -3654,11 +3654,11 @@ L 153.16961 191.311823
 L 153.145228 191.516851 
 L 153.120846 191.720996 
 L 153.096464 191.924265 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_115">
     <defs>
-     <path id="m20421d9ea6" d="M -1.25 2.5 
+     <path id="m4de26fc92e" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -3673,16 +3673,16 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p8c12040a6d)">
-     <use xlink:href="#m20421d9ea6" x="301.619021" y="150.561849" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m20421d9ea6" x="250.236474" y="156.671134" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m20421d9ea6" x="225.418659" y="160.842551" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m20421d9ea6" x="212.328936" y="161.382211" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m20421d9ea6" x="209.030149" y="166.25091" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m20421d9ea6" x="197.547749" y="171.432451" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m20421d9ea6" x="194.819287" y="175.129495" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m20421d9ea6" x="193.12279" y="181.606362" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m20421d9ea6" x="192.79794" y="189.451167" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p61f30a6cbc)">
+     <use xlink:href="#m4de26fc92e" x="301.619021" y="150.561849" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4de26fc92e" x="250.236474" y="156.671134" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4de26fc92e" x="225.418659" y="160.842551" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4de26fc92e" x="212.328936" y="161.382211" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4de26fc92e" x="209.030149" y="166.25091" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4de26fc92e" x="197.547749" y="171.432451" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4de26fc92e" x="194.819287" y="175.129495" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4de26fc92e" x="193.12279" y="181.606362" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4de26fc92e" x="192.79794" y="189.451167" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_116">
@@ -3735,7 +3735,7 @@ L 253.447883 156.311526
 L 252.377414 156.431699 
 L 251.306944 156.551567 
 L 250.236474 156.671134 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_117">
     <path d="M 250.236474 156.671134 
@@ -3787,7 +3787,7 @@ L 226.969772 160.592321
 L 226.452735 160.675878 
 L 225.935697 160.759287 
 L 225.418659 160.842551 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_118">
     <path d="M 225.418659 160.842551 
@@ -3839,7 +3839,7 @@ L 213.147044 161.348661
 L 212.874341 161.359847 
 L 212.601639 161.37103 
 L 212.328936 161.382211 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_119">
     <path d="M 212.328936 161.382211 
@@ -3891,7 +3891,7 @@ L 209.236323 165.960837
 L 209.167599 166.057725 
 L 209.098874 166.154416 
 L 209.030149 166.25091 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_120">
     <path d="M 209.030149 166.25091 
@@ -3943,7 +3943,7 @@ L 198.265399 171.124681
 L 198.026182 171.227493 
 L 197.786966 171.330083 
 L 197.547749 171.432451 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_121">
     <path d="M 197.547749 171.432451 
@@ -3995,7 +3995,7 @@ L 194.989815 174.906688
 L 194.932972 174.981074 
 L 194.876129 175.055342 
 L 194.819287 175.129495 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_122">
     <path d="M 194.819287 175.129495 
@@ -4047,7 +4047,7 @@ L 193.228821 181.226479
 L 193.193478 181.353445 
 L 193.158134 181.480072 
 L 193.12279 181.606362 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_123">
     <path d="M 193.12279 181.606362 
@@ -4099,11 +4099,11 @@ L 192.818243 188.997124
 L 192.811475 189.148955 
 L 192.804707 189.300302 
 L 192.79794 189.451167 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_124">
     <defs>
-     <path id="ma42e9d258e" d="M 0 -2.5 
+     <path id="m20086b9ea8" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -4116,16 +4116,16 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p8c12040a6d)">
-     <use xlink:href="#ma42e9d258e" x="206.45578" y="118.584066" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#ma42e9d258e" x="206.45578" y="118.258949" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#ma42e9d258e" x="206.45578" y="118.759361" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#ma42e9d258e" x="206.45578" y="118.234957" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#ma42e9d258e" x="171.767499" y="134.097889" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#ma42e9d258e" x="163.54283" y="144.663903" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#ma42e9d258e" x="160.174881" y="151.505345" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#ma42e9d258e" x="154.179217" y="169.303726" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#ma42e9d258e" x="152.4406" y="178.584542" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p61f30a6cbc)">
+     <use xlink:href="#m20086b9ea8" x="206.45578" y="118.584066" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m20086b9ea8" x="206.45578" y="118.258949" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m20086b9ea8" x="206.45578" y="118.759361" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m20086b9ea8" x="206.45578" y="118.234957" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m20086b9ea8" x="171.767499" y="134.097889" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m20086b9ea8" x="163.54283" y="144.663903" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m20086b9ea8" x="160.174881" y="151.505345" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m20086b9ea8" x="154.179217" y="169.303726" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m20086b9ea8" x="152.4406" y="178.584542" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_125">
@@ -4178,7 +4178,7 @@ L 206.45578 118.279335
 L 206.45578 118.27254 
 L 206.45578 118.265745 
 L 206.45578 118.258949 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_126">
     <path d="M 206.45578 118.258949 
@@ -4230,7 +4230,7 @@ L 206.45578 118.728239
 L 206.45578 118.738615 
 L 206.45578 118.748989 
 L 206.45578 118.759361 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_127">
     <path d="M 206.45578 118.759361 
@@ -4282,7 +4282,7 @@ L 206.45578 118.267903
 L 206.45578 118.256924 
 L 206.45578 118.245942 
 L 206.45578 118.234957 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_128">
     <path d="M 206.45578 118.234957 
@@ -4334,7 +4334,7 @@ L 173.935517 133.247721
 L 173.212844 133.532808 
 L 172.490172 133.816191 
 L 171.767499 134.097889 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_129">
     <path d="M 171.767499 134.097889 
@@ -4386,7 +4386,7 @@ L 164.056872 144.068227
 L 163.885524 144.267619 
 L 163.714177 144.466175 
 L 163.54283 144.663903 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_130">
     <path d="M 163.54283 144.663903 
@@ -4438,7 +4438,7 @@ L 160.385378 151.105499
 L 160.315212 151.239156 
 L 160.245047 151.372438 
 L 160.174881 151.505345 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_131">
     <path d="M 160.174881 151.505345 
@@ -4490,7 +4490,7 @@ L 154.553946 168.367127
 L 154.429036 168.681387 
 L 154.304126 168.993578 
 L 154.179217 169.303726 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_132">
     <path d="M 154.179217 169.303726 
@@ -4542,11 +4542,11 @@ L 152.549264 178.054798
 L 152.513043 178.232038 
 L 152.476822 178.408618 
 L 152.4406 178.584542 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_133">
     <defs>
-     <path id="m0f8843e116" d="M 0 -2.5 
+     <path id="m0a5c0dbaa7" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -4555,16 +4555,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p8c12040a6d)">
-     <use xlink:href="#m0f8843e116" x="610.467188" y="172.829682" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0f8843e116" x="592.067397" y="173.763838" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0f8843e116" x="534.807821" y="180.385179" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0f8843e116" x="327.802209" y="176.172104" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0f8843e116" x="275.83761" y="186.734601" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0f8843e116" x="258.25125" y="198.783148" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0f8843e116" x="256.777056" y="203.737732" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0f8843e116" x="248.769854" y="217.74136" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0f8843e116" x="246.264594" y="227.740017" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p61f30a6cbc)">
+     <use xlink:href="#m0a5c0dbaa7" x="610.467188" y="172.829682" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0a5c0dbaa7" x="592.067397" y="173.763838" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0a5c0dbaa7" x="534.807821" y="180.385179" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0a5c0dbaa7" x="327.802209" y="176.172104" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0a5c0dbaa7" x="275.83761" y="186.734601" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0a5c0dbaa7" x="258.25125" y="198.783148" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0a5c0dbaa7" x="256.777056" y="203.737732" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0a5c0dbaa7" x="248.769854" y="217.74136" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0a5c0dbaa7" x="246.264594" y="227.740017" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_134">
@@ -4617,7 +4617,7 @@ L 593.217384 173.705989
 L 592.834055 173.72528 
 L 592.450726 173.744563 
 L 592.067397 173.763838 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_135">
     <path d="M 592.067397 173.763838 
@@ -4669,7 +4669,7 @@ L 538.386544 179.997367
 L 537.193636 180.126991 
 L 536.000728 180.25626 
 L 534.807821 180.385179 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_136">
     <path d="M 534.807821 180.385179 
@@ -4721,7 +4721,7 @@ L 340.74006 176.446681
 L 336.427443 176.355332 
 L 332.114826 176.263806 
 L 327.802209 176.172104 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_137">
     <path d="M 327.802209 176.172104 
@@ -4773,7 +4773,7 @@ L 279.085397 186.139102
 L 278.002801 186.338434 
 L 276.920205 186.536931 
 L 275.83761 186.734601 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_138">
     <path d="M 275.83761 186.734601 
@@ -4825,7 +4825,7 @@ L 259.350398 198.113494
 L 258.984015 198.337765 
 L 258.617633 198.560979 
 L 258.25125 198.783148 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_139">
     <path d="M 258.25125 198.783148 
@@ -4877,7 +4877,7 @@ L 256.869193 203.442789
 L 256.838481 203.541307 
 L 256.807768 203.639621 
 L 256.777056 203.737732 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_140">
     <path d="M 256.777056 203.737732 
@@ -4929,7 +4929,7 @@ L 249.270304 216.977455
 L 249.103487 217.23346 
 L 248.93667 217.48809 
 L 248.769854 217.74136 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_141">
     <path d="M 248.769854 217.74136 
@@ -4981,7 +4981,7 @@ L 246.421172 227.173237
 L 246.368979 227.362918 
 L 246.316786 227.551842 
 L 246.264594 227.740017 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="legend_1">
     <g id="patch_7">
@@ -4999,7 +4999,7 @@ z
     </g>
     <g id="line2d_142">
      <defs>
-      <path id="ma19fcd5eac" d="M 0 3.5 
+      <path id="ma81e4a4ccf" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -5012,7 +5012,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#ma19fcd5eac" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#ma81e4a4ccf" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -5071,7 +5071,7 @@ z
     </g>
     <g id="line2d_143">
      <g>
-      <use xlink:href="#m40a142740f" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m2845fccc9c" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -5085,7 +5085,7 @@ z
     </g>
     <g id="line2d_144">
      <g>
-      <use xlink:href="#m5c81e47066" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mf1ab5fe0cf" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -5130,7 +5130,7 @@ z
     </g>
     <g id="line2d_145">
      <g>
-      <use xlink:href="#m33358be08b" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mec2de86622" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -5173,7 +5173,7 @@ z
     </g>
     <g id="line2d_146">
      <g>
-      <use xlink:href="#m3ddeeba6d8" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#me1d9b0f7ca" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -5189,7 +5189,7 @@ z
     </g>
     <g id="line2d_147">
      <g>
-      <use xlink:href="#m1969300a46" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mca87767e6e" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -5243,7 +5243,7 @@ z
     </g>
     <g id="line2d_148">
      <g>
-      <use xlink:href="#m20421d9ea6" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m4de26fc92e" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -5308,7 +5308,7 @@ z
     </g>
     <g id="line2d_149">
      <g>
-      <use xlink:href="#ma42e9d258e" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#m20086b9ea8" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -5346,7 +5346,7 @@ z
     </g>
     <g id="line2d_150">
      <g>
-      <use xlink:href="#m0f8843e116" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m0a5c0dbaa7" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -5416,486 +5416,486 @@ z
     </g>
    </g>
    <g id="line2d_151">
-    <g clip-path="url(#p8c12040a6d)">
-     <use xlink:href="#ma19fcd5eac" x="289.783126" y="148.992231" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#ma19fcd5eac" x="223.847406" y="159.16883" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#ma19fcd5eac" x="212.445767" y="163.265133" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#ma19fcd5eac" x="181.367844" y="169.605394" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#ma19fcd5eac" x="165.308999" y="178.516756" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#ma19fcd5eac" x="157.029538" y="188.373389" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#ma19fcd5eac" x="152.709397" y="194.486606" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#ma19fcd5eac" x="149.72506" y="197.352703" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#ma19fcd5eac" x="115.00257" y="273.867142" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#ma19fcd5eac" x="99.775489" y="300.307177" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <g clip-path="url(#p61f30a6cbc)">
+     <use xlink:href="#ma81e4a4ccf" x="289.783126" y="149.052867" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma81e4a4ccf" x="223.847406" y="159.35275" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma81e4a4ccf" x="212.445767" y="163.386117" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma81e4a4ccf" x="181.367844" y="169.636697" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma81e4a4ccf" x="165.308999" y="178.596658" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma81e4a4ccf" x="160.074948" y="185.413222" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma81e4a4ccf" x="157.029538" y="188.39389" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma81e4a4ccf" x="149.72506" y="197.290589" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma81e4a4ccf" x="115.00257" y="273.582376" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma81e4a4ccf" x="99.775489" y="299.729413" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
    <g id="line2d_152">
-    <path d="M 289.783126 148.992231 
-L 288.409466 149.228135 
-L 287.035805 149.462871 
-L 285.662144 149.69645 
-L 284.288483 149.928884 
-L 282.914822 150.160183 
-L 281.541161 150.39036 
-L 280.167501 150.619424 
-L 278.79384 150.847386 
-L 277.420179 151.074257 
-L 276.046518 151.300048 
-L 274.672857 151.524768 
-L 273.299196 151.748427 
-L 271.925536 151.971036 
-L 270.551875 152.192605 
-L 269.178214 152.413142 
-L 267.804553 152.632659 
-L 266.430892 152.851163 
-L 265.057231 153.068665 
-L 263.68357 153.285173 
-L 262.30991 153.500697 
-L 260.936249 153.715245 
-L 259.562588 153.928826 
-L 258.188927 154.141449 
-L 256.815266 154.353123 
-L 255.441605 154.563856 
-L 254.067945 154.773656 
-L 252.694284 154.982531 
-L 251.320623 155.19049 
-L 249.946962 155.39754 
-L 248.573301 155.60369 
-L 247.19964 155.808948 
-L 245.82598 156.01332 
-L 244.452319 156.216815 
-L 243.078658 156.41944 
-L 241.704997 156.621202 
-L 240.331336 156.822109 
-L 238.957675 157.022169 
-L 237.584015 157.221387 
-L 236.210354 157.419772 
-L 234.836693 157.617329 
-L 233.463032 157.814067 
-L 232.089371 158.009991 
-L 230.71571 158.205109 
-L 229.34205 158.399427 
-L 227.968389 158.592952 
-L 226.594728 158.78569 
-L 225.221067 158.977647 
-L 223.847406 159.16883 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 289.783126 149.052867 
+L 288.409466 149.291943 
+L 287.035805 149.529819 
+L 285.662144 149.766507 
+L 284.288483 150.00202 
+L 282.914822 150.236368 
+L 281.541161 150.469563 
+L 280.167501 150.701616 
+L 278.79384 150.932539 
+L 277.420179 151.162342 
+L 276.046518 151.391036 
+L 274.672857 151.618632 
+L 273.299196 151.845141 
+L 271.925536 152.070572 
+L 270.551875 152.294936 
+L 269.178214 152.518244 
+L 267.804553 152.740504 
+L 266.430892 152.961726 
+L 265.057231 153.181921 
+L 263.68357 153.401098 
+L 262.30991 153.619266 
+L 260.936249 153.836435 
+L 259.562588 154.052613 
+L 258.188927 154.267809 
+L 256.815266 154.482033 
+L 255.441605 154.695293 
+L 254.067945 154.907598 
+L 252.694284 155.118956 
+L 251.320623 155.329376 
+L 249.946962 155.538865 
+L 248.573301 155.747433 
+L 247.19964 155.955088 
+L 245.82598 156.161836 
+L 244.452319 156.367687 
+L 243.078658 156.572647 
+L 241.704997 156.776725 
+L 240.331336 156.979928 
+L 238.957675 157.182264 
+L 237.584015 157.38374 
+L 236.210354 157.584362 
+L 234.836693 157.78414 
+L 233.463032 157.983079 
+L 232.089371 158.181186 
+L 230.71571 158.378469 
+L 229.34205 158.574934 
+L 227.968389 158.770588 
+L 226.594728 158.965437 
+L 225.221067 159.159489 
+L 223.847406 159.35275 
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_153">
-    <path d="M 223.847406 159.16883 
-L 223.609872 159.257882 
-L 223.372338 159.346767 
-L 223.134804 159.435486 
-L 222.89727 159.524039 
-L 222.659735 159.612427 
-L 222.422201 159.70065 
-L 222.184667 159.78871 
-L 221.947133 159.876606 
-L 221.709599 159.964339 
-L 221.472065 160.05191 
-L 221.23453 160.13932 
-L 220.996996 160.226569 
-L 220.759462 160.313658 
-L 220.521928 160.400587 
-L 220.284394 160.487357 
-L 220.04686 160.573968 
-L 219.809325 160.660421 
-L 219.571791 160.746717 
-L 219.334257 160.832856 
-L 219.096723 160.918839 
-L 218.859189 161.004666 
-L 218.621655 161.090338 
-L 218.38412 161.175855 
-L 218.146586 161.261219 
-L 217.909052 161.346429 
-L 217.671518 161.431486 
-L 217.433984 161.51639 
-L 217.19645 161.601143 
-L 216.958916 161.685745 
-L 216.721381 161.770196 
-L 216.483847 161.854496 
-L 216.246313 161.938647 
-L 216.008779 162.022649 
-L 215.771245 162.106502 
-L 215.533711 162.190207 
-L 215.296176 162.273765 
-L 215.058642 162.357176 
-L 214.821108 162.44044 
-L 214.583574 162.523558 
-L 214.34604 162.60653 
-L 214.108506 162.689358 
-L 213.870971 162.772041 
-L 213.633437 162.85458 
-L 213.395903 162.936975 
-L 213.158369 163.019228 
-L 212.920835 163.101338 
-L 212.683301 163.183306 
-L 212.445767 163.265133 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 223.847406 159.35275 
+L 223.609872 159.440376 
+L 223.372338 159.527841 
+L 223.134804 159.615144 
+L 222.89727 159.702287 
+L 222.659735 159.78927 
+L 222.422201 159.876094 
+L 222.184667 159.962759 
+L 221.947133 160.049265 
+L 221.709599 160.135615 
+L 221.472065 160.221807 
+L 221.23453 160.307842 
+L 220.996996 160.393722 
+L 220.759462 160.479447 
+L 220.521928 160.565016 
+L 220.284394 160.650432 
+L 220.04686 160.735694 
+L 219.809325 160.820802 
+L 219.571791 160.905759 
+L 219.334257 160.990563 
+L 219.096723 161.075216 
+L 218.859189 161.159717 
+L 218.621655 161.244069 
+L 218.38412 161.32827 
+L 218.146586 161.412323 
+L 217.909052 161.496226 
+L 217.671518 161.579982 
+L 217.433984 161.663589 
+L 217.19645 161.747049 
+L 216.958916 161.830363 
+L 216.721381 161.91353 
+L 216.483847 161.996552 
+L 216.246313 162.079429 
+L 216.008779 162.162161 
+L 215.771245 162.244748 
+L 215.533711 162.327193 
+L 215.296176 162.409494 
+L 215.058642 162.491652 
+L 214.821108 162.573668 
+L 214.583574 162.655542 
+L 214.34604 162.737276 
+L 214.108506 162.818868 
+L 213.870971 162.900321 
+L 213.633437 162.981633 
+L 213.395903 163.062807 
+L 213.158369 163.143842 
+L 212.920835 163.224738 
+L 212.683301 163.305496 
+L 212.445767 163.386117 
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_154">
-    <path d="M 212.445767 163.265133 
-L 211.79831 163.406253 
-L 211.150853 163.546954 
-L 210.503396 163.687239 
-L 209.85594 163.82711 
-L 209.208483 163.96657 
-L 208.561026 164.10562 
-L 207.913569 164.244263 
-L 207.266113 164.382503 
-L 206.618656 164.52034 
-L 205.971199 164.657777 
-L 205.323743 164.794818 
-L 204.676286 164.931463 
-L 204.028829 165.067715 
-L 203.381372 165.203577 
-L 202.733916 165.33905 
-L 202.086459 165.474138 
-L 201.439002 165.608841 
-L 200.791546 165.743163 
-L 200.144089 165.877105 
-L 199.496632 166.01067 
-L 198.849175 166.143859 
-L 198.201719 166.276675 
-L 197.554262 166.40912 
-L 196.906805 166.541196 
-L 196.259348 166.672905 
-L 195.611892 166.804249 
-L 194.964435 166.935231 
-L 194.316978 167.065851 
-L 193.669522 167.196112 
-L 193.022065 167.326016 
-L 192.374608 167.455565 
-L 191.727151 167.584761 
-L 191.079695 167.713606 
-L 190.432238 167.842101 
-L 189.784781 167.97025 
-L 189.137324 168.098052 
-L 188.489868 168.225511 
-L 187.842411 168.352628 
-L 187.194954 168.479405 
-L 186.547498 168.605844 
-L 185.900041 168.731947 
-L 185.252584 168.857715 
-L 184.605127 168.98315 
-L 183.957671 169.108254 
-L 183.310214 169.233028 
-L 182.662757 169.357476 
-L 182.015301 169.481597 
-L 181.367844 169.605394 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 212.445767 163.386117 
+L 211.79831 163.52511 
+L 211.150853 163.663697 
+L 210.503396 163.801879 
+L 209.85594 163.93966 
+L 209.208483 164.077041 
+L 208.561026 164.214026 
+L 207.913569 164.350615 
+L 207.266113 164.486812 
+L 206.618656 164.622619 
+L 205.971199 164.758038 
+L 205.323743 164.893071 
+L 204.676286 165.027721 
+L 204.028829 165.161989 
+L 203.381372 165.295877 
+L 202.733916 165.429389 
+L 202.086459 165.562526 
+L 201.439002 165.69529 
+L 200.791546 165.827682 
+L 200.144089 165.959707 
+L 199.496632 166.091364 
+L 198.849175 166.222657 
+L 198.201719 166.353587 
+L 197.554262 166.484156 
+L 196.906805 166.614367 
+L 196.259348 166.744221 
+L 195.611892 166.87372 
+L 194.964435 167.002866 
+L 194.316978 167.131662 
+L 193.669522 167.260108 
+L 193.022065 167.388208 
+L 192.374608 167.515962 
+L 191.727151 167.643372 
+L 191.079695 167.770441 
+L 190.432238 167.897171 
+L 189.784781 168.023562 
+L 189.137324 168.149617 
+L 188.489868 168.275338 
+L 187.842411 168.400726 
+L 187.194954 168.525784 
+L 186.547498 168.650512 
+L 185.900041 168.774913 
+L 185.252584 168.898989 
+L 184.605127 169.02274 
+L 183.957671 169.146169 
+L 183.310214 169.269278 
+L 182.662757 169.392068 
+L 182.015301 169.51454 
+L 181.367844 169.636697 
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_155">
-    <path d="M 181.367844 169.605394 
-L 181.033285 169.809208 
-L 180.698725 170.012149 
-L 180.364166 170.214225 
-L 180.029607 170.415443 
-L 179.695047 170.61581 
-L 179.360488 170.815334 
-L 179.025929 171.014022 
-L 178.69137 171.21188 
-L 178.35681 171.408916 
-L 178.022251 171.605136 
-L 177.687692 171.800547 
-L 177.353133 171.995156 
-L 177.018573 172.188969 
-L 176.684014 172.381993 
-L 176.349455 172.574234 
-L 176.014895 172.765699 
-L 175.680336 172.956393 
-L 175.345777 173.146323 
-L 175.011218 173.335495 
-L 174.676658 173.523915 
-L 174.342099 173.711589 
-L 174.00754 173.898523 
-L 173.672981 174.084722 
-L 173.338421 174.270193 
-L 173.003862 174.454941 
-L 172.669303 174.638971 
-L 172.334743 174.82229 
-L 172.000184 175.004903 
-L 171.665625 175.186815 
-L 171.331066 175.368031 
-L 170.996506 175.548557 
-L 170.661947 175.728398 
-L 170.327388 175.90756 
-L 169.992829 176.086046 
-L 169.658269 176.263863 
-L 169.32371 176.441016 
-L 168.989151 176.617509 
-L 168.654591 176.793347 
-L 168.320032 176.968535 
-L 167.985473 177.143078 
-L 167.650914 177.316981 
-L 167.316354 177.490248 
-L 166.981795 177.662884 
-L 166.647236 177.834893 
-L 166.312676 178.006281 
-L 165.978117 178.177051 
-L 165.643558 178.347208 
-L 165.308999 178.516756 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 181.367844 169.636697 
+L 181.033285 169.841728 
+L 180.698725 170.045876 
+L 180.364166 170.249148 
+L 180.029607 170.451553 
+L 179.695047 170.653097 
+L 179.360488 170.853787 
+L 179.025929 171.053631 
+L 178.69137 171.252637 
+L 178.35681 171.45081 
+L 178.022251 171.648158 
+L 177.687692 171.844688 
+L 177.353133 172.040406 
+L 177.018573 172.23532 
+L 176.684014 172.429435 
+L 176.349455 172.622759 
+L 176.014895 172.815297 
+L 175.680336 173.007056 
+L 175.345777 173.198043 
+L 175.011218 173.388263 
+L 174.676658 173.577723 
+L 174.342099 173.766428 
+L 174.00754 173.954386 
+L 173.672981 174.1416 
+L 173.338421 174.328079 
+L 173.003862 174.513826 
+L 172.669303 174.698849 
+L 172.334743 174.883152 
+L 172.000184 175.066741 
+L 171.665625 175.249622 
+L 171.331066 175.4318 
+L 170.996506 175.61328 
+L 170.661947 175.794068 
+L 170.327388 175.97417 
+L 169.992829 176.153589 
+L 169.658269 176.332332 
+L 169.32371 176.510404 
+L 168.989151 176.687809 
+L 168.654591 176.864552 
+L 168.320032 177.040639 
+L 167.985473 177.216074 
+L 167.650914 177.390862 
+L 167.316354 177.565008 
+L 166.981795 177.738516 
+L 166.647236 177.911392 
+L 166.312676 178.08364 
+L 165.978117 178.255263 
+L 165.643558 178.426268 
+L 165.308999 178.596658 
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_156">
-    <path d="M 165.308999 178.516756 
-L 165.13651 178.744466 
-L 164.964021 178.971087 
-L 164.791532 179.19663 
-L 164.619044 179.421105 
-L 164.446555 179.644521 
-L 164.274066 179.86689 
-L 164.101577 180.08822 
-L 163.929089 180.308521 
-L 163.7566 180.527803 
-L 163.584111 180.746076 
-L 163.411622 180.963347 
-L 163.239134 181.179628 
-L 163.066645 181.394926 
-L 162.894156 181.60925 
-L 162.721667 181.82261 
-L 162.549178 182.035014 
-L 162.37669 182.24647 
-L 162.204201 182.456987 
-L 162.031712 182.666573 
-L 161.859223 182.875236 
-L 161.686735 183.082985 
-L 161.514246 183.289827 
-L 161.341757 183.495771 
-L 161.169268 183.700824 
-L 160.99678 183.904993 
-L 160.824291 184.108287 
-L 160.651802 184.310712 
-L 160.479313 184.512277 
-L 160.306825 184.712988 
-L 160.134336 184.912853 
-L 159.961847 185.111878 
-L 159.789358 185.310072 
-L 159.61687 185.50744 
-L 159.444381 185.703989 
-L 159.271892 185.899727 
-L 159.099403 186.09466 
-L 158.926914 186.288795 
-L 158.754426 186.482138 
-L 158.581937 186.674695 
-L 158.409448 186.866473 
-L 158.236959 187.057478 
-L 158.064471 187.247717 
-L 157.891982 187.437195 
-L 157.719493 187.625919 
-L 157.547004 187.813894 
-L 157.374516 188.001127 
-L 157.202027 188.187623 
-L 157.029538 188.373389 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 165.308999 178.596658 
+L 165.199956 178.749143 
+L 165.090913 178.90114 
+L 164.98187 179.05265 
+L 164.872828 179.203678 
+L 164.763785 179.354226 
+L 164.654742 179.504297 
+L 164.5457 179.653895 
+L 164.436657 179.803022 
+L 164.327614 179.951682 
+L 164.218571 180.099876 
+L 164.109529 180.247609 
+L 164.000486 180.394883 
+L 163.891443 180.5417 
+L 163.782401 180.688064 
+L 163.673358 180.833978 
+L 163.564315 180.979444 
+L 163.455272 181.124465 
+L 163.34623 181.269043 
+L 163.237187 181.413182 
+L 163.128144 181.556883 
+L 163.019101 181.700151 
+L 162.910059 181.842986 
+L 162.801016 181.985393 
+L 162.691973 182.127373 
+L 162.582931 182.268929 
+L 162.473888 182.410063 
+L 162.364845 182.550779 
+L 162.255802 182.691078 
+L 162.14676 182.830962 
+L 162.037717 182.970436 
+L 161.928674 183.1095 
+L 161.819631 183.248157 
+L 161.710589 183.38641 
+L 161.601546 183.52426 
+L 161.492503 183.661711 
+L 161.383461 183.798765 
+L 161.274418 183.935423 
+L 161.165375 184.071689 
+L 161.056332 184.207564 
+L 160.94729 184.34305 
+L 160.838247 184.478151 
+L 160.729204 184.612867 
+L 160.620161 184.747201 
+L 160.511119 184.881156 
+L 160.402076 185.014734 
+L 160.293033 185.147936 
+L 160.183991 185.280764 
+L 160.074948 185.413222 
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_157">
-    <path d="M 157.029538 188.373389 
-L 156.939535 188.509131 
-L 156.849532 188.644485 
-L 156.759529 188.779454 
-L 156.669526 188.914039 
-L 156.579523 189.048244 
-L 156.48952 189.182069 
-L 156.399517 189.315518 
-L 156.309515 189.448592 
-L 156.219512 189.581294 
-L 156.129509 189.713625 
-L 156.039506 189.845588 
-L 155.949503 189.977184 
-L 155.8595 190.108416 
-L 155.769497 190.239286 
-L 155.679494 190.369795 
-L 155.589491 190.499946 
-L 155.499488 190.629741 
-L 155.409485 190.759181 
-L 155.319482 190.888268 
-L 155.229479 191.017005 
-L 155.139476 191.145394 
-L 155.049473 191.273435 
-L 154.95947 191.401131 
-L 154.869467 191.528485 
-L 154.779464 191.655497 
-L 154.689461 191.78217 
-L 154.599459 191.908505 
-L 154.509456 192.034504 
-L 154.419453 192.160169 
-L 154.32945 192.285502 
-L 154.239447 192.410504 
-L 154.149444 192.535178 
-L 154.059441 192.659524 
-L 153.969438 192.783546 
-L 153.879435 192.907243 
-L 153.789432 193.030619 
-L 153.699429 193.153674 
-L 153.609426 193.27641 
-L 153.519423 193.39883 
-L 153.42942 193.520934 
-L 153.339417 193.642724 
-L 153.249414 193.764203 
-L 153.159411 193.885371 
-L 153.069408 194.006229 
-L 152.979406 194.126781 
-L 152.889403 194.247026 
-L 152.7994 194.366968 
-L 152.709397 194.486606 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 160.074948 185.413222 
+L 160.011502 185.47727 
+L 159.948056 185.541232 
+L 159.88461 185.605107 
+L 159.821164 185.668896 
+L 159.757718 185.7326 
+L 159.694272 185.796218 
+L 159.630826 185.859751 
+L 159.56738 185.923199 
+L 159.503933 185.986562 
+L 159.440487 186.049841 
+L 159.377041 186.113035 
+L 159.313595 186.176145 
+L 159.250149 186.239171 
+L 159.186703 186.302113 
+L 159.123257 186.364972 
+L 159.059811 186.427748 
+L 158.996365 186.49044 
+L 158.932919 186.55305 
+L 158.869473 186.615577 
+L 158.806027 186.678022 
+L 158.742581 186.740385 
+L 158.679135 186.802665 
+L 158.615689 186.864864 
+L 158.552243 186.926982 
+L 158.488797 186.989018 
+L 158.425351 187.050973 
+L 158.361905 187.112847 
+L 158.298459 187.174641 
+L 158.235013 187.236354 
+L 158.171567 187.297987 
+L 158.108121 187.359539 
+L 158.044675 187.421012 
+L 157.981229 187.482406 
+L 157.917783 187.54372 
+L 157.854337 187.604954 
+L 157.790891 187.66611 
+L 157.727444 187.727187 
+L 157.663998 187.788185 
+L 157.600552 187.849105 
+L 157.537106 187.909947 
+L 157.47366 187.970711 
+L 157.410214 188.031397 
+L 157.346768 188.092005 
+L 157.283322 188.152536 
+L 157.219876 188.21299 
+L 157.15643 188.273366 
+L 157.092984 188.333666 
+L 157.029538 188.39389 
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_158">
-    <path d="M 152.709397 194.486606 
-L 152.647223 194.548119 
-L 152.585049 194.609552 
-L 152.522876 194.670905 
-L 152.460702 194.732179 
-L 152.398528 194.793374 
-L 152.336355 194.85449 
-L 152.274181 194.915528 
-L 152.212007 194.976487 
-L 152.149834 195.037367 
-L 152.08766 195.09817 
-L 152.025486 195.158894 
-L 151.963313 195.219541 
-L 151.901139 195.280111 
-L 151.838965 195.340603 
-L 151.776792 195.401018 
-L 151.714618 195.461356 
-L 151.652444 195.521617 
-L 151.590271 195.581802 
-L 151.528097 195.64191 
-L 151.465923 195.701943 
-L 151.40375 195.761899 
-L 151.341576 195.82178 
-L 151.279402 195.881585 
-L 151.217229 195.941315 
-L 151.155055 196.000969 
-L 151.092881 196.060549 
-L 151.030708 196.120054 
-L 150.968534 196.179484 
-L 150.90636 196.23884 
-L 150.844187 196.298122 
-L 150.782013 196.357329 
-L 150.719839 196.416463 
-L 150.657665 196.475523 
-L 150.595492 196.534509 
-L 150.533318 196.593422 
-L 150.471144 196.652262 
-L 150.408971 196.711029 
-L 150.346797 196.769724 
-L 150.284623 196.828345 
-L 150.22245 196.886895 
-L 150.160276 196.945372 
-L 150.098102 197.003777 
-L 150.035929 197.06211 
-L 149.973755 197.120371 
-L 149.911581 197.178561 
-L 149.849408 197.23668 
-L 149.787234 197.294727 
-L 149.72506 197.352703 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 157.029538 188.39389 
+L 156.877361 188.597336 
+L 156.725185 188.799914 
+L 156.573008 189.001629 
+L 156.420832 189.202489 
+L 156.268655 189.402502 
+L 156.116478 189.601674 
+L 155.964302 189.800013 
+L 155.812125 189.997526 
+L 155.659949 190.194218 
+L 155.507772 190.390098 
+L 155.355595 190.585172 
+L 155.203419 190.779446 
+L 155.051242 190.972927 
+L 154.899065 191.165622 
+L 154.746889 191.357536 
+L 154.594712 191.548677 
+L 154.442536 191.73905 
+L 154.290359 191.928661 
+L 154.138182 192.117517 
+L 153.986006 192.305623 
+L 153.833829 192.492986 
+L 153.681652 192.679611 
+L 153.529476 192.865504 
+L 153.377299 193.050671 
+L 153.225123 193.235117 
+L 153.072946 193.418848 
+L 152.920769 193.60187 
+L 152.768593 193.784188 
+L 152.616416 193.965807 
+L 152.46424 194.146734 
+L 152.312063 194.326972 
+L 152.159886 194.506527 
+L 152.00771 194.685405 
+L 151.855533 194.86361 
+L 151.703356 195.041148 
+L 151.55118 195.218023 
+L 151.399003 195.39424 
+L 151.246827 195.569805 
+L 151.09465 195.744722 
+L 150.942473 195.918996 
+L 150.790297 196.092632 
+L 150.63812 196.265633 
+L 150.485943 196.438006 
+L 150.333767 196.609754 
+L 150.18159 196.780882 
+L 150.029414 196.951394 
+L 149.877237 197.121295 
+L 149.72506 197.290589 
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_159">
-    <path d="M 149.72506 197.352703 
-L 149.001675 201.16869 
-L 148.27829 204.700218 
-L 147.554905 207.986772 
-L 146.831519 211.060144 
-L 146.108134 213.946313 
-L 145.384749 216.666782 
-L 144.661364 219.239549 
-L 143.937979 221.679829 
-L 143.214593 224.000601 
-L 142.491208 226.213027 
-L 141.767823 228.326773 
-L 141.044438 230.350267 
-L 140.321052 232.290902 
-L 139.597667 234.155198 
-L 138.874282 235.948934 
-L 138.150897 237.677256 
-L 137.427512 239.34477 
-L 136.704126 240.955607 
-L 135.980741 242.513496 
-L 135.257356 244.021805 
-L 134.533971 245.483595 
-L 133.810585 246.901648 
-L 133.0872 248.278506 
-L 132.363815 249.616495 
-L 131.64043 250.917749 
-L 130.917045 252.184233 
-L 130.193659 253.417755 
-L 129.470274 254.619988 
-L 128.746889 255.79248 
-L 128.023504 256.936668 
-L 127.300118 258.053885 
-L 126.576733 259.145374 
-L 125.853348 260.212294 
-L 125.129963 261.255725 
-L 124.406577 262.27668 
-L 123.683192 263.276108 
-L 122.959807 264.254896 
-L 122.236422 265.213881 
-L 121.513037 266.153847 
-L 120.789651 267.075535 
-L 120.066266 267.979642 
-L 119.342881 268.866825 
-L 118.619496 269.737708 
-L 117.89611 270.592878 
-L 117.172725 271.432891 
-L 116.44934 272.258277 
-L 115.725955 273.069536 
-L 115.00257 273.867142 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 149.72506 197.290589 
+L 149.001675 201.085119 
+L 148.27829 204.598264 
+L 147.554905 207.868891 
+L 146.831519 210.928332 
+L 146.108134 213.802213 
+L 145.384749 216.511762 
+L 144.661364 219.07476 
+L 143.937979 221.50625 
+L 143.214593 223.819071 
+L 142.491208 226.02427 
+L 141.767823 228.131418 
+L 141.044438 230.148866 
+L 140.321052 232.083938 
+L 139.597667 233.9431 
+L 138.874282 235.732083 
+L 138.150897 237.455992 
+L 137.427512 239.119397 
+L 136.704126 240.7264 
+L 135.980741 242.280702 
+L 135.257356 243.785649 
+L 134.533971 245.244281 
+L 133.810585 246.659361 
+L 133.0872 248.033417 
+L 132.363815 249.36876 
+L 131.64043 250.667511 
+L 130.917045 251.931624 
+L 130.193659 253.162896 
+L 129.470274 254.362992 
+L 128.746889 255.533452 
+L 128.023504 256.675704 
+L 127.300118 257.791076 
+L 126.576733 258.880803 
+L 125.853348 259.946039 
+L 125.129963 260.98786 
+L 124.406577 262.007274 
+L 123.683192 263.005224 
+L 122.959807 263.982596 
+L 122.236422 264.94022 
+L 121.513037 265.87888 
+L 120.789651 266.799311 
+L 120.066266 267.702209 
+L 119.342881 268.588228 
+L 118.619496 269.457989 
+L 117.89611 270.312077 
+L 117.172725 271.151047 
+L 116.44934 271.975425 
+L 115.725955 272.78571 
+L 115.00257 273.582376 
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_160">
-    <path d="M 115.00257 273.867142 
-L 114.685339 274.59897 
-L 114.368108 275.31967 
-L 114.050877 276.029576 
-L 113.733646 276.729006 
-L 113.416415 277.418265 
-L 113.099184 278.097644 
-L 112.781954 278.767423 
-L 112.464723 279.42787 
-L 112.147492 280.07924 
-L 111.830261 280.72178 
-L 111.51303 281.355726 
-L 111.195799 281.981305 
-L 110.878569 282.598736 
-L 110.561338 283.208226 
-L 110.244107 283.809979 
-L 109.926876 284.404188 
-L 109.609645 284.99104 
-L 109.292414 285.570714 
-L 108.975184 286.143385 
-L 108.657953 286.70922 
-L 108.340722 287.268379 
-L 108.023491 287.821019 
-L 107.70626 288.36729 
-L 107.389029 288.907337 
-L 107.071799 289.441299 
-L 106.754568 289.969314 
-L 106.437337 290.491511 
-L 106.120106 291.008018 
-L 105.802875 291.518957 
-L 105.485644 292.024447 
-L 105.168414 292.524603 
-L 104.851183 293.019536 
-L 104.533952 293.509355 
-L 104.216721 293.994164 
-L 103.89949 294.474064 
-L 103.582259 294.949154 
-L 103.265028 295.419529 
-L 102.947798 295.885282 
-L 102.630567 296.346503 
-L 102.313336 296.803279 
-L 101.996105 297.255696 
-L 101.678874 297.703835 
-L 101.361643 298.147776 
-L 101.044413 298.587599 
-L 100.727182 299.023377 
-L 100.409951 299.455186 
-L 100.09272 299.883096 
-L 99.775489 300.307177 
-" clip-path="url(#p8c12040a6d)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 115.00257 273.582376 
+L 114.685339 274.303735 
+L 114.368108 275.01428 
+L 114.050877 275.714331 
+L 113.733646 276.404193 
+L 113.416415 277.084158 
+L 113.099184 277.754506 
+L 112.781954 278.415506 
+L 112.464723 279.067415 
+L 112.147492 279.710479 
+L 111.830261 280.344935 
+L 111.51303 280.971011 
+L 111.195799 281.588925 
+L 110.878569 282.198887 
+L 110.561338 282.801099 
+L 110.244107 283.395756 
+L 109.926876 283.983045 
+L 109.609645 284.563146 
+L 109.292414 285.136233 
+L 108.975184 285.702474 
+L 108.657953 286.26203 
+L 108.340722 286.815058 
+L 108.023491 287.361707 
+L 107.70626 287.902124 
+L 107.389029 288.436448 
+L 107.071799 288.964816 
+L 106.754568 289.487359 
+L 106.437337 290.004205 
+L 106.120106 290.515475 
+L 105.802875 291.021289 
+L 105.485644 291.521763 
+L 105.168414 292.017007 
+L 104.851183 292.50713 
+L 104.533952 292.992237 
+L 104.216721 293.472429 
+L 103.89949 293.947805 
+L 103.582259 294.418461 
+L 103.265028 294.88449 
+L 102.947798 295.345981 
+L 102.630567 295.803022 
+L 102.313336 296.255698 
+L 101.996105 296.704092 
+L 101.678874 297.148283 
+L 101.361643 297.588351 
+L 101.044413 298.02437 
+L 100.727182 298.456415 
+L 100.409951 298.884558 
+L 100.09272 299.308867 
+L 99.775489 299.729413 
+" clip-path="url(#p61f30a6cbc)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
   </g>
   <g id="text_25">
@@ -6254,8 +6254,8 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-07-08T22:12:55Z  ·  Linux chungus2 x86_64  ·  commit 30251fb3  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(44.380078 465.66) scale(0.07 -0.07)">
+   <!-- 2026-07-08T22:38:10Z  ·  Linux chungus2 x86_64  ·  commit f6be9ada  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(44.622344 465.66) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -6289,31 +6289,6 @@ L 1409 3309
 L 1409 2516 
 L 750 2516 
 L 750 3309 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-b7" d="M 684 2619 
@@ -6373,6 +6348,36 @@ Q 2894 3584 3203 3211
 Q 3513 2838 3513 2113 
 z
 " transform="scale(0.015625)"/>
+     <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
      <path id="DejaVuSans-3d" d="M 678 2906 
 L 4684 2906 
 L 4684 2381 
@@ -6416,11 +6421,11 @@ z
     <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -6460,109 +6465,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3262.744141 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3326.367188 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3389.990234 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3425.195312 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3488.671875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3552.294922 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3584.082031 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3615.869141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3647.65625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3679.443359 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3711.230469 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3739.013672 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3800.537109 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3861.816406 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3925.195312 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3988.671875 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4027.535156 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4088.716797 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4147.896484 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4209.419922 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4250.533203 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4284.224609 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4312.007812 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4373.53125 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4434.810547 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4498.189453 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4561.8125 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4595.503906 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4654.683594 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4718.306641 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4750.09375 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4813.716797 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4877.339844 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4909.126953 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4972.75 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5008.833984 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5047.697266 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5102.677734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5166.300781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5198.087891 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5229.875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5261.662109 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5293.449219 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5325.236328 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5364.445312 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5427.824219 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5466.6875 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5527.869141 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5591.248047 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5654.724609 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5718.103516 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5781.580078 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5844.958984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5884.167969 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5915.955078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5999.744141 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6031.53125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6128.943359 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6190.466797 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6253.943359 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6281.726562 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6343.005859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6406.384766 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6438.171875 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6490.271484 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6553.650391 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6614.929688 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6678.40625 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6730.505859 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6793.884766 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6855.066406 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6894.275391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6927.966797 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6959.753906 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7000.867188 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7062.146484 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7101.355469 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7129.138672 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7190.320312 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7222.107422 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7249.890625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7301.990234 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7333.777344 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7397.253906 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7458.777344 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7497.986328 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7559.509766 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7598.873047 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7696.285156 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7724.068359 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7787.447266 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7815.230469 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7867.330078 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7906.539062 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7934.322266 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3107.080078 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3170.703125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3234.179688 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3295.703125 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3359.326172 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3420.605469 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3484.082031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3545.361328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3577.148438 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3608.935547 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3640.722656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3672.509766 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3704.296875 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3732.080078 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3793.603516 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3854.882812 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3918.261719 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3981.738281 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4020.601562 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4081.783203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4140.962891 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4202.486328 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4243.599609 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4277.291016 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4305.074219 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4366.597656 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4427.876953 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4491.255859 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4554.878906 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4588.570312 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4647.75 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4711.373047 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4743.160156 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4806.783203 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4870.40625 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4902.193359 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4965.816406 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5001.900391 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5040.763672 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5095.744141 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5159.367188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5191.154297 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5222.941406 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5254.728516 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5286.515625 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5318.302734 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5357.511719 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5420.890625 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5459.753906 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5520.935547 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5584.314453 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5647.791016 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5711.169922 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5774.646484 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5838.025391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5877.234375 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5909.021484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5992.810547 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6024.597656 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6122.009766 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6183.533203 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6247.009766 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6274.792969 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6336.072266 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6399.451172 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6431.238281 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6483.337891 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6546.716797 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6607.996094 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6671.472656 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6723.572266 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6786.951172 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6848.132812 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6887.341797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6921.033203 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6952.820312 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6993.933594 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7055.212891 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7094.421875 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7122.205078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7183.386719 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7215.173828 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7242.957031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7295.056641 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7326.84375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7390.320312 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7451.84375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7491.052734 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7552.576172 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7591.939453 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7689.351562 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7717.134766 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7780.513672 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7808.296875 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7860.396484 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7899.605469 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7927.388672 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p8c12040a6d">
+  <clipPath id="p61f30a6cbc">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_ratio_heatmap.svg
+++ b/bench/graphs/canterbury_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#pd721f650a7)">
+   <g clip-path="url(#pb72e048c24)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAI7UlEQVR4nO3Yz4plVx2G4XOqq8rqBBsMnT8ER0JmEhw4sScZ505yBQ4l81xH4g0IIqITUZw4EWfiTCSETifpdLdV1af28RLawJKfnPd5ruDbg732u9d+++rT4+7UPHs8vWCp45en9Ty73W73z5//anrCUv/46/PpCct98NmH0xOW2//kp9MT1tqfTS9Y7+nn0wvWu3owvWCpX779yfSE5U7wTQIA+O+JIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCAtP3N4dfH6RGrHXfb9ISl9ifYrBdnl9MTlrrdrqcnLHfxtz9PT1ju8ONH0xOWOmy30xOWe354Oj1huYcndjy8fPBwesJyp/eVBQD4DsQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAEDa+cXzr6c3rHfzYnrBWsdtesF69x9ML1jqcnrA/8Dx6fPpCctdfPtkesJSF9thesJy90/xvLt+Nr1gqYvz0zvx3AwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgbX/YfnucHrHa8bhNT1hqO7Hn2e12u4uzy+kJS90dD9MTlrv37Mn0hPW+/9b0gqVebrfTE5b78vpf0xOWe+fmfHrCUtsP3p2esJybIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAg7fwvX/xxesNyZ7v99ISl3nzt4fSE5e62w/SEpS7vXU1PWO6j3/9hesJyH//svekJSx2O2/SE5X7xp79PT1ju0buvT09Y6qP3H01PWM7NEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANL2L+9+c5wesdrt3fX0hKXu76+mJ/AKt/vD9ITlvrl5PD1huTeu3pmesNR23KYnLPf1zRfTE5Z7cvP59ISlfvTg/ekJy7kZAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQNp+2353nB4B/B863E4vWO/8cnoBr3B992J6wnJX916bnsAruBkCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBA2vn0AKKO2/QCXuHfu9vpCct978SOvLMT/J+9uXsxPWG5b24fT09Y6u2rH05PWO703iQAgO9ADAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApP0HV5aGIrf8pikAAAAASUVORK5CYII=" id="image600a2ba333" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAI/ElEQVR4nO3YwYqkVx2H4aqe7qZnxAFlEodZCu4kuMjG2bj2TnIFLsW91xG9AUFEdCOKGzfiTrILEmIyxnEmdNdUf+UlTIQT/lLv81zB71DU+V7OfvvXh6fduXn12fSCpU6fn9d5drvd7uOf/Gp6wlIf/fX19ITlfvSLH09PWG7/g/enJ6y1v5hesN7LT6YXrHfzeHrBUr/8zs+nJyx3hv8kAICvTgwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKTt746/Pk2PWO2026YnLLU/w2a9urienrDUYbudnrDc1d/+PD1hueP3n09PWOq4HaYnLPf6+HJ6wnJPzux6ePP4yfSE5c7vKwsA8D8QQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaZdXr7+Y3rDe3ZfTC9Y6bdML1nv4eHrBUtfTA74Gp5evpycsd/WfF9MTlrrajtMTlnt4jvfd7avpBUtdXZ7fjedlCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGn74/bb0/SI1U6nbXrCUtuZnWe32+2uLq6nJyx1fzpOT1juwasX0xPW++a70wuWerMdpics9/ntP6YnLPf07nJ6wlLbt55NT1jOyxAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkHb5l0//OL1huYvdfnrCUu88ejI9Ybn77Tg9YanrBzfTE5b74Pd/mJ6w3M9++L3pCUsdT9v0hOV++qe/T09Y7vmzb0xPWOqD955PT1jOyxAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDS9m/uf3OaHrHa4f52esJSD/c30xN4i8P+OD1huX/ffTY9Yblv3zydnrDUdtqmJyz3xd2n0xOWe3H3yfSEpb77+L3pCct5GQIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAEDaftt+d5oeAfwfOh6mF6x3eT29gLe4vf9yesJyNw8eTU/gLbwMAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIO1yd3+c3rDexZk13v7MzrPb7XZvbqcXrHVxOb1gucPFNj1huevpAaudzu83Om6H6QnL/fPwYnrCUu/cPJuesNwZfmUBAL46MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkPZfKmeKG6wY/4kAAAAASUVORK5CYII=" id="imagebaf74482c1" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m4e9e360035" d="M 0 0 
+       <path id="m96309cf1f1" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m4e9e360035" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m96309cf1f1" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m4e9e360035" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m96309cf1f1" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m4e9e360035" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m96309cf1f1" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m4e9e360035" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m96309cf1f1" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m4e9e360035" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m96309cf1f1" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m4e9e360035" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m96309cf1f1" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m4e9e360035" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m96309cf1f1" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m4e9e360035" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m96309cf1f1" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m4e9e360035" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m96309cf1f1" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m4e9e360035" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m96309cf1f1" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m4e9e360035" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m96309cf1f1" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="m825d0082e4" d="M 0 0 
+       <path id="mb3eb1c2c19" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m825d0082e4" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb3eb1c2c19" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m825d0082e4" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb3eb1c2c19" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m825d0082e4" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb3eb1c2c19" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m825d0082e4" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb3eb1c2c19" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m825d0082e4" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb3eb1c2c19" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m825d0082e4" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb3eb1c2c19" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m825d0082e4" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb3eb1c2c19" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m825d0082e4" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb3eb1c2c19" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1334,17 +1334,17 @@ z
     </g>
    </g>
    <g id="text_22">
-    <!-- -0 -->
-    <g transform="translate(187.111194 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(36.083984 0)"/>
+    <!-- +0 -->
+    <g transform="translate(185.560334 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_23">
-    <!-- +0 -->
+    <!-- +1 -->
     <g transform="translate(223.430452 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_24">
@@ -1362,65 +1362,31 @@ z
     </g>
    </g>
    <g id="text_26">
-    <!-- -0 -->
-    <g transform="translate(338.591666 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(36.083984 0)"/>
+    <!-- +0 -->
+    <g transform="translate(337.040806 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_27">
-    <!-- -0 -->
-    <g transform="translate(376.461784 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(36.083984 0)"/>
+    <!-- +0 -->
+    <g transform="translate(374.910924 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_28">
-    <!-- -2 -->
+    <!-- -1 -->
     <g transform="translate(414.331902 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_29">
-    <!-- -3 -->
+    <!-- -2 -->
     <g transform="translate(452.20202 68.904519) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-33" d="M 2597 2516 
-Q 3050 2419 3304 2112 
-Q 3559 1806 3559 1356 
-Q 3559 666 3084 287 
-Q 2609 -91 1734 -91 
-Q 1441 -91 1130 -33 
-Q 819 25 488 141 
-L 488 750 
-Q 750 597 1062 519 
-Q 1375 441 1716 441 
-Q 2309 441 2620 675 
-Q 2931 909 2931 1356 
-Q 2931 1769 2642 2001 
-Q 2353 2234 1838 2234 
-L 1294 2234 
-L 1294 2753 
-L 1863 2753 
-Q 2328 2753 2575 2939 
-Q 2822 3125 2822 3475 
-Q 2822 3834 2567 4026 
-Q 2313 4219 1838 4219 
-Q 1578 4219 1281 4162 
-Q 984 4106 628 3988 
-L 628 4550 
-Q 988 4650 1302 4700 
-Q 1616 4750 1894 4750 
-Q 2613 4750 3031 4423 
-Q 3450 4097 3450 3541 
-Q 3450 3153 3228 2886 
-Q 3006 2619 2597 2516 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_30">
@@ -1622,6 +1588,40 @@ z
    <g id="text_55">
     <!-- -3 -->
     <g transform="translate(187.111194 174.957073) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
     </g>
@@ -2092,18 +2092,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="image8cee542aae" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
+iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="image465934bd57" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="m7e5077aad9" d="M 0 0 
+       <path id="m2a2e226dae" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m7e5077aad9" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2a2e226dae" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
@@ -2129,7 +2129,7 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m7e5077aad9" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2a2e226dae" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
@@ -2146,7 +2146,7 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m7e5077aad9" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2a2e226dae" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
@@ -2163,7 +2163,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m7e5077aad9" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2a2e226dae" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
@@ -2180,7 +2180,7 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m7e5077aad9" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2a2e226dae" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_112">
@@ -2196,7 +2196,7 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m7e5077aad9" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2a2e226dae" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
@@ -2212,7 +2212,7 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m7e5077aad9" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2a2e226dae" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
@@ -2228,7 +2228,7 @@ z
     <g id="ytick_16">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#m7e5077aad9" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2a2e226dae" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_115">
@@ -2244,7 +2244,7 @@ z
     <g id="ytick_17">
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m7e5077aad9" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2a2e226dae" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_116">
@@ -2882,8 +2882,8 @@ z
    </g>
   </g>
   <g id="text_119">
-   <!-- 2026-07-08T22:12:55Z  ·  Linux chungus2 x86_64  ·  commit 30251fb3  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(17.380078 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-08T22:38:10Z  ·  Linux chungus2 x86_64  ·  commit f6be9ada  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(17.622344 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2955,11 +2955,11 @@ z
     <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2999,109 +2999,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3262.744141 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3326.367188 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3389.990234 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3425.195312 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3488.671875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3552.294922 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3584.082031 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3615.869141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3647.65625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3679.443359 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3711.230469 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3739.013672 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3800.537109 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3861.816406 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3925.195312 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3988.671875 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4027.535156 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4088.716797 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4147.896484 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4209.419922 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4250.533203 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4284.224609 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4312.007812 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4373.53125 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4434.810547 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4498.189453 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4561.8125 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4595.503906 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4654.683594 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4718.306641 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4750.09375 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4813.716797 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4877.339844 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4909.126953 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4972.75 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5008.833984 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5047.697266 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5102.677734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5166.300781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5198.087891 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5229.875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5261.662109 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5293.449219 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5325.236328 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5364.445312 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5427.824219 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5466.6875 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5527.869141 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5591.248047 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5654.724609 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5718.103516 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5781.580078 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5844.958984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5884.167969 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5915.955078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5999.744141 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6031.53125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6128.943359 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6190.466797 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6253.943359 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6281.726562 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6343.005859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6406.384766 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6438.171875 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6490.271484 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6553.650391 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6614.929688 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6678.40625 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6730.505859 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6793.884766 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6855.066406 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6894.275391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6927.966797 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6959.753906 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7000.867188 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7062.146484 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7101.355469 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7129.138672 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7190.320312 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7222.107422 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7249.890625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7301.990234 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7333.777344 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7397.253906 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7458.777344 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7497.986328 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7559.509766 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7598.873047 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7696.285156 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7724.068359 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7787.447266 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7815.230469 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7867.330078 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7906.539062 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7934.322266 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3107.080078 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3170.703125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3234.179688 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3295.703125 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3359.326172 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3420.605469 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3484.082031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3545.361328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3577.148438 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3608.935547 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3640.722656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3672.509766 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3704.296875 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3732.080078 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3793.603516 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3854.882812 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3918.261719 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3981.738281 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4020.601562 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4081.783203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4140.962891 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4202.486328 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4243.599609 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4277.291016 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4305.074219 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4366.597656 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4427.876953 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4491.255859 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4554.878906 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4588.570312 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4647.75 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4711.373047 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4743.160156 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4806.783203 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4870.40625 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4902.193359 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4965.816406 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5001.900391 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5040.763672 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5095.744141 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5159.367188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5191.154297 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5222.941406 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5254.728516 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5286.515625 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5318.302734 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5357.511719 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5420.890625 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5459.753906 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5520.935547 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5584.314453 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5647.791016 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5711.169922 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5774.646484 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5838.025391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5877.234375 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5909.021484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5992.810547 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6024.597656 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6122.009766 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6183.533203 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6247.009766 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6274.792969 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6336.072266 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6399.451172 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6431.238281 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6483.337891 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6546.716797 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6607.996094 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6671.472656 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6723.572266 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6786.951172 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6848.132812 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6887.341797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6921.033203 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6952.820312 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6993.933594 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7055.212891 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7094.421875 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7122.205078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7183.386719 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7215.173828 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7242.957031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7295.056641 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7326.84375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7390.320312 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7451.84375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7491.052734 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7552.576172 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7591.939453 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7689.351562 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7717.134766 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7780.513672 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7808.296875 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7860.396484 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7899.605469 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7927.388672 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pd721f650a7">
+  <clipPath id="pb72e048c24">
    <rect x="95.67625" y="49.4355" width="416.571298" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_summary.svg
+++ b/bench/graphs/canterbury_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="573.639844pt" height="386.202469pt" viewBox="0 0 573.639844 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="573.155312pt" height="386.202469pt" viewBox="0 0 573.155312 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,232 +22,232 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 386.202469 
-L 573.639844 386.202469 
-L 573.639844 0 
+L 573.155312 386.202469 
+L 573.155312 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 188.944922 104.1264 
-L 293.569922 104.1264 
-L 293.569922 74.7432 
-L 188.944922 74.7432 
+    <path d="M 188.702656 104.1264 
+L 293.327656 104.1264 
+L 293.327656 74.7432 
+L 188.702656 74.7432 
 z
-" clip-path="url(#p2dd898885e)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0fffa0a551)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 293.569922 104.1264 
-L 398.194922 104.1264 
-L 398.194922 74.7432 
-L 293.569922 74.7432 
+    <path d="M 293.327656 104.1264 
+L 397.952656 104.1264 
+L 397.952656 74.7432 
+L 293.327656 74.7432 
 z
-" clip-path="url(#p2dd898885e)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0fffa0a551)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 398.194922 104.1264 
-L 502.819922 104.1264 
-L 502.819922 74.7432 
-L 398.194922 74.7432 
+    <path d="M 397.952656 104.1264 
+L 502.577656 104.1264 
+L 502.577656 74.7432 
+L 397.952656 74.7432 
 z
-" clip-path="url(#p2dd898885e)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0fffa0a551)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 188.944922 133.5096 
-L 293.569922 133.5096 
-L 293.569922 104.1264 
-L 188.944922 104.1264 
+    <path d="M 188.702656 133.5096 
+L 293.327656 133.5096 
+L 293.327656 104.1264 
+L 188.702656 104.1264 
 z
-" clip-path="url(#p2dd898885e)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0fffa0a551)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 293.569922 133.5096 
-L 398.194922 133.5096 
-L 398.194922 104.1264 
-L 293.569922 104.1264 
+    <path d="M 293.327656 133.5096 
+L 397.952656 133.5096 
+L 397.952656 104.1264 
+L 293.327656 104.1264 
 z
-" clip-path="url(#p2dd898885e)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0fffa0a551)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 398.194922 133.5096 
-L 502.819922 133.5096 
-L 502.819922 104.1264 
-L 398.194922 104.1264 
+    <path d="M 397.952656 133.5096 
+L 502.577656 133.5096 
+L 502.577656 104.1264 
+L 397.952656 104.1264 
 z
-" clip-path="url(#p2dd898885e)" style="fill: #fdb768; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0fffa0a551)" style="fill: #fdb768; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 188.944922 162.8928 
-L 293.569922 162.8928 
-L 293.569922 133.5096 
-L 188.944922 133.5096 
+    <path d="M 188.702656 162.8928 
+L 293.327656 162.8928 
+L 293.327656 133.5096 
+L 188.702656 133.5096 
 z
-" clip-path="url(#p2dd898885e)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0fffa0a551)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 293.569922 162.8928 
-L 398.194922 162.8928 
-L 398.194922 133.5096 
-L 293.569922 133.5096 
+    <path d="M 293.327656 162.8928 
+L 397.952656 162.8928 
+L 397.952656 133.5096 
+L 293.327656 133.5096 
 z
-" clip-path="url(#p2dd898885e)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0fffa0a551)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 398.194922 162.8928 
-L 502.819922 162.8928 
-L 502.819922 133.5096 
-L 398.194922 133.5096 
+    <path d="M 397.952656 162.8928 
+L 502.577656 162.8928 
+L 502.577656 133.5096 
+L 397.952656 133.5096 
 z
-" clip-path="url(#p2dd898885e)" style="fill: #bbe278; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0fffa0a551)" style="fill: #bbe278; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 188.944922 192.276 
-L 293.569922 192.276 
-L 293.569922 162.8928 
-L 188.944922 162.8928 
+    <path d="M 188.702656 192.276 
+L 293.327656 192.276 
+L 293.327656 162.8928 
+L 188.702656 162.8928 
 z
-" clip-path="url(#p2dd898885e)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0fffa0a551)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 293.569922 192.276 
-L 398.194922 192.276 
-L 398.194922 162.8928 
-L 293.569922 162.8928 
+    <path d="M 293.327656 192.276 
+L 397.952656 192.276 
+L 397.952656 162.8928 
+L 293.327656 162.8928 
 z
-" clip-path="url(#p2dd898885e)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0fffa0a551)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 398.194922 192.276 
-L 502.819922 192.276 
-L 502.819922 162.8928 
-L 398.194922 162.8928 
+    <path d="M 397.952656 192.276 
+L 502.577656 192.276 
+L 502.577656 162.8928 
+L 397.952656 162.8928 
 z
-" clip-path="url(#p2dd898885e)" style="fill: #fdc776; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0fffa0a551)" style="fill: #fdc776; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 188.944922 221.6592 
-L 293.569922 221.6592 
-L 293.569922 192.276 
-L 188.944922 192.276 
+    <path d="M 188.702656 221.6592 
+L 293.327656 221.6592 
+L 293.327656 192.276 
+L 188.702656 192.276 
 z
-" clip-path="url(#p2dd898885e)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0fffa0a551)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 293.569922 221.6592 
-L 398.194922 221.6592 
-L 398.194922 192.276 
-L 293.569922 192.276 
+    <path d="M 293.327656 221.6592 
+L 397.952656 221.6592 
+L 397.952656 192.276 
+L 293.327656 192.276 
 z
-" clip-path="url(#p2dd898885e)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0fffa0a551)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 398.194922 221.6592 
-L 502.819922 221.6592 
-L 502.819922 192.276 
-L 398.194922 192.276 
+    <path d="M 397.952656 221.6592 
+L 502.577656 221.6592 
+L 502.577656 192.276 
+L 397.952656 192.276 
 z
-" clip-path="url(#p2dd898885e)" style="fill: #addc6f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0fffa0a551)" style="fill: #addc6f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 188.944922 251.0424 
-L 293.569922 251.0424 
-L 293.569922 221.6592 
-L 188.944922 221.6592 
+    <path d="M 188.702656 251.0424 
+L 293.327656 251.0424 
+L 293.327656 221.6592 
+L 188.702656 221.6592 
 z
-" clip-path="url(#p2dd898885e)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0fffa0a551)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 293.569922 251.0424 
-L 398.194922 251.0424 
-L 398.194922 221.6592 
-L 293.569922 221.6592 
+    <path d="M 293.327656 251.0424 
+L 397.952656 251.0424 
+L 397.952656 221.6592 
+L 293.327656 221.6592 
 z
-" clip-path="url(#p2dd898885e)" style="fill: #fdbd6d; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0fffa0a551)" style="fill: #fdbd6d; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 398.194922 251.0424 
-L 502.819922 251.0424 
-L 502.819922 221.6592 
-L 398.194922 221.6592 
+    <path d="M 397.952656 251.0424 
+L 502.577656 251.0424 
+L 502.577656 221.6592 
+L 397.952656 221.6592 
 z
-" clip-path="url(#p2dd898885e)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0fffa0a551)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 188.944922 280.4256 
-L 293.569922 280.4256 
-L 293.569922 251.0424 
-L 188.944922 251.0424 
+    <path d="M 188.702656 280.4256 
+L 293.327656 280.4256 
+L 293.327656 251.0424 
+L 188.702656 251.0424 
 z
-" clip-path="url(#p2dd898885e)" style="fill: #f1f9ac; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0fffa0a551)" style="fill: #f5fbb2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 293.569922 280.4256 
-L 398.194922 280.4256 
-L 398.194922 251.0424 
-L 293.569922 251.0424 
+    <path d="M 293.327656 280.4256 
+L 397.952656 280.4256 
+L 397.952656 251.0424 
+L 293.327656 251.0424 
 z
-" clip-path="url(#p2dd898885e)" style="fill: #fb9d59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0fffa0a551)" style="fill: #fba35c; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 398.194922 280.4256 
-L 502.819922 280.4256 
-L 502.819922 251.0424 
-L 398.194922 251.0424 
+    <path d="M 397.952656 280.4256 
+L 502.577656 280.4256 
+L 502.577656 251.0424 
+L 397.952656 251.0424 
 z
-" clip-path="url(#p2dd898885e)" style="fill: #fca55d; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0fffa0a551)" style="fill: #fca55d; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 188.944922 309.8088 
-L 293.569922 309.8088 
-L 293.569922 280.4256 
-L 188.944922 280.4256 
+    <path d="M 188.702656 309.8088 
+L 293.327656 309.8088 
+L 293.327656 280.4256 
+L 188.702656 280.4256 
 z
-" clip-path="url(#p2dd898885e)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0fffa0a551)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 293.569922 309.8088 
-L 398.194922 309.8088 
-L 398.194922 280.4256 
-L 293.569922 280.4256 
+    <path d="M 293.327656 309.8088 
+L 397.952656 309.8088 
+L 397.952656 280.4256 
+L 293.327656 280.4256 
 z
-" clip-path="url(#p2dd898885e)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0fffa0a551)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 398.194922 309.8088 
-L 502.819922 309.8088 
-L 502.819922 280.4256 
-L 398.194922 280.4256 
+    <path d="M 397.952656 309.8088 
+L 502.577656 309.8088 
+L 502.577656 280.4256 
+L 397.952656 280.4256 
 z
-" clip-path="url(#p2dd898885e)" style="fill: #ee613e; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0fffa0a551)" style="fill: #ee613e; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 188.944922 339.192 
-L 293.569922 339.192 
-L 293.569922 309.8088 
-L 188.944922 309.8088 
+    <path d="M 188.702656 339.192 
+L 293.327656 339.192 
+L 293.327656 309.8088 
+L 188.702656 309.8088 
 z
-" clip-path="url(#p2dd898885e)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0fffa0a551)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 293.569922 339.192 
-L 398.194922 339.192 
-L 398.194922 309.8088 
-L 293.569922 309.8088 
+    <path d="M 293.327656 339.192 
+L 397.952656 339.192 
+L 397.952656 309.8088 
+L 293.327656 309.8088 
 z
-" clip-path="url(#p2dd898885e)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0fffa0a551)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 398.194922 339.192 
-L 502.819922 339.192 
-L 502.819922 309.8088 
-L 398.194922 309.8088 
+    <path d="M 397.952656 339.192 
+L 502.577656 339.192 
+L 502.577656 309.8088 
+L 397.952656 309.8088 
 z
-" clip-path="url(#p2dd898885e)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0fffa0a551)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(121.932188 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(121.689922 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(229.216406 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(228.974141 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(307.788516 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(307.54625 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(406.140234 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(405.897969 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(117.869922 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(117.627656 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.296 -->
-    <g transform="translate(229.806172 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(229.563906 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -946,7 +946,7 @@ z
    </g>
    <g id="text_7">
     <!-- 158 -->
-    <g transform="translate(338.247422 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(338.005156 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -1034,7 +1034,7 @@ z
    </g>
    <g id="text_8">
     <!-- 925 -->
-    <g transform="translate(442.872422 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(442.630156 91.6423) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-39"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
@@ -1042,7 +1042,7 @@ z
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(112.508047 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(112.265781 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1141,7 +1141,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.299 -->
-    <g transform="translate(229.806172 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(229.563906 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1151,7 +1151,7 @@ z
    </g>
    <g id="text_11">
     <!-- 73 -->
-    <g transform="translate(340.792422 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(340.550156 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -1202,7 +1202,7 @@ z
    </g>
    <g id="text_12">
     <!-- 283 -->
-    <g transform="translate(442.872422 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(442.630156 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(127.246094 0)"/>
@@ -1210,7 +1210,7 @@ z
    </g>
    <g id="text_13">
     <!-- zlib -->
-    <g transform="translate(129.771172 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(129.528906 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1234,7 +1234,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.299 -->
-    <g transform="translate(229.806172 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(229.563906 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1244,14 +1244,14 @@ z
    </g>
    <g id="text_15">
     <!-- 55 -->
-    <g transform="translate(340.792422 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(340.550156 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
     <!-- 692 -->
-    <g transform="translate(442.872422 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(442.630156 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-36"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
@@ -1259,7 +1259,7 @@ z
    </g>
    <g id="text_17">
     <!-- Go compress/flate -->
-    <g transform="translate(100.201172 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(99.958906 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -1430,7 +1430,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.299 -->
-    <g transform="translate(229.806172 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(229.563906 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1440,14 +1440,14 @@ z
    </g>
    <g id="text_19">
     <!-- 52 -->
-    <g transform="translate(340.792422 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(340.550156 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
     <!-- 323 -->
-    <g transform="translate(442.872422 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(442.630156 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(127.246094 0)"/>
@@ -1455,7 +1455,7 @@ z
    </g>
    <g id="text_21">
     <!-- miniz_oxide -->
-    <g transform="translate(113.077422 209.06385) scale(0.08 -0.08)">
+    <g transform="translate(112.835156 209.06385) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6e" d="M 3513 2113 
 L 3513 0 
@@ -1514,7 +1514,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.299 -->
-    <g transform="translate(229.806172 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(229.563906 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1524,14 +1524,14 @@ z
    </g>
    <g id="text_23">
     <!-- 51 -->
-    <g transform="translate(340.792422 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(340.550156 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_24">
     <!-- 729 -->
-    <g transform="translate(442.872422 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(442.630156 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-37"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(127.246094 0)"/>
@@ -1539,7 +1539,7 @@ z
    </g>
    <g id="text_25">
     <!-- JS fflate -->
-    <g transform="translate(121.233672 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(120.991406 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1599,7 +1599,7 @@ z
    </g>
    <g id="text_26">
     <!-- 0.307 -->
-    <g transform="translate(229.806172 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(229.563906 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1609,7 +1609,7 @@ z
    </g>
    <g id="text_27">
     <!-- 41 -->
-    <g transform="translate(340.792422 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(340.550156 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1637,14 +1637,14 @@ z
    </g>
    <g id="text_28">
     <!-- 80 -->
-    <g transform="translate(445.417422 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(445.175156 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-38"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_29">
     <!-- lean-zip (native) -->
-    <g transform="translate(99.579297 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(99.337031 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1752,8 +1752,8 @@ z
     </g>
    </g>
    <g id="text_30">
-    <!-- 0.298 -->
-    <g transform="translate(228.605547 267.9415) scale(0.08 -0.08)">
+    <!-- 0.299 -->
+    <g transform="translate(228.363281 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1835,6 +1835,92 @@ Q 1491 2759 1650 2554
 Q 1809 2350 2125 2350 
 z
 " transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-Bold-30"/>
+     <use xlink:href="#DejaVuSans-Bold-2e" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-32" transform="translate(107.568359 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-39" transform="translate(177.148438 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-39" transform="translate(246.728516 0)"/>
+    </g>
+   </g>
+   <g id="text_31">
+    <!-- 31 -->
+    <g transform="translate(340.073906 267.9415) scale(0.08 -0.08)">
+     <defs>
+      <path id="DejaVuSans-Bold-33" d="M 2981 2516 
+Q 3453 2394 3698 2092 
+Q 3944 1791 3944 1325 
+Q 3944 631 3412 270 
+Q 2881 -91 1863 -91 
+Q 1503 -91 1142 -33 
+Q 781 25 428 141 
+L 428 1069 
+Q 766 900 1098 814 
+Q 1431 728 1753 728 
+Q 2231 728 2486 893 
+Q 2741 1059 2741 1369 
+Q 2741 1688 2480 1852 
+Q 2219 2016 1709 2016 
+L 1228 2016 
+L 1228 2791 
+L 1734 2791 
+Q 2188 2791 2409 2933 
+Q 2631 3075 2631 3366 
+Q 2631 3634 2415 3781 
+Q 2200 3928 1806 3928 
+Q 1516 3928 1219 3862 
+Q 922 3797 628 3669 
+L 628 4550 
+Q 984 4650 1334 4700 
+Q 1684 4750 2022 4750 
+Q 2931 4750 3382 4451 
+Q 3834 4153 3834 3553 
+Q 3834 3144 3618 2883 
+Q 3403 2622 2981 2516 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-31" d="M 750 831 
+L 1813 831 
+L 1813 3847 
+L 722 3622 
+L 722 4441 
+L 1806 4666 
+L 2950 4666 
+L 2950 831 
+L 4013 831 
+L 4013 0 
+L 750 0 
+L 750 831 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-Bold-33"/>
+     <use xlink:href="#DejaVuSans-Bold-31" transform="translate(69.580078 0)"/>
+    </g>
+   </g>
+   <g id="text_32">
+    <!-- 248 -->
+    <g transform="translate(441.915781 267.9415) scale(0.08 -0.08)">
+     <defs>
+      <path id="DejaVuSans-Bold-34" d="M 2356 3675 
+L 1038 1722 
+L 2356 1722 
+L 2356 3675 
+z
+M 2156 4666 
+L 3494 4666 
+L 3494 1722 
+L 4159 1722 
+L 4159 850 
+L 3494 850 
+L 3494 0 
+L 2356 0 
+L 2356 850 
+L 288 850 
+L 288 1881 
+L 2156 4666 
+z
+" transform="scale(0.015625)"/>
       <path id="DejaVuSans-Bold-38" d="M 2228 2088 
 Q 1891 2088 1709 1903 
 Q 1528 1719 1528 1375 
@@ -1875,62 +1961,14 @@ Q 1631 3694 1631 3419
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-Bold-30"/>
-     <use xlink:href="#DejaVuSans-Bold-2e" transform="translate(69.580078 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-32" transform="translate(107.568359 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-39" transform="translate(177.148438 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-38" transform="translate(246.728516 0)"/>
-    </g>
-   </g>
-   <g id="text_31">
-    <!-- 29 -->
-    <g transform="translate(340.316172 267.9415) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-Bold-32"/>
-     <use xlink:href="#DejaVuSans-Bold-39" transform="translate(69.580078 0)"/>
-    </g>
-   </g>
-   <g id="text_32">
-    <!-- 247 -->
-    <g transform="translate(442.158047 267.9415) scale(0.08 -0.08)">
-     <defs>
-      <path id="DejaVuSans-Bold-34" d="M 2356 3675 
-L 1038 1722 
-L 2356 1722 
-L 2356 3675 
-z
-M 2156 4666 
-L 3494 4666 
-L 3494 1722 
-L 4159 1722 
-L 4159 850 
-L 3494 850 
-L 3494 0 
-L 2356 0 
-L 2356 850 
-L 288 850 
-L 288 1881 
-L 2156 4666 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-37" d="M 428 4666 
-L 3944 4666 
-L 3944 3988 
-L 2125 0 
-L 953 0 
-L 2675 3781 
-L 428 3781 
-L 428 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-Bold-32"/>
      <use xlink:href="#DejaVuSans-Bold-34" transform="translate(69.580078 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-37" transform="translate(139.160156 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-38" transform="translate(139.160156 0)"/>
     </g>
    </g>
    <g id="text_33">
     <!-- OCaml decompress -->
-    <g transform="translate(97.694297 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(97.452031 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -1995,7 +2033,7 @@ z
    </g>
    <g id="text_34">
     <!-- 0.321 -->
-    <g transform="translate(229.806172 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(229.563906 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -2005,14 +2043,14 @@ z
    </g>
    <g id="text_35">
     <!-- 23 -->
-    <g transform="translate(340.792422 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(340.550156 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_36">
     <!-- 117 -->
-    <g transform="translate(442.872422 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(442.630156 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
@@ -2020,7 +2058,7 @@ z
    </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(125.915547 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(125.673281 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -2031,7 +2069,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.279 -->
-    <g transform="translate(229.806172 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(229.563906 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -2041,13 +2079,13 @@ z
    </g>
    <g id="text_39">
     <!-- 0 -->
-    <g transform="translate(343.337422 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(343.095156 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(446.507422 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(446.265156 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2063,7 +2101,7 @@ z
   </g>
   <g id="text_41">
    <!-- canterbury — geomean over files, level 6 -->
-   <g transform="translate(136.328672 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(136.086406 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-62" d="M 2400 722 
 Q 2759 722 2948 984 
@@ -2276,7 +2314,7 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-07-08T22:12:55Z  ·  Linux chungus2 x86_64  ·  commit 30251fb3  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-07-08T22:38:10Z  ·  Linux chungus2 x86_64  ·  commit f6be9ada  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2420,11 +2458,11 @@ z
     <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2464,110 +2502,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3262.744141 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3326.367188 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3389.990234 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3425.195312 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3488.671875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3552.294922 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3584.082031 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3615.869141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3647.65625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3679.443359 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3711.230469 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3739.013672 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3800.537109 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3861.816406 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3925.195312 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3988.671875 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4027.535156 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4088.716797 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4147.896484 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4209.419922 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4250.533203 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4284.224609 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4312.007812 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4373.53125 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4434.810547 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4498.189453 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4561.8125 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4595.503906 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4654.683594 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4718.306641 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4750.09375 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4813.716797 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4877.339844 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4909.126953 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4972.75 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5008.833984 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5047.697266 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5102.677734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5166.300781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5198.087891 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5229.875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5261.662109 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5293.449219 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5325.236328 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5364.445312 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5427.824219 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5466.6875 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5527.869141 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5591.248047 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5654.724609 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5718.103516 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5781.580078 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5844.958984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5884.167969 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5915.955078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5999.744141 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6031.53125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6128.943359 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6190.466797 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6253.943359 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6281.726562 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6343.005859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6406.384766 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6438.171875 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6490.271484 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6553.650391 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6614.929688 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6678.40625 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6730.505859 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6793.884766 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6855.066406 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6894.275391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6927.966797 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6959.753906 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7000.867188 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7062.146484 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7101.355469 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7129.138672 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7190.320312 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7222.107422 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7249.890625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7301.990234 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7333.777344 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7397.253906 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7458.777344 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7497.986328 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7559.509766 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7598.873047 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7696.285156 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7724.068359 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7787.447266 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7815.230469 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7867.330078 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7906.539062 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7934.322266 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3107.080078 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3170.703125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3234.179688 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3295.703125 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3359.326172 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3420.605469 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3484.082031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3545.361328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3577.148438 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3608.935547 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3640.722656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3672.509766 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3704.296875 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3732.080078 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3793.603516 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3854.882812 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3918.261719 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3981.738281 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4020.601562 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4081.783203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4140.962891 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4202.486328 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4243.599609 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4277.291016 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4305.074219 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4366.597656 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4427.876953 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4491.255859 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4554.878906 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4588.570312 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4647.75 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4711.373047 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4743.160156 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4806.783203 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4870.40625 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4902.193359 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4965.816406 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5001.900391 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5040.763672 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5095.744141 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5159.367188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5191.154297 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5222.941406 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5254.728516 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5286.515625 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5318.302734 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5357.511719 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5420.890625 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5459.753906 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5520.935547 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5584.314453 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5647.791016 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5711.169922 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5774.646484 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5838.025391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5877.234375 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5909.021484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5992.810547 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6024.597656 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6122.009766 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6183.533203 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6247.009766 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6274.792969 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6336.072266 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6399.451172 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6431.238281 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6483.337891 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6546.716797 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6607.996094 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6671.472656 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6723.572266 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6786.951172 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6848.132812 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6887.341797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6921.033203 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6952.820312 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6993.933594 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7055.212891 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7094.421875 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7122.205078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7183.386719 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7215.173828 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7242.957031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7295.056641 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7326.84375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7390.320312 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7451.84375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7491.052734 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7552.576172 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7591.939453 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7689.351562 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7717.134766 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7780.513672 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7808.296875 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7860.396484 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7899.605469 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7927.388672 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p2dd898885e">
-   <rect x="84.319922" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="p0fffa0a551">
+   <rect x="84.077656" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/graphs/silesia_compress_heatmap.svg
+++ b/bench/graphs/silesia_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.34175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p5fc832b6a3)">
+   <g clip-path="url(#p7ad8372bd0)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAqAAAAGaCAYAAADQNfGTAAAJ9ElEQVR4nO3YMW5lZx2H4bF9feNx0CiZCCuD0kCDEAUKUoTYButIlZY1sAE6yiyAgiYFBVJoUqYiUhKQokFEZDRMbuxrO4uIvvdvjp5nBb+j75573nNO7v7zp/tHW3b9anrBWien0wvWujtOL1hr6+d3vJ5esNblG9ML1vru5fQCfoiz/fSCtbb++zy/mF6w1MaffgAAPDQCFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACA1O6T4xfTG5ban++mJyx1OF5PT1jq2ZOfTE9Y6vMXX05PWOp4cjs9YalfPH46PWGp42sX0xOW+tfLf05PWOrq8dX0hKUO++P0hKVOHr2anrCUL6AAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBqd3V5Nb1hqWev/2x6wlLPX30xPWGptw/bfkd68tavpicstT+7mJ6w1O3dcXrCUls/v81f3+m2r293+s70hKUuDofpCUtt++kOAMCDI0ABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEjtXju7nN6w1NeHr6YnLLX187t98+n0hKW+/O8n0xOWenlzmJ6w1Htvvjc9Yanr++P0hKU+f/HZ9ISlfvnWr6cnLPXxV3+bnrDUuz/e9vn5AgoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQOrn96wf30yOWurubXsAPsfXzO/UOCGO2fv/5//z/djxOL1hq46cHAMBDI0ABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEjtrj7+dHrDUmf7s+kJSz3/9N/TE5b64/vvTk9Y6g9/3/b5/fadJ9MTlvrwo8+mJyz1+9/9fHrCUn/+xzfTE5b66RuPpycs9fW3N9MTlvrNs8vpCUv5AgoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKRObm7/cj89YqWzm+vpCWud7acXrHU8TC9Ya3cxvWCts930grXu76YXrHWz8fvvZOPfYE63ff/dnGz7/js/HqcnLLXxuw8AgIdGgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkNr97/hiesNST47bbuzr3bavb394OT1hrR9dTC9Y67ttn9/1+W56wlL7b7f9fHj0+tPpBWudbvv5cP7N8+kJa+0vpxcste1fJwAAD44ABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAg9T1Rn3nGMjFSOwAAAABJRU5ErkJggg==" id="image6c52d2c3ec" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="483.84" height="295.2"/>
+iVBORw0KGgoAAAANSUhEUgAAAqAAAAGaCAYAAADQNfGTAAAJ+ElEQVR4nO3YsW7kVx2G4Yw96/U6aLXZJIZFaaBBiAIFKULcBtdBRcs15AbSpeQCKGgoKJBCkzIVkZIAijYhWiJrMfZ4zEVE5/0tfz3PFXyj4+N55+yO//rw/rUtu3k5vWCt3cn0grWOh+kFa239/A430wvWungyvWCt/15NL+C7OD2bXrDW1v8+H5xPL1hq499+AAC8agQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAACp/ceHz6c3LHX2YD89Yanrw830hKWePf7h9ISlPvv2i+kJSx12d9MTlvrpo6fTE5Y6PDyfnrDUP67+Pj1hqctHl9MTlro+O0xPWGr32svpCUt5AQUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFL7y4vL6Q1LPXv9x9MTlnr+8vPpCUv94Hrbv5Eev/nz6QlLnZ2eT09Y6u54mJ6w1NbPb/Of72Tbn29/8s70hKXOr6+nJyy17W93AABeOQIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAIDU/uHpxfSGpb65/nJ6wlJbP7+7N55OT1jqixcfT09Y6ur2enrCUu+98d70hKVu7g/TE5b67NtPpycs9bM3fzE9YamPvvzL9ISl3n172+fnBRQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgtbv782/vp0csdTxOL+C72Pr5nfgNCGO2fv/8//z/djhML1hq46cHAMCrRoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJDaX370yfSGpU7PTqcnLPX8k6+mJyz1wW/enZ6w1Pt/3fb5/eqdx9MTlvr9nz6dnrDU7379k+kJS/3hb/+enrDUj548mp6w1Df/uZ2esNQvn11MT1jKCygAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJDa3d798X56xEqntzfTE9Y6PZtesNbhenrBWvvz6QVrne6nF6x1f5xesNbtxu/fbuNvMCfbvn+3u23fvweHw/SEpTZ++wAAeNUIUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUvuvr/85vWGp75++NT1hqavj1fSEpb53N71gsYf76QVr3bycXrDU18cX0xOWeutwNj1hrdefTi9Y6ribXrDWgxfPpyesdfFkesFSXkABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUv8DgEJ7yNQNkacAAAAASUVORK5CYII=" id="image427d4a4866" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="483.84" height="295.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m5fba026dfd" d="M 0 0 
+       <path id="mc9d77cff22" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m5fba026dfd" x="115.814949" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc9d77cff22" x="115.814949" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m5fba026dfd" x="156.092348" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc9d77cff22" x="156.092348" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m5fba026dfd" x="196.369746" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc9d77cff22" x="196.369746" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m5fba026dfd" x="236.647145" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc9d77cff22" x="236.647145" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m5fba026dfd" x="276.924544" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc9d77cff22" x="276.924544" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m5fba026dfd" x="317.201942" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc9d77cff22" x="317.201942" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m5fba026dfd" x="357.479341" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc9d77cff22" x="357.479341" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m5fba026dfd" x="397.756739" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc9d77cff22" x="397.756739" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m5fba026dfd" x="438.034138" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc9d77cff22" x="438.034138" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m5fba026dfd" x="478.311536" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc9d77cff22" x="478.311536" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m5fba026dfd" x="518.588935" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc9d77cff22" x="518.588935" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m5fba026dfd" x="558.866334" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc9d77cff22" x="558.866334" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="m60e196f623" d="M 0 0 
+       <path id="m8d5693b00e" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m60e196f623" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8d5693b00e" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m60e196f623" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8d5693b00e" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m60e196f623" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8d5693b00e" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m60e196f623" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8d5693b00e" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -836,7 +836,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m60e196f623" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8d5693b00e" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -899,7 +899,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m60e196f623" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8d5693b00e" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -966,7 +966,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m60e196f623" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8d5693b00e" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1047,7 +1047,7 @@ z
     <g id="ytick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m60e196f623" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8d5693b00e" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -1138,7 +1138,7 @@ L 579.005033 49.34175
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_21">
-    <!-- +22 -->
+    <!-- +37 -->
     <g transform="translate(108.955926 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-2b" d="M 2944 4013 
@@ -1156,197 +1156,6 @@ L 2419 4013
 L 2944 4013 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-32" d="M 1228 531 
-L 3431 531 
-L 3431 0 
-L 469 0 
-L 469 531 
-Q 828 903 1448 1529 
-Q 2069 2156 2228 2338 
-Q 2531 2678 2651 2914 
-Q 2772 3150 2772 3378 
-Q 2772 3750 2511 3984 
-Q 2250 4219 1831 4219 
-Q 1534 4219 1204 4116 
-Q 875 4013 500 3803 
-L 500 4441 
-Q 881 4594 1212 4672 
-Q 1544 4750 1819 4750 
-Q 2544 4750 2975 4387 
-Q 3406 4025 3406 3419 
-Q 3406 3131 3298 2873 
-Q 3191 2616 2906 2266 
-Q 2828 2175 2409 1742 
-Q 1991 1309 1228 531 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_22">
-    <!-- -20 -->
-    <g transform="translate(150.784184 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-30" d="M 2034 4250 
-Q 1547 4250 1301 3770 
-Q 1056 3291 1056 2328 
-Q 1056 1369 1301 889 
-Q 1547 409 2034 409 
-Q 2525 409 2770 889 
-Q 3016 1369 3016 2328 
-Q 3016 3291 2770 3770 
-Q 2525 4250 2034 4250 
-z
-M 2034 4750 
-Q 2819 4750 3233 4129 
-Q 3647 3509 3647 2328 
-Q 3647 1150 3233 529 
-Q 2819 -91 2034 -91 
-Q 1250 -91 836 529 
-Q 422 1150 422 2328 
-Q 422 3509 836 4129 
-Q 1250 4750 2034 4750 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_23">
-    <!-- +11 -->
-    <g transform="translate(189.510723 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-31" d="M 794 531 
-L 1825 531 
-L 1825 4091 
-L 703 3866 
-L 703 4441 
-L 1819 4666 
-L 2450 4666 
-L 2450 531 
-L 3481 531 
-L 3481 0 
-L 794 0 
-L 794 531 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_24">
-    <!-- -29 -->
-    <g transform="translate(231.338981 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-39" d="M 703 97 
-L 703 672 
-Q 941 559 1184 500 
-Q 1428 441 1663 441 
-Q 2288 441 2617 861 
-Q 2947 1281 2994 2138 
-Q 2813 1869 2534 1725 
-Q 2256 1581 1919 1581 
-Q 1219 1581 811 2004 
-Q 403 2428 403 3163 
-Q 403 3881 828 4315 
-Q 1253 4750 1959 4750 
-Q 2769 4750 3195 4129 
-Q 3622 3509 3622 2328 
-Q 3622 1225 3098 567 
-Q 2575 -91 1691 -91 
-Q 1453 -91 1209 -44 
-Q 966 3 703 97 
-z
-M 1959 2075 
-Q 2384 2075 2632 2365 
-Q 2881 2656 2881 3163 
-Q 2881 3666 2632 3958 
-Q 2384 4250 1959 4250 
-Q 1534 4250 1286 3958 
-Q 1038 3666 1038 3163 
-Q 1038 2656 1286 2365 
-Q 1534 2075 1959 2075 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_25">
-    <!-- -7 -->
-    <g transform="translate(273.684192 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_26">
-    <!-- -15 -->
-    <g transform="translate(311.893778 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_27">
-    <!-- +11 -->
-    <g transform="translate(350.620317 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_28">
-    <!-- -30 -->
-    <g transform="translate(392.448575 69.553235) scale(0.065 -0.065)">
-     <defs>
       <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
 Q 3559 1806 3559 1356 
@@ -1379,81 +1188,189 @@ Q 3450 3153 3228 2886
 Q 3006 2619 2597 2516 
 z
 " transform="scale(0.015625)"/>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
     </g>
    </g>
-   <g id="text_29">
-    <!-- -8 -->
-    <g transform="translate(434.793786 69.553235) scale(0.065 -0.065)">
+   <g id="text_22">
+    <!-- -13 -->
+    <g transform="translate(150.784184 69.553235) scale(0.065 -0.065)">
      <defs>
-      <path id="DejaVuSans-38" d="M 2034 2216 
-Q 1584 2216 1326 1975 
-Q 1069 1734 1069 1313 
-Q 1069 891 1326 650 
-Q 1584 409 2034 409 
-Q 2484 409 2743 651 
-Q 3003 894 3003 1313 
-Q 3003 1734 2745 1975 
-Q 2488 2216 2034 2216 
-z
-M 1403 2484 
-Q 997 2584 770 2862 
-Q 544 3141 544 3541 
-Q 544 4100 942 4425 
-Q 1341 4750 2034 4750 
-Q 2731 4750 3128 4425 
-Q 3525 4100 3525 3541 
-Q 3525 3141 3298 2862 
-Q 3072 2584 2669 2484 
-Q 3125 2378 3379 2068 
-Q 3634 1759 3634 1313 
-Q 3634 634 3220 271 
-Q 2806 -91 2034 -91 
-Q 1263 -91 848 271 
-Q 434 634 434 1313 
-Q 434 1759 690 2068 
-Q 947 2378 1403 2484 
-z
-M 1172 3481 
-Q 1172 3119 1398 2916 
-Q 1625 2713 2034 2713 
-Q 2441 2713 2670 2916 
-Q 2900 3119 2900 3481 
-Q 2900 3844 2670 4047 
-Q 2441 4250 2034 4250 
-Q 1625 4250 1398 4047 
-Q 1172 3844 1172 3481 
+      <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
     </g>
    </g>
-   <g id="text_30">
-    <!-- -5 -->
-    <g transform="translate(475.071185 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
+   <g id="text_23">
+    <!-- +20 -->
+    <g transform="translate(189.510723 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
     </g>
    </g>
-   <g id="text_31">
-    <!-- -32 -->
-    <g transform="translate(513.280771 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_32">
+   <g id="text_24">
     <!-- -20 -->
-    <g transform="translate(553.558169 69.553235) scale(0.065 -0.065)">
+    <g transform="translate(231.338981 69.553235) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_25">
+    <!-- -2 -->
+    <g transform="translate(273.684192 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_26">
+    <!-- -13 -->
+    <g transform="translate(311.893778 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_27">
+    <!-- +31 -->
+    <g transform="translate(350.620317 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_28">
+    <!-- -24 -->
+    <g transform="translate(392.448575 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_29">
+    <!-- -3 -->
+    <g transform="translate(434.793786 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_30">
+    <!-- +4 -->
+    <g transform="translate(473.520325 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_31">
+    <!-- -31 -->
+    <g transform="translate(513.280771 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_32">
+    <!-- -12 -->
+    <g transform="translate(553.558169 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_33">
@@ -1474,6 +1391,33 @@ z
    <g id="text_35">
     <!-- -5 -->
     <g transform="translate(193.129395 106.389018) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
     </g>
@@ -1535,27 +1479,6 @@ z
    <g id="text_39">
     <!-- -4 -->
     <g transform="translate(354.238989 106.389018) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-34" d="M 2419 4116 
-L 825 1625 
-L 2419 1625 
-L 2419 4116 
-z
-M 2253 4666 
-L 3047 4666 
-L 3047 1625 
-L 3713 1625 
-L 3713 1100 
-L 3047 1100 
-L 3047 0 
-L 2419 0 
-L 2419 1100 
-L 313 1100 
-L 313 1709 
-L 2253 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
     </g>
@@ -1586,6 +1509,38 @@ z
    <g id="text_43">
     <!-- +9 -->
     <g transform="translate(513.797724 106.389018) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(83.789062 0)"/>
     </g>
@@ -1646,6 +1601,47 @@ z
    <g id="text_50">
     <!-- +184 -->
     <g transform="translate(308.275106 143.2248) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-38" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
@@ -2195,18 +2191,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB1ElEQVR4nO2b0a3DMAwD7cSzvM3fmI47gvpxCK6ENABhnkQ5aZH5P/7OAGpdFyEzBiQDnija2qSEghnZhIIZCa3NyWQkmZFOKJhRsDXsOopmJJwjaEPOmxHirE3MWjOqhSBr2EAGMyKtMVpc+ynYwe3viNQVbA0LrZDRFbxGbNbWyM3auG0RGbo1Qp0IZCSMiG2OgtNvbL+Oke6BvddIWaQ1qP3RjGSTLXypwdaIMP2ctWb0olAzKkr4LhLMCPvnOJiRbo6CrTWjF4WCGYHWJtU1TKgZvSZkfNAKZhRsDftFa96MkJCRrf29ausyWrOtWiMjmxDH6FAfDJzzIEKctQc60ToDEqJOBLbfZs04RxQjobWOSFXrjM0IdURqIaG1jkhVPmvGOUqOCPLJMdh+6kRk+zFGMtjKOdK13zbZ2EBGMxLOkSz90YygK9tozSbUa6Qu4RxtRifZ2np0jDY32YiOc44gIQo2aI1ZkB2Rb4SiIyJbtcr0Q0IPdCQyIpCQDnZHpC5uQ27uOtJFBBptH2zlHOnab+uaMSK29htXrW2NKK0hOtlrxLaPjIxys4a99x9dRKgTgUK69gsZ9RxVFWzNyIi6RZIZtbXfE+qI1BU8R5i1D2e5X2tFkZmlAAAAAElFTkSuQmCC" id="image833f8e29c7" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-69.84" width="12.96" height="253.44"/>
+iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB1ElEQVR4nO2b0a3DMAwD7cSzvM3fmI47gvpxCK6ENABhnkQ5aZH5P/7OAGpdFyEzBiQDnija2qSEghnZhIIZCa3NyWQkmZFOKJhRsDXsOopmJJwjaEPOmxHirE3MWjOqhSBr2EAGMyKtMVpc+ynYwe3viNQVbA0LrZDRFbxGbNbWyM3auG0RGbo1Qp0IZCSMiG2OgtNvbL+Oke6BvddIWaQ1qP3RjGSTLXypwdaIMP2ctWb0olAzKkr4LhLMCPvnOJiRbo6CrTWjF4WCGYHWJtU1TKgZvSZkfNAKZhRsDftFa96MkJCRrf29ausyWrOtWiMjmxDH6FAfDJzzIEKctQc60ToDEqJOBLbfZs04RxQjobWOSFXrjM0IdURqIaG1jkhVPmvGOUqOCPLJMdh+6kRk+zFGMtjKOdK13zbZ2EBGMxLOkSz90YygK9tozSbUa6Qu4RxtRifZ2np0jDY32YiOc44gIQo2aI1ZkB2Rb4SiIyJbtcr0Q0IPdCQyIpCQDnZHpC5uQ27uOtJFBBptH2zlHOnab+uaMSK29htXrW2NKK0hOtlrxLaPjIxys4a99x9dRKgTgUK69gsZ9RxVFWzNyIi6RZIZtbXfE+qI1BU8R5i1D2e5X2tFkZmlAAAAAElFTkSuQmCC" id="image1e09f6da06" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-69.84" width="12.96" height="253.44"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_21">
       <defs>
-       <path id="m6445d7a25b" d="M 0 0 
+       <path id="mba808af966" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m6445d7a25b" x="601.779688" y="322.507463" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mba808af966" x="601.779688" y="322.507463" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_117">
@@ -2229,7 +2225,7 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m6445d7a25b" x="601.779688" y="280.566603" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mba808af966" x="601.779688" y="280.566603" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_118">
@@ -2243,7 +2239,7 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m6445d7a25b" x="601.779688" y="238.625742" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mba808af966" x="601.779688" y="238.625742" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_119">
@@ -2257,7 +2253,7 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m6445d7a25b" x="601.779688" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mba808af966" x="601.779688" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_120">
@@ -2270,7 +2266,7 @@ z
     <g id="ytick_13">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m6445d7a25b" x="601.779688" y="154.74402" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mba808af966" x="601.779688" y="154.74402" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_121">
@@ -2283,7 +2279,7 @@ z
     <g id="ytick_14">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m6445d7a25b" x="601.779688" y="112.803159" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mba808af966" x="601.779688" y="112.803159" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_122">
@@ -2296,7 +2292,7 @@ z
     <g id="ytick_15">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#m6445d7a25b" x="601.779688" y="70.862298" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mba808af966" x="601.779688" y="70.862298" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_123">
@@ -2912,8 +2908,8 @@ z
    </g>
   </g>
   <g id="text_126">
-   <!-- 2026-07-08T22:12:55Z  ·  Linux chungus2 x86_64  ·  commit 30251fb3  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(44.380078 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-08T22:38:10Z  ·  Linux chungus2 x86_64  ·  commit f6be9ada  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(44.622344 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -3007,11 +3003,11 @@ z
     <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3051,109 +3047,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3262.744141 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3326.367188 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3389.990234 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3425.195312 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3488.671875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3552.294922 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3584.082031 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3615.869141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3647.65625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3679.443359 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3711.230469 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3739.013672 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3800.537109 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3861.816406 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3925.195312 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3988.671875 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4027.535156 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4088.716797 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4147.896484 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4209.419922 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4250.533203 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4284.224609 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4312.007812 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4373.53125 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4434.810547 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4498.189453 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4561.8125 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4595.503906 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4654.683594 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4718.306641 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4750.09375 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4813.716797 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4877.339844 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4909.126953 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4972.75 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5008.833984 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5047.697266 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5102.677734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5166.300781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5198.087891 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5229.875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5261.662109 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5293.449219 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5325.236328 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5364.445312 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5427.824219 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5466.6875 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5527.869141 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5591.248047 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5654.724609 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5718.103516 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5781.580078 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5844.958984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5884.167969 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5915.955078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5999.744141 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6031.53125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6128.943359 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6190.466797 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6253.943359 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6281.726562 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6343.005859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6406.384766 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6438.171875 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6490.271484 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6553.650391 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6614.929688 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6678.40625 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6730.505859 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6793.884766 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6855.066406 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6894.275391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6927.966797 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6959.753906 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7000.867188 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7062.146484 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7101.355469 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7129.138672 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7190.320312 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7222.107422 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7249.890625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7301.990234 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7333.777344 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7397.253906 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7458.777344 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7497.986328 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7559.509766 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7598.873047 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7696.285156 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7724.068359 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7787.447266 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7815.230469 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7867.330078 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7906.539062 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7934.322266 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3107.080078 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3170.703125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3234.179688 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3295.703125 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3359.326172 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3420.605469 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3484.082031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3545.361328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3577.148438 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3608.935547 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3640.722656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3672.509766 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3704.296875 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3732.080078 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3793.603516 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3854.882812 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3918.261719 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3981.738281 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4020.601562 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4081.783203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4140.962891 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4202.486328 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4243.599609 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4277.291016 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4305.074219 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4366.597656 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4427.876953 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4491.255859 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4554.878906 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4588.570312 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4647.75 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4711.373047 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4743.160156 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4806.783203 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4870.40625 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4902.193359 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4965.816406 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5001.900391 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5040.763672 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5095.744141 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5159.367188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5191.154297 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5222.941406 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5254.728516 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5286.515625 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5318.302734 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5357.511719 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5420.890625 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5459.753906 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5520.935547 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5584.314453 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5647.791016 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5711.169922 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5774.646484 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5838.025391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5877.234375 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5909.021484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5992.810547 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6024.597656 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6122.009766 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6183.533203 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6247.009766 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6274.792969 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6336.072266 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6399.451172 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6431.238281 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6483.337891 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6546.716797 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6607.996094 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6671.472656 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6723.572266 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6786.951172 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6848.132812 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6887.341797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6921.033203 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6952.820312 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6993.933594 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7055.212891 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7094.421875 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7122.205078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7183.386719 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7215.173828 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7242.957031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7295.056641 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7326.84375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7390.320312 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7451.84375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7491.052734 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7552.576172 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7591.939453 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7689.351562 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7717.134766 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7780.513672 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7808.296875 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7860.396484 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7899.605469 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7927.388672 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p5fc832b6a3">
+  <clipPath id="p7ad8372bd0">
    <rect x="95.67625" y="49.34175" width="483.328783" height="294.686261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_compress_pareto.svg
+++ b/bench/graphs/silesia_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 61.085542 412.80375 
 L 61.085542 48.323125 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m7b18aaf7d6" d="M 0 0 
+       <path id="m6e7e127bc7" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m7b18aaf7d6" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6e7e127bc7" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -130,11 +130,11 @@ z
      <g id="line2d_3">
       <path d="M 145.270284 412.80375 
 L 145.270284 48.323125 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m7b18aaf7d6" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6e7e127bc7" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -177,11 +177,11 @@ z
      <g id="line2d_5">
       <path d="M 229.455026 412.80375 
 L 229.455026 48.323125 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m7b18aaf7d6" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6e7e127bc7" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -219,11 +219,11 @@ z
      <g id="line2d_7">
       <path d="M 313.639768 412.80375 
 L 313.639768 48.323125 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m7b18aaf7d6" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6e7e127bc7" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -272,11 +272,11 @@ z
      <g id="line2d_9">
       <path d="M 397.82451 412.80375 
 L 397.82451 48.323125 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m7b18aaf7d6" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6e7e127bc7" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -334,11 +334,11 @@ z
      <g id="line2d_11">
       <path d="M 482.009253 412.80375 
 L 482.009253 48.323125 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m7b18aaf7d6" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6e7e127bc7" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -355,11 +355,11 @@ L 482.009253 48.323125
      <g id="line2d_13">
       <path d="M 566.193995 412.80375 
 L 566.193995 48.323125 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m7b18aaf7d6" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6e7e127bc7" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -856,16 +856,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 368.08164 
 L 637.2 368.08164 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="mb4e36a9d5f" d="M 0 0 
+       <path id="mbd00dde7f4" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mb4e36a9d5f" x="49.078125" y="368.08164" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbd00dde7f4" x="49.078125" y="368.08164" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -897,11 +897,11 @@ z
      <g id="line2d_17">
       <path d="M 49.078125 243.439835 
 L 637.2 243.439835 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mb4e36a9d5f" x="49.078125" y="243.439835" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbd00dde7f4" x="49.078125" y="243.439835" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -917,11 +917,11 @@ L 637.2 243.439835
      <g id="line2d_19">
       <path d="M 49.078125 118.798029 
 L 637.2 118.798029 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#mb4e36a9d5f" x="49.078125" y="118.798029" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbd00dde7f4" x="49.078125" y="118.798029" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -937,16 +937,16 @@ L 637.2 118.798029
      <g id="line2d_21">
       <path d="M 49.078125 405.602562 
 L 637.2 405.602562 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="m82e6c9389b" d="M 0 0 
+       <path id="me077337287" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m82e6c9389b" x="49.078125" y="405.602562" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me077337287" x="49.078125" y="405.602562" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -954,11 +954,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 395.733268 
 L 637.2 395.733268 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m82e6c9389b" x="49.078125" y="395.733268" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me077337287" x="49.078125" y="395.733268" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -966,11 +966,11 @@ L 637.2 395.733268
      <g id="line2d_25">
       <path d="M 49.078125 387.3889 
 L 637.2 387.3889 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m82e6c9389b" x="49.078125" y="387.3889" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me077337287" x="49.078125" y="387.3889" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -978,11 +978,11 @@ L 637.2 387.3889
      <g id="line2d_27">
       <path d="M 49.078125 380.160679 
 L 637.2 380.160679 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m82e6c9389b" x="49.078125" y="380.160679" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me077337287" x="49.078125" y="380.160679" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -990,11 +990,11 @@ L 637.2 380.160679
      <g id="line2d_29">
       <path d="M 49.078125 373.784936 
 L 637.2 373.784936 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m82e6c9389b" x="49.078125" y="373.784936" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me077337287" x="49.078125" y="373.784936" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1002,11 +1002,11 @@ L 637.2 373.784936
      <g id="line2d_31">
       <path d="M 49.078125 330.560718 
 L 637.2 330.560718 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m82e6c9389b" x="49.078125" y="330.560718" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me077337287" x="49.078125" y="330.560718" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1014,11 +1014,11 @@ L 637.2 330.560718
      <g id="line2d_33">
       <path d="M 49.078125 308.612385 
 L 637.2 308.612385 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m82e6c9389b" x="49.078125" y="308.612385" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me077337287" x="49.078125" y="308.612385" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1026,11 +1026,11 @@ L 637.2 308.612385
      <g id="line2d_35">
       <path d="M 49.078125 293.039796 
 L 637.2 293.039796 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m82e6c9389b" x="49.078125" y="293.039796" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me077337287" x="49.078125" y="293.039796" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1038,11 +1038,11 @@ L 637.2 293.039796
      <g id="line2d_37">
       <path d="M 49.078125 280.960757 
 L 637.2 280.960757 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m82e6c9389b" x="49.078125" y="280.960757" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me077337287" x="49.078125" y="280.960757" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1050,11 +1050,11 @@ L 637.2 280.960757
      <g id="line2d_39">
       <path d="M 49.078125 271.091463 
 L 637.2 271.091463 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m82e6c9389b" x="49.078125" y="271.091463" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me077337287" x="49.078125" y="271.091463" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1062,11 +1062,11 @@ L 637.2 271.091463
      <g id="line2d_41">
       <path d="M 49.078125 262.747094 
 L 637.2 262.747094 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m82e6c9389b" x="49.078125" y="262.747094" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me077337287" x="49.078125" y="262.747094" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1074,11 +1074,11 @@ L 637.2 262.747094
      <g id="line2d_43">
       <path d="M 49.078125 255.518874 
 L 637.2 255.518874 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m82e6c9389b" x="49.078125" y="255.518874" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me077337287" x="49.078125" y="255.518874" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1086,11 +1086,11 @@ L 637.2 255.518874
      <g id="line2d_45">
       <path d="M 49.078125 249.143131 
 L 637.2 249.143131 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m82e6c9389b" x="49.078125" y="249.143131" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me077337287" x="49.078125" y="249.143131" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1098,11 +1098,11 @@ L 637.2 249.143131
      <g id="line2d_47">
       <path d="M 49.078125 205.918912 
 L 637.2 205.918912 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m82e6c9389b" x="49.078125" y="205.918912" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me077337287" x="49.078125" y="205.918912" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1110,11 +1110,11 @@ L 637.2 205.918912
      <g id="line2d_49">
       <path d="M 49.078125 183.97058 
 L 637.2 183.97058 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m82e6c9389b" x="49.078125" y="183.97058" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me077337287" x="49.078125" y="183.97058" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1122,11 +1122,11 @@ L 637.2 183.97058
      <g id="line2d_51">
       <path d="M 49.078125 168.39799 
 L 637.2 168.39799 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m82e6c9389b" x="49.078125" y="168.39799" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me077337287" x="49.078125" y="168.39799" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1134,11 +1134,11 @@ L 637.2 168.39799
      <g id="line2d_53">
       <path d="M 49.078125 156.318951 
 L 637.2 156.318951 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#m82e6c9389b" x="49.078125" y="156.318951" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me077337287" x="49.078125" y="156.318951" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1146,11 +1146,11 @@ L 637.2 156.318951
      <g id="line2d_55">
       <path d="M 49.078125 146.449658 
 L 637.2 146.449658 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#m82e6c9389b" x="49.078125" y="146.449658" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me077337287" x="49.078125" y="146.449658" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1158,11 +1158,11 @@ L 637.2 146.449658
      <g id="line2d_57">
       <path d="M 49.078125 138.105289 
 L 637.2 138.105289 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#m82e6c9389b" x="49.078125" y="138.105289" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me077337287" x="49.078125" y="138.105289" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1170,11 +1170,11 @@ L 637.2 138.105289
      <g id="line2d_59">
       <path d="M 49.078125 130.877068 
 L 637.2 130.877068 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#m82e6c9389b" x="49.078125" y="130.877068" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me077337287" x="49.078125" y="130.877068" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1182,11 +1182,11 @@ L 637.2 130.877068
      <g id="line2d_61">
       <path d="M 49.078125 124.501326 
 L 637.2 124.501326 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#m82e6c9389b" x="49.078125" y="124.501326" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me077337287" x="49.078125" y="124.501326" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1194,11 +1194,11 @@ L 637.2 124.501326
      <g id="line2d_63">
       <path d="M 49.078125 81.277107 
 L 637.2 81.277107 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#m82e6c9389b" x="49.078125" y="81.277107" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me077337287" x="49.078125" y="81.277107" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1206,11 +1206,11 @@ L 637.2 81.277107
      <g id="line2d_65">
       <path d="M 49.078125 59.328775 
 L 637.2 59.328775 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#m82e6c9389b" x="49.078125" y="59.328775" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me077337287" x="49.078125" y="59.328775" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1332,7 +1332,7 @@ L 637.2 48.323125
    </g>
    <g id="text_13">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(324.643112 118.414237) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(324.643112 118.587384) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1364,7 +1364,7 @@ z
    </g>
    <g id="text_14">
     <!-- L10 -->
-    <g style="fill: #d62728" transform="translate(102.814287 308.867065) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(102.814287 308.392483) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1686,23 +1686,23 @@ z
    </g>
    <g id="line2d_67">
     <defs>
-     <path id="mcd3f418712" d="M -2.5 2.5 
+     <path id="mb12648aec5" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p5ca6112d80)">
-     <use xlink:href="#mcd3f418712" x="377.110281" y="104.685421" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcd3f418712" x="323.801439" y="110.409833" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcd3f418712" x="272.665744" y="126.308323" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcd3f418712" x="235.168828" y="128.026741" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcd3f418712" x="186.228265" y="149.377587" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcd3f418712" x="158.303164" y="171.457731" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcd3f418712" x="149.489547" y="182.192614" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcd3f418712" x="140.563162" y="202.482797" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcd3f418712" x="138.984853" y="209.328911" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p064081e379)">
+     <use xlink:href="#mb12648aec5" x="377.110281" y="104.685421" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb12648aec5" x="323.801439" y="110.409833" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb12648aec5" x="272.665744" y="126.308323" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb12648aec5" x="235.168828" y="128.026741" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb12648aec5" x="186.228265" y="149.377587" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb12648aec5" x="158.303164" y="171.457731" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb12648aec5" x="149.489547" y="182.192614" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb12648aec5" x="140.563162" y="202.482797" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb12648aec5" x="138.984853" y="209.328911" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_68">
@@ -1755,7 +1755,7 @@ L 327.133241 110.069256
 L 326.02264 110.18302 
 L 324.91204 110.296545 
 L 323.801439 110.409833 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_69">
     <path d="M 323.801439 110.409833 
@@ -1807,7 +1807,7 @@ L 275.861725 125.44037
 L 274.796398 125.731236 
 L 273.731071 126.020548 
 L 272.665744 126.308323 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_70">
     <path d="M 272.665744 126.308323 
@@ -1859,7 +1859,7 @@ L 237.512385 127.920923
 L 236.7312 127.956219 
 L 235.950014 127.991491 
 L 235.168828 128.026741 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_71">
     <path d="M 235.168828 128.026741 
@@ -1911,7 +1911,7 @@ L 189.28705 148.263499
 L 188.267455 148.637415 
 L 187.24786 149.008766 
 L 186.228265 149.377587 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_72">
     <path d="M 186.228265 149.377587 
@@ -1963,7 +1963,7 @@ L 160.048483 170.312481
 L 159.46671 170.696929 
 L 158.884937 171.078667 
 L 158.303164 171.457731 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_73">
     <path d="M 158.303164 171.457731 
@@ -2015,7 +2015,7 @@ L 150.040398 181.580576
 L 149.856781 181.785359 
 L 149.673164 181.989369 
 L 149.489547 182.192614 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_74">
     <path d="M 149.489547 182.192614 
@@ -2067,7 +2067,7 @@ L 141.121061 201.414753
 L 140.935095 201.773114 
 L 140.749129 202.129119 
 L 140.563162 202.482797 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_75">
     <path d="M 140.563162 202.482797 
@@ -2119,26 +2119,26 @@ L 139.083497 208.925481
 L 139.050616 209.060292 
 L 139.017734 209.194768 
 L 138.984853 209.328911 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_76">
     <defs>
-     <path id="m7f0a0c0000" d="M 0 -2.5 
+     <path id="maecbc320be" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p5ca6112d80)">
-     <use xlink:href="#m7f0a0c0000" x="610.467187" y="71.939349" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7f0a0c0000" x="319.880958" y="101.884157" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7f0a0c0000" x="210.281253" y="129.778154" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7f0a0c0000" x="196.287076" y="133.586625" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7f0a0c0000" x="176.054419" y="147.38645" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7f0a0c0000" x="152.161413" y="174.753272" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7f0a0c0000" x="146.720208" y="186.587648" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7f0a0c0000" x="143.994022" y="196.356323" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7f0a0c0000" x="142.666037" y="200.180971" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p064081e379)">
+     <use xlink:href="#maecbc320be" x="610.467187" y="71.939349" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#maecbc320be" x="319.880958" y="101.884157" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#maecbc320be" x="210.281253" y="129.778154" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#maecbc320be" x="196.287076" y="133.586625" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#maecbc320be" x="176.054419" y="147.38645" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#maecbc320be" x="152.161413" y="174.753272" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#maecbc320be" x="146.720208" y="186.587648" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#maecbc320be" x="143.994022" y="196.356323" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#maecbc320be" x="142.666037" y="200.180971" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_77">
@@ -2191,7 +2191,7 @@ L 338.042598 100.427247
 L 331.988718 100.917253 
 L 325.934838 101.402864 
 L 319.880958 101.884157 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_78">
     <path d="M 319.880958 101.884157 
@@ -2243,7 +2243,7 @@ L 217.131235 128.398367
 L 214.847908 128.862215 
 L 212.564581 129.322122 
 L 210.281253 129.778154 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_79">
     <path d="M 210.281253 129.778154 
@@ -2295,7 +2295,7 @@ L 197.161712 133.356286
 L 196.870166 133.433175 
 L 196.578621 133.509954 
 L 196.287076 133.586625 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_80">
     <path d="M 196.287076 133.586625 
@@ -2347,7 +2347,7 @@ L 177.31896 146.619719
 L 176.897447 146.876504 
 L 176.475933 147.132078 
 L 176.054419 147.38645 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_81">
     <path d="M 176.054419 147.38645 
@@ -2399,7 +2399,7 @@ L 153.654726 173.393769
 L 153.156955 173.850741 
 L 152.659184 174.303887 
 L 152.161413 174.753272 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_82">
     <path d="M 152.161413 174.753272 
@@ -2451,7 +2451,7 @@ L 147.060283 185.919158
 L 146.946925 186.142906 
 L 146.833566 186.365734 
 L 146.720208 186.587648 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_83">
     <path d="M 146.720208 186.587648 
@@ -2503,7 +2503,7 @@ L 144.164409 195.794799
 L 144.107613 195.982622 
 L 144.050817 196.169795 
 L 143.994022 196.356323 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_84">
     <path d="M 143.994022 196.356323 
@@ -2555,30 +2555,30 @@ L 142.749036 199.949687
 L 142.72137 200.026891 
 L 142.693704 200.103986 
 L 142.666037 200.180971 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_85">
     <defs>
-     <path id="m2fa6edb34c" d="M -0 3.535534 
+     <path id="m49e4b76b53" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p5ca6112d80)">
-     <use xlink:href="#m2fa6edb34c" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2fa6edb34c" x="242.839153" y="80.778898" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2fa6edb34c" x="218.251194" y="86.377096" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2fa6edb34c" x="197.814984" y="90.309617" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2fa6edb34c" x="166.378359" y="99.066934" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2fa6edb34c" x="145.830392" y="110.431955" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2fa6edb34c" x="134.598477" y="126.026287" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2fa6edb34c" x="124.077268" y="149.033155" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2fa6edb34c" x="122.462976" y="157.476606" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2fa6edb34c" x="81.012077" y="220.06889" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2fa6edb34c" x="77.44276" y="239.652656" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2fa6edb34c" x="76.953425" y="252.706566" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p064081e379)">
+     <use xlink:href="#m49e4b76b53" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m49e4b76b53" x="242.839153" y="80.778898" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m49e4b76b53" x="218.251194" y="86.377096" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m49e4b76b53" x="197.814984" y="90.309617" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m49e4b76b53" x="166.378359" y="99.066934" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m49e4b76b53" x="145.830392" y="110.431955" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m49e4b76b53" x="134.598477" y="126.026287" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m49e4b76b53" x="124.077268" y="149.033155" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m49e4b76b53" x="122.462976" y="157.476606" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m49e4b76b53" x="81.012077" y="220.06889" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m49e4b76b53" x="77.44276" y="239.652656" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m49e4b76b53" x="76.953425" y="252.706566" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_86">
@@ -2631,7 +2631,7 @@ L 245.91379 79.91142
 L 244.888911 80.202126 
 L 243.864032 80.49128 
 L 242.839153 80.778898 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_87">
     <path d="M 242.839153 80.778898 
@@ -2683,7 +2683,7 @@ L 219.787941 86.043669
 L 219.275692 86.155039 
 L 218.763443 86.266182 
 L 218.251194 86.377096 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_88">
     <path d="M 218.251194 86.377096 
@@ -2735,7 +2735,7 @@ L 199.092247 90.072029
 L 198.666492 90.151341 
 L 198.240738 90.230537 
 L 197.814984 90.309617 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_89">
     <path d="M 197.814984 90.309617 
@@ -2787,7 +2787,7 @@ L 168.343148 98.559208
 L 167.688219 98.72898 
 L 167.033289 98.898221 
 L 166.378359 99.066934 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_90">
     <path d="M 166.378359 99.066934 
@@ -2839,7 +2839,7 @@ L 147.11464 109.78743
 L 146.686557 110.003126 
 L 146.258475 110.217965 
 L 145.830392 110.431955 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_91">
     <path d="M 145.830392 110.431955 
@@ -2891,7 +2891,7 @@ L 135.300472 125.172774
 L 135.066474 125.458776 
 L 134.832476 125.743276 
 L 134.598477 126.026287 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_92">
     <path d="M 134.598477 126.026287 
@@ -2943,7 +2943,7 @@ L 124.734843 147.848882
 L 124.515652 148.246526 
 L 124.29646 148.641269 
 L 124.077268 149.033155 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_93">
     <path d="M 124.077268 149.033155 
@@ -2995,7 +2995,7 @@ L 122.56387 156.985769
 L 122.530239 157.149876 
 L 122.496607 157.313488 
 L 122.462976 157.476606 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_94">
     <path d="M 122.462976 157.476606 
@@ -3047,7 +3047,7 @@ L 83.602758 217.699074
 L 82.739198 218.500595 
 L 81.875637 219.290422 
 L 81.012077 220.06889 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_95">
     <path d="M 81.012077 220.06889 
@@ -3099,7 +3099,7 @@ L 77.665842 238.615761
 L 77.591481 238.963605 
 L 77.517121 239.309227 
 L 77.44276 239.652656 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_96">
     <path d="M 77.44276 239.652656 
@@ -3151,23 +3151,23 @@ L 76.984008 251.97672
 L 76.973814 252.221097 
 L 76.96362 252.464376 
 L 76.953425 252.706566 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_97">
     <defs>
-     <path id="m0b530f356d" d="M -0 2.5 
+     <path id="mc5ae06a1be" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p5ca6112d80)">
-     <use xlink:href="#m0b530f356d" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p064081e379)">
+     <use xlink:href="#mc5ae06a1be" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_98">
     <defs>
-     <path id="m5253f1838b" d="M -0.833333 2.5 
+     <path id="meb4a948f6a" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -3182,16 +3182,16 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p5ca6112d80)">
-     <use xlink:href="#m5253f1838b" x="432.495268" y="96.067622" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5253f1838b" x="300.62247" y="112.493412" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5253f1838b" x="266.967623" y="120.8136" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5253f1838b" x="226.040946" y="122.099593" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5253f1838b" x="180.985721" y="141.85872" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5253f1838b" x="164.441833" y="156.106179" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5253f1838b" x="157.761315" y="165.23787" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5253f1838b" x="151.269082" y="178.700983" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5253f1838b" x="150.327087" y="185.23695" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p064081e379)">
+     <use xlink:href="#meb4a948f6a" x="432.495268" y="96.067622" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#meb4a948f6a" x="300.62247" y="112.493412" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#meb4a948f6a" x="266.967623" y="120.8136" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#meb4a948f6a" x="226.040946" y="122.099593" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#meb4a948f6a" x="180.985721" y="141.85872" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#meb4a948f6a" x="164.441833" y="156.106179" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#meb4a948f6a" x="157.761315" y="165.23787" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#meb4a948f6a" x="151.269082" y="178.700983" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#meb4a948f6a" x="150.327087" y="185.23695" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_99">
@@ -3244,7 +3244,7 @@ L 308.86452 111.600609
 L 306.11717 111.899849 
 L 303.36982 112.197444 
 L 300.62247 112.493412 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_100">
     <path d="M 300.62247 112.493412 
@@ -3296,7 +3296,7 @@ L 269.071051 120.329422
 L 268.369908 120.491297 
 L 267.668766 120.652688 
 L 266.967623 120.8136 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_101">
     <path d="M 266.967623 120.8136 
@@ -3348,7 +3348,7 @@ L 228.598863 122.020108
 L 227.746224 122.046616 
 L 226.893585 122.073111 
 L 226.040946 122.099593 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_102">
     <path d="M 226.040946 122.099593 
@@ -3400,7 +3400,7 @@ L 183.801673 140.814056
 L 182.863022 141.164522 
 L 181.924372 141.512734 
 L 180.985721 141.85872 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_103">
     <path d="M 180.985721 141.85872 
@@ -3452,7 +3452,7 @@ L 165.475826 155.317544
 L 165.131161 155.581701 
 L 164.786497 155.844575 
 L 164.441833 156.106179 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_104">
     <path d="M 164.441833 156.106179 
@@ -3504,7 +3504,7 @@ L 158.178848 164.710119
 L 158.03967 164.886608 
 L 157.900493 165.062524 
 L 157.761315 165.23787 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_105">
     <path d="M 157.761315 165.23787 
@@ -3556,7 +3556,7 @@ L 151.674847 177.950842
 L 151.539592 178.202046 
 L 151.404337 178.452089 
 L 151.269082 178.700983 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_106">
     <path d="M 151.269082 178.700983 
@@ -3608,11 +3608,11 @@ L 150.385962 184.850776
 L 150.366337 184.979807 
 L 150.346712 185.108531 
 L 150.327087 185.23695 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_107">
     <defs>
-     <path id="m35056ef38d" d="M -1.25 2.5 
+     <path id="me2583f7e51" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -3627,16 +3627,16 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p5ca6112d80)">
-     <use xlink:href="#m35056ef38d" x="345.030867" y="136.859359" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m35056ef38d" x="273.364924" y="143.571257" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m35056ef38d" x="240.719951" y="149.310846" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m35056ef38d" x="221.353978" y="154.160538" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m35056ef38d" x="207.129625" y="156.092215" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m35056ef38d" x="181.064802" y="166.758473" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m35056ef38d" x="179.282169" y="170.289343" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m35056ef38d" x="177.719335" y="175.489948" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m35056ef38d" x="177.643939" y="181.552088" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p064081e379)">
+     <use xlink:href="#me2583f7e51" x="345.030867" y="136.859359" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me2583f7e51" x="273.364924" y="143.571257" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me2583f7e51" x="240.719951" y="149.310846" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me2583f7e51" x="221.353978" y="154.160538" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me2583f7e51" x="207.129625" y="156.092215" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me2583f7e51" x="181.064802" y="166.758473" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me2583f7e51" x="179.282169" y="170.289343" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me2583f7e51" x="177.719335" y="175.489948" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me2583f7e51" x="177.643939" y="181.552088" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_108">
@@ -3689,7 +3689,7 @@ L 277.844045 143.175283
 L 276.351005 143.307597 
 L 274.857964 143.439587 
 L 273.364924 143.571257 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_109">
     <path d="M 273.364924 143.571257 
@@ -3741,7 +3741,7 @@ L 242.760262 148.96941
 L 242.080158 149.083462 
 L 241.400055 149.197273 
 L 240.719951 149.310846 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_110">
     <path d="M 240.719951 149.310846 
@@ -3793,7 +3793,7 @@ L 222.564351 153.869835
 L 222.160893 153.966909 
 L 221.757435 154.06381 
 L 221.353978 154.160538 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_111">
     <path d="M 221.353978 154.160538 
@@ -3845,7 +3845,7 @@ L 208.018647 155.973483
 L 207.722306 156.013089 
 L 207.425965 156.052666 
 L 207.129625 156.092215 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_112">
     <path d="M 207.129625 156.092215 
@@ -3897,7 +3897,7 @@ L 182.693853 166.149994
 L 182.150836 166.353581 
 L 181.607819 166.556405 
 L 181.064802 166.758473 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_113">
     <path d="M 181.064802 166.758473 
@@ -3949,7 +3949,7 @@ L 179.393584 170.075284
 L 179.356445 170.146731 
 L 179.319307 170.218084 
 L 179.282169 170.289343 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_114">
     <path d="M 179.282169 170.289343 
@@ -4001,7 +4001,7 @@ L 177.817012 175.179146
 L 177.784453 175.282945 
 L 177.751894 175.386546 
 L 177.719335 175.489948 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_115">
     <path d="M 177.719335 175.489948 
@@ -4053,11 +4053,11 @@ L 177.648651 181.192458
 L 177.64708 181.3126 
 L 177.645509 181.432477 
 L 177.643939 181.552088 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_116">
     <defs>
-     <path id="m4ae4a2483a" d="M 0 -2.5 
+     <path id="m152b391f0c" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -4070,16 +4070,16 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p5ca6112d80)">
-     <use xlink:href="#m4ae4a2483a" x="226.871027" y="113.224491" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m4ae4a2483a" x="226.871027" y="113.066324" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m4ae4a2483a" x="226.871027" y="113.178221" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m4ae4a2483a" x="226.871027" y="113.089884" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m4ae4a2483a" x="177.768423" y="132.327899" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m4ae4a2483a" x="160.37503" y="145.652356" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m4ae4a2483a" x="153.995779" y="152.678629" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m4ae4a2483a" x="147.106887" y="168.143801" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m4ae4a2483a" x="145.871703" y="175.118358" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p064081e379)">
+     <use xlink:href="#m152b391f0c" x="226.871027" y="113.224491" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m152b391f0c" x="226.871027" y="113.066324" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m152b391f0c" x="226.871027" y="113.178221" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m152b391f0c" x="226.871027" y="113.089884" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m152b391f0c" x="177.768423" y="132.327899" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m152b391f0c" x="160.37503" y="145.652356" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m152b391f0c" x="153.995779" y="152.678629" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m152b391f0c" x="147.106887" y="168.143801" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m152b391f0c" x="145.871703" y="175.118358" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_117">
@@ -4132,7 +4132,7 @@ L 226.871027 113.076223
 L 226.871027 113.072924 
 L 226.871027 113.069624 
 L 226.871027 113.066324 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_118">
     <path d="M 226.871027 113.066324 
@@ -4184,7 +4184,7 @@ L 226.871027 113.171234
 L 226.871027 113.173563 
 L 226.871027 113.175892 
 L 226.871027 113.178221 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_119">
     <path d="M 226.871027 113.178221 
@@ -4236,7 +4236,7 @@ L 226.871027 113.09541
 L 226.871027 113.093568 
 L 226.871027 113.091726 
 L 226.871027 113.089884 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_120">
     <path d="M 226.871027 113.089884 
@@ -4288,7 +4288,7 @@ L 180.837336 131.306392
 L 179.814365 131.649041 
 L 178.791394 131.989534 
 L 177.768423 132.327899 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_121">
     <path d="M 177.768423 132.327899 
@@ -4340,7 +4340,7 @@ L 161.462117 144.909076
 L 161.099755 145.157972 
 L 160.737393 145.405728 
 L 160.37503 145.652356 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_122">
     <path d="M 160.37503 145.652356 
@@ -4392,7 +4392,7 @@ L 154.394483 152.265218
 L 154.261581 152.403373 
 L 154.12868 152.541176 
 L 153.995779 152.678629 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_123">
     <path d="M 153.995779 152.678629 
@@ -4444,7 +4444,7 @@ L 147.537442 167.296442
 L 147.393924 167.580372 
 L 147.250405 167.862819 
 L 147.106887 168.143801 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_124">
     <path d="M 147.106887 168.143801 
@@ -4496,11 +4496,11 @@ L 145.948902 174.70781
 L 145.923169 174.845005 
 L 145.897436 174.981854 
 L 145.871703 175.118358 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_125">
     <defs>
-     <path id="mcf2ccd7d9a" d="M 0 -2.5 
+     <path id="m0b96157d4f" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -4509,16 +4509,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p5ca6112d80)">
-     <use xlink:href="#mcf2ccd7d9a" x="585.66883" y="173.051371" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcf2ccd7d9a" x="527.144592" y="175.326465" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcf2ccd7d9a" x="457.339427" y="183.688849" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcf2ccd7d9a" x="292.124837" y="178.486631" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcf2ccd7d9a" x="243.129344" y="190.369032" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcf2ccd7d9a" x="213.541392" y="204.43395" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcf2ccd7d9a" x="204.551957" y="212.140784" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcf2ccd7d9a" x="195.860087" y="228.582256" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcf2ccd7d9a" x="194.019853" y="234.294862" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p064081e379)">
+     <use xlink:href="#m0b96157d4f" x="585.66883" y="173.051371" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0b96157d4f" x="527.144592" y="175.326465" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0b96157d4f" x="457.339427" y="183.688849" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0b96157d4f" x="292.124837" y="178.486631" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0b96157d4f" x="243.129344" y="190.369032" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0b96157d4f" x="213.541392" y="204.43395" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0b96157d4f" x="204.551957" y="212.140784" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0b96157d4f" x="195.860087" y="228.582256" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0b96157d4f" x="194.019853" y="234.294862" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_126">
@@ -4571,7 +4571,7 @@ L 530.802357 175.187039
 L 529.583102 175.233554 
 L 528.363847 175.28003 
 L 527.144592 175.326465 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_127">
     <path d="M 527.144592 175.326465 
@@ -4623,7 +4623,7 @@ L 461.70225 183.20239
 L 460.247976 183.36503 
 L 458.793701 183.527182 
 L 457.339427 183.688849 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_128">
     <path d="M 457.339427 183.688849 
@@ -4675,7 +4675,7 @@ L 302.450749 178.826834
 L 299.008779 178.713671 
 L 295.566808 178.60027 
 L 292.124837 178.486631 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_129">
     <path d="M 292.124837 178.486631 
@@ -4727,7 +4727,7 @@ L 246.191563 189.6981
 L 245.170823 189.922669 
 L 244.150084 190.146311 
 L 243.129344 190.369032 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_130">
     <path d="M 243.129344 190.369032 
@@ -4779,7 +4779,7 @@ L 215.390639 203.654226
 L 214.774224 203.915384 
 L 214.157808 204.175288 
 L 213.541392 204.43395 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_131">
     <path d="M 213.541392 204.43395 
@@ -4831,7 +4831,7 @@ L 205.113797 211.689953
 L 204.926517 211.840648 
 L 204.739237 211.990924 
 L 204.551957 212.140784 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_132">
     <path d="M 204.551957 212.140784 
@@ -4883,7 +4883,7 @@ L 196.403329 227.688717
 L 196.222248 227.988205 
 L 196.041168 228.286045 
 L 195.860087 228.582256 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_133">
     <path d="M 195.860087 228.582256 
@@ -4935,7 +4935,7 @@ L 194.134867 233.954953
 L 194.096529 234.068494 
 L 194.058191 234.181796 
 L 194.019853 234.294862 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="legend_1">
     <g id="patch_7">
@@ -4953,7 +4953,7 @@ z
     </g>
     <g id="line2d_134">
      <defs>
-      <path id="m801ab00cd6" d="M 0 3.5 
+      <path id="m7d4cb54953" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -4966,7 +4966,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m801ab00cd6" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m7d4cb54953" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -5025,7 +5025,7 @@ z
     </g>
     <g id="line2d_135">
      <g>
-      <use xlink:href="#mcd3f418712" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mb12648aec5" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -5039,7 +5039,7 @@ z
     </g>
     <g id="line2d_136">
      <g>
-      <use xlink:href="#m7f0a0c0000" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#maecbc320be" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -5084,7 +5084,7 @@ z
     </g>
     <g id="line2d_137">
      <g>
-      <use xlink:href="#m2fa6edb34c" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m49e4b76b53" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -5127,7 +5127,7 @@ z
     </g>
     <g id="line2d_138">
      <g>
-      <use xlink:href="#m0b530f356d" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mc5ae06a1be" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -5143,7 +5143,7 @@ z
     </g>
     <g id="line2d_139">
      <g>
-      <use xlink:href="#m5253f1838b" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#meb4a948f6a" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -5197,7 +5197,7 @@ z
     </g>
     <g id="line2d_140">
      <g>
-      <use xlink:href="#m35056ef38d" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#me2583f7e51" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -5262,7 +5262,7 @@ z
     </g>
     <g id="line2d_141">
      <g>
-      <use xlink:href="#m4ae4a2483a" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#m152b391f0c" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -5300,7 +5300,7 @@ z
     </g>
     <g id="line2d_142">
      <g>
-      <use xlink:href="#mcf2ccd7d9a" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m0b96157d4f" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -5370,486 +5370,486 @@ z
     </g>
    </g>
    <g id="line2d_143">
-    <g clip-path="url(#p5ca6112d80)">
-     <use xlink:href="#m801ab00cd6" x="319.643112" y="123.414237" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m801ab00cd6" x="269.129958" y="139.002078" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m801ab00cd6" x="247.452898" y="144.112782" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m801ab00cd6" x="192.820547" y="153.120134" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m801ab00cd6" x="180.389901" y="164.441353" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m801ab00cd6" x="149.634124" y="178.135959" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m801ab00cd6" x="141.251771" y="187.434135" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m801ab00cd6" x="139.514773" y="191.335418" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m801ab00cd6" x="119.666036" y="285.286593" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m801ab00cd6" x="97.814287" y="313.867065" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <g clip-path="url(#p064081e379)">
+     <use xlink:href="#m7d4cb54953" x="319.643112" y="123.587384" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m7d4cb54953" x="269.129958" y="138.868786" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m7d4cb54953" x="247.452898" y="144.085302" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m7d4cb54953" x="192.820547" y="153.108552" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m7d4cb54953" x="180.389901" y="164.427715" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m7d4cb54953" x="155.351585" y="173.856146" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m7d4cb54953" x="149.634124" y="178.058944" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m7d4cb54953" x="139.514773" y="191.289547" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m7d4cb54953" x="119.666036" y="285.262681" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m7d4cb54953" x="97.814287" y="313.392483" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
    <g id="line2d_144">
-    <path d="M 319.643112 123.414237 
-L 318.590755 123.78927 
-L 317.538397 124.161723 
-L 316.48604 124.53163 
-L 315.433682 124.899027 
-L 314.381325 125.263947 
-L 313.328968 125.626423 
-L 312.27661 125.986489 
-L 311.224253 126.344175 
-L 310.171896 126.699513 
-L 309.119538 127.052533 
-L 308.067181 127.403267 
-L 307.014823 127.751742 
-L 305.962466 128.097989 
-L 304.910109 128.442034 
-L 303.857751 128.783907 
-L 302.805394 129.123635 
-L 301.753037 129.461243 
-L 300.700679 129.796759 
-L 299.648322 130.130208 
-L 298.595965 130.461616 
-L 297.543607 130.791007 
-L 296.49125 131.118405 
-L 295.438892 131.443836 
-L 294.386535 131.767322 
-L 293.334178 132.088886 
-L 292.28182 132.408551 
-L 291.229463 132.726339 
-L 290.177106 133.042273 
-L 289.124748 133.356373 
-L 288.072391 133.668662 
-L 287.020033 133.979159 
-L 285.967676 134.287885 
-L 284.915319 134.59486 
-L 283.862961 134.900105 
-L 282.810604 135.203637 
-L 281.758247 135.505478 
-L 280.705889 135.805644 
-L 279.653532 136.104155 
-L 278.601175 136.401029 
-L 277.548817 136.696284 
-L 276.49646 136.989937 
-L 275.444102 137.282006 
-L 274.391745 137.572507 
-L 273.339388 137.861458 
-L 272.28703 138.148874 
-L 271.234673 138.434772 
-L 270.182316 138.719168 
-L 269.129958 139.002078 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 319.643112 123.587384 
+L 318.590755 123.953984 
+L 317.538397 124.318118 
+L 316.48604 124.679819 
+L 315.433682 125.03912 
+L 314.381325 125.396051 
+L 313.328968 125.750644 
+L 312.27661 126.10293 
+L 311.224253 126.452937 
+L 310.171896 126.800696 
+L 309.119538 127.146235 
+L 308.067181 127.489583 
+L 307.014823 127.830766 
+L 305.962466 128.169812 
+L 304.910109 128.506748 
+L 303.857751 128.8416 
+L 302.805394 129.174393 
+L 301.753037 129.505152 
+L 300.700679 129.833903 
+L 299.648322 130.160669 
+L 298.595965 130.485475 
+L 297.543607 130.808343 
+L 296.49125 131.129297 
+L 295.438892 131.448359 
+L 294.386535 131.765551 
+L 293.334178 132.080896 
+L 292.28182 132.394414 
+L 291.229463 132.706127 
+L 290.177106 133.016055 
+L 289.124748 133.324219 
+L 288.072391 133.630638 
+L 287.020033 133.935333 
+L 285.967676 134.238322 
+L 284.915319 134.539624 
+L 283.862961 134.839259 
+L 282.810604 135.137244 
+L 281.758247 135.433598 
+L 280.705889 135.728338 
+L 279.653532 136.021482 
+L 278.601175 136.313048 
+L 277.548817 136.603051 
+L 276.49646 136.891508 
+L 275.444102 137.178437 
+L 274.391745 137.463853 
+L 273.339388 137.747772 
+L 272.28703 138.030209 
+L 271.234673 138.311181 
+L 270.182316 138.590701 
+L 269.129958 138.868786 
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_145">
-    <path d="M 269.129958 139.002078 
-L 268.678353 139.113624 
-L 268.226747 139.224941 
-L 267.775142 139.33603 
-L 267.323537 139.44689 
-L 266.871931 139.557525 
-L 266.420326 139.667933 
-L 265.96872 139.778117 
-L 265.517115 139.888077 
-L 265.065509 139.997814 
-L 264.613904 140.10733 
-L 264.162299 140.216624 
-L 263.710693 140.325697 
-L 263.259088 140.434552 
-L 262.807482 140.543188 
-L 262.355877 140.651606 
-L 261.904271 140.759808 
-L 261.452666 140.867794 
-L 261.001061 140.975565 
-L 260.549455 141.083121 
-L 260.09785 141.190465 
-L 259.646244 141.297596 
-L 259.194639 141.404515 
-L 258.743034 141.511224 
-L 258.291428 141.617722 
-L 257.839823 141.724012 
-L 257.388217 141.830093 
-L 256.936612 141.935967 
-L 256.485006 142.041634 
-L 256.033401 142.147095 
-L 255.581796 142.252352 
-L 255.13019 142.357404 
-L 254.678585 142.462252 
-L 254.226979 142.566898 
-L 253.775374 142.671342 
-L 253.323769 142.775584 
-L 252.872163 142.879627 
-L 252.420558 142.983469 
-L 251.968952 143.087113 
-L 251.517347 143.190559 
-L 251.065741 143.293808 
-L 250.614136 143.39686 
-L 250.162531 143.499716 
-L 249.710925 143.602377 
-L 249.25932 143.704844 
-L 248.807714 143.807117 
-L 248.356109 143.909197 
-L 247.904503 144.011085 
-L 247.452898 144.112782 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 269.129958 138.868786 
+L 268.678353 138.982752 
+L 268.226747 139.096479 
+L 267.775142 139.209967 
+L 267.323537 139.323218 
+L 266.871931 139.436233 
+L 266.420326 139.549012 
+L 265.96872 139.661556 
+L 265.517115 139.773867 
+L 265.065509 139.885946 
+L 264.613904 139.997793 
+L 264.162299 140.109409 
+L 263.710693 140.220795 
+L 263.259088 140.331953 
+L 262.807482 140.442883 
+L 262.355877 140.553587 
+L 261.904271 140.664064 
+L 261.452666 140.774316 
+L 261.001061 140.884344 
+L 260.549455 140.994149 
+L 260.09785 141.103732 
+L 259.646244 141.213093 
+L 259.194639 141.322234 
+L 258.743034 141.431155 
+L 258.291428 141.539858 
+L 257.839823 141.648342 
+L 257.388217 141.75661 
+L 256.936612 141.864662 
+L 256.485006 141.972498 
+L 256.033401 142.08012 
+L 255.581796 142.187528 
+L 255.13019 142.294724 
+L 254.678585 142.401707 
+L 254.226979 142.50848 
+L 253.775374 142.615043 
+L 253.323769 142.721396 
+L 252.872163 142.82754 
+L 252.420558 142.933477 
+L 251.968952 143.039207 
+L 251.517347 143.144731 
+L 251.065741 143.25005 
+L 250.614136 143.355164 
+L 250.162531 143.460074 
+L 249.710925 143.564782 
+L 249.25932 143.669287 
+L 248.807714 143.773591 
+L 248.356109 143.877694 
+L 247.904503 143.981598 
+L 247.452898 144.085302 
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_146">
-    <path d="M 247.452898 144.112782 
-L 246.314724 144.316567 
-L 245.17655 144.519588 
-L 244.038376 144.72185 
-L 242.900202 144.923359 
-L 241.762028 145.12412 
-L 240.623854 145.32414 
-L 239.48568 145.523424 
-L 238.347506 145.721976 
-L 237.209332 145.919803 
-L 236.071158 146.11691 
-L 234.932984 146.313301 
-L 233.79481 146.508983 
-L 232.656636 146.70396 
-L 231.518462 146.898237 
-L 230.380288 147.091819 
-L 229.242114 147.284711 
-L 228.10394 147.476918 
-L 226.965766 147.668446 
-L 225.827592 147.859298 
-L 224.689418 148.049479 
-L 223.551244 148.238995 
-L 222.41307 148.42785 
-L 221.274896 148.616048 
-L 220.136722 148.803594 
-L 218.998548 148.990492 
-L 217.860374 149.176747 
-L 216.7222 149.362364 
-L 215.584026 149.547346 
-L 214.445852 149.731698 
-L 213.307678 149.915425 
-L 212.169505 150.09853 
-L 211.031331 150.281018 
-L 209.893157 150.462893 
-L 208.754983 150.644158 
-L 207.616809 150.824819 
-L 206.478635 151.004879 
-L 205.340461 151.184342 
-L 204.202287 151.363211 
-L 203.064113 151.541492 
-L 201.925939 151.719187 
-L 200.787765 151.896302 
-L 199.649591 152.072838 
-L 198.511417 152.2488 
-L 197.373243 152.424193 
-L 196.235069 152.599019 
-L 195.096895 152.773282 
-L 193.958721 152.946986 
-L 192.820547 153.120134 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 247.452898 144.085302 
+L 246.314724 144.289477 
+L 245.17655 144.492884 
+L 244.038376 144.69553 
+L 242.900202 144.89742 
+L 241.762028 145.09856 
+L 240.623854 145.298956 
+L 239.48568 145.498612 
+L 238.347506 145.697534 
+L 237.209332 145.895729 
+L 236.071158 146.0932 
+L 234.932984 146.289953 
+L 233.79481 146.485994 
+L 232.656636 146.681327 
+L 231.518462 146.875959 
+L 230.380288 147.069892 
+L 229.242114 147.263134 
+L 228.10394 147.455688 
+L 226.965766 147.64756 
+L 225.827592 147.838754 
+L 224.689418 148.029274 
+L 223.551244 148.219127 
+L 222.41307 148.408316 
+L 221.274896 148.596847 
+L 220.136722 148.784723 
+L 218.998548 148.971949 
+L 217.860374 149.15853 
+L 216.7222 149.34447 
+L 215.584026 149.529773 
+L 214.445852 149.714444 
+L 213.307678 149.898487 
+L 212.169505 150.081907 
+L 211.031331 150.264707 
+L 209.893157 150.446893 
+L 208.754983 150.628467 
+L 207.616809 150.809433 
+L 206.478635 150.989797 
+L 205.340461 151.169562 
+L 204.202287 151.348732 
+L 203.064113 151.527311 
+L 201.925939 151.705303 
+L 200.787765 151.882711 
+L 199.649591 152.05954 
+L 198.511417 152.235793 
+L 197.373243 152.411474 
+L 196.235069 152.586587 
+L 195.096895 152.761135 
+L 193.958721 152.935122 
+L 192.820547 153.108552 
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_147">
-    <path d="M 192.820547 153.120134 
-L 192.561575 153.381837 
-L 192.302603 153.64228 
-L 192.043631 153.901477 
-L 191.78466 154.159438 
-L 191.525688 154.416175 
-L 191.266716 154.671701 
-L 191.007744 154.926026 
-L 190.748773 155.179162 
-L 190.489801 155.43112 
-L 190.230829 155.68191 
-L 189.971857 155.931544 
-L 189.712885 156.180032 
-L 189.453914 156.427384 
-L 189.194942 156.673611 
-L 188.93597 156.918724 
-L 188.676998 157.162731 
-L 188.418027 157.405643 
-L 188.159055 157.64747 
-L 187.900083 157.888222 
-L 187.641111 158.127908 
-L 187.382139 158.366537 
-L 187.123168 158.604119 
-L 186.864196 158.840662 
-L 186.605224 159.076176 
-L 186.346252 159.31067 
-L 186.087281 159.544153 
-L 185.828309 159.776633 
-L 185.569337 160.008119 
-L 185.310365 160.238619 
-L 185.051393 160.468142 
-L 184.792422 160.696695 
-L 184.53345 160.924288 
-L 184.274478 161.150927 
-L 184.015506 161.376622 
-L 183.756535 161.60138 
-L 183.497563 161.825208 
-L 183.238591 162.048115 
-L 182.979619 162.270107 
-L 182.720647 162.491193 
-L 182.461676 162.71138 
-L 182.202704 162.930674 
-L 181.943732 163.149084 
-L 181.68476 163.366616 
-L 181.425789 163.583277 
-L 181.166817 163.799075 
-L 180.907845 164.014015 
-L 180.648873 164.228106 
-L 180.389901 164.441353 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 192.820547 153.108552 
+L 192.561575 153.370202 
+L 192.302603 153.630593 
+L 192.043631 153.889738 
+L 191.78466 154.147648 
+L 191.525688 154.404335 
+L 191.266716 154.659811 
+L 191.007744 154.914086 
+L 190.748773 155.167173 
+L 190.489801 155.419082 
+L 190.230829 155.669824 
+L 189.971857 155.91941 
+L 189.712885 156.167851 
+L 189.453914 156.415156 
+L 189.194942 156.661337 
+L 188.93597 156.906403 
+L 188.676998 157.150365 
+L 188.418027 157.393232 
+L 188.159055 157.635014 
+L 187.900083 157.875721 
+L 187.641111 158.115363 
+L 187.382139 158.353948 
+L 187.123168 158.591487 
+L 186.864196 158.827987 
+L 186.605224 159.063459 
+L 186.346252 159.297911 
+L 186.087281 159.531352 
+L 185.828309 159.76379 
+L 185.569337 159.995235 
+L 185.310365 160.225694 
+L 185.051393 160.455177 
+L 184.792422 160.68369 
+L 184.53345 160.911243 
+L 184.274478 161.137843 
+L 184.015506 161.363499 
+L 183.756535 161.588218 
+L 183.497563 161.812008 
+L 183.238591 162.034876 
+L 182.979619 162.256831 
+L 182.720647 162.477879 
+L 182.461676 162.698029 
+L 182.202704 162.917286 
+L 181.943732 163.13566 
+L 181.68476 163.353155 
+L 181.425789 163.569781 
+L 181.166817 163.785542 
+L 180.907845 164.000448 
+L 180.648873 164.214503 
+L 180.389901 164.427715 
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_148">
-    <path d="M 180.389901 164.441353 
-L 179.749156 164.765023 
-L 179.108411 165.08677 
-L 178.467665 165.406615 
-L 177.82692 165.724581 
-L 177.186175 166.040691 
-L 176.545429 166.354965 
-L 175.904684 166.667426 
-L 175.263939 166.978093 
-L 174.623193 167.286987 
-L 173.982448 167.594128 
-L 173.341702 167.899537 
-L 172.700957 168.203232 
-L 172.060212 168.505233 
-L 171.419466 168.805558 
-L 170.778721 169.104226 
-L 170.137976 169.401256 
-L 169.49723 169.696664 
-L 168.856485 169.990469 
-L 168.215739 170.282688 
-L 167.574994 170.573338 
-L 166.934249 170.862436 
-L 166.293503 171.149998 
-L 165.652758 171.43604 
-L 165.012013 171.720579 
-L 164.371267 172.00363 
-L 163.730522 172.285209 
-L 163.089777 172.56533 
-L 162.449031 172.844009 
-L 161.808286 173.121261 
-L 161.16754 173.3971 
-L 160.526795 173.671541 
-L 159.88605 173.944597 
-L 159.245304 174.216283 
-L 158.604559 174.486612 
-L 157.963814 174.755598 
-L 157.323068 175.023254 
-L 156.682323 175.289592 
-L 156.041577 175.554627 
-L 155.400832 175.81837 
-L 154.760087 176.080835 
-L 154.119341 176.342033 
-L 153.478596 176.601977 
-L 152.837851 176.860678 
-L 152.197105 177.118149 
-L 151.55636 177.374402 
-L 150.915614 177.629446 
-L 150.274869 177.883295 
-L 149.634124 178.135959 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 180.389901 164.427715 
+L 179.86827 164.641861 
+L 179.346638 164.855163 
+L 178.825007 165.067628 
+L 178.303375 165.279262 
+L 177.781744 165.490073 
+L 177.260112 165.700065 
+L 176.73848 165.909245 
+L 176.216849 166.117621 
+L 175.695217 166.325197 
+L 175.173586 166.531981 
+L 174.651954 166.737978 
+L 174.130322 166.943193 
+L 173.608691 167.147634 
+L 173.087059 167.351305 
+L 172.565428 167.554213 
+L 172.043796 167.756363 
+L 171.522165 167.957761 
+L 171.000533 168.158413 
+L 170.478901 168.358323 
+L 169.95727 168.557498 
+L 169.435638 168.755943 
+L 168.914007 168.953663 
+L 168.392375 169.150663 
+L 167.870743 169.346949 
+L 167.349112 169.542526 
+L 166.82748 169.737399 
+L 166.305849 169.931573 
+L 165.784217 170.125052 
+L 165.262586 170.317843 
+L 164.740954 170.509949 
+L 164.219322 170.701376 
+L 163.697691 170.892129 
+L 163.176059 171.082211 
+L 162.654428 171.271629 
+L 162.132796 171.460386 
+L 161.611164 171.648487 
+L 161.089533 171.835937 
+L 160.567901 172.02274 
+L 160.04627 172.2089 
+L 159.524638 172.394422 
+L 159.003007 172.579311 
+L 158.481375 172.76357 
+L 157.959743 172.947205 
+L 157.438112 173.130218 
+L 156.91648 173.312615 
+L 156.394849 173.494399 
+L 155.873217 173.675575 
+L 155.351585 173.856146 
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_149">
-    <path d="M 149.634124 178.135959 
-L 149.459491 178.346892 
-L 149.284859 178.557005 
-L 149.110227 178.766307 
-L 148.935594 178.974802 
-L 148.760962 179.182497 
-L 148.58633 179.389398 
-L 148.411697 179.595512 
-L 148.237065 179.800844 
-L 148.062433 180.005399 
-L 147.8878 180.209185 
-L 147.713168 180.412206 
-L 147.538535 180.614469 
-L 147.363903 180.815979 
-L 147.189271 181.016741 
-L 147.014638 181.216762 
-L 146.840006 181.416046 
-L 146.665374 181.6146 
-L 146.490741 181.812427 
-L 146.316109 182.009535 
-L 146.141477 182.205927 
-L 145.966844 182.401609 
-L 145.792212 182.596586 
-L 145.61758 182.790864 
-L 145.442947 182.984447 
-L 145.268315 183.17734 
-L 145.093683 183.369548 
-L 144.91905 183.561076 
-L 144.744418 183.751929 
-L 144.569785 183.942111 
-L 144.395153 184.131627 
-L 144.220521 184.320483 
-L 144.045888 184.508681 
-L 143.871256 184.696228 
-L 143.696624 184.883127 
-L 143.521991 185.069383 
-L 143.347359 185.255 
-L 143.172727 185.439983 
-L 142.998094 185.624336 
-L 142.823462 185.808063 
-L 142.64883 185.991169 
-L 142.474197 186.173657 
-L 142.299565 186.355532 
-L 142.124933 186.536799 
-L 141.9503 186.71746 
-L 141.775668 186.89752 
-L 141.601035 187.076984 
-L 141.426403 187.255854 
-L 141.251771 187.434135 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 155.351585 173.856146 
+L 155.232472 173.947117 
+L 155.113358 174.037935 
+L 154.994244 174.128601 
+L 154.87513 174.219115 
+L 154.756017 174.309478 
+L 154.636903 174.399691 
+L 154.517789 174.489753 
+L 154.398675 174.579666 
+L 154.279561 174.66943 
+L 154.160448 174.759045 
+L 154.041334 174.848512 
+L 153.92222 174.937831 
+L 153.803106 175.027003 
+L 153.683992 175.116029 
+L 153.564879 175.204909 
+L 153.445765 175.293642 
+L 153.326651 175.382231 
+L 153.207537 175.470675 
+L 153.088424 175.558974 
+L 152.96931 175.64713 
+L 152.850196 175.735142 
+L 152.731082 175.823012 
+L 152.611968 175.910739 
+L 152.492855 175.998324 
+L 152.373741 176.085768 
+L 152.254627 176.17307 
+L 152.135513 176.260232 
+L 152.016399 176.347254 
+L 151.897286 176.434136 
+L 151.778172 176.520879 
+L 151.659058 176.607484 
+L 151.539944 176.69395 
+L 151.420831 176.780278 
+L 151.301717 176.866468 
+L 151.182603 176.952522 
+L 151.063489 177.038439 
+L 150.944375 177.12422 
+L 150.825262 177.209865 
+L 150.706148 177.295375 
+L 150.587034 177.38075 
+L 150.46792 177.46599 
+L 150.348806 177.551096 
+L 150.229693 177.636069 
+L 150.110579 177.720909 
+L 149.991465 177.805616 
+L 149.872351 177.890191 
+L 149.753238 177.974633 
+L 149.634124 178.058944 
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_150">
-    <path d="M 141.251771 187.434135 
-L 141.215583 187.518347 
-L 141.179396 187.602428 
-L 141.143208 187.686378 
-L 141.107021 187.770199 
-L 141.070833 187.85389 
-L 141.034646 187.937451 
-L 140.998459 188.020884 
-L 140.962271 188.104189 
-L 140.926084 188.187365 
-L 140.889896 188.270414 
-L 140.853709 188.353336 
-L 140.817521 188.436131 
-L 140.781334 188.518799 
-L 140.745146 188.601341 
-L 140.708959 188.683758 
-L 140.672772 188.766049 
-L 140.636584 188.848216 
-L 140.600397 188.930258 
-L 140.564209 189.012176 
-L 140.528022 189.09397 
-L 140.491834 189.17564 
-L 140.455647 189.257188 
-L 140.419459 189.338613 
-L 140.383272 189.419915 
-L 140.347084 189.501096 
-L 140.310897 189.582155 
-L 140.27471 189.663093 
-L 140.238522 189.74391 
-L 140.202335 189.824606 
-L 140.166147 189.905183 
-L 140.12996 189.98564 
-L 140.093772 190.065977 
-L 140.057585 190.146195 
-L 140.021397 190.226295 
-L 139.98521 190.306276 
-L 139.949022 190.386139 
-L 139.912835 190.465884 
-L 139.876648 190.545513 
-L 139.84046 190.625024 
-L 139.804273 190.704419 
-L 139.768085 190.783697 
-L 139.731898 190.862859 
-L 139.69571 190.941906 
-L 139.659523 191.020838 
-L 139.623335 191.099654 
-L 139.587148 191.178356 
-L 139.55096 191.256944 
-L 139.514773 191.335418 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 149.634124 178.058944 
+L 149.423304 178.370291 
+L 149.212484 178.679857 
+L 149.001664 178.987662 
+L 148.790845 179.293727 
+L 148.580025 179.598072 
+L 148.369205 179.900715 
+L 148.158385 180.201675 
+L 147.947565 180.500971 
+L 147.736745 180.798621 
+L 147.525926 181.094644 
+L 147.315106 181.389057 
+L 147.104286 181.681877 
+L 146.893466 181.973121 
+L 146.682646 182.262807 
+L 146.471827 182.550951 
+L 146.261007 182.837569 
+L 146.050187 183.122678 
+L 145.839367 183.406293 
+L 145.628547 183.688429 
+L 145.417728 183.969103 
+L 145.206908 184.248329 
+L 144.996088 184.526122 
+L 144.785268 184.802496 
+L 144.574448 185.077467 
+L 144.363629 185.351048 
+L 144.152809 185.623253 
+L 143.941989 185.894096 
+L 143.731169 186.163591 
+L 143.520349 186.431751 
+L 143.30953 186.698589 
+L 143.09871 186.964118 
+L 142.88789 187.228351 
+L 142.67707 187.4913 
+L 142.46625 187.752979 
+L 142.25543 188.013398 
+L 142.044611 188.27257 
+L 141.833791 188.530508 
+L 141.622971 188.787222 
+L 141.412151 189.042724 
+L 141.201331 189.297027 
+L 140.990512 189.55014 
+L 140.779692 189.802075 
+L 140.568872 190.052843 
+L 140.358052 190.302454 
+L 140.147232 190.55092 
+L 139.936413 190.798251 
+L 139.725593 191.044456 
+L 139.514773 191.289547 
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_151">
-    <path d="M 139.514773 191.335418 
-L 139.101258 196.363735 
-L 138.687742 200.964409 
-L 138.274227 205.204512 
-L 137.860712 209.136478 
-L 137.447196 212.802074 
-L 137.033681 216.235113 
-L 136.620165 219.46335 
-L 136.20665 222.509852 
-L 135.793135 225.393994 
-L 135.379619 228.132209 
-L 134.966104 230.738556 
-L 134.552589 233.225155 
-L 134.139073 235.602528 
-L 133.725558 237.879867 
-L 133.312043 240.065252 
-L 132.898527 242.165823 
-L 132.485012 244.187916 
-L 132.071496 246.137185 
-L 131.657981 248.018694 
-L 131.244466 249.836996 
-L 130.83095 251.5962 
-L 130.417435 253.300026 
-L 130.00392 254.951856 
-L 129.590404 256.554769 
-L 129.176889 258.111578 
-L 128.763374 259.624863 
-L 128.349858 261.096991 
-L 127.936343 262.530141 
-L 127.522827 263.926325 
-L 127.109312 265.287401 
-L 126.695797 266.615091 
-L 126.282281 267.910996 
-L 125.868766 269.1766 
-L 125.455251 270.413288 
-L 125.041735 271.622354 
-L 124.62822 272.805002 
-L 124.214705 273.962364 
-L 123.801189 275.095498 
-L 123.387674 276.205397 
-L 122.974158 277.292996 
-L 122.560643 278.359172 
-L 122.147128 279.404754 
-L 121.733612 280.430522 
-L 121.320097 281.437213 
-L 120.906582 282.425523 
-L 120.493066 283.396113 
-L 120.079551 284.349605 
-L 119.666036 285.286593 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 139.514773 191.289547 
+L 139.101258 196.32023 
+L 138.687742 200.922884 
+L 138.274227 205.164668 
+L 137.860712 209.098079 
+L 137.447196 212.764932 
+L 137.033681 216.199073 
+L 136.620165 219.428285 
+L 136.20665 222.475654 
+L 135.793135 225.360573 
+L 135.379619 228.09949 
+L 134.966104 230.706472 
+L 134.552589 233.193649 
+L 134.139073 235.571549 
+L 133.725558 237.849373 
+L 133.312043 240.035205 
+L 132.898527 242.136188 
+L 132.485012 244.158663 
+L 132.071496 246.108287 
+L 131.657981 247.990127 
+L 131.244466 249.808738 
+L 130.83095 251.568231 
+L 130.417435 253.272329 
+L 130.00392 254.924414 
+L 129.590404 256.527567 
+L 129.176889 258.084603 
+L 128.763374 259.598102 
+L 128.349858 261.070432 
+L 127.936343 262.503774 
+L 127.522827 263.90014 
+L 127.109312 265.261389 
+L 126.695797 266.589244 
+L 126.282281 267.885305 
+L 125.868766 269.151059 
+L 125.455251 270.387891 
+L 125.041735 271.597093 
+L 124.62822 272.779872 
+L 124.214705 273.937359 
+L 123.801189 275.070613 
+L 123.387674 276.180627 
+L 122.974158 277.268337 
+L 122.560643 278.334619 
+L 122.147128 279.380303 
+L 121.733612 280.406169 
+L 121.320097 281.412955 
+L 120.906582 282.401357 
+L 120.493066 283.372034 
+L 120.079551 284.325612 
+L 119.666036 285.262681 
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_152">
-    <path d="M 119.666036 285.286593 
-L 119.210791 286.065317 
-L 118.755546 286.832998 
-L 118.300301 287.589943 
-L 117.845056 288.33645 
-L 117.389812 289.072801 
-L 116.934567 289.79927 
-L 116.479322 290.516119 
-L 116.024077 291.223598 
-L 115.568833 291.92195 
-L 115.113588 292.611407 
-L 114.658343 293.292193 
-L 114.203098 293.964524 
-L 113.747854 294.628606 
-L 113.292609 295.28464 
-L 112.837364 295.932818 
-L 112.382119 296.573326 
-L 111.926875 297.206344 
-L 111.47163 297.832046 
-L 111.016385 298.450597 
-L 110.56114 299.06216 
-L 110.105895 299.66689 
-L 109.650651 300.26494 
-L 109.195406 300.856454 
-L 108.740161 301.441574 
-L 108.284916 302.020438 
-L 107.829672 302.593176 
-L 107.374427 303.159918 
-L 106.919182 303.720788 
-L 106.463937 304.275906 
-L 106.008693 304.825389 
-L 105.553448 305.36935 
-L 105.098203 305.907899 
-L 104.642958 306.441143 
-L 104.187713 306.969185 
-L 103.732469 307.492126 
-L 103.277224 308.010064 
-L 102.821979 308.523092 
-L 102.366734 309.031304 
-L 101.91149 309.534789 
-L 101.456245 310.033634 
-L 101.001 310.527924 
-L 100.545755 311.017741 
-L 100.090511 311.503166 
-L 99.635266 311.984276 
-L 99.180021 312.461148 
-L 98.724776 312.933856 
-L 98.269531 313.402471 
-L 97.814287 313.867065 
-" clip-path="url(#p5ca6112d80)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 119.666036 285.262681 
+L 119.210791 286.025777 
+L 118.755546 286.778264 
+L 118.300301 287.520435 
+L 117.845056 288.252567 
+L 117.389812 288.974929 
+L 116.934567 289.687778 
+L 116.479322 290.391361 
+L 116.024077 291.085917 
+L 115.568833 291.771674 
+L 115.113588 292.448852 
+L 114.658343 293.117663 
+L 114.203098 293.778311 
+L 113.747854 294.430994 
+L 113.292609 295.0759 
+L 112.837364 295.713214 
+L 112.382119 296.343111 
+L 111.926875 296.965763 
+L 111.47163 297.581335 
+L 111.016385 298.189984 
+L 110.56114 298.791866 
+L 110.105895 299.387129 
+L 109.650651 299.975918 
+L 109.195406 300.558371 
+L 108.740161 301.134624 
+L 108.284916 301.704806 
+L 107.829672 302.269045 
+L 107.374427 302.827464 
+L 106.919182 303.38018 
+L 106.463937 303.92731 
+L 106.008693 304.468965 
+L 105.553448 305.005254 
+L 105.098203 305.536282 
+L 104.642958 306.062151 
+L 104.187713 306.582961 
+L 103.732469 307.098807 
+L 103.277224 307.609784 
+L 102.821979 308.115982 
+L 102.366734 308.617491 
+L 101.91149 309.114396 
+L 101.456245 309.606781 
+L 101.001 310.094728 
+L 100.545755 310.578315 
+L 100.090511 311.057621 
+L 99.635266 311.53272 
+L 99.180021 312.003685 
+L 98.724776 312.470588 
+L 98.269531 312.933498 
+L 97.814287 313.392483 
+" clip-path="url(#p064081e379)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
   </g>
   <g id="text_25">
@@ -6166,8 +6166,8 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-07-08T22:12:55Z  ·  Linux chungus2 x86_64  ·  commit 30251fb3  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(44.380078 465.66) scale(0.07 -0.07)">
+   <!-- 2026-07-08T22:38:10Z  ·  Linux chungus2 x86_64  ·  commit f6be9ada  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(44.622344 465.66) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -6201,31 +6201,6 @@ L 1409 3309
 L 1409 2516 
 L 750 2516 
 L 750 3309 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-b7" d="M 684 2619 
@@ -6285,6 +6260,36 @@ Q 2894 3584 3203 3211
 Q 3513 2838 3513 2113 
 z
 " transform="scale(0.015625)"/>
+     <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
      <path id="DejaVuSans-3d" d="M 678 2906 
 L 4684 2906 
 L 4684 2381 
@@ -6328,11 +6333,11 @@ z
     <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -6372,109 +6377,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3262.744141 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3326.367188 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3389.990234 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3425.195312 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3488.671875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3552.294922 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3584.082031 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3615.869141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3647.65625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3679.443359 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3711.230469 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3739.013672 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3800.537109 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3861.816406 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3925.195312 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3988.671875 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4027.535156 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4088.716797 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4147.896484 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4209.419922 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4250.533203 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4284.224609 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4312.007812 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4373.53125 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4434.810547 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4498.189453 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4561.8125 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4595.503906 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4654.683594 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4718.306641 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4750.09375 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4813.716797 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4877.339844 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4909.126953 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4972.75 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5008.833984 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5047.697266 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5102.677734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5166.300781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5198.087891 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5229.875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5261.662109 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5293.449219 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5325.236328 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5364.445312 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5427.824219 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5466.6875 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5527.869141 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5591.248047 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5654.724609 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5718.103516 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5781.580078 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5844.958984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5884.167969 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5915.955078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5999.744141 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6031.53125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6128.943359 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6190.466797 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6253.943359 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6281.726562 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6343.005859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6406.384766 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6438.171875 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6490.271484 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6553.650391 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6614.929688 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6678.40625 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6730.505859 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6793.884766 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6855.066406 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6894.275391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6927.966797 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6959.753906 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7000.867188 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7062.146484 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7101.355469 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7129.138672 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7190.320312 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7222.107422 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7249.890625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7301.990234 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7333.777344 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7397.253906 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7458.777344 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7497.986328 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7559.509766 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7598.873047 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7696.285156 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7724.068359 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7787.447266 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7815.230469 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7867.330078 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7906.539062 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7934.322266 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3107.080078 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3170.703125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3234.179688 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3295.703125 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3359.326172 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3420.605469 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3484.082031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3545.361328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3577.148438 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3608.935547 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3640.722656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3672.509766 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3704.296875 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3732.080078 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3793.603516 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3854.882812 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3918.261719 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3981.738281 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4020.601562 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4081.783203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4140.962891 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4202.486328 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4243.599609 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4277.291016 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4305.074219 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4366.597656 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4427.876953 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4491.255859 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4554.878906 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4588.570312 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4647.75 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4711.373047 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4743.160156 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4806.783203 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4870.40625 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4902.193359 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4965.816406 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5001.900391 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5040.763672 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5095.744141 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5159.367188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5191.154297 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5222.941406 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5254.728516 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5286.515625 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5318.302734 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5357.511719 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5420.890625 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5459.753906 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5520.935547 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5584.314453 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5647.791016 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5711.169922 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5774.646484 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5838.025391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5877.234375 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5909.021484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5992.810547 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6024.597656 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6122.009766 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6183.533203 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6247.009766 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6274.792969 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6336.072266 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6399.451172 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6431.238281 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6483.337891 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6546.716797 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6607.996094 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6671.472656 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6723.572266 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6786.951172 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6848.132812 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6887.341797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6921.033203 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6952.820312 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6993.933594 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7055.212891 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7094.421875 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7122.205078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7183.386719 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7215.173828 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7242.957031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7295.056641 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7326.84375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7390.320312 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7451.84375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7491.052734 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7552.576172 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7591.939453 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7689.351562 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7717.134766 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7780.513672 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7808.296875 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7860.396484 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7899.605469 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7927.388672 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p5ca6112d80">
+  <clipPath id="p064081e379">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_decode_density.svg
+++ b/bench/graphs/silesia_decode_density.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 82.373685 412.80375 
 L 82.373685 47.3475 
-" clip-path="url(#pead9396e02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8821101eab)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="mf60d624f33" d="M 0 0 
+       <path id="m7d2abf9a86" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mf60d624f33" x="82.373685" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7d2abf9a86" x="82.373685" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -111,11 +111,11 @@ z
      <g id="line2d_3">
       <path d="M 165.44644 412.80375 
 L 165.44644 47.3475 
-" clip-path="url(#pead9396e02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8821101eab)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mf60d624f33" x="165.44644" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7d2abf9a86" x="165.44644" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -157,11 +157,11 @@ z
      <g id="line2d_5">
       <path d="M 248.519195 412.80375 
 L 248.519195 47.3475 
-" clip-path="url(#pead9396e02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8821101eab)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#mf60d624f33" x="248.519195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7d2abf9a86" x="248.519195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -211,11 +211,11 @@ z
      <g id="line2d_7">
       <path d="M 331.59195 412.80375 
 L 331.59195 47.3475 
-" clip-path="url(#pead9396e02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8821101eab)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#mf60d624f33" x="331.59195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7d2abf9a86" x="331.59195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -252,11 +252,11 @@ z
      <g id="line2d_9">
       <path d="M 414.664704 412.80375 
 L 414.664704 47.3475 
-" clip-path="url(#pead9396e02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8821101eab)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#mf60d624f33" x="414.664704" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7d2abf9a86" x="414.664704" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -299,11 +299,11 @@ z
      <g id="line2d_11">
       <path d="M 497.737459 412.80375 
 L 497.737459 47.3475 
-" clip-path="url(#pead9396e02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8821101eab)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#mf60d624f33" x="497.737459" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7d2abf9a86" x="497.737459" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -351,11 +351,11 @@ z
      <g id="line2d_13">
       <path d="M 580.810214 412.80375 
 L 580.810214 47.3475 
-" clip-path="url(#pead9396e02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8821101eab)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mf60d624f33" x="580.810214" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7d2abf9a86" x="580.810214" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -897,16 +897,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 391.33747 
 L 637.2 391.33747 
-" clip-path="url(#pead9396e02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8821101eab)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="m14036431f3" d="M 0 0 
+       <path id="m38269175e6" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m14036431f3" x="49.078125" y="391.33747" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m38269175e6" x="49.078125" y="391.33747" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -922,11 +922,11 @@ L -3.5 0
      <g id="line2d_17">
       <path d="M 49.078125 263.934445 
 L 637.2 263.934445 
-" clip-path="url(#pead9396e02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8821101eab)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m14036431f3" x="49.078125" y="263.934445" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m38269175e6" x="49.078125" y="263.934445" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -942,11 +942,11 @@ L 637.2 263.934445
      <g id="line2d_19">
       <path d="M 49.078125 136.53142 
 L 637.2 136.53142 
-" clip-path="url(#pead9396e02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8821101eab)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m14036431f3" x="49.078125" y="136.53142" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m38269175e6" x="49.078125" y="136.53142" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -962,16 +962,16 @@ L 637.2 136.53142
      <g id="line2d_21">
       <path d="M 49.078125 411.072449 
 L 637.2 411.072449 
-" clip-path="url(#pead9396e02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8821101eab)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="m3f0d699ef5" d="M 0 0 
+       <path id="m5609dd2a7c" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m3f0d699ef5" x="49.078125" y="411.072449" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m5609dd2a7c" x="49.078125" y="411.072449" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -979,11 +979,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 403.684099 
 L 637.2 403.684099 
-" clip-path="url(#pead9396e02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8821101eab)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m3f0d699ef5" x="49.078125" y="403.684099" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m5609dd2a7c" x="49.078125" y="403.684099" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -991,11 +991,11 @@ L 637.2 403.684099
      <g id="line2d_25">
       <path d="M 49.078125 397.167113 
 L 637.2 397.167113 
-" clip-path="url(#pead9396e02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8821101eab)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m3f0d699ef5" x="49.078125" y="397.167113" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m5609dd2a7c" x="49.078125" y="397.167113" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1003,11 +1003,11 @@ L 637.2 397.167113
      <g id="line2d_27">
       <path d="M 49.078125 352.985338 
 L 637.2 352.985338 
-" clip-path="url(#pead9396e02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8821101eab)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m3f0d699ef5" x="49.078125" y="352.985338" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m5609dd2a7c" x="49.078125" y="352.985338" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1015,11 +1015,11 @@ L 637.2 352.985338
      <g id="line2d_29">
       <path d="M 49.078125 330.550779 
 L 637.2 330.550779 
-" clip-path="url(#pead9396e02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8821101eab)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m3f0d699ef5" x="49.078125" y="330.550779" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m5609dd2a7c" x="49.078125" y="330.550779" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1027,11 +1027,11 @@ L 637.2 330.550779
      <g id="line2d_31">
       <path d="M 49.078125 314.633206 
 L 637.2 314.633206 
-" clip-path="url(#pead9396e02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8821101eab)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m3f0d699ef5" x="49.078125" y="314.633206" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m5609dd2a7c" x="49.078125" y="314.633206" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1039,11 +1039,11 @@ L 637.2 314.633206
      <g id="line2d_33">
       <path d="M 49.078125 302.286577 
 L 637.2 302.286577 
-" clip-path="url(#pead9396e02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8821101eab)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m3f0d699ef5" x="49.078125" y="302.286577" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m5609dd2a7c" x="49.078125" y="302.286577" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1051,11 +1051,11 @@ L 637.2 302.286577
      <g id="line2d_35">
       <path d="M 49.078125 292.198647 
 L 637.2 292.198647 
-" clip-path="url(#pead9396e02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8821101eab)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m3f0d699ef5" x="49.078125" y="292.198647" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m5609dd2a7c" x="49.078125" y="292.198647" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1063,11 +1063,11 @@ L 637.2 292.198647
      <g id="line2d_37">
       <path d="M 49.078125 283.669424 
 L 637.2 283.669424 
-" clip-path="url(#pead9396e02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8821101eab)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m3f0d699ef5" x="49.078125" y="283.669424" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m5609dd2a7c" x="49.078125" y="283.669424" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1075,11 +1075,11 @@ L 637.2 283.669424
      <g id="line2d_39">
       <path d="M 49.078125 276.281074 
 L 637.2 276.281074 
-" clip-path="url(#pead9396e02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8821101eab)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m3f0d699ef5" x="49.078125" y="276.281074" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m5609dd2a7c" x="49.078125" y="276.281074" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1087,11 +1087,11 @@ L 637.2 276.281074
      <g id="line2d_41">
       <path d="M 49.078125 269.764088 
 L 637.2 269.764088 
-" clip-path="url(#pead9396e02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8821101eab)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m3f0d699ef5" x="49.078125" y="269.764088" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m5609dd2a7c" x="49.078125" y="269.764088" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1099,11 +1099,11 @@ L 637.2 269.764088
      <g id="line2d_43">
       <path d="M 49.078125 225.582313 
 L 637.2 225.582313 
-" clip-path="url(#pead9396e02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8821101eab)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m3f0d699ef5" x="49.078125" y="225.582313" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m5609dd2a7c" x="49.078125" y="225.582313" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1111,11 +1111,11 @@ L 637.2 225.582313
      <g id="line2d_45">
       <path d="M 49.078125 203.147754 
 L 637.2 203.147754 
-" clip-path="url(#pead9396e02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8821101eab)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m3f0d699ef5" x="49.078125" y="203.147754" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m5609dd2a7c" x="49.078125" y="203.147754" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1123,11 +1123,11 @@ L 637.2 203.147754
      <g id="line2d_47">
       <path d="M 49.078125 187.230181 
 L 637.2 187.230181 
-" clip-path="url(#pead9396e02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8821101eab)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m3f0d699ef5" x="49.078125" y="187.230181" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m5609dd2a7c" x="49.078125" y="187.230181" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1135,11 +1135,11 @@ L 637.2 187.230181
      <g id="line2d_49">
       <path d="M 49.078125 174.883552 
 L 637.2 174.883552 
-" clip-path="url(#pead9396e02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8821101eab)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m3f0d699ef5" x="49.078125" y="174.883552" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m5609dd2a7c" x="49.078125" y="174.883552" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1147,11 +1147,11 @@ L 637.2 174.883552
      <g id="line2d_51">
       <path d="M 49.078125 164.795622 
 L 637.2 164.795622 
-" clip-path="url(#pead9396e02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8821101eab)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m3f0d699ef5" x="49.078125" y="164.795622" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m5609dd2a7c" x="49.078125" y="164.795622" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1159,11 +1159,11 @@ L 637.2 164.795622
      <g id="line2d_53">
       <path d="M 49.078125 156.266399 
 L 637.2 156.266399 
-" clip-path="url(#pead9396e02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8821101eab)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#m3f0d699ef5" x="49.078125" y="156.266399" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m5609dd2a7c" x="49.078125" y="156.266399" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1171,11 +1171,11 @@ L 637.2 156.266399
      <g id="line2d_55">
       <path d="M 49.078125 148.878049 
 L 637.2 148.878049 
-" clip-path="url(#pead9396e02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8821101eab)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#m3f0d699ef5" x="49.078125" y="148.878049" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m5609dd2a7c" x="49.078125" y="148.878049" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1183,11 +1183,11 @@ L 637.2 148.878049
      <g id="line2d_57">
       <path d="M 49.078125 142.361063 
 L 637.2 142.361063 
-" clip-path="url(#pead9396e02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8821101eab)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#m3f0d699ef5" x="49.078125" y="142.361063" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m5609dd2a7c" x="49.078125" y="142.361063" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1195,11 +1195,11 @@ L 637.2 142.361063
      <g id="line2d_59">
       <path d="M 49.078125 98.179288 
 L 637.2 98.179288 
-" clip-path="url(#pead9396e02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8821101eab)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#m3f0d699ef5" x="49.078125" y="98.179288" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m5609dd2a7c" x="49.078125" y="98.179288" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1207,11 +1207,11 @@ L 637.2 98.179288
      <g id="line2d_61">
       <path d="M 49.078125 75.744729 
 L 637.2 75.744729 
-" clip-path="url(#pead9396e02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8821101eab)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#m3f0d699ef5" x="49.078125" y="75.744729" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m5609dd2a7c" x="49.078125" y="75.744729" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1219,11 +1219,11 @@ L 637.2 75.744729
      <g id="line2d_63">
       <path d="M 49.078125 59.827156 
 L 637.2 59.827156 
-" clip-path="url(#pead9396e02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8821101eab)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#m3f0d699ef5" x="49.078125" y="59.827156" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m5609dd2a7c" x="49.078125" y="59.827156" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1231,11 +1231,11 @@ L 637.2 59.827156
      <g id="line2d_65">
       <path d="M 49.078125 47.480527 
 L 637.2 47.480527 
-" clip-path="url(#pead9396e02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8821101eab)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#m3f0d699ef5" x="49.078125" y="47.480527" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m5609dd2a7c" x="49.078125" y="47.480527" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1398,7 +1398,7 @@ z
    <g id="line2d_67">
     <path d="M 49.078125 63.959148 
 L 637.2 63.959148 
-" clip-path="url(#pead9396e02)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
+" clip-path="url(#p8821101eab)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
    </g>
    <g id="patch_3">
     <path d="M 49.078125 412.80375 
@@ -1762,78 +1762,78 @@ z
    </g>
    <g id="line2d_68">
     <defs>
-     <path id="m96af1c15e7" d="M -2.5 2.5 
+     <path id="mc0ac986378" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pead9396e02)">
-     <use xlink:href="#m96af1c15e7" x="75.810937" y="263.190298" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m96af1c15e7" x="105.634056" y="267.887378" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m96af1c15e7" x="204.490635" y="300.240046" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m96af1c15e7" x="234.479899" y="306.367428" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m96af1c15e7" x="242.537956" y="316.909198" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m96af1c15e7" x="300.771958" y="297.352079" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m96af1c15e7" x="303.26414" y="310.698625" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m96af1c15e7" x="304.261013" y="317.548512" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m96af1c15e7" x="313.897453" y="317.953886" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m96af1c15e7" x="414.166268" y="334.149272" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m96af1c15e7" x="587.289889" y="327.780982" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m96af1c15e7" x="610.467187" y="318.981257" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p8821101eab)">
+     <use xlink:href="#mc0ac986378" x="75.810937" y="263.190298" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc0ac986378" x="105.634056" y="267.887378" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc0ac986378" x="204.490635" y="300.240046" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc0ac986378" x="234.479899" y="306.367428" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc0ac986378" x="242.537956" y="316.909198" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc0ac986378" x="300.771958" y="297.352079" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc0ac986378" x="303.26414" y="310.698625" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc0ac986378" x="304.261013" y="317.548512" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc0ac986378" x="313.897453" y="317.953886" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc0ac986378" x="414.166268" y="334.149272" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc0ac986378" x="587.289889" y="327.780982" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc0ac986378" x="610.467187" y="318.981257" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_69">
     <defs>
-     <path id="mf976e4499d" d="M 0 -2.5 
+     <path id="m5fd9379964" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pead9396e02)">
-     <use xlink:href="#mf976e4499d" x="75.810937" y="260.629553" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf976e4499d" x="105.634056" y="253.888028" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf976e4499d" x="204.490635" y="301.454063" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf976e4499d" x="234.479899" y="296.198152" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf976e4499d" x="242.537956" y="306.497434" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf976e4499d" x="300.771958" y="285.157082" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf976e4499d" x="303.26414" y="299.127298" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf976e4499d" x="304.261013" y="312.289143" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf976e4499d" x="313.897453" y="305.55147" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf976e4499d" x="414.166268" y="323.799851" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf976e4499d" x="587.289889" y="327.192921" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf976e4499d" x="610.467187" y="316.49707" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p8821101eab)">
+     <use xlink:href="#m5fd9379964" x="75.810937" y="260.629553" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5fd9379964" x="105.634056" y="253.888028" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5fd9379964" x="204.490635" y="301.454063" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5fd9379964" x="234.479899" y="296.198152" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5fd9379964" x="242.537956" y="306.497434" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5fd9379964" x="300.771958" y="285.157082" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5fd9379964" x="303.26414" y="299.127298" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5fd9379964" x="304.261013" y="312.289143" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5fd9379964" x="313.897453" y="305.55147" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5fd9379964" x="414.166268" y="323.799851" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5fd9379964" x="587.289889" y="327.192921" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5fd9379964" x="610.467187" y="316.49707" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_70">
     <defs>
-     <path id="m6f9479ee88" d="M -0 3.535534 
+     <path id="mb2cd9565dd" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pead9396e02)">
-     <use xlink:href="#m6f9479ee88" x="75.810937" y="229.675972" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6f9479ee88" x="105.634056" y="230.807252" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6f9479ee88" x="204.490635" y="262.817606" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6f9479ee88" x="234.479899" y="260.308889" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6f9479ee88" x="242.537956" y="274.651617" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6f9479ee88" x="300.771958" y="258.820574" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6f9479ee88" x="303.26414" y="270.569757" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6f9479ee88" x="304.261013" y="279.042037" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6f9479ee88" x="313.897453" y="275.908162" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6f9479ee88" x="414.166268" y="294.938772" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6f9479ee88" x="587.289889" y="301.872049" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6f9479ee88" x="610.467187" y="298.545064" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p8821101eab)">
+     <use xlink:href="#mb2cd9565dd" x="75.810937" y="229.675972" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb2cd9565dd" x="105.634056" y="230.807252" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb2cd9565dd" x="204.490635" y="262.817606" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb2cd9565dd" x="234.479899" y="260.308889" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb2cd9565dd" x="242.537956" y="274.651617" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb2cd9565dd" x="300.771958" y="258.820574" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb2cd9565dd" x="303.26414" y="270.569757" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb2cd9565dd" x="304.261013" y="279.042037" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb2cd9565dd" x="313.897453" y="275.908162" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb2cd9565dd" x="414.166268" y="294.938772" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb2cd9565dd" x="587.289889" y="301.872049" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb2cd9565dd" x="610.467187" y="298.545064" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_71">
     <defs>
-     <path id="m0c0c4e7e0d" d="M -0.833333 2.5 
+     <path id="m4bf8d0285c" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -1848,24 +1848,24 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pead9396e02)">
-     <use xlink:href="#m0c0c4e7e0d" x="75.810937" y="286.028664" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0c0c4e7e0d" x="105.634056" y="293.887771" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0c0c4e7e0d" x="204.490635" y="326.335201" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0c0c4e7e0d" x="234.479899" y="337.903307" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0c0c4e7e0d" x="242.537956" y="341.092058" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0c0c4e7e0d" x="300.771958" y="336.485034" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0c0c4e7e0d" x="303.26414" y="344.754119" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0c0c4e7e0d" x="304.261013" y="344.606502" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0c0c4e7e0d" x="313.897453" y="351.527394" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0c0c4e7e0d" x="414.166268" y="363.295034" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0c0c4e7e0d" x="587.289889" y="368.159128" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0c0c4e7e0d" x="610.467187" y="356.976913" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p8821101eab)">
+     <use xlink:href="#m4bf8d0285c" x="75.810937" y="286.028664" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4bf8d0285c" x="105.634056" y="293.887771" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4bf8d0285c" x="204.490635" y="326.335201" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4bf8d0285c" x="234.479899" y="337.903307" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4bf8d0285c" x="242.537956" y="341.092058" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4bf8d0285c" x="300.771958" y="336.485034" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4bf8d0285c" x="303.26414" y="344.754119" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4bf8d0285c" x="304.261013" y="344.606502" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4bf8d0285c" x="313.897453" y="351.527394" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4bf8d0285c" x="414.166268" y="363.295034" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4bf8d0285c" x="587.289889" y="368.159128" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4bf8d0285c" x="610.467187" y="356.976913" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_72">
     <defs>
-     <path id="mef5ffc0799" d="M -1.25 2.5 
+     <path id="m05baed0ffd" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -1880,24 +1880,24 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pead9396e02)">
-     <use xlink:href="#mef5ffc0799" x="75.810937" y="327.723121" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mef5ffc0799" x="105.634056" y="342.646685" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mef5ffc0799" x="204.490635" y="362.850184" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mef5ffc0799" x="234.479899" y="371.338643" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mef5ffc0799" x="242.537956" y="367.245927" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mef5ffc0799" x="300.771958" y="360.026985" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mef5ffc0799" x="303.26414" y="374.683393" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mef5ffc0799" x="304.261013" y="357.457726" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mef5ffc0799" x="313.897453" y="374.58929" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mef5ffc0799" x="414.166268" y="385.027438" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mef5ffc0799" x="587.289889" y="394.333029" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mef5ffc0799" x="610.467187" y="391.249012" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p8821101eab)">
+     <use xlink:href="#m05baed0ffd" x="75.810937" y="327.723121" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m05baed0ffd" x="105.634056" y="342.646685" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m05baed0ffd" x="204.490635" y="362.850184" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m05baed0ffd" x="234.479899" y="371.338643" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m05baed0ffd" x="242.537956" y="367.245927" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m05baed0ffd" x="300.771958" y="360.026985" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m05baed0ffd" x="303.26414" y="374.683393" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m05baed0ffd" x="304.261013" y="357.457726" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m05baed0ffd" x="313.897453" y="374.58929" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m05baed0ffd" x="414.166268" y="385.027438" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m05baed0ffd" x="587.289889" y="394.333029" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m05baed0ffd" x="610.467187" y="391.249012" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_73">
     <defs>
-     <path id="m03241c48d0" d="M 0 -2.5 
+     <path id="macbb8c9174" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -1910,24 +1910,24 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#pead9396e02)">
-     <use xlink:href="#m03241c48d0" x="75.810937" y="273.778134" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m03241c48d0" x="105.634056" y="286.227815" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m03241c48d0" x="204.490635" y="319.608779" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m03241c48d0" x="234.479899" y="321.188418" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m03241c48d0" x="242.537956" y="325.921453" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m03241c48d0" x="300.771958" y="333.05015" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m03241c48d0" x="303.26414" y="336.951003" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m03241c48d0" x="304.261013" y="345.759761" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m03241c48d0" x="313.897453" y="336.754653" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m03241c48d0" x="414.166268" y="357.454726" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m03241c48d0" x="587.289889" y="366.280671" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m03241c48d0" x="610.467187" y="360.878702" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p8821101eab)">
+     <use xlink:href="#macbb8c9174" x="75.810937" y="273.778134" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#macbb8c9174" x="105.634056" y="286.227815" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#macbb8c9174" x="204.490635" y="319.608779" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#macbb8c9174" x="234.479899" y="321.188418" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#macbb8c9174" x="242.537956" y="325.921453" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#macbb8c9174" x="300.771958" y="333.05015" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#macbb8c9174" x="303.26414" y="336.951003" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#macbb8c9174" x="304.261013" y="345.759761" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#macbb8c9174" x="313.897453" y="336.754653" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#macbb8c9174" x="414.166268" y="357.454726" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#macbb8c9174" x="587.289889" y="366.280671" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#macbb8c9174" x="610.467187" y="360.878702" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_74">
     <defs>
-     <path id="m716a489fbc" d="M 0 -2.5 
+     <path id="mb7506a1bb0" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -1936,19 +1936,19 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pead9396e02)">
-     <use xlink:href="#m716a489fbc" x="75.810937" y="347.176172" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m716a489fbc" x="105.634056" y="348.704001" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m716a489fbc" x="204.490635" y="367.31757" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m716a489fbc" x="234.479899" y="373.033423" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m716a489fbc" x="242.537956" y="380.00037" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m716a489fbc" x="300.771958" y="370.53122" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m716a489fbc" x="303.26414" y="375.375651" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m716a489fbc" x="304.261013" y="383.030012" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m716a489fbc" x="313.897453" y="385.215351" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m716a489fbc" x="414.166268" y="391.648192" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m716a489fbc" x="587.289889" y="396.192102" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m716a489fbc" x="610.467187" y="383.710333" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p8821101eab)">
+     <use xlink:href="#mb7506a1bb0" x="75.810937" y="347.176172" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb7506a1bb0" x="105.634056" y="348.704001" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb7506a1bb0" x="204.490635" y="367.31757" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb7506a1bb0" x="234.479899" y="373.033423" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb7506a1bb0" x="242.537956" y="380.00037" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb7506a1bb0" x="300.771958" y="370.53122" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb7506a1bb0" x="303.26414" y="375.375651" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb7506a1bb0" x="304.261013" y="383.030012" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb7506a1bb0" x="313.897453" y="385.215351" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb7506a1bb0" x="414.166268" y="391.648192" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb7506a1bb0" x="587.289889" y="396.192102" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb7506a1bb0" x="610.467187" y="383.710333" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="legend_1">
@@ -1967,7 +1967,7 @@ z
     </g>
     <g id="line2d_75">
      <defs>
-      <path id="me4a11aaffc" d="M 0 3.5 
+      <path id="mdb1193d3a9" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -1980,7 +1980,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#me4a11aaffc" x="434.04625" y="211.758125" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#mdb1193d3a9" x="434.04625" y="211.758125" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_15">
@@ -2039,7 +2039,7 @@ z
     </g>
     <g id="line2d_76">
      <g>
-      <use xlink:href="#m96af1c15e7" x="434.04625" y="223.500625" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mc0ac986378" x="434.04625" y="223.500625" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_16">
@@ -2053,7 +2053,7 @@ z
     </g>
     <g id="line2d_77">
      <g>
-      <use xlink:href="#mf976e4499d" x="434.04625" y="235.243125" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m5fd9379964" x="434.04625" y="235.243125" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -2098,7 +2098,7 @@ z
     </g>
     <g id="line2d_78">
      <g>
-      <use xlink:href="#m6f9479ee88" x="434.04625" y="247.208125" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mb2cd9565dd" x="434.04625" y="247.208125" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -2118,7 +2118,7 @@ z
     </g>
     <g id="line2d_79">
      <g>
-      <use xlink:href="#m0c0c4e7e0d" x="537.72375" y="211.758125" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m4bf8d0285c" x="537.72375" y="211.758125" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -2145,7 +2145,7 @@ z
     </g>
     <g id="line2d_80">
      <g>
-      <use xlink:href="#mef5ffc0799" x="537.72375" y="223.500625" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m05baed0ffd" x="537.72375" y="223.500625" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -2210,7 +2210,7 @@ z
     </g>
     <g id="line2d_81">
      <g>
-      <use xlink:href="#m03241c48d0" x="537.72375" y="235.243125" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#macbb8c9174" x="537.72375" y="235.243125" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_21">
@@ -2248,7 +2248,7 @@ z
     </g>
     <g id="line2d_82">
      <g>
-      <use xlink:href="#m716a489fbc" x="537.72375" y="246.985625" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mb7506a1bb0" x="537.72375" y="246.985625" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -2318,19 +2318,19 @@ z
     </g>
    </g>
    <g id="line2d_83">
-    <g clip-path="url(#pead9396e02)">
-     <use xlink:href="#me4a11aaffc" x="75.810937" y="272.143954" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#me4a11aaffc" x="105.634056" y="288.399073" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#me4a11aaffc" x="204.490635" y="322.103822" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#me4a11aaffc" x="234.479899" y="324.29343" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#me4a11aaffc" x="242.537956" y="324.418753" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#me4a11aaffc" x="300.771958" y="312.453798" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#me4a11aaffc" x="303.26414" y="333.249253" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#me4a11aaffc" x="304.261013" y="351.748791" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#me4a11aaffc" x="313.897453" y="337.048403" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#me4a11aaffc" x="414.166268" y="356.441315" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#me4a11aaffc" x="587.289889" y="359.296601" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#me4a11aaffc" x="610.467187" y="343.193293" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <g clip-path="url(#p8821101eab)">
+     <use xlink:href="#mdb1193d3a9" x="75.810937" y="272.143954" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mdb1193d3a9" x="105.634056" y="288.399073" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mdb1193d3a9" x="204.490635" y="322.103822" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mdb1193d3a9" x="234.479899" y="324.29343" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mdb1193d3a9" x="242.537956" y="324.418753" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mdb1193d3a9" x="300.771958" y="312.453798" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mdb1193d3a9" x="303.26414" y="333.249253" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mdb1193d3a9" x="304.261013" y="351.748791" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mdb1193d3a9" x="313.897453" y="337.048403" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mdb1193d3a9" x="414.166268" y="356.441315" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mdb1193d3a9" x="587.289889" y="359.296601" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mdb1193d3a9" x="610.467187" y="343.193293" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
   </g>
@@ -3154,7 +3154,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="pead9396e02">
+  <clipPath id="p8821101eab">
    <rect x="49.078125" y="47.3475" width="588.121875" height="365.45625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_decode_ranking.svg
+++ b/bench/graphs/silesia_decode_ranking.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 292.269187 308.04375 
 L 292.269187 56.7075 
-" clip-path="url(#pb8387c6509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd69463d254)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="mf9f4403cc9" d="M 0 0 
+       <path id="m0b90387e6a" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mf9f4403cc9" x="292.269187" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0b90387e6a" x="292.269187" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -136,11 +136,11 @@ z
      <g id="line2d_3">
       <path d="M 449.991563 308.04375 
 L 449.991563 56.7075 
-" clip-path="url(#pb8387c6509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd69463d254)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mf9f4403cc9" x="449.991563" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0b90387e6a" x="449.991563" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -177,16 +177,16 @@ z
      <g id="line2d_5">
       <path d="M 182.025977 308.04375 
 L 182.025977 56.7075 
-" clip-path="url(#pb8387c6509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd69463d254)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <defs>
-       <path id="mb1df935b97" d="M 0 0 
+       <path id="m2f068f7667" d="M 0 0 
 L 0 2 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#mb1df935b97" x="182.025977" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2f068f7667" x="182.025977" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -194,11 +194,11 @@ L 0 2
      <g id="line2d_7">
       <path d="M 209.799509 308.04375 
 L 209.799509 56.7075 
-" clip-path="url(#pb8387c6509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd69463d254)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#mb1df935b97" x="209.799509" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2f068f7667" x="209.799509" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -206,11 +206,11 @@ L 209.799509 56.7075
      <g id="line2d_9">
       <path d="M 229.505143 308.04375 
 L 229.505143 56.7075 
-" clip-path="url(#pb8387c6509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd69463d254)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#mb1df935b97" x="229.505143" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2f068f7667" x="229.505143" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -218,11 +218,11 @@ L 229.505143 56.7075
      <g id="line2d_11">
       <path d="M 244.790021 308.04375 
 L 244.790021 56.7075 
-" clip-path="url(#pb8387c6509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd69463d254)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#mb1df935b97" x="244.790021" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2f068f7667" x="244.790021" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -230,11 +230,11 @@ L 244.790021 56.7075
      <g id="line2d_13">
       <path d="M 257.278675 308.04375 
 L 257.278675 56.7075 
-" clip-path="url(#pb8387c6509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd69463d254)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mb1df935b97" x="257.278675" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2f068f7667" x="257.278675" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -242,11 +242,11 @@ L 257.278675 56.7075
      <g id="line2d_15">
       <path d="M 267.837682 308.04375 
 L 267.837682 56.7075 
-" clip-path="url(#pb8387c6509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd69463d254)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <g>
-       <use xlink:href="#mb1df935b97" x="267.837682" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2f068f7667" x="267.837682" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -254,11 +254,11 @@ L 267.837682 56.7075
      <g id="line2d_17">
       <path d="M 276.984309 308.04375 
 L 276.984309 56.7075 
-" clip-path="url(#pb8387c6509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd69463d254)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mb1df935b97" x="276.984309" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2f068f7667" x="276.984309" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -266,11 +266,11 @@ L 276.984309 56.7075
      <g id="line2d_19">
       <path d="M 285.052207 308.04375 
 L 285.052207 56.7075 
-" clip-path="url(#pb8387c6509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd69463d254)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#mb1df935b97" x="285.052207" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2f068f7667" x="285.052207" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -278,11 +278,11 @@ L 285.052207 56.7075
      <g id="line2d_21">
       <path d="M 339.748353 308.04375 
 L 339.748353 56.7075 
-" clip-path="url(#pb8387c6509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd69463d254)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#mb1df935b97" x="339.748353" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2f068f7667" x="339.748353" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -290,11 +290,11 @@ L 339.748353 56.7075
      <g id="line2d_23">
       <path d="M 367.521885 308.04375 
 L 367.521885 56.7075 
-" clip-path="url(#pb8387c6509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd69463d254)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mb1df935b97" x="367.521885" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2f068f7667" x="367.521885" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -302,11 +302,11 @@ L 367.521885 56.7075
      <g id="line2d_25">
       <path d="M 387.227519 308.04375 
 L 387.227519 56.7075 
-" clip-path="url(#pb8387c6509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd69463d254)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mb1df935b97" x="387.227519" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2f068f7667" x="387.227519" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -314,11 +314,11 @@ L 387.227519 56.7075
      <g id="line2d_27">
       <path d="M 402.512397 308.04375 
 L 402.512397 56.7075 
-" clip-path="url(#pb8387c6509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd69463d254)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#mb1df935b97" x="402.512397" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2f068f7667" x="402.512397" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -326,11 +326,11 @@ L 402.512397 56.7075
      <g id="line2d_29">
       <path d="M 415.001051 308.04375 
 L 415.001051 56.7075 
-" clip-path="url(#pb8387c6509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd69463d254)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#mb1df935b97" x="415.001051" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2f068f7667" x="415.001051" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -338,11 +338,11 @@ L 415.001051 56.7075
      <g id="line2d_31">
       <path d="M 425.560057 308.04375 
 L 425.560057 56.7075 
-" clip-path="url(#pb8387c6509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd69463d254)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#mb1df935b97" x="425.560057" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2f068f7667" x="425.560057" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -350,11 +350,11 @@ L 425.560057 56.7075
      <g id="line2d_33">
       <path d="M 434.706685 308.04375 
 L 434.706685 56.7075 
-" clip-path="url(#pb8387c6509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd69463d254)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#mb1df935b97" x="434.706685" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2f068f7667" x="434.706685" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -362,11 +362,11 @@ L 434.706685 56.7075
      <g id="line2d_35">
       <path d="M 442.774583 308.04375 
 L 442.774583 56.7075 
-" clip-path="url(#pb8387c6509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd69463d254)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#mb1df935b97" x="442.774583" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2f068f7667" x="442.774583" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -374,11 +374,11 @@ L 442.774583 56.7075
      <g id="line2d_37">
       <path d="M 497.470729 308.04375 
 L 497.470729 56.7075 
-" clip-path="url(#pb8387c6509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd69463d254)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#mb1df935b97" x="497.470729" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2f068f7667" x="497.470729" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -386,11 +386,11 @@ L 497.470729 56.7075
      <g id="line2d_39">
       <path d="M 525.24426 308.04375 
 L 525.24426 56.7075 
-" clip-path="url(#pb8387c6509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd69463d254)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#mb1df935b97" x="525.24426" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2f068f7667" x="525.24426" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -398,11 +398,11 @@ L 525.24426 56.7075
      <g id="line2d_41">
       <path d="M 544.949895 308.04375 
 L 544.949895 56.7075 
-" clip-path="url(#pb8387c6509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd69463d254)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#mb1df935b97" x="544.949895" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2f068f7667" x="544.949895" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -410,11 +410,11 @@ L 544.949895 56.7075
      <g id="line2d_43">
       <path d="M 560.234772 308.04375 
 L 560.234772 56.7075 
-" clip-path="url(#pb8387c6509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd69463d254)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#mb1df935b97" x="560.234772" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2f068f7667" x="560.234772" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1016,12 +1016,12 @@ z
     <g id="ytick_1">
      <g id="line2d_45">
       <defs>
-       <path id="m8eb4b6b303" d="M 0 0 
+       <path id="m2ba45d0b94" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m8eb4b6b303" x="139.360469" y="296.619375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2ba45d0b94" x="139.360469" y="296.619375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -1093,7 +1093,7 @@ z
     <g id="ytick_2">
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m8eb4b6b303" x="139.360469" y="263.978304" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2ba45d0b94" x="139.360469" y="263.978304" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -1160,7 +1160,7 @@ z
     <g id="ytick_3">
      <g id="line2d_47">
       <g>
-       <use xlink:href="#m8eb4b6b303" x="139.360469" y="231.337232" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2ba45d0b94" x="139.360469" y="231.337232" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -1216,7 +1216,7 @@ z
     <g id="ytick_4">
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m8eb4b6b303" x="139.360469" y="198.696161" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2ba45d0b94" x="139.360469" y="198.696161" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -1263,7 +1263,7 @@ z
     <g id="ytick_5">
      <g id="line2d_49">
       <g>
-       <use xlink:href="#m8eb4b6b303" x="139.360469" y="166.055089" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2ba45d0b94" x="139.360469" y="166.055089" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -1376,7 +1376,7 @@ z
     <g id="ytick_6">
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m8eb4b6b303" x="139.360469" y="133.414018" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2ba45d0b94" x="139.360469" y="133.414018" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -1392,7 +1392,7 @@ z
     <g id="ytick_7">
      <g id="line2d_51">
       <g>
-       <use xlink:href="#m8eb4b6b303" x="139.360469" y="100.772946" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2ba45d0b94" x="139.360469" y="100.772946" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -1439,7 +1439,7 @@ z
     <g id="ytick_8">
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m8eb4b6b303" x="139.360469" y="68.131875" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2ba45d0b94" x="139.360469" y="68.131875" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -1462,47 +1462,47 @@ z
    <g id="LineCollection_1">
     <path d="M 139.360469 296.619375 
 L 154.645346 296.619375 
-" clip-path="url(#pb8387c6509)" style="fill: none; stroke: #17becf; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#pd69463d254)" style="fill: none; stroke: #17becf; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_2">
     <path d="M 139.360469 263.978304 
 L 161.142927 263.978304 
-" clip-path="url(#pb8387c6509)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#pd69463d254)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_3">
     <path d="M 139.360469 231.337232 
 L 200.65327 231.337232 
-" clip-path="url(#pb8387c6509)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#pd69463d254)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_4">
     <path d="M 139.360469 198.696161 
 L 208.426981 198.696161 
-" clip-path="url(#pb8387c6509)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#pd69463d254)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_5">
     <path d="M 139.360469 166.055089 
 L 212.673671 166.055089 
-" clip-path="url(#pb8387c6509)" style="fill: none; stroke: #d62728; stroke-opacity: 0.9; stroke-width: 2.4"/>
+" clip-path="url(#pd69463d254)" style="fill: none; stroke: #d62728; stroke-opacity: 0.9; stroke-width: 2.4"/>
    </g>
    <g id="LineCollection_6">
     <path d="M 139.360469 133.414018 
 L 239.878265 133.414018 
-" clip-path="url(#pb8387c6509)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#pd69463d254)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_7">
     <path d="M 139.360469 100.772946 
 L 248.943982 100.772946 
-" clip-path="url(#pb8387c6509)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#pd69463d254)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_8">
     <path d="M 139.360469 68.131875 
 L 284.774562 68.131875 
-" clip-path="url(#pb8387c6509)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#pd69463d254)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="line2d_53">
     <path d="M 542.152339 308.04375 
 L 542.152339 56.7075 
-" clip-path="url(#pb8387c6509)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
+" clip-path="url(#pd69463d254)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
    </g>
    <g id="patch_3">
     <path d="M 139.360469 308.04375 
@@ -1888,7 +1888,7 @@ z
    </g>
    <g id="line2d_54">
     <defs>
-     <path id="m946a711b4c" d="M 0 3 
+     <path id="m705e9903b1" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1900,13 +1900,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #17becf"/>
     </defs>
-    <g clip-path="url(#pb8387c6509)">
-     <use xlink:href="#m946a711b4c" x="154.645346" y="296.619375" style="fill: #17becf; stroke: #17becf"/>
+    <g clip-path="url(#pd69463d254)">
+     <use xlink:href="#m705e9903b1" x="154.645346" y="296.619375" style="fill: #17becf; stroke: #17becf"/>
     </g>
    </g>
    <g id="line2d_55">
     <defs>
-     <path id="m02d906a529" d="M 0 3 
+     <path id="ma627fc16ca" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1918,13 +1918,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #e377c2"/>
     </defs>
-    <g clip-path="url(#pb8387c6509)">
-     <use xlink:href="#m02d906a529" x="161.142927" y="263.978304" style="fill: #e377c2; stroke: #e377c2"/>
+    <g clip-path="url(#pd69463d254)">
+     <use xlink:href="#ma627fc16ca" x="161.142927" y="263.978304" style="fill: #e377c2; stroke: #e377c2"/>
     </g>
    </g>
    <g id="line2d_56">
     <defs>
-     <path id="me45a5a9a61" d="M 0 3 
+     <path id="m193da29946" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1936,13 +1936,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #8c564b"/>
     </defs>
-    <g clip-path="url(#pb8387c6509)">
-     <use xlink:href="#me45a5a9a61" x="200.65327" y="231.337232" style="fill: #8c564b; stroke: #8c564b"/>
+    <g clip-path="url(#pd69463d254)">
+     <use xlink:href="#m193da29946" x="200.65327" y="231.337232" style="fill: #8c564b; stroke: #8c564b"/>
     </g>
    </g>
    <g id="line2d_57">
     <defs>
-     <path id="m5c773b735c" d="M 0 3 
+     <path id="m97dd709148" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1954,13 +1954,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #bcbd22"/>
     </defs>
-    <g clip-path="url(#pb8387c6509)">
-     <use xlink:href="#m5c773b735c" x="208.426981" y="198.696161" style="fill: #bcbd22; stroke: #bcbd22"/>
+    <g clip-path="url(#pd69463d254)">
+     <use xlink:href="#m97dd709148" x="208.426981" y="198.696161" style="fill: #bcbd22; stroke: #bcbd22"/>
     </g>
    </g>
    <g id="line2d_58">
     <defs>
-     <path id="mbc09d81826" d="M 0 5 
+     <path id="m23075e263c" d="M 0 5 
 C 1.326016 5 2.597899 4.473168 3.535534 3.535534 
 C 4.473168 2.597899 5 1.326016 5 0 
 C 5 -1.326016 4.473168 -2.597899 3.535534 -3.535534 
@@ -1972,13 +1972,13 @@ C -2.597899 4.473168 -1.326016 5 0 5
 z
 " style="stroke: #d62728"/>
     </defs>
-    <g clip-path="url(#pb8387c6509)">
-     <use xlink:href="#mbc09d81826" x="212.673671" y="166.055089" style="fill: #d62728; stroke: #d62728"/>
+    <g clip-path="url(#pd69463d254)">
+     <use xlink:href="#m23075e263c" x="212.673671" y="166.055089" style="fill: #d62728; stroke: #d62728"/>
     </g>
    </g>
    <g id="line2d_59">
     <defs>
-     <path id="m360148a81c" d="M 0 3 
+     <path id="m9b706501ca" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1990,13 +1990,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #1f77b4"/>
     </defs>
-    <g clip-path="url(#pb8387c6509)">
-     <use xlink:href="#m360148a81c" x="239.878265" y="133.414018" style="fill: #1f77b4; stroke: #1f77b4"/>
+    <g clip-path="url(#pd69463d254)">
+     <use xlink:href="#m9b706501ca" x="239.878265" y="133.414018" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_60">
     <defs>
-     <path id="m24e46c7d43" d="M 0 3 
+     <path id="m109f8eb087" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -2008,13 +2008,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #2ca02c"/>
     </defs>
-    <g clip-path="url(#pb8387c6509)">
-     <use xlink:href="#m24e46c7d43" x="248.943982" y="100.772946" style="fill: #2ca02c; stroke: #2ca02c"/>
+    <g clip-path="url(#pd69463d254)">
+     <use xlink:href="#m109f8eb087" x="248.943982" y="100.772946" style="fill: #2ca02c; stroke: #2ca02c"/>
     </g>
    </g>
    <g id="line2d_61">
     <defs>
-     <path id="m092fafc338" d="M 0 3 
+     <path id="mdab609fbaf" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -2026,8 +2026,8 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #9467bd"/>
     </defs>
-    <g clip-path="url(#pb8387c6509)">
-     <use xlink:href="#m092fafc338" x="284.774562" y="68.131875" style="fill: #9467bd; stroke: #9467bd"/>
+    <g clip-path="url(#pd69463d254)">
+     <use xlink:href="#mdab609fbaf" x="284.774562" y="68.131875" style="fill: #9467bd; stroke: #9467bd"/>
     </g>
    </g>
   </g>
@@ -2967,7 +2967,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="pb8387c6509">
+  <clipPath id="pd69463d254">
    <rect x="139.360469" y="56.7075" width="425.839531" height="251.33625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_ratio_heatmap.svg
+++ b/bench/graphs/silesia_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.34175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#pc0cea4624c)">
+   <g clip-path="url(#p2827e78830)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAosAAAGaCAYAAABniAm0AAAJ9ElEQVR4nO3YvY5dVx2H4RnPjG08E49tQYgICAlHNCFQolBQpUJQcA1cAQ0VFeIOqLgBOhRRukmJFL4JFRHhQ3zIGmLsDMbY45k5XMFboLD0R0fPcwW/o7O19rvX7uX97292ttDZD+5NT1ji4I3Xpicss/viJ6YnLLH51a+nJyyx+/lXpycssXlyOj1hmZNvvTk9YYkXv/vV6QlL7N75+PSENc6eTC9Y5vIn23neX5keAADA/y+xCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA2v3n2Zub6RErHP7jZHrCEu/fvDE9YZl/nz+enrDEpz44m56wxAcfe2l6whKXm8vpCcvc3r8zPWGNB3+cXrDE6e3t/L9e+MNvpycss/nsF6cnLOFmEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAtH/44P70hjVu3JpesMRmczY9YZlPvvWz6QlrvPGV6QVLHL//t+kJa1yeTy9Y53BLz49rR9MLlrj59+18Pz/89N3pCcvc/vM70xOWcLMIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAApN3nF/c20yNW2Dv5/fSEJe6/cHV6wjKPnz+anrDE3T89mp6wxPnnvjQ9YYkn56fTE5Y53rs1PWGJzXs/nZ6wxNPPvDY9YYnr77w9PWGZZ194fXrCEm4WAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgLT7o/e+uZkescKd64fTE5Z499GD6QnLfON7v5iesMQvv/O16QlLHF87np6wxLd//PPpCct8+eXr0xOW+Prd16cnLPHWX96enrDE0cF2Poc7Ozs7P/zdw+kJS7hZBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAANLu84t7m+kRKzx8djI9YYnD/ZvTE5Z599Fvpics8cqtV6cnLLHZXE5PWOLofHu/of96uZ3n4suHr0xPWOLpxZPpCUts69mxs7Ozs3dlf3rCEtt7KgIA8KGJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACDt7+3uT29Y4qN7d6YnrLF3dXrBMsfXjqcnLHG4f3N6whIXm/PpCUtcHmzvN/RLmxvTE/gvbOv7+WzzdHrCMqfPTqYnLLG9pyIAAB+aWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIO1PD1jl4eXp9IQlDs6vTk9Y5nD/5vSEJc4un05PWOLsYjt/19HBrekJy/zr4vH0hCW29ey4srud9zkf2T+anrDMxeZ8esIS2/kkAgDwPyEWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBIYhEAgCQWAQBI/wHC8pgry+eQtQAAAABJRU5ErkJggg==" id="imaged01622bea7" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="468.72" height="295.2"/>
+iVBORw0KGgoAAAANSUhEUgAAAosAAAGaCAYAAABniAm0AAAJ80lEQVR4nO3YO44dZhnH4TOe8UUe22NbECICAuGIghAoUSioUiEoWAMroKGiQuyAig3QoYjSTUqkcCdURISLuMgaYnzBcuzxzBxW8CtQ9OlFR8+zgr80Z97zO9/e+b0fbTc76OTHd6cnLHHxzdenJyyz99Inpycssf3t76YnLLH3pdemJyyxffp4esIyx999a3rCEi/94BvTE5bYu/2J6QlrnDydXrDM+c93895fmB4AAMD/L7EIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEDa+8/JW9vpESsc/vt4esISH9y4Oj1hmQ9Pn0xPWOLTj06mJyzx6OMvT09Y4nx7Pj1hmVsHt6cnrHH/L9MLlnh8azf/Xtf//IfpCctsP/+V6QlLeFkEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACAdHN6/N71hjas3pxcssd2eTE9Y5lNv/3J6whpvfn16wRJHH/xzesIa56fTC9Y53NH7cfna9IIlbvxrN7+fH3zmzvSEZW797d3pCUt4WQQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAADS3ouzu9vpESvsH/9pesIS965fmp6wzJMXD6cnLHHnrw+nJyxx+sWvTk9Y4unp4+kJyxzt35yesMT2/V9MT1ji2eden56wxJV335mesMzzL78xPWEJL4sAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA2vvp+9/ZTo9Y4faVw+kJS7z38P70hGW+/cNfT09Y4jff/+b0hCWOLh9NT1jiez/71fSEZb72ypXpCUt8684b0xOWePvv70xPWOLaxd38HG42m81P/vhgesISXhYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAtPfi7O52esQKD54fT09Y4vDgxvSEZd57+PvpCUu8evO16QlLbLfn0xOWuHa6u7+h/3G+m3fxlcNXpycs8ezs6fSEJXb1dmw2m83+hYPpCUvs7lUEAOAjE4sAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAOtjfO5jesMTH9m9PT1hj/9L0gmWOLh9NT1ji8ODG9IQlzran0xOWOL+4u7+hX95enZ7A/2BXv59Pts+mJyzz+Pnx9IQldvcqAgDwkYlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAADSwWZ7Pr1hiUfbJ9MTljg4uzQ9YZnPXv/C9IQlzran0xOW+PB0N//Hrm2uTE9Y5tmF3bz3+9MDFrm4v5v3fv/CwfSEZQ73rk5PWMLLIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJD+C2EVlmm8G2EiAAAAAElFTkSuQmCC" id="imagec1517028f9" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="468.72" height="295.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m90f0714b7c" d="M 0 0 
+       <path id="m97d59fe800" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m90f0714b7c" x="115.182137" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m97d59fe800" x="115.182137" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m90f0714b7c" x="154.193912" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m97d59fe800" x="154.193912" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m90f0714b7c" x="193.205687" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m97d59fe800" x="193.205687" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m90f0714b7c" x="232.217462" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m97d59fe800" x="232.217462" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m90f0714b7c" x="271.229237" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m97d59fe800" x="271.229237" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m90f0714b7c" x="310.241012" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m97d59fe800" x="310.241012" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m90f0714b7c" x="349.252787" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m97d59fe800" x="349.252787" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m90f0714b7c" x="388.264562" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m97d59fe800" x="388.264562" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m90f0714b7c" x="427.276336" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m97d59fe800" x="427.276336" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m90f0714b7c" x="466.288111" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m97d59fe800" x="466.288111" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m90f0714b7c" x="505.299886" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m97d59fe800" x="505.299886" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m90f0714b7c" x="544.311661" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m97d59fe800" x="544.311661" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="mc39904a297" d="M 0 0 
+       <path id="m356d5aac60" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mc39904a297" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m356d5aac60" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mc39904a297" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m356d5aac60" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#mc39904a297" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m356d5aac60" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#mc39904a297" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m356d5aac60" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -836,7 +836,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#mc39904a297" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m356d5aac60" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -899,7 +899,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mc39904a297" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m356d5aac60" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -966,7 +966,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#mc39904a297" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m356d5aac60" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1047,7 +1047,7 @@ z
     <g id="ytick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#mc39904a297" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m356d5aac60" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -1138,9 +1138,24 @@ L 563.817548 49.34175
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_21">
-    <!-- -0 -->
-    <g transform="translate(111.941786 69.553235) scale(0.065 -0.065)">
+    <!-- +0 -->
+    <g transform="translate(110.390926 69.553235) scale(0.065 -0.065)">
      <defs>
+      <path id="DejaVuSans-2b" d="M 2944 4013 
+L 2944 2272 
+L 4684 2272 
+L 4684 1741 
+L 2944 1741 
+L 2944 0 
+L 2419 0 
+L 2419 1741 
+L 678 1741 
+L 678 2272 
+L 2419 2272 
+L 2419 4013 
+L 2944 4013 
+z
+" transform="scale(0.015625)"/>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
 Q 1056 3291 1056 2328 
@@ -1163,8 +1178,8 @@ Q 1250 4750 2034 4750
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_22">
@@ -1198,36 +1213,10 @@ z
     </g>
    </g>
    <g id="text_24">
-    <!-- -2 -->
-    <g transform="translate(228.97711 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-32" d="M 1228 531 
-L 3431 531 
-L 3431 0 
-L 469 0 
-L 469 531 
-Q 828 903 1448 1529 
-Q 2069 2156 2228 2338 
-Q 2531 2678 2651 2914 
-Q 2772 3150 2772 3378 
-Q 2772 3750 2511 3984 
-Q 2250 4219 1831 4219 
-Q 1534 4219 1204 4116 
-Q 875 4013 500 3803 
-L 500 4441 
-Q 881 4594 1212 4672 
-Q 1544 4750 1819 4750 
-Q 2544 4750 2975 4387 
-Q 3406 4025 3406 3419 
-Q 3406 3131 3298 2873 
-Q 3191 2616 2906 2266 
-Q 2828 2175 2409 1742 
-Q 1991 1309 1228 531 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
+    <!-- +0 -->
+    <g transform="translate(227.426251 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_25">
@@ -1247,23 +1236,6 @@ z
    <g id="text_27">
     <!-- +0 -->
     <g transform="translate(344.461576 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-2b" d="M 2944 4013 
-L 2944 2272 
-L 4684 2272 
-L 4684 1741 
-L 2944 1741 
-L 2944 0 
-L 2419 0 
-L 2419 1741 
-L 678 1741 
-L 678 2272 
-L 2419 2272 
-L 2419 4013 
-L 2944 4013 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
     </g>
@@ -1283,10 +1255,10 @@ z
     </g>
    </g>
    <g id="text_30">
-    <!-- -0 -->
-    <g transform="translate(463.04776 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(36.083984 0)"/>
+    <!-- +0 -->
+    <g transform="translate(461.4969 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_31">
@@ -1297,10 +1269,10 @@ z
     </g>
    </g>
    <g id="text_32">
-    <!-- -1 -->
-    <g transform="translate(541.071309 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+    <!-- +0 -->
+    <g transform="translate(539.52045 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_33">
@@ -1327,6 +1299,32 @@ z
    <g id="text_36">
     <!-- -2 -->
     <g transform="translate(228.97711 106.389018) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
     </g>
@@ -2062,18 +2060,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABEAAAFUCAYAAADCj9eRAAAB2ElEQVR4nO2aQY7EIAwEIeFP+6X9/33C3MPcKKSS1TygZRftNlLS2//fbJtn9KvvajAi17ZCM7Uzeg+TEyJhsh4TE8D25ZhYRMJkPSYmmZ0zIhfQEMPkJq74JpgQlUBMABkIrOV2KLMRItXMhrQjqcQUSszsbGuomFSbHULEAlblE0klor1zMaG0XwnDBDAsBVY0O4CIBizlE4ntEbCijK3mE8vKUPkEEIF8YslYje2RZFP5BJkdCxOonf1i6jEhRICOyjEBzFaPiWd2iChoYbKKhMkqgmSsh4kkHkU+6UyeACJEJaLZ6QQTzy7WtGPyicX2Kp/c+yKaATTliSWoTXsnPllEEtTLGX37f+7WRpuPQ4RhomlntCdMTohATIDbKceEaGfOD1BJZueIiImJZQBNTCxgw2Q91N7Zf7RBsxMmR0TqMdmvxPRmI0TmDJNVJExWkTBZRcJkFSnFZH6Q5aVhQrQzkYUOVEIxIXxSjAnRDjQ7mndsZud9VEwsPtFcsWjvaNZofHKoEpFPELCPJmORdqblMWxiYjEbw+QJk/dR+SQD+BbROFbEJAP4Q4RgQpiNCupKIhAT4gewakws7YTJIREoY4FPeNWYaNoJk18iQNqXY1LKJ1/07Ct/l+QCQgAAAABJRU5ErkJggg==" id="image9781825cce" transform="scale(1 -1) translate(0 -244.8)" x="573.84" y="-74.16" width="12.24" height="244.8"/>
+iVBORw0KGgoAAAANSUhEUgAAABEAAAFUCAYAAADCj9eRAAAB2ElEQVR4nO2aQY7EIAwEIeFP+6X9/33C3MPcKKSS1TygZRftNlLS2//fbJtn9KvvajAi17ZCM7Uzeg+TEyJhsh4TE8D25ZhYRMJkPSYmmZ0zIhfQEMPkJq74JpgQlUBMABkIrOV2KLMRItXMhrQjqcQUSszsbGuomFSbHULEAlblE0klor1zMaG0XwnDBDAsBVY0O4CIBizlE4ntEbCijK3mE8vKUPkEEIF8YslYje2RZFP5BJkdCxOonf1i6jEhRICOyjEBzFaPiWd2iChoYbKKhMkqgmSsh4kkHkU+6UyeACJEJaLZ6QQTzy7WtGPyicX2Kp/c+yKaATTliSWoTXsnPllEEtTLGX37f+7WRpuPQ4RhomlntCdMTohATIDbKceEaGfOD1BJZueIiImJZQBNTCxgw2Q91N7Zf7RBsxMmR0TqMdmvxPRmI0TmDJNVJExWkTBZRcJkFSnFZH6Q5aVhQrQzkYUOVEIxIXxSjAnRDjQ7mndsZud9VEwsPtFcsWjvaNZofHKoEpFPELCPJmORdqblMWxiYjEbw+QJk/dR+SQD+BbROFbEJAP4Q4RgQpiNCupKIhAT4gewakws7YTJIREoY4FPeNWYaNoJk18iQNqXY1LKJ1/07Ct/l+QCQgAAAABJRU5ErkJggg==" id="image5d050a3c3b" transform="scale(1 -1) translate(0 -244.8)" x="573.84" y="-74.16" width="12.24" height="244.8"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_21">
       <defs>
-       <path id="m3320da5097" d="M 0 0 
+       <path id="md5969d3769" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m3320da5097" x="585.876562" y="282.022672" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md5969d3769" x="585.876562" y="282.022672" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_117">
@@ -2099,7 +2097,7 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m3320da5097" x="585.876562" y="239.353777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md5969d3769" x="585.876562" y="239.353777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_118">
@@ -2116,7 +2114,7 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m3320da5097" x="585.876562" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md5969d3769" x="585.876562" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_119">
@@ -2132,7 +2130,7 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m3320da5097" x="585.876562" y="154.015985" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md5969d3769" x="585.876562" y="154.015985" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_120">
@@ -2148,7 +2146,7 @@ z
     <g id="ytick_13">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m3320da5097" x="585.876562" y="111.347089" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md5969d3769" x="585.876562" y="111.347089" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_121">
@@ -2741,8 +2739,8 @@ z
    </g>
   </g>
   <g id="text_124">
-   <!-- 2026-07-08T22:12:55Z  ·  Linux chungus2 x86_64  ·  commit 30251fb3  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(44.380078 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-08T22:38:10Z  ·  Linux chungus2 x86_64  ·  commit f6be9ada  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(44.622344 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -2875,11 +2873,11 @@ z
     <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2919,109 +2917,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3262.744141 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3326.367188 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3389.990234 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3425.195312 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3488.671875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3552.294922 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3584.082031 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3615.869141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3647.65625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3679.443359 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3711.230469 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3739.013672 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3800.537109 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3861.816406 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3925.195312 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3988.671875 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4027.535156 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4088.716797 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4147.896484 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4209.419922 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4250.533203 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4284.224609 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4312.007812 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4373.53125 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4434.810547 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4498.189453 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4561.8125 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4595.503906 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4654.683594 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4718.306641 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4750.09375 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4813.716797 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4877.339844 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4909.126953 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4972.75 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5008.833984 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5047.697266 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5102.677734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5166.300781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5198.087891 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5229.875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5261.662109 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5293.449219 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5325.236328 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5364.445312 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5427.824219 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5466.6875 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5527.869141 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5591.248047 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5654.724609 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5718.103516 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5781.580078 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5844.958984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5884.167969 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5915.955078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5999.744141 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6031.53125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6128.943359 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6190.466797 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6253.943359 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6281.726562 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6343.005859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6406.384766 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6438.171875 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6490.271484 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6553.650391 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6614.929688 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6678.40625 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6730.505859 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6793.884766 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6855.066406 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6894.275391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6927.966797 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6959.753906 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7000.867188 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7062.146484 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7101.355469 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7129.138672 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7190.320312 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7222.107422 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7249.890625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7301.990234 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7333.777344 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7397.253906 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7458.777344 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7497.986328 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7559.509766 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7598.873047 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7696.285156 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7724.068359 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7787.447266 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7815.230469 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7867.330078 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7906.539062 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7934.322266 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3107.080078 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3170.703125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3234.179688 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3295.703125 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3359.326172 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3420.605469 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3484.082031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3545.361328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3577.148438 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3608.935547 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3640.722656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3672.509766 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3704.296875 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3732.080078 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3793.603516 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3854.882812 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3918.261719 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3981.738281 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4020.601562 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4081.783203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4140.962891 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4202.486328 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4243.599609 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4277.291016 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4305.074219 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4366.597656 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4427.876953 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4491.255859 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4554.878906 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4588.570312 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4647.75 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4711.373047 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4743.160156 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4806.783203 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4870.40625 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4902.193359 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4965.816406 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5001.900391 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5040.763672 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5095.744141 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5159.367188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5191.154297 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5222.941406 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5254.728516 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5286.515625 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5318.302734 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5357.511719 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5420.890625 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5459.753906 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5520.935547 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5584.314453 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5647.791016 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5711.169922 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5774.646484 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5838.025391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5877.234375 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5909.021484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5992.810547 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6024.597656 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6122.009766 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6183.533203 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6247.009766 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6274.792969 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6336.072266 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6399.451172 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6431.238281 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6483.337891 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6546.716797 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6607.996094 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6671.472656 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6723.572266 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6786.951172 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6848.132812 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6887.341797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6921.033203 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6952.820312 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6993.933594 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7055.212891 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7094.421875 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7122.205078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7183.386719 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7215.173828 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7242.957031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7295.056641 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7326.84375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7390.320312 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7451.84375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7491.052734 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7552.576172 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7591.939453 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7689.351562 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7717.134766 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7780.513672 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7808.296875 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7860.396484 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7899.605469 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7927.388672 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pc0cea4624c">
+  <clipPath id="p2827e78830">
    <rect x="95.67625" y="49.34175" width="468.141298" height="294.686261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_summary.svg
+++ b/bench/graphs/silesia_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="573.639844pt" height="386.202469pt" viewBox="0 0 573.639844 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="573.155312pt" height="386.202469pt" viewBox="0 0 573.155312 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,232 +22,232 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 386.202469 
-L 573.639844 386.202469 
-L 573.639844 0 
+L 573.155312 386.202469 
+L 573.155312 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 188.944922 104.1264 
-L 293.569922 104.1264 
-L 293.569922 74.7432 
-L 188.944922 74.7432 
+    <path d="M 188.702656 104.1264 
+L 293.327656 104.1264 
+L 293.327656 74.7432 
+L 188.702656 74.7432 
 z
-" clip-path="url(#p696bf80384)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p595e2dd777)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 293.569922 104.1264 
-L 398.194922 104.1264 
-L 398.194922 74.7432 
-L 293.569922 74.7432 
+    <path d="M 293.327656 104.1264 
+L 397.952656 104.1264 
+L 397.952656 74.7432 
+L 293.327656 74.7432 
 z
-" clip-path="url(#p696bf80384)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p595e2dd777)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 398.194922 104.1264 
-L 502.819922 104.1264 
-L 502.819922 74.7432 
-L 398.194922 74.7432 
+    <path d="M 397.952656 104.1264 
+L 502.577656 104.1264 
+L 502.577656 74.7432 
+L 397.952656 74.7432 
 z
-" clip-path="url(#p696bf80384)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p595e2dd777)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 188.944922 133.5096 
-L 293.569922 133.5096 
-L 293.569922 104.1264 
-L 188.944922 104.1264 
+    <path d="M 188.702656 133.5096 
+L 293.327656 133.5096 
+L 293.327656 104.1264 
+L 188.702656 104.1264 
 z
-" clip-path="url(#p696bf80384)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p595e2dd777)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 293.569922 133.5096 
-L 398.194922 133.5096 
-L 398.194922 104.1264 
-L 293.569922 104.1264 
+    <path d="M 293.327656 133.5096 
+L 397.952656 133.5096 
+L 397.952656 104.1264 
+L 293.327656 104.1264 
 z
-" clip-path="url(#p696bf80384)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p595e2dd777)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 398.194922 133.5096 
-L 502.819922 133.5096 
-L 502.819922 104.1264 
-L 398.194922 104.1264 
+    <path d="M 397.952656 133.5096 
+L 502.577656 133.5096 
+L 502.577656 104.1264 
+L 397.952656 104.1264 
 z
-" clip-path="url(#p696bf80384)" style="fill: #fece7c; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p595e2dd777)" style="fill: #fece7c; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 188.944922 162.8928 
-L 293.569922 162.8928 
-L 293.569922 133.5096 
-L 188.944922 133.5096 
+    <path d="M 188.702656 162.8928 
+L 293.327656 162.8928 
+L 293.327656 133.5096 
+L 188.702656 133.5096 
 z
-" clip-path="url(#p696bf80384)" style="fill: #fee08b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p595e2dd777)" style="fill: #fee08b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 293.569922 162.8928 
-L 398.194922 162.8928 
-L 398.194922 133.5096 
-L 293.569922 133.5096 
+    <path d="M 293.327656 162.8928 
+L 397.952656 162.8928 
+L 397.952656 133.5096 
+L 293.327656 133.5096 
 z
-" clip-path="url(#p696bf80384)" style="fill: #feefa3; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p595e2dd777)" style="fill: #feefa3; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 398.194922 162.8928 
-L 502.819922 162.8928 
-L 502.819922 133.5096 
-L 398.194922 133.5096 
+    <path d="M 397.952656 162.8928 
+L 502.577656 162.8928 
+L 502.577656 133.5096 
+L 397.952656 133.5096 
 z
-" clip-path="url(#p696bf80384)" style="fill: #fdbf6f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p595e2dd777)" style="fill: #fdbf6f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 188.944922 192.276 
-L 293.569922 192.276 
-L 293.569922 162.8928 
-L 188.944922 162.8928 
+    <path d="M 188.702656 192.276 
+L 293.327656 192.276 
+L 293.327656 162.8928 
+L 188.702656 162.8928 
 z
-" clip-path="url(#p696bf80384)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p595e2dd777)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 293.569922 192.276 
-L 398.194922 192.276 
-L 398.194922 162.8928 
-L 293.569922 162.8928 
+    <path d="M 293.327656 192.276 
+L 397.952656 192.276 
+L 397.952656 162.8928 
+L 293.327656 162.8928 
 z
-" clip-path="url(#p696bf80384)" style="fill: #fede89; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p595e2dd777)" style="fill: #fede89; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 398.194922 192.276 
-L 502.819922 192.276 
-L 502.819922 162.8928 
-L 398.194922 162.8928 
+    <path d="M 397.952656 192.276 
+L 502.577656 192.276 
+L 502.577656 162.8928 
+L 397.952656 162.8928 
 z
-" clip-path="url(#p696bf80384)" style="fill: #f7814c; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p595e2dd777)" style="fill: #f7814c; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 188.944922 221.6592 
-L 293.569922 221.6592 
-L 293.569922 192.276 
-L 188.944922 192.276 
+    <path d="M 188.702656 221.6592 
+L 293.327656 221.6592 
+L 293.327656 192.276 
+L 188.702656 192.276 
 z
-" clip-path="url(#p696bf80384)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p595e2dd777)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 293.569922 221.6592 
-L 398.194922 221.6592 
-L 398.194922 192.276 
-L 293.569922 192.276 
+    <path d="M 293.327656 221.6592 
+L 397.952656 221.6592 
+L 397.952656 192.276 
+L 293.327656 192.276 
 z
-" clip-path="url(#p696bf80384)" style="fill: #fed27f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p595e2dd777)" style="fill: #fed27f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 398.194922 221.6592 
-L 502.819922 221.6592 
-L 502.819922 192.276 
-L 398.194922 192.276 
+    <path d="M 397.952656 221.6592 
+L 502.577656 221.6592 
+L 502.577656 192.276 
+L 397.952656 192.276 
 z
-" clip-path="url(#p696bf80384)" style="fill: #fffcba; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p595e2dd777)" style="fill: #fffcba; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 188.944922 251.0424 
-L 293.569922 251.0424 
-L 293.569922 221.6592 
-L 188.944922 221.6592 
+    <path d="M 188.702656 251.0424 
+L 293.327656 251.0424 
+L 293.327656 221.6592 
+L 188.702656 221.6592 
 z
-" clip-path="url(#p696bf80384)" style="fill: #fff3ac; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p595e2dd777)" style="fill: #feefa3; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 293.569922 251.0424 
-L 398.194922 251.0424 
-L 398.194922 221.6592 
-L 293.569922 221.6592 
+    <path d="M 293.327656 251.0424 
+L 397.952656 251.0424 
+L 397.952656 221.6592 
+L 293.327656 221.6592 
 z
-" clip-path="url(#p696bf80384)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p595e2dd777)" style="fill: #fece7c; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 398.194922 251.0424 
-L 502.819922 251.0424 
-L 502.819922 221.6592 
-L 398.194922 221.6592 
+    <path d="M 397.952656 251.0424 
+L 502.577656 251.0424 
+L 502.577656 221.6592 
+L 397.952656 221.6592 
 z
-" clip-path="url(#p696bf80384)" style="fill: #e8f59f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p595e2dd777)" style="fill: #fec877; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 188.944922 280.4256 
-L 293.569922 280.4256 
-L 293.569922 251.0424 
-L 188.944922 251.0424 
+    <path d="M 188.702656 280.4256 
+L 293.327656 280.4256 
+L 293.327656 251.0424 
+L 188.702656 251.0424 
 z
-" clip-path="url(#p696bf80384)" style="fill: #fff7b2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p595e2dd777)" style="fill: #fff3ac; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 293.569922 280.4256 
-L 398.194922 280.4256 
-L 398.194922 251.0424 
-L 293.569922 251.0424 
+    <path d="M 293.327656 280.4256 
+L 397.952656 280.4256 
+L 397.952656 251.0424 
+L 293.327656 251.0424 
 z
-" clip-path="url(#p696bf80384)" style="fill: #fdc776; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p595e2dd777)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 398.194922 280.4256 
-L 502.819922 280.4256 
-L 502.819922 251.0424 
-L 398.194922 251.0424 
+    <path d="M 397.952656 280.4256 
+L 502.577656 280.4256 
+L 502.577656 251.0424 
+L 397.952656 251.0424 
 z
-" clip-path="url(#p696bf80384)" style="fill: #fec877; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p595e2dd777)" style="fill: #e8f59f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 188.944922 309.8088 
-L 293.569922 309.8088 
-L 293.569922 280.4256 
-L 188.944922 280.4256 
+    <path d="M 188.702656 309.8088 
+L 293.327656 309.8088 
+L 293.327656 280.4256 
+L 188.702656 280.4256 
 z
-" clip-path="url(#p696bf80384)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p595e2dd777)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 293.569922 309.8088 
-L 398.194922 309.8088 
-L 398.194922 280.4256 
-L 293.569922 280.4256 
+    <path d="M 293.327656 309.8088 
+L 397.952656 309.8088 
+L 397.952656 280.4256 
+L 293.327656 280.4256 
 z
-" clip-path="url(#p696bf80384)" style="fill: #fa9b58; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p595e2dd777)" style="fill: #fa9b58; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 398.194922 309.8088 
-L 502.819922 309.8088 
-L 502.819922 280.4256 
-L 398.194922 280.4256 
+    <path d="M 397.952656 309.8088 
+L 502.577656 309.8088 
+L 502.577656 280.4256 
+L 397.952656 280.4256 
 z
-" clip-path="url(#p696bf80384)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p595e2dd777)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 188.944922 339.192 
-L 293.569922 339.192 
-L 293.569922 309.8088 
-L 188.944922 309.8088 
+    <path d="M 188.702656 339.192 
+L 293.327656 339.192 
+L 293.327656 309.8088 
+L 188.702656 309.8088 
 z
-" clip-path="url(#p696bf80384)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p595e2dd777)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 293.569922 339.192 
-L 398.194922 339.192 
-L 398.194922 309.8088 
-L 293.569922 309.8088 
+    <path d="M 293.327656 339.192 
+L 397.952656 339.192 
+L 397.952656 309.8088 
+L 293.327656 309.8088 
 z
-" clip-path="url(#p696bf80384)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p595e2dd777)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 398.194922 339.192 
-L 502.819922 339.192 
-L 502.819922 309.8088 
-L 398.194922 309.8088 
+    <path d="M 397.952656 339.192 
+L 502.577656 339.192 
+L 502.577656 309.8088 
+L 397.952656 309.8088 
 z
-" clip-path="url(#p696bf80384)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p595e2dd777)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(121.932188 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(121.689922 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(229.216406 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(228.974141 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(307.788516 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(307.54625 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(406.140234 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(405.897969 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(117.869922 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(117.627656 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.320 -->
-    <g transform="translate(229.806172 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(229.563906 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -918,7 +918,7 @@ z
    </g>
    <g id="text_7">
     <!-- 117 -->
-    <g transform="translate(338.247422 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(338.005156 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -952,7 +952,7 @@ z
    </g>
    <g id="text_8">
     <!-- 852 -->
-    <g transform="translate(442.872422 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(442.630156 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -1026,7 +1026,7 @@ z
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(112.508047 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(112.265781 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1125,7 +1125,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.324 -->
-    <g transform="translate(229.806172 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(229.563906 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1156,7 +1156,7 @@ z
    </g>
    <g id="text_11">
     <!-- 61 -->
-    <g transform="translate(340.792422 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(340.550156 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -1195,7 +1195,7 @@ z
    </g>
    <g id="text_12">
     <!-- 312 -->
-    <g transform="translate(442.872422 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(442.630156 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
@@ -1203,7 +1203,7 @@ z
    </g>
    <g id="text_13">
     <!-- Go compress/flate -->
-    <g transform="translate(100.201172 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(99.958906 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -1374,7 +1374,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.325 -->
-    <g transform="translate(229.806172 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(229.563906 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1384,14 +1384,14 @@ z
    </g>
    <g id="text_15">
     <!-- 50 -->
-    <g transform="translate(340.792422 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(340.550156 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
     <!-- 275 -->
-    <g transform="translate(442.872422 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(442.630156 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
@@ -1399,7 +1399,7 @@ z
    </g>
    <g id="text_17">
     <!-- JS fflate -->
-    <g transform="translate(121.233672 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(120.991406 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1459,7 +1459,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.329 -->
-    <g transform="translate(229.806172 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(229.563906 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-39" d="M 703 97 
 L 703 672 
@@ -1501,14 +1501,14 @@ z
    </g>
    <g id="text_19">
     <!-- 41 -->
-    <g transform="translate(340.792422 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(340.550156 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
     <!-- 160 -->
-    <g transform="translate(442.872422 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(442.630156 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -1516,7 +1516,7 @@ z
    </g>
    <g id="text_21">
     <!-- zlib -->
-    <g transform="translate(129.771172 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(129.528906 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1540,7 +1540,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.323 -->
-    <g transform="translate(229.806172 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(229.563906 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1550,106 +1550,22 @@ z
    </g>
    <g id="text_23">
     <!-- 38 -->
-    <g transform="translate(340.792422 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(340.550156 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_24">
     <!-- 448 -->
-    <g transform="translate(442.872422 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(442.630156 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_25">
-    <!-- miniz_oxide -->
-    <g transform="translate(113.077422 238.44705) scale(0.08 -0.08)">
-     <defs>
-      <path id="DejaVuSans-6e" d="M 3513 2113 
-L 3513 0 
-L 2938 0 
-L 2938 2094 
-Q 2938 2591 2744 2837 
-Q 2550 3084 2163 3084 
-Q 1697 3084 1428 2787 
-Q 1159 2491 1159 1978 
-L 1159 0 
-L 581 0 
-L 581 3500 
-L 1159 3500 
-L 1159 2956 
-Q 1366 3272 1645 3428 
-Q 1925 3584 2291 3584 
-Q 2894 3584 3203 3211 
-Q 3513 2838 3513 2113 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-5f" d="M 3263 -1063 
-L 3263 -1509 
-L -63 -1509 
-L -63 -1063 
-L 3263 -1063 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-78" d="M 3513 3500 
-L 2247 1797 
-L 3578 0 
-L 2900 0 
-L 1881 1375 
-L 863 0 
-L 184 0 
-L 1544 1831 
-L 300 3500 
-L 978 3500 
-L 1906 2253 
-L 2834 3500 
-L 3513 3500 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-6d"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(97.412109 0)"/>
-     <use xlink:href="#DejaVuSans-6e" transform="translate(125.195312 0)"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(188.574219 0)"/>
-     <use xlink:href="#DejaVuSans-7a" transform="translate(216.357422 0)"/>
-     <use xlink:href="#DejaVuSans-5f" transform="translate(268.847656 0)"/>
-     <use xlink:href="#DejaVuSans-6f" transform="translate(318.847656 0)"/>
-     <use xlink:href="#DejaVuSans-78" transform="translate(376.904297 0)"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(436.083984 0)"/>
-     <use xlink:href="#DejaVuSans-64" transform="translate(463.867188 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(527.34375 0)"/>
-    </g>
-   </g>
-   <g id="text_26">
-    <!-- 0.322 -->
-    <g transform="translate(229.806172 238.5583) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-30"/>
-     <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(159.033203 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(222.65625 0)"/>
-    </g>
-   </g>
-   <g id="text_27">
-    <!-- 36 -->
-    <g transform="translate(340.792422 238.5583) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-33"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
-    </g>
-   </g>
-   <g id="text_28">
-    <!-- 527 -->
-    <g transform="translate(442.872422 238.5583) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
-    </g>
-   </g>
-   <g id="text_29">
     <!-- lean-zip (native) -->
-    <g transform="translate(99.579297 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(99.337031 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1756,9 +1672,9 @@ z
      <use xlink:href="#DejaVuSans-Bold-29" transform="translate(880.615234 0)"/>
     </g>
    </g>
-   <g id="text_30">
-    <!-- 0.321 -->
-    <g transform="translate(228.605547 267.9415) scale(0.08 -0.08)">
+   <g id="text_26">
+    <!-- 0.322 -->
+    <g transform="translate(228.363281 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1842,38 +1758,56 @@ Q 3472 2313 2841 1759
 L 1844 884 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-31" d="M 750 831 
-L 1813 831 
-L 1813 3847 
-L 722 3622 
-L 722 4441 
-L 1806 4666 
-L 2950 4666 
-L 2950 831 
-L 4013 831 
-L 4013 0 
-L 750 0 
-L 750 831 
-z
-" transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-Bold-30"/>
      <use xlink:href="#DejaVuSans-Bold-2e" transform="translate(69.580078 0)"/>
      <use xlink:href="#DejaVuSans-Bold-33" transform="translate(107.568359 0)"/>
      <use xlink:href="#DejaVuSans-Bold-32" transform="translate(177.148438 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-31" transform="translate(246.728516 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-32" transform="translate(246.728516 0)"/>
     </g>
    </g>
-   <g id="text_31">
-    <!-- 33 -->
-    <g transform="translate(340.316172 267.9415) scale(0.08 -0.08)">
+   <g id="text_27">
+    <!-- 36 -->
+    <g transform="translate(340.073906 238.5583) scale(0.08 -0.08)">
+     <defs>
+      <path id="DejaVuSans-Bold-36" d="M 2316 2303 
+Q 2000 2303 1842 2098 
+Q 1684 1894 1684 1484 
+Q 1684 1075 1842 870 
+Q 2000 666 2316 666 
+Q 2634 666 2792 870 
+Q 2950 1075 2950 1484 
+Q 2950 1894 2792 2098 
+Q 2634 2303 2316 2303 
+z
+M 3803 4544 
+L 3803 3681 
+Q 3506 3822 3243 3889 
+Q 2981 3956 2731 3956 
+Q 2194 3956 1894 3657 
+Q 1594 3359 1544 2772 
+Q 1750 2925 1990 3001 
+Q 2231 3078 2516 3078 
+Q 3231 3078 3670 2659 
+Q 4109 2241 4109 1563 
+Q 4109 813 3618 361 
+Q 3128 -91 2303 -91 
+Q 1394 -91 895 523 
+Q 397 1138 397 2266 
+Q 397 3422 980 4083 
+Q 1563 4744 2578 4744 
+Q 2900 4744 3203 4694 
+Q 3506 4644 3803 4544 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-Bold-33"/>
-     <use xlink:href="#DejaVuSans-Bold-33" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-36" transform="translate(69.580078 0)"/>
     </g>
    </g>
-   <g id="text_32">
+   <g id="text_28">
     <!-- 297 -->
-    <g transform="translate(442.158047 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(441.915781 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-39" d="M 641 103 
 L 641 966 
@@ -1921,9 +1855,93 @@ z
      <use xlink:href="#DejaVuSans-Bold-37" transform="translate(139.160156 0)"/>
     </g>
    </g>
+   <g id="text_29">
+    <!-- miniz_oxide -->
+    <g transform="translate(112.835156 267.83025) scale(0.08 -0.08)">
+     <defs>
+      <path id="DejaVuSans-6e" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-5f" d="M 3263 -1063 
+L 3263 -1509 
+L -63 -1509 
+L -63 -1063 
+L 3263 -1063 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-78" d="M 3513 3500 
+L 2247 1797 
+L 3578 0 
+L 2900 0 
+L 1881 1375 
+L 863 0 
+L 184 0 
+L 1544 1831 
+L 300 3500 
+L 978 3500 
+L 1906 2253 
+L 2834 3500 
+L 3513 3500 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-6d"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(97.412109 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(125.195312 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(188.574219 0)"/>
+     <use xlink:href="#DejaVuSans-7a" transform="translate(216.357422 0)"/>
+     <use xlink:href="#DejaVuSans-5f" transform="translate(268.847656 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(318.847656 0)"/>
+     <use xlink:href="#DejaVuSans-78" transform="translate(376.904297 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(436.083984 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(463.867188 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(527.34375 0)"/>
+    </g>
+   </g>
+   <g id="text_30">
+    <!-- 0.322 -->
+    <g transform="translate(229.563906 267.9415) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-30"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(159.033203 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(222.65625 0)"/>
+    </g>
+   </g>
+   <g id="text_31">
+    <!-- 36 -->
+    <g transform="translate(340.550156 267.9415) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-33"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
+    </g>
+   </g>
+   <g id="text_32">
+    <!-- 527 -->
+    <g transform="translate(442.630156 267.9415) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-35"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
+    </g>
+   </g>
    <g id="text_33">
     <!-- OCaml decompress -->
-    <g transform="translate(97.694297 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(97.452031 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -1988,7 +2006,7 @@ z
    </g>
    <g id="text_34">
     <!-- 0.336 -->
-    <g transform="translate(229.806172 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(229.563906 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1998,21 +2016,21 @@ z
    </g>
    <g id="text_35">
     <!-- 21 -->
-    <g transform="translate(340.792422 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(340.550156 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_36">
     <!-- 69 -->
-    <g transform="translate(445.417422 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(445.175156 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-36"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(125.915547 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(125.673281 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -2023,7 +2041,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.303 -->
-    <g transform="translate(229.806172 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(229.563906 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -2033,13 +2051,13 @@ z
    </g>
    <g id="text_39">
     <!-- 1 -->
-    <g transform="translate(343.337422 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(343.095156 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(446.507422 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(446.265156 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2055,7 +2073,7 @@ z
   </g>
   <g id="text_41">
    <!-- silesia — geomean over files, level 6 -->
-   <g transform="translate(153.421641 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(153.179375 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-2014" d="M 344 2156 
 L 6056 2156 
@@ -2128,36 +2146,6 @@ L 653 256
 L 653 1209 
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Bold-36" d="M 2316 2303 
-Q 2000 2303 1842 2098 
-Q 1684 1894 1684 1484 
-Q 1684 1075 1842 870 
-Q 2000 666 2316 666 
-Q 2634 666 2792 870 
-Q 2950 1075 2950 1484 
-Q 2950 1894 2792 2098 
-Q 2634 2303 2316 2303 
-z
-M 3803 4544 
-L 3803 3681 
-Q 3506 3822 3243 3889 
-Q 2981 3956 2731 3956 
-Q 2194 3956 1894 3657 
-Q 1594 3359 1544 2772 
-Q 1750 2925 1990 3001 
-Q 2231 3078 2516 3078 
-Q 3231 3078 3670 2659 
-Q 4109 2241 4109 1563 
-Q 4109 813 3618 361 
-Q 3128 -91 2303 -91 
-Q 1394 -91 895 523 
-Q 397 1138 397 2266 
-Q 397 3422 980 4083 
-Q 1563 4744 2578 4744 
-Q 2900 4744 3203 4694 
-Q 3506 4644 3803 4544 
-z
-" transform="scale(0.015625)"/>
     </defs>
     <use xlink:href="#DejaVuSans-Bold-73"/>
     <use xlink:href="#DejaVuSans-Bold-69" transform="translate(59.521484 0)"/>
@@ -2199,7 +2187,7 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-07-08T22:12:55Z  ·  Linux chungus2 x86_64  ·  commit 30251fb3  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-07-08T22:38:10Z  ·  Linux chungus2 x86_64  ·  commit f6be9ada  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2343,11 +2331,11 @@ z
     <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2387,110 +2375,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3262.744141 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3326.367188 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3389.990234 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3425.195312 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3488.671875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3552.294922 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3584.082031 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3615.869141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3647.65625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3679.443359 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3711.230469 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3739.013672 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3800.537109 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3861.816406 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3925.195312 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3988.671875 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4027.535156 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4088.716797 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4147.896484 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4209.419922 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4250.533203 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4284.224609 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4312.007812 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4373.53125 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4434.810547 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4498.189453 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4561.8125 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4595.503906 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4654.683594 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4718.306641 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4750.09375 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4813.716797 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4877.339844 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4909.126953 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4972.75 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5008.833984 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5047.697266 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5102.677734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5166.300781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5198.087891 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5229.875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5261.662109 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5293.449219 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5325.236328 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5364.445312 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5427.824219 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5466.6875 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5527.869141 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5591.248047 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5654.724609 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5718.103516 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5781.580078 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5844.958984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5884.167969 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5915.955078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5999.744141 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6031.53125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6128.943359 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6190.466797 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6253.943359 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6281.726562 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6343.005859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6406.384766 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6438.171875 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6490.271484 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6553.650391 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6614.929688 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6678.40625 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6730.505859 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6793.884766 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6855.066406 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6894.275391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6927.966797 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6959.753906 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7000.867188 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7062.146484 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7101.355469 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7129.138672 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7190.320312 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7222.107422 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7249.890625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7301.990234 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7333.777344 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7397.253906 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7458.777344 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7497.986328 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7559.509766 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7598.873047 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7696.285156 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7724.068359 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7787.447266 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7815.230469 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7867.330078 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7906.539062 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7934.322266 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3107.080078 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3170.703125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3234.179688 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3295.703125 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3359.326172 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3420.605469 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3484.082031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3545.361328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3577.148438 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3608.935547 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3640.722656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3672.509766 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3704.296875 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3732.080078 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3793.603516 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3854.882812 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3918.261719 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3981.738281 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4020.601562 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4081.783203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4140.962891 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4202.486328 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4243.599609 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4277.291016 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4305.074219 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4366.597656 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4427.876953 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4491.255859 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4554.878906 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4588.570312 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4647.75 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4711.373047 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4743.160156 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4806.783203 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4870.40625 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4902.193359 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4965.816406 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5001.900391 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5040.763672 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5095.744141 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5159.367188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5191.154297 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5222.941406 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5254.728516 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5286.515625 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5318.302734 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5357.511719 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5420.890625 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5459.753906 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5520.935547 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5584.314453 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5647.791016 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5711.169922 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5774.646484 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5838.025391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5877.234375 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5909.021484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5992.810547 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6024.597656 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6122.009766 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6183.533203 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6247.009766 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6274.792969 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6336.072266 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6399.451172 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6431.238281 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6483.337891 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6546.716797 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6607.996094 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6671.472656 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6723.572266 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6786.951172 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6848.132812 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6887.341797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6921.033203 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6952.820312 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6993.933594 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7055.212891 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7094.421875 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7122.205078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7183.386719 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7215.173828 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7242.957031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7295.056641 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7326.84375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7390.320312 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7451.84375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7491.052734 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7552.576172 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7591.939453 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7689.351562 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7717.134766 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7780.513672 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7808.296875 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7860.396484 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7899.605469 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7927.388672 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p696bf80384">
-   <rect x="84.319922" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="p595e2dd777">
+   <rect x="84.077656" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/lakefile.lean
+++ b/bench/lakefile.lean
@@ -349,6 +349,10 @@ lean_exe «lazy2-sweep» where
   root := `ZipLazy2Sweep
 
 @[default_target]
+lean_exe «gate-sweep» where
+  root := `ZipGateSweep
+
+@[default_target]
 lean_exe «huff-bench» where
   root := `ZipHuffBench
 

--- a/bench/results/latest.json
+++ b/bench/results/latest.json
@@ -1,8 +1,8 @@
 {
  "meta": {
-  "date": "2026-07-08T22:12:55Z",
+  "date": "2026-07-08T22:38:10Z",
   "machine": "Linux chungus2 x86_64",
-  "git_commit": "30251fb3",
+  "git_commit": "f6be9ada",
   "toolchain": "leanprover/lean4:v4.30.0-rc2",
   "note": "compress_mbps/decompress_mbps are a median-of-5 snapshot on the machine above; ratio is deterministic"
  },
@@ -14,8 +14,8 @@
    "level": 1,
    "out_size": 60455,
    "ratio": 0.3975,
-   "compress_mbps": 73.47,
-   "decompress_mbps": 213.85
+   "compress_mbps": 72.98,
+   "decompress_mbps": 214.9
   },
   {
    "compressor": "native",
@@ -24,8 +24,8 @@
    "level": 2,
    "out_size": 56316,
    "ratio": 0.3703,
-   "compress_mbps": 54.11,
-   "decompress_mbps": 244.38
+   "compress_mbps": 52.86,
+   "decompress_mbps": 246.48
   },
   {
    "compressor": "native",
@@ -34,8 +34,8 @@
    "level": 3,
    "out_size": 55646,
    "ratio": 0.3659,
-   "compress_mbps": 46.97,
-   "decompress_mbps": 268.94
+   "compress_mbps": 46.83,
+   "decompress_mbps": 270.25
   },
   {
    "compressor": "native",
@@ -44,8 +44,8 @@
    "level": 4,
    "out_size": 54357,
    "ratio": 0.3574,
-   "compress_mbps": 37.96,
-   "decompress_mbps": 271.87
+   "compress_mbps": 37.8,
+   "decompress_mbps": 272.57
   },
   {
    "compressor": "native",
@@ -54,28 +54,28 @@
    "level": 5,
    "out_size": 54078,
    "ratio": 0.3556,
-   "compress_mbps": 30.6,
-   "decompress_mbps": 271.94
+   "compress_mbps": 30.45,
+   "decompress_mbps": 272.76
   },
   {
    "compressor": "native",
    "pattern": "canterbury/alice29.txt",
    "size": 152089,
    "level": 6,
-   "out_size": 54469,
-   "ratio": 0.3581,
-   "compress_mbps": 28.42,
-   "decompress_mbps": 279.7
+   "out_size": 54593,
+   "ratio": 0.359,
+   "compress_mbps": 31.41,
+   "decompress_mbps": 279.01
   },
   {
    "compressor": "native",
    "pattern": "canterbury/alice29.txt",
    "size": 152089,
    "level": 7,
-   "out_size": 54234,
-   "ratio": 0.3566,
-   "compress_mbps": 23.66,
-   "decompress_mbps": 280.92
+   "out_size": 54469,
+   "ratio": 0.3581,
+   "compress_mbps": 28.39,
+   "decompress_mbps": 280.53
   },
   {
    "compressor": "native",
@@ -84,8 +84,8 @@
    "level": 8,
    "out_size": 54216,
    "ratio": 0.3565,
-   "compress_mbps": 22.48,
-   "decompress_mbps": 281.26
+   "compress_mbps": 22.58,
+   "decompress_mbps": 281.18
   },
   {
    "compressor": "native",
@@ -94,8 +94,8 @@
    "level": 9,
    "out_size": 52732,
    "ratio": 0.3467,
-   "compress_mbps": 4.32,
-   "decompress_mbps": 281.82
+   "compress_mbps": 4.34,
+   "decompress_mbps": 280.82
   },
   {
    "compressor": "native",
@@ -104,7 +104,7 @@
    "level": 10,
    "out_size": 52078,
    "ratio": 0.3424,
-   "compress_mbps": 2.41,
+   "compress_mbps": 2.42,
    "decompress_mbps": null
   },
   {
@@ -114,8 +114,8 @@
    "level": 1,
    "out_size": 53135,
    "ratio": 0.4245,
-   "compress_mbps": 66.05,
-   "decompress_mbps": 207.2
+   "compress_mbps": 65.89,
+   "decompress_mbps": 208.31
   },
   {
    "compressor": "native",
@@ -124,8 +124,8 @@
    "level": 2,
    "out_size": 50187,
    "ratio": 0.4009,
-   "compress_mbps": 49.42,
-   "decompress_mbps": 225.34
+   "compress_mbps": 49.48,
+   "decompress_mbps": 227.12
   },
   {
    "compressor": "native",
@@ -134,8 +134,8 @@
    "level": 3,
    "out_size": 49810,
    "ratio": 0.3979,
-   "compress_mbps": 44.29,
-   "decompress_mbps": 247.81
+   "compress_mbps": 44.5,
+   "decompress_mbps": 247.85
   },
   {
    "compressor": "native",
@@ -144,8 +144,8 @@
    "level": 4,
    "out_size": 48687,
    "ratio": 0.3889,
-   "compress_mbps": 35.15,
-   "decompress_mbps": 251.56
+   "compress_mbps": 35.33,
+   "decompress_mbps": 251.25
   },
   {
    "compressor": "native",
@@ -154,28 +154,28 @@
    "level": 5,
    "out_size": 48586,
    "ratio": 0.3881,
-   "compress_mbps": 30.54,
-   "decompress_mbps": 251.42
+   "compress_mbps": 30.58,
+   "decompress_mbps": 251.04
   },
   {
    "compressor": "native",
    "pattern": "canterbury/asyoulik.txt",
    "size": 125179,
    "level": 6,
-   "out_size": 48910,
-   "ratio": 0.3907,
-   "compress_mbps": 27.15,
-   "decompress_mbps": 255.6
+   "out_size": 49005,
+   "ratio": 0.3915,
+   "compress_mbps": 29.92,
+   "decompress_mbps": 255.49
   },
   {
    "compressor": "native",
    "pattern": "canterbury/asyoulik.txt",
    "size": 125179,
    "level": 7,
-   "out_size": 48843,
-   "ratio": 0.3902,
-   "compress_mbps": 24.19,
-   "decompress_mbps": 255.96
+   "out_size": 48910,
+   "ratio": 0.3907,
+   "compress_mbps": 27.03,
+   "decompress_mbps": 256.5
   },
   {
    "compressor": "native",
@@ -184,8 +184,8 @@
    "level": 8,
    "out_size": 48839,
    "ratio": 0.3902,
-   "compress_mbps": 24.03,
-   "decompress_mbps": 256.11
+   "compress_mbps": 24.42,
+   "decompress_mbps": 255.59
   },
   {
    "compressor": "native",
@@ -195,7 +195,7 @@
    "out_size": 47433,
    "ratio": 0.3789,
    "compress_mbps": 4.67,
-   "decompress_mbps": 256.83
+   "decompress_mbps": 256.07
   },
   {
    "compressor": "native",
@@ -204,7 +204,7 @@
    "level": 10,
    "out_size": 46866,
    "ratio": 0.3744,
-   "compress_mbps": 2.8,
+   "compress_mbps": 2.83,
    "decompress_mbps": null
   },
   {
@@ -214,8 +214,8 @@
    "level": 1,
    "out_size": 8476,
    "ratio": 0.3445,
-   "compress_mbps": 65.41,
-   "decompress_mbps": 272.52
+   "compress_mbps": 64.79,
+   "decompress_mbps": 273.39
   },
   {
    "compressor": "native",
@@ -224,8 +224,8 @@
    "level": 2,
    "out_size": 8271,
    "ratio": 0.3362,
-   "compress_mbps": 55.18,
-   "decompress_mbps": 284.2
+   "compress_mbps": 54.88,
+   "decompress_mbps": 282.68
   },
   {
    "compressor": "native",
@@ -234,8 +234,8 @@
    "level": 3,
    "out_size": 8159,
    "ratio": 0.3316,
-   "compress_mbps": 53.12,
-   "decompress_mbps": 285.38
+   "compress_mbps": 52.92,
+   "decompress_mbps": 286.32
   },
   {
    "compressor": "native",
@@ -244,8 +244,8 @@
    "level": 4,
    "out_size": 7948,
    "ratio": 0.3231,
-   "compress_mbps": 48.32,
-   "decompress_mbps": 294.67
+   "compress_mbps": 48.41,
+   "decompress_mbps": 293.58
   },
   {
    "compressor": "native",
@@ -254,28 +254,28 @@
    "level": 5,
    "out_size": 7899,
    "ratio": 0.3211,
-   "compress_mbps": 41.25,
-   "decompress_mbps": 300.91
+   "compress_mbps": 41.47,
+   "decompress_mbps": 299.82
   },
   {
    "compressor": "native",
    "pattern": "canterbury/cp.html",
    "size": 24603,
    "level": 6,
-   "out_size": 7950,
-   "ratio": 0.3231,
-   "compress_mbps": 35.0,
-   "decompress_mbps": 299.04
+   "out_size": 7962,
+   "ratio": 0.3236,
+   "compress_mbps": 36.39,
+   "decompress_mbps": 300.97
   },
   {
    "compressor": "native",
    "pattern": "canterbury/cp.html",
    "size": 24603,
    "level": 7,
-   "out_size": 7934,
-   "ratio": 0.3225,
-   "compress_mbps": 31.87,
-   "decompress_mbps": 305.18
+   "out_size": 7950,
+   "ratio": 0.3231,
+   "compress_mbps": 34.91,
+   "decompress_mbps": 304.58
   },
   {
    "compressor": "native",
@@ -284,8 +284,8 @@
    "level": 8,
    "out_size": 7934,
    "ratio": 0.3225,
-   "compress_mbps": 31.76,
-   "decompress_mbps": 304.07
+   "compress_mbps": 31.74,
+   "decompress_mbps": 305.57
   },
   {
    "compressor": "native",
@@ -294,8 +294,8 @@
    "level": 9,
    "out_size": 7803,
    "ratio": 0.3172,
-   "compress_mbps": 4.98,
-   "decompress_mbps": 306.75
+   "compress_mbps": 5.0,
+   "decompress_mbps": 304.16
   },
   {
    "compressor": "native",
@@ -304,7 +304,7 @@
    "level": 10,
    "out_size": 7737,
    "ratio": 0.3145,
-   "compress_mbps": 2.93,
+   "compress_mbps": 2.98,
    "decompress_mbps": null
   },
   {
@@ -314,8 +314,8 @@
    "level": 1,
    "out_size": 3509,
    "ratio": 0.3147,
-   "compress_mbps": 49.39,
-   "decompress_mbps": 186.84
+   "compress_mbps": 49.3,
+   "decompress_mbps": 184.87
   },
   {
    "compressor": "native",
@@ -324,8 +324,8 @@
    "level": 2,
    "out_size": 3269,
    "ratio": 0.2932,
-   "compress_mbps": 43.58,
-   "decompress_mbps": 188.28
+   "compress_mbps": 43.52,
+   "decompress_mbps": 186.18
   },
   {
    "compressor": "native",
@@ -334,8 +334,8 @@
    "level": 3,
    "out_size": 3209,
    "ratio": 0.2878,
-   "compress_mbps": 42.35,
-   "decompress_mbps": 192.51
+   "compress_mbps": 42.33,
+   "decompress_mbps": 190.38
   },
   {
    "compressor": "native",
@@ -344,8 +344,8 @@
    "level": 4,
    "out_size": 3128,
    "ratio": 0.2805,
-   "compress_mbps": 39.79,
-   "decompress_mbps": 197.21
+   "compress_mbps": 39.69,
+   "decompress_mbps": 194.72
   },
   {
    "compressor": "native",
@@ -354,28 +354,28 @@
    "level": 5,
    "out_size": 3112,
    "ratio": 0.2791,
-   "compress_mbps": 35.71,
-   "decompress_mbps": 197.3
+   "compress_mbps": 35.55,
+   "decompress_mbps": 194.63
   },
   {
    "compressor": "native",
    "pattern": "canterbury/fields.c",
    "size": 11150,
    "level": 6,
-   "out_size": 3122,
-   "ratio": 0.28,
-   "compress_mbps": 32.32,
-   "decompress_mbps": 197.97
+   "out_size": 3136,
+   "ratio": 0.2813,
+   "compress_mbps": 33.29,
+   "decompress_mbps": 195.51
   },
   {
    "compressor": "native",
    "pattern": "canterbury/fields.c",
    "size": 11150,
    "level": 7,
-   "out_size": 3117,
-   "ratio": 0.2796,
-   "compress_mbps": 30.34,
-   "decompress_mbps": 197.86
+   "out_size": 3122,
+   "ratio": 0.28,
+   "compress_mbps": 32.3,
+   "decompress_mbps": 196.28
   },
   {
    "compressor": "native",
@@ -384,8 +384,8 @@
    "level": 8,
    "out_size": 3117,
    "ratio": 0.2796,
-   "compress_mbps": 30.2,
-   "decompress_mbps": 197.83
+   "compress_mbps": 29.93,
+   "decompress_mbps": 196.58
   },
   {
    "compressor": "native",
@@ -395,7 +395,7 @@
    "out_size": 3056,
    "ratio": 0.2741,
    "compress_mbps": 5.48,
-   "decompress_mbps": 198.13
+   "decompress_mbps": 197.69
   },
   {
    "compressor": "native",
@@ -404,7 +404,7 @@
    "level": 10,
    "out_size": 3031,
    "ratio": 0.2718,
-   "compress_mbps": 3.07,
+   "compress_mbps": 3.1,
    "decompress_mbps": null
   },
   {
@@ -414,8 +414,8 @@
    "level": 1,
    "out_size": 1283,
    "ratio": 0.3448,
-   "compress_mbps": 24.98,
-   "decompress_mbps": 84.73
+   "compress_mbps": 25.02,
+   "decompress_mbps": 85.09
   },
   {
    "compressor": "native",
@@ -424,8 +424,8 @@
    "level": 2,
    "out_size": 1225,
    "ratio": 0.3292,
-   "compress_mbps": 23.77,
-   "decompress_mbps": 85.62
+   "compress_mbps": 23.78,
+   "decompress_mbps": 86.11
   },
   {
    "compressor": "native",
@@ -434,8 +434,8 @@
    "level": 3,
    "out_size": 1222,
    "ratio": 0.3284,
-   "compress_mbps": 23.45,
-   "decompress_mbps": 85.71
+   "compress_mbps": 23.44,
+   "decompress_mbps": 86.1
   },
   {
    "compressor": "native",
@@ -444,8 +444,8 @@
    "level": 4,
    "out_size": 1213,
    "ratio": 0.326,
-   "compress_mbps": 21.78,
-   "decompress_mbps": 85.82
+   "compress_mbps": 21.71,
+   "decompress_mbps": 86.28
   },
   {
    "compressor": "native",
@@ -454,18 +454,18 @@
    "level": 5,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 21.21,
-   "decompress_mbps": 86.43
+   "compress_mbps": 21.18,
+   "decompress_mbps": 86.67
   },
   {
    "compressor": "native",
    "pattern": "canterbury/grammar.lsp",
    "size": 3721,
    "level": 6,
-   "out_size": 1219,
-   "ratio": 0.3276,
-   "compress_mbps": 19.47,
-   "decompress_mbps": 86.68
+   "out_size": 1220,
+   "ratio": 0.3279,
+   "compress_mbps": 19.49,
+   "decompress_mbps": 87.07
   },
   {
    "compressor": "native",
@@ -474,8 +474,8 @@
    "level": 7,
    "out_size": 1219,
    "ratio": 0.3276,
-   "compress_mbps": 19.26,
-   "decompress_mbps": 86.73
+   "compress_mbps": 19.18,
+   "decompress_mbps": 87.26
   },
   {
    "compressor": "native",
@@ -484,8 +484,8 @@
    "level": 8,
    "out_size": 1219,
    "ratio": 0.3276,
-   "compress_mbps": 19.29,
-   "decompress_mbps": 86.71
+   "compress_mbps": 18.95,
+   "decompress_mbps": 86.89
   },
   {
    "compressor": "native",
@@ -494,8 +494,8 @@
    "level": 9,
    "out_size": 1205,
    "ratio": 0.3238,
-   "compress_mbps": 4.95,
-   "decompress_mbps": 86.69
+   "compress_mbps": 4.96,
+   "decompress_mbps": 87.26
   },
   {
    "compressor": "native",
@@ -504,7 +504,7 @@
    "level": 10,
    "out_size": 1191,
    "ratio": 0.3201,
-   "compress_mbps": 2.96,
+   "compress_mbps": 3.0,
    "decompress_mbps": null
   },
   {
@@ -514,8 +514,8 @@
    "level": 1,
    "out_size": 251793,
    "ratio": 0.2445,
-   "compress_mbps": 143.5,
-   "decompress_mbps": 396.3
+   "compress_mbps": 143.81,
+   "decompress_mbps": 398.43
   },
   {
    "compressor": "native",
@@ -524,8 +524,8 @@
    "level": 2,
    "out_size": 242565,
    "ratio": 0.2356,
-   "compress_mbps": 108.74,
-   "decompress_mbps": 426.25
+   "compress_mbps": 108.19,
+   "decompress_mbps": 430.09
   },
   {
    "compressor": "native",
@@ -534,8 +534,8 @@
    "level": 3,
    "out_size": 242532,
    "ratio": 0.2355,
-   "compress_mbps": 89.75,
-   "decompress_mbps": 452.86
+   "compress_mbps": 89.31,
+   "decompress_mbps": 458.15
   },
   {
    "compressor": "native",
@@ -544,8 +544,8 @@
    "level": 4,
    "out_size": 239953,
    "ratio": 0.233,
-   "compress_mbps": 96.89,
-   "decompress_mbps": 482.5
+   "compress_mbps": 96.04,
+   "decompress_mbps": 485.4
   },
   {
    "compressor": "native",
@@ -554,28 +554,28 @@
    "level": 5,
    "out_size": 218565,
    "ratio": 0.2123,
-   "compress_mbps": 54.14,
-   "decompress_mbps": 465.58
+   "compress_mbps": 53.66,
+   "decompress_mbps": 466.05
   },
   {
    "compressor": "native",
    "pattern": "canterbury/kennedy.xls",
    "size": 1029744,
    "level": 6,
-   "out_size": 201821,
-   "ratio": 0.196,
-   "compress_mbps": 36.35,
-   "decompress_mbps": 482.06
+   "out_size": 202437,
+   "ratio": 0.1966,
+   "compress_mbps": 39.06,
+   "decompress_mbps": 484.57
   },
   {
    "compressor": "native",
    "pattern": "canterbury/kennedy.xls",
    "size": 1029744,
    "level": 7,
-   "out_size": 201362,
-   "ratio": 0.1955,
-   "compress_mbps": 28.18,
-   "decompress_mbps": 487.25
+   "out_size": 201821,
+   "ratio": 0.196,
+   "compress_mbps": 36.71,
+   "decompress_mbps": 488.48
   },
   {
    "compressor": "native",
@@ -584,8 +584,8 @@
    "level": 8,
    "out_size": 200869,
    "ratio": 0.1951,
-   "compress_mbps": 21.27,
-   "decompress_mbps": 497.79
+   "compress_mbps": 21.47,
+   "decompress_mbps": 496.87
   },
   {
    "compressor": "native",
@@ -594,8 +594,8 @@
    "level": 9,
    "out_size": 182511,
    "ratio": 0.1772,
-   "compress_mbps": 3.47,
-   "decompress_mbps": 498.44
+   "compress_mbps": 3.51,
+   "decompress_mbps": 494.92
   },
   {
    "compressor": "native",
@@ -604,7 +604,7 @@
    "level": 10,
    "out_size": 178069,
    "ratio": 0.1729,
-   "compress_mbps": 1.46,
+   "compress_mbps": 1.47,
    "decompress_mbps": null
   },
   {
@@ -614,8 +614,8 @@
    "level": 1,
    "out_size": 160674,
    "ratio": 0.3765,
-   "compress_mbps": 78.84,
-   "decompress_mbps": 223.97
+   "compress_mbps": 78.92,
+   "decompress_mbps": 224.27
   },
   {
    "compressor": "native",
@@ -624,8 +624,8 @@
    "level": 2,
    "out_size": 149787,
    "ratio": 0.351,
-   "compress_mbps": 56.78,
-   "decompress_mbps": 242.81
+   "compress_mbps": 55.93,
+   "decompress_mbps": 242.86
   },
   {
    "compressor": "native",
@@ -634,8 +634,8 @@
    "level": 3,
    "out_size": 148055,
    "ratio": 0.3469,
-   "compress_mbps": 50.12,
-   "decompress_mbps": 270.54
+   "compress_mbps": 48.84,
+   "decompress_mbps": 270.98
   },
   {
    "compressor": "native",
@@ -644,8 +644,8 @@
    "level": 4,
    "out_size": 144750,
    "ratio": 0.3392,
-   "compress_mbps": 41.25,
-   "decompress_mbps": 272.36
+   "compress_mbps": 41.2,
+   "decompress_mbps": 272.98
   },
   {
    "compressor": "native",
@@ -654,28 +654,28 @@
    "level": 5,
    "out_size": 144408,
    "ratio": 0.3384,
-   "compress_mbps": 33.43,
-   "decompress_mbps": 273.23
+   "compress_mbps": 33.39,
+   "decompress_mbps": 274.47
   },
   {
    "compressor": "native",
    "pattern": "canterbury/lcet10.txt",
    "size": 426754,
    "level": 6,
-   "out_size": 144583,
-   "ratio": 0.3388,
-   "compress_mbps": 28.08,
-   "decompress_mbps": 279.29
+   "out_size": 144872,
+   "ratio": 0.3395,
+   "compress_mbps": 30.98,
+   "decompress_mbps": 277.98
   },
   {
    "compressor": "native",
    "pattern": "canterbury/lcet10.txt",
    "size": 426754,
    "level": 7,
-   "out_size": 144099,
-   "ratio": 0.3377,
-   "compress_mbps": 24.24,
-   "decompress_mbps": 280.8
+   "out_size": 144583,
+   "ratio": 0.3388,
+   "compress_mbps": 28.12,
+   "decompress_mbps": 279.92
   },
   {
    "compressor": "native",
@@ -684,8 +684,8 @@
    "level": 8,
    "out_size": 144045,
    "ratio": 0.3375,
-   "compress_mbps": 23.38,
-   "decompress_mbps": 279.83
+   "compress_mbps": 23.49,
+   "decompress_mbps": 278.76
   },
   {
    "compressor": "native",
@@ -694,8 +694,8 @@
    "level": 9,
    "out_size": 140323,
    "ratio": 0.3288,
-   "compress_mbps": 4.26,
-   "decompress_mbps": 279.36
+   "compress_mbps": 4.32,
+   "decompress_mbps": 281.08
   },
   {
    "compressor": "native",
@@ -704,7 +704,7 @@
    "level": 10,
    "out_size": 138833,
    "ratio": 0.3253,
-   "compress_mbps": 2.51,
+   "compress_mbps": 2.55,
    "decompress_mbps": null
   },
   {
@@ -714,8 +714,8 @@
    "level": 1,
    "out_size": 212588,
    "ratio": 0.4412,
-   "compress_mbps": 67.15,
-   "decompress_mbps": 193.51
+   "compress_mbps": 67.38,
+   "decompress_mbps": 193.38
   },
   {
    "compressor": "native",
@@ -724,8 +724,8 @@
    "level": 2,
    "out_size": 199981,
    "ratio": 0.415,
-   "compress_mbps": 48.43,
-   "decompress_mbps": 216.53
+   "compress_mbps": 48.61,
+   "decompress_mbps": 216.15
   },
   {
    "compressor": "native",
@@ -734,8 +734,8 @@
    "level": 3,
    "out_size": 198551,
    "ratio": 0.4121,
-   "compress_mbps": 42.98,
-   "decompress_mbps": 237.73
+   "compress_mbps": 43.05,
+   "decompress_mbps": 237.72
   },
   {
    "compressor": "native",
@@ -744,8 +744,8 @@
    "level": 4,
    "out_size": 193783,
    "ratio": 0.4022,
-   "compress_mbps": 31.86,
-   "decompress_mbps": 241.2
+   "compress_mbps": 31.74,
+   "decompress_mbps": 241.17
   },
   {
    "compressor": "native",
@@ -754,28 +754,28 @@
    "level": 5,
    "out_size": 193223,
    "ratio": 0.401,
-   "compress_mbps": 26.69,
-   "decompress_mbps": 237.49
+   "compress_mbps": 26.71,
+   "decompress_mbps": 237.18
   },
   {
    "compressor": "native",
    "pattern": "canterbury/plrabn12.txt",
    "size": 481861,
    "level": 6,
-   "out_size": 195104,
-   "ratio": 0.4049,
-   "compress_mbps": 24.57,
-   "decompress_mbps": 241.6
+   "out_size": 195643,
+   "ratio": 0.406,
+   "compress_mbps": 27.62,
+   "decompress_mbps": 241.33
   },
   {
    "compressor": "native",
    "pattern": "canterbury/plrabn12.txt",
    "size": 481861,
    "level": 7,
-   "out_size": 194378,
-   "ratio": 0.4034,
-   "compress_mbps": 20.65,
-   "decompress_mbps": 241.96
+   "out_size": 195104,
+   "ratio": 0.4049,
+   "compress_mbps": 24.74,
+   "decompress_mbps": 241.36
   },
   {
    "compressor": "native",
@@ -784,8 +784,8 @@
    "level": 8,
    "out_size": 194355,
    "ratio": 0.4033,
-   "compress_mbps": 20.17,
-   "decompress_mbps": 242.05
+   "compress_mbps": 20.16,
+   "decompress_mbps": 242.01
   },
   {
    "compressor": "native",
@@ -794,8 +794,8 @@
    "level": 9,
    "out_size": 189368,
    "ratio": 0.393,
-   "compress_mbps": 4.05,
-   "decompress_mbps": 242.23
+   "compress_mbps": 4.08,
+   "decompress_mbps": 242.5
   },
   {
    "compressor": "native",
@@ -804,7 +804,7 @@
    "level": 10,
    "out_size": 186146,
    "ratio": 0.3863,
-   "compress_mbps": 2.44,
+   "compress_mbps": 2.47,
    "decompress_mbps": null
   },
   {
@@ -814,8 +814,8 @@
    "level": 1,
    "out_size": 60161,
    "ratio": 0.1172,
-   "compress_mbps": 231.73,
-   "decompress_mbps": 586.9
+   "compress_mbps": 229.65,
+   "decompress_mbps": 590.65
   },
   {
    "compressor": "native",
@@ -824,8 +824,8 @@
    "level": 2,
    "out_size": 58873,
    "ratio": 0.1147,
-   "compress_mbps": 171.49,
-   "decompress_mbps": 615.62
+   "compress_mbps": 171.03,
+   "decompress_mbps": 615.86
   },
   {
    "compressor": "native",
@@ -834,8 +834,8 @@
    "level": 3,
    "out_size": 58327,
    "ratio": 0.1137,
-   "compress_mbps": 149.46,
-   "decompress_mbps": 641.62
+   "compress_mbps": 149.25,
+   "decompress_mbps": 645.04
   },
   {
    "compressor": "native",
@@ -844,8 +844,8 @@
    "level": 4,
    "out_size": 55586,
    "ratio": 0.1083,
-   "compress_mbps": 121.58,
-   "decompress_mbps": 663.36
+   "compress_mbps": 121.98,
+   "decompress_mbps": 665.87
   },
   {
    "compressor": "native",
@@ -854,28 +854,28 @@
    "level": 5,
    "out_size": 55097,
    "ratio": 0.1074,
-   "compress_mbps": 90.77,
-   "decompress_mbps": 684.29
+   "compress_mbps": 90.27,
+   "decompress_mbps": 689.25
   },
   {
    "compressor": "native",
    "pattern": "canterbury/ptt5",
    "size": 513216,
    "level": 6,
-   "out_size": 55495,
-   "ratio": 0.1081,
-   "compress_mbps": 66.85,
-   "decompress_mbps": 709.57
+   "out_size": 55674,
+   "ratio": 0.1085,
+   "compress_mbps": 73.19,
+   "decompress_mbps": 713.48
   },
   {
    "compressor": "native",
    "pattern": "canterbury/ptt5",
    "size": 513216,
    "level": 7,
-   "out_size": 54556,
-   "ratio": 0.1063,
-   "compress_mbps": 50.45,
-   "decompress_mbps": 723.25
+   "out_size": 55495,
+   "ratio": 0.1081,
+   "compress_mbps": 66.44,
+   "decompress_mbps": 724.89
   },
   {
    "compressor": "native",
@@ -884,8 +884,8 @@
    "level": 8,
    "out_size": 53384,
    "ratio": 0.104,
-   "compress_mbps": 42.73,
-   "decompress_mbps": 749.59
+   "compress_mbps": 42.62,
+   "decompress_mbps": 751.42
   },
   {
    "compressor": "native",
@@ -894,8 +894,8 @@
    "level": 9,
    "out_size": 52603,
    "ratio": 0.1025,
-   "compress_mbps": 5.85,
-   "decompress_mbps": 760.53
+   "compress_mbps": 5.94,
+   "decompress_mbps": 763.37
   },
   {
    "compressor": "native",
@@ -904,7 +904,7 @@
    "level": 10,
    "out_size": 52236,
    "ratio": 0.1018,
-   "compress_mbps": 3.77,
+   "compress_mbps": 3.83,
    "decompress_mbps": null
   },
   {
@@ -914,8 +914,8 @@
    "level": 1,
    "out_size": 14249,
    "ratio": 0.3726,
-   "compress_mbps": 59.36,
-   "decompress_mbps": 239.63
+   "compress_mbps": 59.79,
+   "decompress_mbps": 243.38
   },
   {
    "compressor": "native",
@@ -924,8 +924,8 @@
    "level": 2,
    "out_size": 13825,
    "ratio": 0.3615,
-   "compress_mbps": 51.85,
-   "decompress_mbps": 248.35
+   "compress_mbps": 52.09,
+   "decompress_mbps": 250.57
   },
   {
    "compressor": "native",
@@ -934,8 +934,8 @@
    "level": 3,
    "out_size": 13751,
    "ratio": 0.3596,
-   "compress_mbps": 49.71,
-   "decompress_mbps": 250.26
+   "compress_mbps": 49.94,
+   "decompress_mbps": 248.57
   },
   {
    "compressor": "native",
@@ -944,8 +944,8 @@
    "level": 4,
    "out_size": 13290,
    "ratio": 0.3475,
-   "compress_mbps": 45.19,
-   "decompress_mbps": 256.39
+   "compress_mbps": 45.22,
+   "decompress_mbps": 260.3
   },
   {
    "compressor": "native",
@@ -954,28 +954,28 @@
    "level": 5,
    "out_size": 13244,
    "ratio": 0.3463,
-   "compress_mbps": 38.87,
-   "decompress_mbps": 264.09
+   "compress_mbps": 38.84,
+   "decompress_mbps": 267.32
   },
   {
    "compressor": "native",
    "pattern": "canterbury/sum",
    "size": 38240,
    "level": 6,
-   "out_size": 12653,
-   "ratio": 0.3309,
-   "compress_mbps": 20.12,
-   "decompress_mbps": 267.6
+   "out_size": 12675,
+   "ratio": 0.3315,
+   "compress_mbps": 20.91,
+   "decompress_mbps": 270.35
   },
   {
    "compressor": "native",
    "pattern": "canterbury/sum",
    "size": 38240,
    "level": 7,
-   "out_size": 12635,
-   "ratio": 0.3304,
-   "compress_mbps": 18.3,
-   "decompress_mbps": 269.94
+   "out_size": 12653,
+   "ratio": 0.3309,
+   "compress_mbps": 20.19,
+   "decompress_mbps": 272.37
   },
   {
    "compressor": "native",
@@ -984,8 +984,8 @@
    "level": 8,
    "out_size": 12632,
    "ratio": 0.3303,
-   "compress_mbps": 16.67,
-   "decompress_mbps": 272.46
+   "compress_mbps": 16.76,
+   "decompress_mbps": 272.74
   },
   {
    "compressor": "native",
@@ -994,8 +994,8 @@
    "level": 9,
    "out_size": 12427,
    "ratio": 0.325,
-   "compress_mbps": 5.43,
-   "decompress_mbps": 274.58
+   "compress_mbps": 5.46,
+   "decompress_mbps": 278.59
   },
   {
    "compressor": "native",
@@ -1004,7 +1004,7 @@
    "level": 10,
    "out_size": 12273,
    "ratio": 0.3209,
-   "compress_mbps": 3.08,
+   "compress_mbps": 3.15,
    "decompress_mbps": null
   },
   {
@@ -1015,7 +1015,7 @@
    "out_size": 1800,
    "ratio": 0.4258,
    "compress_mbps": 26.55,
-   "decompress_mbps": 91.55
+   "decompress_mbps": 92.59
   },
   {
    "compressor": "native",
@@ -1024,8 +1024,8 @@
    "level": 2,
    "out_size": 1750,
    "ratio": 0.414,
-   "compress_mbps": 25.2,
-   "decompress_mbps": 91.41
+   "compress_mbps": 25.21,
+   "decompress_mbps": 92.35
   },
   {
    "compressor": "native",
@@ -1034,8 +1034,8 @@
    "level": 3,
    "out_size": 1742,
    "ratio": 0.4121,
-   "compress_mbps": 25.11,
-   "decompress_mbps": 91.39
+   "compress_mbps": 25.13,
+   "decompress_mbps": 92.07
   },
   {
    "compressor": "native",
@@ -1044,8 +1044,8 @@
    "level": 4,
    "out_size": 1726,
    "ratio": 0.4083,
-   "compress_mbps": 23.25,
-   "decompress_mbps": 93.02
+   "compress_mbps": 23.38,
+   "decompress_mbps": 93.79
   },
   {
    "compressor": "native",
@@ -1054,18 +1054,18 @@
    "level": 5,
    "out_size": 1722,
    "ratio": 0.4074,
-   "compress_mbps": 23.09,
-   "decompress_mbps": 92.97
+   "compress_mbps": 23.12,
+   "decompress_mbps": 93.86
   },
   {
    "compressor": "native",
    "pattern": "canterbury/xargs.1",
    "size": 4227,
    "level": 6,
-   "out_size": 1734,
-   "ratio": 0.4102,
-   "compress_mbps": 20.35,
-   "decompress_mbps": 93.07
+   "out_size": 1735,
+   "ratio": 0.4105,
+   "compress_mbps": 20.43,
+   "decompress_mbps": 93.92
   },
   {
    "compressor": "native",
@@ -1074,8 +1074,8 @@
    "level": 7,
    "out_size": 1734,
    "ratio": 0.4102,
-   "compress_mbps": 20.34,
-   "decompress_mbps": 93.15
+   "compress_mbps": 20.42,
+   "decompress_mbps": 93.86
   },
   {
    "compressor": "native",
@@ -1084,8 +1084,8 @@
    "level": 8,
    "out_size": 1734,
    "ratio": 0.4102,
-   "compress_mbps": 20.33,
-   "decompress_mbps": 93.01
+   "compress_mbps": 20.43,
+   "decompress_mbps": 94.0
   },
   {
    "compressor": "native",
@@ -1094,8 +1094,8 @@
    "level": 9,
    "out_size": 1708,
    "ratio": 0.4041,
-   "compress_mbps": 5.44,
-   "decompress_mbps": 93.25
+   "compress_mbps": 5.45,
+   "decompress_mbps": 93.76
   },
   {
    "compressor": "native",
@@ -1104,7 +1104,7 @@
    "level": 10,
    "out_size": 1693,
    "ratio": 0.4005,
-   "compress_mbps": 3.27,
+   "compress_mbps": 3.29,
    "decompress_mbps": null
   },
   {
@@ -4414,8 +4414,8 @@
    "level": 1,
    "out_size": 4259644,
    "ratio": 0.4179,
-   "compress_mbps": 69.73,
-   "decompress_mbps": 197.11
+   "compress_mbps": 69.45,
+   "decompress_mbps": 196.99
   },
   {
    "compressor": "native",
@@ -4424,8 +4424,8 @@
    "level": 2,
    "out_size": 3977395,
    "ratio": 0.3902,
-   "compress_mbps": 50.12,
-   "decompress_mbps": 217.46
+   "compress_mbps": 50.01,
+   "decompress_mbps": 215.87
   },
   {
    "compressor": "native",
@@ -4434,8 +4434,8 @@
    "level": 3,
    "out_size": 3945296,
    "ratio": 0.3871,
-   "compress_mbps": 44.43,
-   "decompress_mbps": 240.37
+   "compress_mbps": 44.06,
+   "decompress_mbps": 238.14
   },
   {
    "compressor": "native",
@@ -4444,8 +4444,8 @@
    "level": 4,
    "out_size": 3851998,
    "ratio": 0.3779,
-   "compress_mbps": 34.24,
-   "decompress_mbps": 238.41
+   "compress_mbps": 34.55,
+   "decompress_mbps": 240.09
   },
   {
    "compressor": "native",
@@ -4454,28 +4454,28 @@
    "level": 5,
    "out_size": 3840481,
    "ratio": 0.3768,
-   "compress_mbps": 28.84,
-   "decompress_mbps": 235.83
+   "compress_mbps": 28.74,
+   "decompress_mbps": 238.41
   },
   {
    "compressor": "native",
    "pattern": "silesia/dickens",
    "size": 10192446,
    "level": 6,
-   "out_size": 3868436,
-   "ratio": 0.3795,
-   "compress_mbps": 25.89,
-   "decompress_mbps": 240.89
+   "out_size": 3878125,
+   "ratio": 0.3805,
+   "compress_mbps": 29.02,
+   "decompress_mbps": 242.57
   },
   {
    "compressor": "native",
    "pattern": "silesia/dickens",
    "size": 10192446,
    "level": 7,
-   "out_size": 3855625,
-   "ratio": 0.3783,
-   "compress_mbps": 21.87,
-   "decompress_mbps": 241.66
+   "out_size": 3868436,
+   "ratio": 0.3795,
+   "compress_mbps": 26.11,
+   "decompress_mbps": 243.63
   },
   {
    "compressor": "native",
@@ -4484,8 +4484,8 @@
    "level": 8,
    "out_size": 3854820,
    "ratio": 0.3782,
-   "compress_mbps": 21.11,
-   "decompress_mbps": 242.44
+   "compress_mbps": 21.1,
+   "decompress_mbps": 244.29
   },
   {
    "compressor": "native",
@@ -4494,8 +4494,8 @@
    "level": 9,
    "out_size": 3766619,
    "ratio": 0.3696,
-   "compress_mbps": 4.19,
-   "decompress_mbps": 254.78
+   "compress_mbps": 4.25,
+   "decompress_mbps": 254.95
   },
   {
    "compressor": "native",
@@ -4504,7 +4504,7 @@
    "level": 10,
    "out_size": 3711208,
    "ratio": 0.3641,
-   "compress_mbps": 2.45,
+   "compress_mbps": 2.48,
    "decompress_mbps": null
   },
   {
@@ -4514,8 +4514,8 @@
    "level": 1,
    "out_size": 21267086,
    "ratio": 0.4152,
-   "compress_mbps": 85.97,
-   "decompress_mbps": 213.55
+   "compress_mbps": 85.45,
+   "decompress_mbps": 216.15
   },
   {
    "compressor": "native",
@@ -4524,8 +4524,8 @@
    "level": 2,
    "out_size": 20802983,
    "ratio": 0.4061,
-   "compress_mbps": 68.83,
-   "decompress_mbps": 228.08
+   "compress_mbps": 69.11,
+   "decompress_mbps": 228.87
   },
   {
    "compressor": "native",
@@ -4534,8 +4534,8 @@
    "level": 3,
    "out_size": 20665485,
    "ratio": 0.4035,
-   "compress_mbps": 64.15,
-   "decompress_mbps": 235.0
+   "compress_mbps": 64.32,
+   "decompress_mbps": 235.44
   },
   {
    "compressor": "native",
@@ -4544,8 +4544,8 @@
    "level": 4,
    "out_size": 20356893,
    "ratio": 0.3974,
-   "compress_mbps": 53.87,
-   "decompress_mbps": 245.63
+   "compress_mbps": 54.22,
+   "decompress_mbps": 244.66
   },
   {
    "compressor": "native",
@@ -4554,28 +4554,28 @@
    "level": 5,
    "out_size": 20209289,
    "ratio": 0.3946,
-   "compress_mbps": 41.27,
-   "decompress_mbps": 246.85
+   "compress_mbps": 41.57,
+   "decompress_mbps": 246.26
   },
   {
    "compressor": "native",
    "pattern": "silesia/mozilla",
    "size": 51220480,
    "level": 6,
-   "out_size": 18835212,
-   "ratio": 0.3677,
-   "compress_mbps": 27.39,
-   "decompress_mbps": 255.05
+   "out_size": 18875267,
+   "ratio": 0.3685,
+   "compress_mbps": 29.94,
+   "decompress_mbps": 258.59
   },
   {
    "compressor": "native",
    "pattern": "silesia/mozilla",
    "size": 51220480,
    "level": 7,
-   "out_size": 18790897,
-   "ratio": 0.3669,
-   "compress_mbps": 22.36,
-   "decompress_mbps": 259.56
+   "out_size": 18835212,
+   "ratio": 0.3677,
+   "compress_mbps": 27.82,
+   "decompress_mbps": 257.99
   },
   {
    "compressor": "native",
@@ -4584,8 +4584,8 @@
    "level": 8,
    "out_size": 18777212,
    "ratio": 0.3666,
-   "compress_mbps": 19.22,
-   "decompress_mbps": 260.1
+   "compress_mbps": 19.2,
+   "decompress_mbps": 259.28
   },
   {
    "compressor": "native",
@@ -4594,8 +4594,8 @@
    "level": 9,
    "out_size": 18688252,
    "ratio": 0.3649,
-   "compress_mbps": 4.45,
-   "decompress_mbps": 254.54
+   "compress_mbps": 4.47,
+   "decompress_mbps": 259.86
   },
   {
    "compressor": "native",
@@ -4604,7 +4604,7 @@
    "level": 10,
    "out_size": 18541040,
    "ratio": 0.362,
-   "compress_mbps": 2.33,
+   "compress_mbps": 2.36,
    "decompress_mbps": null
   },
   {
@@ -4614,8 +4614,8 @@
    "level": 1,
    "out_size": 3864163,
    "ratio": 0.3876,
-   "compress_mbps": 85.71,
-   "decompress_mbps": 243.11
+   "compress_mbps": 86.04,
+   "decompress_mbps": 240.2
   },
   {
    "compressor": "native",
@@ -4624,8 +4624,8 @@
    "level": 2,
    "out_size": 3734957,
    "ratio": 0.3746,
-   "compress_mbps": 66.0,
-   "decompress_mbps": 250.72
+   "compress_mbps": 66.56,
+   "decompress_mbps": 253.72
   },
   {
    "compressor": "native",
@@ -4634,8 +4634,8 @@
    "level": 3,
    "out_size": 3708443,
    "ratio": 0.3719,
-   "compress_mbps": 55.72,
-   "decompress_mbps": 263.48
+   "compress_mbps": 56.67,
+   "decompress_mbps": 263.79
   },
   {
    "compressor": "native",
@@ -4644,8 +4644,8 @@
    "level": 4,
    "out_size": 3683603,
    "ratio": 0.3694,
-   "compress_mbps": 41.4,
-   "decompress_mbps": 248.05
+   "compress_mbps": 41.3,
+   "decompress_mbps": 245.24
   },
   {
    "compressor": "native",
@@ -4655,27 +4655,27 @@
    "out_size": 3677014,
    "ratio": 0.3688,
    "compress_mbps": 33.15,
-   "decompress_mbps": 241.18
+   "decompress_mbps": 242.63
   },
   {
    "compressor": "native",
    "pattern": "silesia/mr",
    "size": 9970564,
    "level": 6,
-   "out_size": 3642579,
-   "ratio": 0.3653,
-   "compress_mbps": 29.15,
-   "decompress_mbps": 248.42
+   "out_size": 3646607,
+   "ratio": 0.3657,
+   "compress_mbps": 31.54,
+   "decompress_mbps": 248.96
   },
   {
    "compressor": "native",
    "pattern": "silesia/mr",
    "size": 9970564,
    "level": 7,
-   "out_size": 3636175,
-   "ratio": 0.3647,
-   "compress_mbps": 23.67,
-   "decompress_mbps": 250.97
+   "out_size": 3642579,
+   "ratio": 0.3653,
+   "compress_mbps": 28.95,
+   "decompress_mbps": 251.92
   },
   {
    "compressor": "native",
@@ -4684,8 +4684,8 @@
    "level": 8,
    "out_size": 3634763,
    "ratio": 0.3645,
-   "compress_mbps": 22.2,
-   "decompress_mbps": 256.51
+   "compress_mbps": 22.22,
+   "decompress_mbps": 255.96
   },
   {
    "compressor": "native",
@@ -4694,8 +4694,8 @@
    "level": 9,
    "out_size": 3581643,
    "ratio": 0.3592,
-   "compress_mbps": 4.85,
-   "decompress_mbps": 268.26
+   "compress_mbps": 4.83,
+   "decompress_mbps": 267.55
   },
   {
    "compressor": "native",
@@ -4704,7 +4704,7 @@
    "level": 10,
    "out_size": 3513006,
    "ratio": 0.3523,
-   "compress_mbps": 2.95,
+   "compress_mbps": 2.96,
    "decompress_mbps": null
   },
   {
@@ -4714,8 +4714,8 @@
    "level": 1,
    "out_size": 3785443,
    "ratio": 0.1128,
-   "compress_mbps": 267.43,
-   "decompress_mbps": 677.75
+   "compress_mbps": 267.37,
+   "decompress_mbps": 655.94
   },
   {
    "compressor": "native",
@@ -4724,8 +4724,8 @@
    "level": 2,
    "out_size": 3761560,
    "ratio": 0.1121,
-   "compress_mbps": 166.07,
-   "decompress_mbps": 728.16
+   "compress_mbps": 168.26,
+   "decompress_mbps": 753.88
   },
   {
    "compressor": "native",
@@ -4734,8 +4734,8 @@
    "level": 3,
    "out_size": 3606997,
    "ratio": 0.1075,
-   "compress_mbps": 145.87,
-   "decompress_mbps": 835.85
+   "compress_mbps": 141.83,
+   "decompress_mbps": 835.16
   },
   {
    "compressor": "native",
@@ -4744,8 +4744,8 @@
    "level": 4,
    "out_size": 3201209,
    "ratio": 0.0954,
-   "compress_mbps": 138.39,
-   "decompress_mbps": 848.64
+   "compress_mbps": 138.61,
+   "decompress_mbps": 850.48
   },
   {
    "compressor": "native",
@@ -4754,28 +4754,28 @@
    "level": 5,
    "out_size": 3091564,
    "ratio": 0.0921,
-   "compress_mbps": 95.18,
-   "decompress_mbps": 923.71
+   "compress_mbps": 95.86,
+   "decompress_mbps": 926.28
   },
   {
    "compressor": "native",
    "pattern": "silesia/nci",
    "size": 33553445,
    "level": 6,
-   "out_size": 3146242,
-   "ratio": 0.0938,
-   "compress_mbps": 80.85,
-   "decompress_mbps": 974.08
+   "out_size": 3205217,
+   "ratio": 0.0955,
+   "compress_mbps": 91.16,
+   "decompress_mbps": 979.63
   },
   {
    "compressor": "native",
    "pattern": "silesia/nci",
    "size": 33553445,
    "level": 7,
-   "out_size": 3095094,
-   "ratio": 0.0922,
-   "compress_mbps": 61.36,
-   "decompress_mbps": 987.0
+   "out_size": 3146242,
+   "ratio": 0.0938,
+   "compress_mbps": 80.61,
+   "decompress_mbps": 983.35
   },
   {
    "compressor": "native",
@@ -4784,8 +4784,8 @@
    "level": 8,
    "out_size": 3078031,
    "ratio": 0.0917,
-   "compress_mbps": 51.02,
-   "decompress_mbps": 997.8
+   "compress_mbps": 51.09,
+   "decompress_mbps": 988.43
   },
   {
    "compressor": "native",
@@ -4795,7 +4795,7 @@
    "out_size": 3031645,
    "ratio": 0.0904,
    "compress_mbps": 3.6,
-   "decompress_mbps": 989.94
+   "decompress_mbps": 1014.28
   },
   {
    "compressor": "native",
@@ -4804,7 +4804,7 @@
    "level": 10,
    "out_size": 2902212,
    "ratio": 0.0865,
-   "compress_mbps": 2.02,
+   "compress_mbps": 2.04,
    "decompress_mbps": null
   },
   {
@@ -4814,8 +4814,8 @@
    "level": 1,
    "out_size": 3357083,
    "ratio": 0.5457,
-   "compress_mbps": 60.54,
-   "decompress_mbps": 148.6
+   "compress_mbps": 59.79,
+   "decompress_mbps": 145.68
   },
   {
    "compressor": "native",
@@ -4824,8 +4824,8 @@
    "level": 2,
    "out_size": 3285077,
    "ratio": 0.534,
-   "compress_mbps": 49.37,
-   "decompress_mbps": 149.32
+   "compress_mbps": 49.38,
+   "decompress_mbps": 149.36
   },
   {
    "compressor": "native",
@@ -4834,8 +4834,8 @@
    "level": 3,
    "out_size": 3272746,
    "ratio": 0.532,
-   "compress_mbps": 47.24,
-   "decompress_mbps": 154.94
+   "compress_mbps": 47.55,
+   "decompress_mbps": 158.25
   },
   {
    "compressor": "native",
@@ -4844,8 +4844,8 @@
    "level": 4,
    "out_size": 3228052,
    "ratio": 0.5247,
-   "compress_mbps": 40.59,
-   "decompress_mbps": 165.74
+   "compress_mbps": 40.75,
+   "decompress_mbps": 164.87
   },
   {
    "compressor": "native",
@@ -4854,28 +4854,28 @@
    "level": 5,
    "out_size": 3223415,
    "ratio": 0.5239,
-   "compress_mbps": 36.52,
-   "decompress_mbps": 169.38
+   "compress_mbps": 36.66,
+   "decompress_mbps": 175.75
   },
   {
    "compressor": "native",
    "pattern": "silesia/ooffice",
    "size": 6152192,
    "level": 6,
-   "out_size": 3082738,
-   "ratio": 0.5011,
-   "compress_mbps": 24.6,
-   "decompress_mbps": 172.93
+   "out_size": 3087517,
+   "ratio": 0.5019,
+   "compress_mbps": 25.96,
+   "decompress_mbps": 172.74
   },
   {
    "compressor": "native",
    "pattern": "silesia/ooffice",
    "size": 6152192,
    "level": 7,
-   "out_size": 3079404,
-   "ratio": 0.5005,
-   "compress_mbps": 22.9,
-   "decompress_mbps": 173.97
+   "out_size": 3082738,
+   "ratio": 0.5011,
+   "compress_mbps": 24.68,
+   "decompress_mbps": 173.29
   },
   {
    "compressor": "native",
@@ -4884,8 +4884,8 @@
    "level": 8,
    "out_size": 3078530,
    "ratio": 0.5004,
-   "compress_mbps": 22.04,
-   "decompress_mbps": 173.17
+   "compress_mbps": 22.13,
+   "decompress_mbps": 173.87
   },
   {
    "compressor": "native",
@@ -4894,8 +4894,8 @@
    "level": 9,
    "out_size": 3049028,
    "ratio": 0.4956,
-   "compress_mbps": 5.21,
-   "decompress_mbps": 177.54
+   "compress_mbps": 5.2,
+   "decompress_mbps": 178.77
   },
   {
    "compressor": "native",
@@ -4904,7 +4904,7 @@
    "level": 10,
    "out_size": 3022127,
    "ratio": 0.4912,
-   "compress_mbps": 3.22,
+   "compress_mbps": 3.24,
    "decompress_mbps": null
   },
   {
@@ -4914,8 +4914,8 @@
    "level": 1,
    "out_size": 3838828,
    "ratio": 0.3806,
-   "compress_mbps": 98.2,
-   "decompress_mbps": 266.26
+   "compress_mbps": 98.03,
+   "decompress_mbps": 264.45
   },
   {
    "compressor": "native",
@@ -4924,8 +4924,8 @@
    "level": 2,
    "out_size": 3792520,
    "ratio": 0.376,
-   "compress_mbps": 73.32,
-   "decompress_mbps": 274.61
+   "compress_mbps": 72.56,
+   "decompress_mbps": 258.53
   },
   {
    "compressor": "native",
@@ -4934,8 +4934,8 @@
    "level": 3,
    "out_size": 3783171,
    "ratio": 0.3751,
-   "compress_mbps": 68.29,
-   "decompress_mbps": 278.95
+   "compress_mbps": 69.74,
+   "decompress_mbps": 263.6
   },
   {
    "compressor": "native",
@@ -4944,8 +4944,8 @@
    "level": 4,
    "out_size": 3648458,
    "ratio": 0.3617,
-   "compress_mbps": 68.76,
-   "decompress_mbps": 277.17
+   "compress_mbps": 68.05,
+   "decompress_mbps": 277.19
   },
   {
    "compressor": "native",
@@ -4954,28 +4954,28 @@
    "level": 5,
    "out_size": 3648472,
    "ratio": 0.3617,
-   "compress_mbps": 63.35,
-   "decompress_mbps": 277.3
+   "compress_mbps": 62.84,
+   "decompress_mbps": 279.2
   },
   {
    "compressor": "native",
    "pattern": "silesia/osdb",
    "size": 10085684,
    "level": 6,
-   "out_size": 3659614,
-   "ratio": 0.3629,
-   "compress_mbps": 42.03,
-   "decompress_mbps": 287.25
+   "out_size": 3661305,
+   "ratio": 0.363,
+   "compress_mbps": 42.89,
+   "decompress_mbps": 287.78
   },
   {
    "compressor": "native",
    "pattern": "silesia/osdb",
    "size": 10085684,
    "level": 7,
-   "out_size": 3659139,
-   "ratio": 0.3628,
-   "compress_mbps": 41.76,
-   "decompress_mbps": 292.2
+   "out_size": 3659614,
+   "ratio": 0.3629,
+   "compress_mbps": 42.13,
+   "decompress_mbps": 292.05
   },
   {
    "compressor": "native",
@@ -4984,8 +4984,8 @@
    "level": 8,
    "out_size": 3659136,
    "ratio": 0.3628,
-   "compress_mbps": 41.64,
-   "decompress_mbps": 291.96
+   "compress_mbps": 42.02,
+   "decompress_mbps": 291.31
   },
   {
    "compressor": "native",
@@ -4994,8 +4994,8 @@
    "level": 9,
    "out_size": 3648156,
    "ratio": 0.3617,
-   "compress_mbps": 6.11,
-   "decompress_mbps": 305.09
+   "compress_mbps": 6.14,
+   "decompress_mbps": 306.51
   },
   {
    "compressor": "native",
@@ -5004,7 +5004,7 @@
    "level": 10,
    "out_size": 3647385,
    "ratio": 0.3616,
-   "compress_mbps": 3.42,
+   "compress_mbps": 3.5,
    "decompress_mbps": null
   },
   {
@@ -5014,8 +5014,8 @@
    "level": 1,
    "out_size": 2254442,
    "ratio": 0.3402,
-   "compress_mbps": 90.01,
-   "decompress_mbps": 247.27
+   "compress_mbps": 89.04,
+   "decompress_mbps": 248.28
   },
   {
    "compressor": "native",
@@ -5024,8 +5024,8 @@
    "level": 2,
    "out_size": 2044843,
    "ratio": 0.3086,
-   "compress_mbps": 60.56,
-   "decompress_mbps": 265.13
+   "compress_mbps": 60.86,
+   "decompress_mbps": 267.71
   },
   {
    "compressor": "native",
@@ -5034,8 +5034,8 @@
    "level": 3,
    "out_size": 1992105,
    "ratio": 0.3006,
-   "compress_mbps": 50.11,
-   "decompress_mbps": 297.13
+   "compress_mbps": 49.61,
+   "decompress_mbps": 306.31
   },
   {
    "compressor": "native",
@@ -5044,8 +5044,8 @@
    "level": 4,
    "out_size": 1890729,
    "ratio": 0.2853,
-   "compress_mbps": 35.47,
-   "decompress_mbps": 295.97
+   "compress_mbps": 35.33,
+   "decompress_mbps": 298.71
   },
   {
    "compressor": "native",
@@ -5054,28 +5054,28 @@
    "level": 5,
    "out_size": 1858234,
    "ratio": 0.2804,
-   "compress_mbps": 22.76,
-   "decompress_mbps": 295.85
+   "compress_mbps": 22.62,
+   "decompress_mbps": 309.58
   },
   {
    "compressor": "native",
    "pattern": "silesia/reymont",
    "size": 6627202,
    "level": 6,
-   "out_size": 1860657,
-   "ratio": 0.2808,
-   "compress_mbps": 25.3,
-   "decompress_mbps": 305.59
+   "out_size": 1869426,
+   "ratio": 0.2821,
+   "compress_mbps": 29.93,
+   "decompress_mbps": 309.29
   },
   {
    "compressor": "native",
    "pattern": "silesia/reymont",
    "size": 6627202,
    "level": 7,
-   "out_size": 1830058,
-   "ratio": 0.2761,
-   "compress_mbps": 15.98,
-   "decompress_mbps": 309.73
+   "out_size": 1860657,
+   "ratio": 0.2808,
+   "compress_mbps": 25.15,
+   "decompress_mbps": 308.41
   },
   {
    "compressor": "native",
@@ -5084,8 +5084,8 @@
    "level": 8,
    "out_size": 1826296,
    "ratio": 0.2756,
-   "compress_mbps": 13.99,
-   "decompress_mbps": 312.52
+   "compress_mbps": 13.98,
+   "decompress_mbps": 309.69
   },
   {
    "compressor": "native",
@@ -5094,8 +5094,8 @@
    "level": 9,
    "out_size": 1773469,
    "ratio": 0.2676,
-   "compress_mbps": 2.97,
-   "decompress_mbps": 326.46
+   "compress_mbps": 2.98,
+   "decompress_mbps": 326.51
   },
   {
    "compressor": "native",
@@ -5114,8 +5114,8 @@
    "level": 1,
    "out_size": 6406301,
    "ratio": 0.2965,
-   "compress_mbps": 120.17,
-   "decompress_mbps": 340.41
+   "compress_mbps": 119.56,
+   "decompress_mbps": 340.76
   },
   {
    "compressor": "native",
@@ -5124,8 +5124,8 @@
    "level": 2,
    "out_size": 6102377,
    "ratio": 0.2824,
-   "compress_mbps": 89.66,
-   "decompress_mbps": 360.09
+   "compress_mbps": 89.23,
+   "decompress_mbps": 361.8
   },
   {
    "compressor": "native",
@@ -5134,8 +5134,8 @@
    "level": 3,
    "out_size": 6022184,
    "ratio": 0.2787,
-   "compress_mbps": 80.38,
-   "decompress_mbps": 376.32
+   "compress_mbps": 80.94,
+   "decompress_mbps": 377.39
   },
   {
    "compressor": "native",
@@ -5144,8 +5144,8 @@
    "level": 4,
    "out_size": 5880892,
    "ratio": 0.2722,
-   "compress_mbps": 68.95,
-   "decompress_mbps": 394.04
+   "compress_mbps": 68.82,
+   "decompress_mbps": 390.81
   },
   {
    "compressor": "native",
@@ -5154,28 +5154,28 @@
    "level": 5,
    "out_size": 5834363,
    "ratio": 0.27,
-   "compress_mbps": 53.58,
-   "decompress_mbps": 401.86
+   "compress_mbps": 53.43,
+   "decompress_mbps": 400.2
   },
   {
    "compressor": "native",
    "pattern": "silesia/samba",
    "size": 21606400,
    "level": 6,
-   "out_size": 5406915,
-   "ratio": 0.2502,
-   "compress_mbps": 39.85,
-   "decompress_mbps": 408.23
+   "out_size": 5418390,
+   "ratio": 0.2508,
+   "compress_mbps": 42.95,
+   "decompress_mbps": 407.11
   },
   {
    "compressor": "native",
    "pattern": "silesia/samba",
    "size": 21606400,
    "level": 7,
-   "out_size": 5389990,
-   "ratio": 0.2495,
-   "compress_mbps": 33.79,
-   "decompress_mbps": 408.46
+   "out_size": 5406915,
+   "ratio": 0.2502,
+   "compress_mbps": 39.53,
+   "decompress_mbps": 407.48
   },
   {
    "compressor": "native",
@@ -5184,8 +5184,8 @@
    "level": 8,
    "out_size": 5387415,
    "ratio": 0.2493,
-   "compress_mbps": 31.72,
-   "decompress_mbps": 410.13
+   "compress_mbps": 31.6,
+   "decompress_mbps": 411.34
   },
   {
    "compressor": "native",
@@ -5195,7 +5195,7 @@
    "out_size": 5236015,
    "ratio": 0.2423,
    "compress_mbps": 4.92,
-   "decompress_mbps": 411.94
+   "decompress_mbps": 410.73
   },
   {
    "compressor": "native",
@@ -5214,8 +5214,8 @@
    "level": 1,
    "out_size": 5612204,
    "ratio": 0.7739,
-   "compress_mbps": 50.51,
-   "decompress_mbps": 148.41
+   "compress_mbps": 50.58,
+   "decompress_mbps": 148.11
   },
   {
    "compressor": "native",
@@ -5224,8 +5224,8 @@
    "level": 2,
    "out_size": 5533875,
    "ratio": 0.7631,
-   "compress_mbps": 41.64,
-   "decompress_mbps": 155.13
+   "compress_mbps": 41.89,
+   "decompress_mbps": 154.66
   },
   {
    "compressor": "native",
@@ -5234,8 +5234,8 @@
    "level": 3,
    "out_size": 5522436,
    "ratio": 0.7615,
-   "compress_mbps": 39.15,
-   "decompress_mbps": 157.31
+   "compress_mbps": 39.25,
+   "decompress_mbps": 158.23
   },
   {
    "compressor": "native",
@@ -5244,8 +5244,8 @@
    "level": 4,
    "out_size": 5494383,
    "ratio": 0.7576,
-   "compress_mbps": 33.71,
-   "decompress_mbps": 163.75
+   "compress_mbps": 33.86,
+   "decompress_mbps": 164.69
   },
   {
    "compressor": "native",
@@ -5254,28 +5254,28 @@
    "level": 5,
    "out_size": 5489807,
    "ratio": 0.757,
-   "compress_mbps": 31.94,
-   "decompress_mbps": 160.52
+   "compress_mbps": 31.87,
+   "decompress_mbps": 160.2
   },
   {
    "compressor": "native",
    "pattern": "silesia/sao",
    "size": 7251944,
    "level": 6,
-   "out_size": 5336745,
-   "ratio": 0.7359,
-   "compress_mbps": 21.26,
-   "decompress_mbps": 164.47
+   "out_size": 5346796,
+   "ratio": 0.7373,
+   "compress_mbps": 22.22,
+   "decompress_mbps": 159.65
   },
   {
    "compressor": "native",
    "pattern": "silesia/sao",
    "size": 7251944,
    "level": 7,
-   "out_size": 5331731,
-   "ratio": 0.7352,
-   "compress_mbps": 20.38,
-   "decompress_mbps": 163.56
+   "out_size": 5336745,
+   "ratio": 0.7359,
+   "compress_mbps": 21.23,
+   "decompress_mbps": 163.94
   },
   {
    "compressor": "native",
@@ -5284,8 +5284,8 @@
    "level": 8,
    "out_size": 5330972,
    "ratio": 0.7351,
-   "compress_mbps": 20.02,
-   "decompress_mbps": 164.65
+   "compress_mbps": 20.15,
+   "decompress_mbps": 163.97
   },
   {
    "compressor": "native",
@@ -5294,8 +5294,8 @@
    "level": 9,
    "out_size": 5284606,
    "ratio": 0.7287,
-   "compress_mbps": 5.41,
-   "decompress_mbps": 161.89
+   "compress_mbps": 5.32,
+   "decompress_mbps": 163.29
   },
   {
    "compressor": "native",
@@ -5304,7 +5304,7 @@
    "level": 10,
    "out_size": 5262387,
    "ratio": 0.7257,
-   "compress_mbps": 3.8,
+   "compress_mbps": 3.75,
    "decompress_mbps": null
   },
   {
@@ -5314,8 +5314,8 @@
    "level": 1,
    "out_size": 13727247,
    "ratio": 0.3311,
-   "compress_mbps": 89.34,
-   "decompress_mbps": 252.77
+   "compress_mbps": 89.72,
+   "decompress_mbps": 253.02
   },
   {
    "compressor": "native",
@@ -5324,8 +5324,8 @@
    "level": 2,
    "out_size": 12940398,
    "ratio": 0.3121,
-   "compress_mbps": 66.56,
-   "decompress_mbps": 274.44
+   "compress_mbps": 66.6,
+   "decompress_mbps": 274.73
   },
   {
    "compressor": "native",
@@ -5334,8 +5334,8 @@
    "level": 3,
    "out_size": 12703756,
    "ratio": 0.3064,
-   "compress_mbps": 60.96,
-   "decompress_mbps": 296.03
+   "compress_mbps": 60.75,
+   "decompress_mbps": 296.14
   },
   {
    "compressor": "native",
@@ -5344,8 +5344,8 @@
    "level": 4,
    "out_size": 12177338,
    "ratio": 0.2937,
-   "compress_mbps": 49.72,
-   "decompress_mbps": 299.28
+   "compress_mbps": 49.53,
+   "decompress_mbps": 299.03
   },
   {
    "compressor": "native",
@@ -5354,28 +5354,28 @@
    "level": 5,
    "out_size": 12051075,
    "ratio": 0.2907,
-   "compress_mbps": 38.36,
-   "decompress_mbps": 302.76
+   "compress_mbps": 38.25,
+   "decompress_mbps": 302.79
   },
   {
    "compressor": "native",
    "pattern": "silesia/webster",
    "size": 41458703,
    "level": 6,
-   "out_size": 12178598,
-   "ratio": 0.2938,
-   "compress_mbps": 34.7,
-   "decompress_mbps": 311.04
+   "out_size": 12220199,
+   "ratio": 0.2948,
+   "compress_mbps": 37.65,
+   "decompress_mbps": 310.61
   },
   {
    "compressor": "native",
    "pattern": "silesia/webster",
    "size": 41458703,
    "level": 7,
-   "out_size": 12104809,
-   "ratio": 0.292,
-   "compress_mbps": 27.72,
-   "decompress_mbps": 312.69
+   "out_size": 12178598,
+   "ratio": 0.2938,
+   "compress_mbps": 34.96,
+   "decompress_mbps": 312.36
   },
   {
    "compressor": "native",
@@ -5384,8 +5384,8 @@
    "level": 8,
    "out_size": 12096772,
    "ratio": 0.2918,
-   "compress_mbps": 26.29,
-   "decompress_mbps": 313.38
+   "compress_mbps": 26.06,
+   "decompress_mbps": 302.61
   },
   {
    "compressor": "native",
@@ -5395,7 +5395,7 @@
    "out_size": 11806641,
    "ratio": 0.2848,
    "compress_mbps": 3.95,
-   "decompress_mbps": 313.55
+   "decompress_mbps": 312.6
   },
   {
    "compressor": "native",
@@ -5404,7 +5404,7 @@
    "level": 10,
    "out_size": 11636945,
    "ratio": 0.2807,
-   "compress_mbps": 2.02,
+   "compress_mbps": 2.05,
    "decompress_mbps": null
   },
   {
@@ -5414,8 +5414,8 @@
    "level": 1,
    "out_size": 6438176,
    "ratio": 0.7597,
-   "compress_mbps": 45.59,
-   "decompress_mbps": 143.3
+   "compress_mbps": 45.46,
+   "decompress_mbps": 143.58
   },
   {
    "compressor": "native",
@@ -5424,8 +5424,8 @@
    "level": 2,
    "out_size": 6392101,
    "ratio": 0.7543,
-   "compress_mbps": 43.25,
-   "decompress_mbps": 145.14
+   "compress_mbps": 43.82,
+   "decompress_mbps": 145.88
   },
   {
    "compressor": "native",
@@ -5434,8 +5434,8 @@
    "level": 3,
    "out_size": 6392124,
    "ratio": 0.7543,
-   "compress_mbps": 43.61,
-   "decompress_mbps": 147.81
+   "compress_mbps": 43.78,
+   "decompress_mbps": 146.86
   },
   {
    "compressor": "native",
@@ -5444,8 +5444,8 @@
    "level": 4,
    "out_size": 6360604,
    "ratio": 0.7506,
-   "compress_mbps": 40.32,
-   "decompress_mbps": 132.69
+   "compress_mbps": 40.24,
+   "decompress_mbps": 133.58
   },
   {
    "compressor": "native",
@@ -5454,28 +5454,28 @@
    "level": 5,
    "out_size": 6360567,
    "ratio": 0.7506,
-   "compress_mbps": 40.37,
-   "decompress_mbps": 134.58
+   "compress_mbps": 40.41,
+   "decompress_mbps": 135.46
   },
   {
    "compressor": "native",
    "pattern": "silesia/x-ray",
    "size": 8474240,
    "level": 6,
-   "out_size": 6036620,
-   "ratio": 0.7123,
-   "compress_mbps": 23.76,
-   "decompress_mbps": 136.42
+   "out_size": 6036758,
+   "ratio": 0.7124,
+   "compress_mbps": 23.89,
+   "decompress_mbps": 136.8
   },
   {
    "compressor": "native",
    "pattern": "silesia/x-ray",
    "size": 8474240,
    "level": 7,
-   "out_size": 6036614,
+   "out_size": 6036620,
    "ratio": 0.7123,
-   "compress_mbps": 23.63,
-   "decompress_mbps": 136.25
+   "compress_mbps": 23.96,
+   "decompress_mbps": 136.53
   },
   {
    "compressor": "native",
@@ -5484,8 +5484,8 @@
    "level": 8,
    "out_size": 6036614,
    "ratio": 0.7123,
-   "compress_mbps": 23.76,
-   "decompress_mbps": 136.38
+   "compress_mbps": 23.86,
+   "decompress_mbps": 135.89
   },
   {
    "compressor": "native",
@@ -5494,8 +5494,8 @@
    "level": 9,
    "out_size": 5952975,
    "ratio": 0.7025,
-   "compress_mbps": 6.3,
-   "decompress_mbps": 140.0
+   "compress_mbps": 6.28,
+   "decompress_mbps": 138.73
   },
   {
    "compressor": "native",
@@ -5504,7 +5504,7 @@
    "level": 10,
    "out_size": 5849157,
    "ratio": 0.6902,
-   "compress_mbps": 4.49,
+   "compress_mbps": 4.61,
    "decompress_mbps": null
   },
   {
@@ -5514,8 +5514,8 @@
    "level": 1,
    "out_size": 858525,
    "ratio": 0.1606,
-   "compress_mbps": 197.71,
-   "decompress_mbps": 506.67
+   "compress_mbps": 196.81,
+   "decompress_mbps": 510.41
   },
   {
    "compressor": "native",
@@ -5524,8 +5524,8 @@
    "level": 2,
    "out_size": 846807,
    "ratio": 0.1584,
-   "compress_mbps": 127.36,
-   "decompress_mbps": 569.2
+   "compress_mbps": 126.92,
+   "decompress_mbps": 572.53
   },
   {
    "compressor": "native",
@@ -5534,8 +5534,8 @@
    "level": 3,
    "out_size": 806798,
    "ratio": 0.1509,
-   "compress_mbps": 116.64,
-   "decompress_mbps": 631.34
+   "compress_mbps": 116.12,
+   "decompress_mbps": 635.8
   },
   {
    "compressor": "native",
@@ -5544,8 +5544,8 @@
    "level": 4,
    "out_size": 717301,
    "ratio": 0.1342,
-   "compress_mbps": 101.78,
-   "decompress_mbps": 624.61
+   "compress_mbps": 101.94,
+   "decompress_mbps": 625.29
   },
   {
    "compressor": "native",
@@ -5554,28 +5554,28 @@
    "level": 5,
    "out_size": 701552,
    "ratio": 0.1312,
-   "compress_mbps": 76.96,
-   "decompress_mbps": 608.18
+   "compress_mbps": 77.69,
+   "decompress_mbps": 613.59
   },
   {
    "compressor": "native",
    "pattern": "silesia/xml",
    "size": 5345280,
    "level": 6,
-   "out_size": 680793,
-   "ratio": 0.1274,
-   "compress_mbps": 63.44,
-   "decompress_mbps": 733.73
+   "out_size": 689796,
+   "ratio": 0.129,
+   "compress_mbps": 70.01,
+   "decompress_mbps": 730.28
   },
   {
    "compressor": "native",
    "pattern": "silesia/xml",
    "size": 5345280,
    "level": 7,
-   "out_size": 666035,
-   "ratio": 0.1246,
-   "compress_mbps": 50.37,
-   "decompress_mbps": 732.63
+   "out_size": 680793,
+   "ratio": 0.1274,
+   "compress_mbps": 63.24,
+   "decompress_mbps": 740.47
   },
   {
    "compressor": "native",
@@ -5584,8 +5584,8 @@
    "level": 8,
    "out_size": 662896,
    "ratio": 0.124,
-   "compress_mbps": 44.37,
-   "decompress_mbps": 752.55
+   "compress_mbps": 44.32,
+   "decompress_mbps": 752.13
   },
   {
    "compressor": "native",
@@ -5594,8 +5594,8 @@
    "level": 9,
    "out_size": 659422,
    "ratio": 0.1234,
-   "compress_mbps": 4.59,
-   "decompress_mbps": 642.57
+   "compress_mbps": 4.61,
+   "decompress_mbps": 649.05
   },
   {
    "compressor": "native",
@@ -5604,7 +5604,7 @@
    "level": 10,
    "out_size": 643101,
    "ratio": 0.1203,
-   "compress_mbps": 3.04,
+   "compress_mbps": 3.07,
    "decompress_mbps": null
   },
   {


### PR DESCRIPTION
This PR re-grids the L6/L7 ladder knobs for the cost structure #2824's hash3 singleton created, so the default level strictly dominates miniz_oxide L6. L6 becomes (chain 64, `goodMatch` 64, `niceLen` 65, `lazyDepth` chain/8, singleton on): weighted Silesia **0.3205 @ ~36.5 MB/s**, better than miniz_oxide L6 (0.3213 @ 35.5) on both axes at once. L7 adopts the old L6 config wholesale (chain 64, gate off, probe /2 — 0.3196 @ ~33.7), so that frontier vertex is kept rather than lost; L8 and every other level are untouched (new L7 is byte-identical to the pre-regrid L6). Chosen by an 11-config sweep (chain × gate × probe depth, all with the singleton; new `bench/gate-sweep` exe included, the modernized `mid-sweep` that pipes parameterized matchers through the exact production sized-prep dispatch) over full Silesia, ratio plus pinned interleaved timing — seven configs strictly dominated miniz L6; this pairing maximizes the frontier (the only give-back is ~−4% on the narrow 0.3184–0.3196 band where the old chain-256 L7 sat, against +8% on the whole 0.3205+ band).

With this and #2824, the achievable mixing frontier at miniz_oxide L6's ratio rises to ~37 MB/s (+4% above it), and every miniz_oxide point from L6 up, plus zlib L7/L8, sits inside our hull. Per-file honesty: the new L6 costs nci +1.9% and xml +1.3% ratio vs the old-L6-with-singleton point — exactly the files for which the new L7 keeps that point one level away. All knobs are emission-re-verified heuristics; no proof changes, `lake exe test` green.

🤖 Prepared with Claude Code