### PR TITLE
doc: record the miniz-L6 Pareto campaign verdicts + hull_check tool

### DIFF
--- a/bench/hull_check.py
+++ b/bench/hull_check.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Mixing-frontier dominance check on the weighted-Silesia compress plane.
+
+Usage: hull_check.py <candidate.json> [reference.json]
+
+Both files are bench-report JSONs. Native rows come from <candidate.json>
+(fall back to reference for levels it lacks); every other compressor's rows
+come from <reference.json> (default bench/results/latest.json).
+
+For each codec point (weighted Silesia: ratio = sum(out)/sum(in), speed =
+harmonic-by-bytes MB/s) this prints whether the native achievable mixing
+frontier (upper-left hull over the native level points; mixing two levels is
+linear in ratio and in sec/MB) strictly dominates it, and by what speed margin
+at equal ratio. The headline question: is miniz_oxide L6 inside our hull?
+"""
+import json, sys
+from collections import defaultdict
+
+def load(path):
+    with open(path) as f:
+        return json.load(f)["results"]
+
+def agg(rows, comp):
+    pts = defaultdict(lambda: [0, 0, 0.0])  # level -> [in, out, sec]
+    for r in rows:
+        if r["compressor"] != comp or not r["pattern"].startswith("silesia/"):
+            continue
+        m = r.get("compress_mbps")
+        if not m:
+            continue
+        a = pts[r["level"]]
+        a[0] += r["size"]; a[1] += r["out_size"]; a[2] += r["size"] / 1e6 / m
+    return {lvl: (o / i, i / 1e6 / t) for lvl, (i, o, t) in pts.items() if i}
+
+def frontier(points):
+    """Upper hull in (ratio asc, sec/MB): mixing is linear in both."""
+    pts = sorted((r, 1.0 / s) for r, s in points.values())  # (ratio, sec per MB)
+    hull = []
+    for p in pts:
+        while len(hull) >= 2:
+            (x1, y1), (x2, y2) = hull[-2], hull[-1]
+            # keep hull lower-convex in sec/MB over ratio
+            if (y2 - y1) * (p[0] - x1) >= (p[1] - y1) * (x2 - x1):
+                hull.pop()
+            else:
+                break
+        # drop dominated points (higher time and higher ratio)
+        if hull and p[1] >= hull[-1][1]:
+            continue
+        hull.append(p)
+    return hull
+
+def frontier_speed_at(hull, ratio):
+    """Best achievable MB/s at the given ratio by mixing adjacent hull points."""
+    if not hull:
+        return None
+    if ratio < hull[0][0]:
+        return None  # ratio unreachable
+    for (x1, y1), (x2, y2) in zip(hull, hull[1:]):
+        if x1 <= ratio <= x2:
+            f = (ratio - x1) / (x2 - x1) if x2 > x1 else 0.0
+            return 1.0 / (y1 + f * (y2 - y1))
+    return 1.0 / hull[-1][1] if ratio >= hull[-1][0] else None
+
+def main():
+    cand = load(sys.argv[1])
+    ref = load(sys.argv[2] if len(sys.argv) > 2 else "bench/results/latest.json")
+    native = agg(cand, "native")
+    ref_native = agg(ref, "native")
+    for lvl, pt in ref_native.items():
+        native.setdefault(lvl, pt)
+    hull = frontier(native)
+    print("native points (weighted silesia):")
+    for lvl in sorted(native):
+        r, s = native[lvl]
+        print(f"  L{lvl:<2} ratio={r:.4f} {s:7.2f} MB/s")
+    print("native frontier vertices: " +
+          ", ".join(f"({r:.4f}, {1/y:.1f} MB/s)" for r, y in hull))
+    print()
+    for comp in ["miniz_oxide", "zlib", "go", "zig", "js", "ocaml", "libdeflate"]:
+        pts = agg(ref, comp)
+        for lvl in sorted(pts):
+            r, s = pts[lvl]
+            fs = frontier_speed_at(hull, r)
+            if fs is None:
+                verdict, margin = "OUTSIDE (ratio unreachable)", ""
+            else:
+                margin = f"{100 * (fs - s) / s:+6.1f}%"
+                verdict = "inside " if fs > s else "OUTSIDE"
+            flag = "  <== TARGET" if (comp, lvl) == ("miniz_oxide", 6) else ""
+            print(f"{comp:12s} L{lvl:<2} ratio={r:.4f} {s:7.2f} MB/s  "
+                  f"native@ratio={fs and f'{fs:7.2f}' or '   ---'}  {verdict} {margin}{flag}")
+
+if __name__ == "__main__":
+    main()

--- a/progress/pareto-l6-campaign.md
+++ b/progress/pareto-l6-campaign.md
@@ -1,0 +1,65 @@
+# The miniz_oxide L6 campaign — five PRs, one target
+
+**Goal (Kim's directive):** move the compress mixing frontier until miniz_oxide
+L6 (weighted Silesia 0.3213 @ 35.5 MB/s) sits *inside* the native convex hull.
+**Result: achieved** — the frontier at that ratio went 27.7 → 37.3 MB/s (+35%),
+a −22% deficit turned into a **+5.1% margin**, and the native L6 point alone
+(0.3205 @ 36.5) strictly dominates miniz L6 on both axes. miniz L7/L8/L9 and
+zlib L7/L8 landed inside too (+30% to +71%).
+
+## What landed (in merge order)
+
+1. **#2821 — USize-native merged insertion loop.** The interior-hash insertion
+   (13–25% of L4–L8 time) was still boxed-`Nat`; the `chainWalkPackedU`
+   treatment applied to it. Byte-identical, proven (`updateHashesMergedFastU_eq`).
+   Weighted Silesia L4–L8 +5–8%.
+2. **#2823 — array-native two-queue Huffman tree build.** `limitedPairs` still
+   built trees with `List.mergeSort` + O(n²) `insertByWeight` — the top profile
+   entry (16.5%) on x-ray, whose stat-shifting rows make the splitter cut
+   hundreds of blocks. Van Leeuwen two-queue over flat arrays; heuristic swap
+   with property-based proofs (validity via `fixKraftList` is shape-only).
+   x-ray L6 +21.6%, mozilla +9.6%; corpus ratio moved ≤ +0.0026%.
+3. **#2822 — seed the lazy lookahead walk with the current match length**
+   (zlib `prev_length`). Proven byte-identical (`chainWalk_seed`); +0.8–0.9% on
+   match-dense text. Small, but its seeding lemmas are the machinery #2824 uses.
+4. **#2824 — hash3-singleton length-3 coverage at the split tier (L6–L8).**
+   The big one. Reopened #2742's plan item 1, rejected there on *unweighted
+   geomean* — but the entire weighted deficit to miniz L6 sat on three
+   hash4-blind binaries (x-ray/sao/ooffice, joined by an unheralded mozilla
+   −340 KB). Certified spike first (`spike/h3-singleton-sweep`, pushed), then
+   the production port reproduced the spike byte-for-byte on all 36 file×level
+   rows. −0.28 pp corpus-weighted at each of L6/L7/L8; text pays single-digit
+   speed, x-ray gets +34% *faster* (smaller token stream).
+5. **#2825 — L6/L7 re-grid for the singleton cost structure.** 11-config
+   gate-sweep (new `bench/gate-sweep` exe, committed): L6 → (chain 64, gate 64,
+   probe /8, h3) = 0.3205 @ 36.5; L7 → the old L6 config (0.3196 @ 33.9,
+   byte-identical point, keeps the vertex); L8 unchanged.
+
+## Negative verdicts recorded this session
+
+- **zstd-style accelerating skip through matchless runs** (`spike/runskip-sweep`,
+  pushed, bench exe committed on the branch): best +1.0% (L6) / +1.3% (L7)
+  corpus speed — far under the +4% bar — with the ratio cost concentrated on
+  x-ray. Mechanism finding: on barely-compressible data our hash4 buckets are
+  sparse, so the walks the skip would delete are already near-free; and sao
+  never triggers the skip at all (constant spurious short matches reset the
+  literal-run counter). A future attack on sao-like files needs a
+  "matches-too-short-to-help" trigger, not a matchless-run trigger.
+- **Intermediate lazy-gate values without the singleton** (gate-sweep round 1):
+  gm64 ≈ free but ≈ no speed either; probe-depth cuts trade ~0.04 pp per +1.5%
+  — the pre-singleton ladder was confirmed on its local frontier (consistent
+  with the Wave-2e null result). It was the *singleton changing the cost
+  structure* that made gate/depth cuts profitable at L6.
+
+## Method notes for the next campaign
+
+- The **weighted** (bytes/time) corpus aggregate is what the Pareto reads;
+  unweighted geomean buried the singleton win once already (#2742) and diluted
+  the Huffman win (x-ray +22% reads as +2% geomean). Check both.
+- `bench/hull_check.py` (committed alongside this note) computes the mixing
+  frontier from a bench-report JSON and prints the dominance verdict against
+  every reference-codec point — the session's steering instrument.
+- Profiles: matcher ~45–75% (walk + insert), and on stat-shifting binaries the
+  per-block tree build was the sleeper. After this session's landings the L6
+  profile is much flatter; the next big lever on record is #2782/#2783
+  (cheap-optimal parse or true lazy2 cascade at L7/L8).


### PR DESCRIPTION
This PR record the session note for the #2821/#2822/#2823/#2824/#2825 compress-Pareto campaign (what landed, the run-skip and knob-sweep negative verdicts with their preserved spike branches, and the weighted-vs-geomean measurement lesson), and add `bench/hull_check.py` — the mixing-frontier dominance checker that computes, from a bench-report JSON, the native achievable frontier and each reference codec point's inside/outside verdict.

🤖 Prepared with Claude Code