### PR TITLE
perf: pack and pre-reverse the dynamic-emit Huffman tables; scalar BitWriter flush kernel

### DIFF
--- a/Zip/Native/BitWriter.lean
+++ b/Zip/Native/BitWriter.lean
@@ -1,3 +1,4 @@
+import Std.Tactic.BVDecide
 import Zip.Native.Wide
 
 /-!
@@ -141,28 +142,173 @@ theorem flushAcc_eq (data : ByteArray) (acc : UInt64) (total : Nat) :
 /-- Batched flush: drain whole bytes only when the pending count reaches
     `flushThreshold`, else keep every bit in the accumulator. Reference form of
     the flush cadence the production `writeBits`/`writeHuffCode` use (they call
-    `flushBytesWide`/`dropBytes` directly for ctor reuse; equal by
-    `writeBits_def`/`writeHuffCode_def`). Byte-identical to `flushAcc` in output
-    bits — only the split between `data` and the pending accumulator differs. -/
+    the scalar `flushBatchedU`, equal by `flushBatchedU_eq`; the ctor is built
+    in the writer after inlining, so ctor reuse still recycles the input cell).
+    Byte-identical to `flushAcc` in output bits — only the split between `data`
+    and the pending accumulator differs. -/
 def flushBatched (data : ByteArray) (acc : UInt64) (total : Nat) : BitWriter :=
   if total ≥ flushThreshold then flushAcc data acc total
   else ⟨data, acc, total.toUInt8⟩
+
+/-! ### Scalar-arithmetic flush kernel (#2827)
+
+The writers run once per DEFLATE field — the hottest call sites in compress
+(11–17% of L1 between `writeHuffCode`/`writeBits` self time). The reference
+forms above do the per-field bookkeeping in `Nat` (`total`, `total / 8`,
+`total % 8`, the `dropBytes` recursion), which the compiler emits as tagged
+`lean_nat_*` calls plus an out-of-line `dropBytes` loop on every flush. The
+`*U` forms below do the same arithmetic in `UInt32`/`UInt64` registers —
+`total` fits `UInt32` exactly (`bitCount, len < 256`, so `total < 512`),
+`/ 8` is `>>> 3`, `% 8` is `&&& 7`, and `dropBytes` collapses to one shift
+(`dropBytesU_eq`). Each is proven equal to its reference form, so
+`writeBits_def`/`writeHuffCode_def` (the equations all spec proofs anchor on)
+keep their exact statements. -/
+
+/-- `dropBytes` as a single shift: `k` byte-shifts of a 64-bit accumulator is
+    `>>> 8k` for `k < 8` and `0` once every byte has been shifted out
+    (`dropBytesU_eq`). Deliberately *not* `@[inline]`: inlining its branch
+    into the writers' flush arm makes the ctor-reuse pass pick the flush-arm
+    join as the sole reuse site, demoting the hot no-flush arm to
+    free-then-alloc (measured −13% on dickens L1). As an out-call (like the
+    old `dropBytes`) both writer arms keep in-place reuse. -/
+def dropBytesU (acc : UInt64) (k : UInt32) : UInt64 :=
+  if k < 8 then acc >>> (k.toUInt64 <<< 3) else 0
+
+/-- `dropBytes` shifts by whole bytes: below 8 iterations it is one `>>> 8k`. -/
+private theorem dropBytes_of_lt_8 (acc : UInt64) (k : Nat) (h : k < 8) :
+    dropBytes acc k = acc >>> (8 * k).toUInt64 := by
+  match k, h with
+  | 0, _ | 1, _ | 2, _ | 3, _ | 4, _ | 5, _ | 6, _ | 7, _ =>
+    apply UInt64.toNat_inj.mp
+    simp only [dropBytes, UInt64.toNat_shiftRight, Nat.reduceMul, Nat.toUInt64_eq,
+      UInt64.toNat_ofNat', UInt64.reduceToNat, Nat.reduceMod, Nat.shiftRight_eq_div_pow,
+      Nat.reducePow, Nat.div_div_eq_div_mul]
+    all_goals omega
+  | n + 8, h => omega
+
+/-- After eight byte-shifts nothing of a 64-bit accumulator remains. -/
+private theorem dropBytes_eight (acc : UInt64) : dropBytes acc 8 = 0 := by
+  simp only [dropBytes]
+  bv_decide
+
+/-- `dropBytes` splits over addition of iteration counts. -/
+private theorem dropBytes_add (acc : UInt64) (a b : Nat) :
+    dropBytes acc (a + b) = dropBytes (dropBytes acc a) b := by
+  induction a generalizing acc with
+  | zero => rw [Nat.zero_add]; rfl
+  | succ a ih =>
+    rw [Nat.add_right_comm]
+    show dropBytes (acc >>> 8) (a + b) = dropBytes (dropBytes (acc >>> 8) a) b
+    exact ih (acc >>> 8)
+
+/-- Shifting nothing yields nothing, for any iteration count. -/
+private theorem dropBytes_zero (k : Nat) : dropBytes 0 k = 0 := by
+  induction k with
+  | zero => rfl
+  | succ k ih => rw [dropBytes]; simpa using ih
+
+/-- The scalar `dropBytesU` is `dropBytes` at the `Nat` view of `k`. -/
+theorem dropBytesU_eq (acc : UInt64) (k : UInt32) :
+    dropBytesU acc k = dropBytes acc k.toNat := by
+  unfold dropBytesU
+  split
+  next h =>
+    have hk : k.toNat < 8 := by
+      have := UInt32.lt_iff_toNat_lt.mp h
+      simpa using this
+    rw [dropBytes_of_lt_8 acc k.toNat hk]
+    congr 1
+    apply UInt64.toNat_inj.mp
+    rw [UInt64.toNat_shiftLeft, UInt32.toNat_toUInt64, Nat.toUInt64_eq, UInt64.toNat_ofNat']
+    have h3 : (3 : UInt64).toNat = 3 := rfl
+    rw [h3, Nat.mod_eq_of_lt (by omega : (3:Nat) < 64), Nat.shiftLeft_eq]
+    omega
+  next h =>
+    have hk : 8 ≤ k.toNat :=
+      Nat.le_of_not_lt fun hh => h (UInt32.lt_iff_toNat_lt.mpr (by simpa using hh))
+    rw [(by omega : k.toNat = 8 + (k.toNat - 8)), dropBytes_add, dropBytes_eight,
+      dropBytes_zero]
+
+/-- `flushBytesWide` with a `UInt32` byte count: the `k ≤ 8` guard is a
+    register compare and the `USize` cast is free (`flushBytesWideU_eq`). -/
+@[inline] def flushBytesWideU (data : ByteArray) (acc : UInt64) (k : UInt32) : ByteArray :=
+  if h : k ≤ 8 then
+    data.pushUInt64LE acc k.toUSize (by
+      simpa using UInt32.le_iff_toNat_le.mp h)
+  else
+    flushBytes data acc k.toNat
+
+/-- The scalar `flushBytesWideU` is `flushBytes` at the `Nat` view of `k`. -/
+theorem flushBytesWideU_eq (data : ByteArray) (acc : UInt64) (k : UInt32) :
+    flushBytesWideU data acc k = flushBytes data acc k.toNat := by
+  unfold flushBytesWideU
+  split
+  next h =>
+    rw [ByteArray.pushUInt64LE, pushLEBytes_eq_flushBytes]
+    simp
+  next => rfl
+
+/-- `flushBatched` in scalar arithmetic: the pending total in `UInt32`
+    (exact — both summands are below 256), `/ 8` as `>>> 3`, `% 8` as
+    `&&& 7`, `dropBytes` as one shift. Equal to `flushBatched` at the `Nat`
+    view of `total` (`flushBatchedU_eq`); `@[inline]` so the result cell is
+    constructed in the calling writer, where ctor reuse recycles the input
+    `BitWriter` cell (#2739). -/
+@[inline] def flushBatchedU (data : ByteArray) (acc : UInt64) (totalU : UInt32) : BitWriter :=
+  if totalU ≥ 32 then
+    ⟨flushBytesWideU data acc (totalU >>> 3), dropBytesU acc (totalU >>> 3),
+      (totalU &&& 7).toUInt8⟩
+  else
+    ⟨data, acc, totalU.toUInt8⟩
+
+/-- The scalar `flushBatchedU` is `flushBatched` at the `Nat` view of the
+    pending total. -/
+theorem flushBatchedU_eq (data : ByteArray) (acc : UInt64) (totalU : UInt32) :
+    flushBatchedU data acc totalU = flushBatched data acc totalU.toNat := by
+  unfold flushBatchedU flushBatched
+  have hshift : (totalU >>> 3).toNat = totalU.toNat / 8 := by
+    rw [UInt32.toNat_shiftRight]
+    have h3 : (3 : UInt32).toNat = 3 := rfl
+    rw [h3, Nat.mod_eq_of_lt (by omega : (3:Nat) < 32), Nat.shiftRight_eq_div_pow]
+  by_cases h : (32 : UInt32) ≤ totalU
+  · have hn : flushThreshold ≤ totalU.toNat := by
+      have := UInt32.le_iff_toNat_le.mp h
+      simpa [flushThreshold] using this
+    rw [if_pos h, if_pos hn, flushAcc_eq, flushBytesWideU_eq, dropBytesU_eq, hshift]
+    congr 1
+    apply UInt8.toNat_inj.mp
+    rw [UInt32.toNat_toUInt8, UInt32.toNat_and]
+    have h7 : (7 : UInt32).toNat = 7 := rfl
+    have hand : totalU.toNat &&& 7 = totalU.toNat % 8 := by
+      simpa using Nat.and_two_pow_sub_one_eq_mod totalU.toNat 3
+    rw [h7, hand, Nat.toUInt8_eq, UInt8.toNat_ofNat']
+  · have hn : ¬ flushThreshold ≤ totalU.toNat := fun hh =>
+      h (UInt32.le_iff_toNat_le.mpr (by simpa [flushThreshold] using hh))
+    rw [if_neg h, if_neg hn]
+    congr 1
 
 /-- Write `n` bits (n ≤ 25) from `val`, LSB first.
     Fixed-width fields in DEFLATE are packed LSB-first.
 
     The low `n` bits of `val` are masked, shifted above the `bitCount`
     bits already in `bitBuf`, OR-ed into a 64-bit accumulator, then whole
-    bytes are flushed. The result cell is constructed here (not in the
-    flush loop) so ctor reuse updates `bw` in place — see `flushAcc`. -/
+    bytes are flushed via the scalar `flushBatchedU` (the `n ≤ 25` guard
+    keeps the `UInt32` total exact; larger `n` — never produced by DEFLATE
+    fields — takes the `Nat` reference path). -/
 def writeBits (bw : BitWriter) (n : Nat) (val : UInt32) : BitWriter :=
   let masked : UInt64 := val.toUInt64 % (1 <<< n.toUInt64)
   let acc : UInt64 := bw.bitBuf ||| (masked <<< bw.bitCount.toUInt64)
-  let total := bw.bitCount.toNat + n
-  if total ≥ flushThreshold then
-    ⟨flushBytesWide bw.data acc (total / 8), dropBytes acc (total / 8), (total % 8).toUInt8⟩
+  if n ≤ 25 then
+    -- `flushBatchedU bw.data acc totalU`, hand-inlined so the result cell is a
+    -- literal ctor in each branch and reuse recycles `bw` on both paths.
+    let totalU : UInt32 := bw.bitCount.toUInt32 + n.toUInt32
+    if totalU ≥ 32 then
+      ⟨flushBytesWideU bw.data acc (totalU >>> 3), dropBytesU acc (totalU >>> 3),
+        (totalU &&& 7).toUInt8⟩
+    else
+      ⟨bw.data, acc, totalU.toUInt8⟩
   else
-    ⟨bw.data, acc, total.toUInt8⟩
+    flushBatched bw.data acc (bw.bitCount.toNat + n)
 
 /-- `writeBits` is `flushBatched` of the merged accumulator — the defining
     equation the spec proofs unfold to. -/
@@ -171,10 +317,15 @@ theorem writeBits_def (bw : BitWriter) (n : Nat) (val : UInt32) :
       flushBatched bw.data
         (bw.bitBuf ||| ((val.toUInt64 % (1 <<< n.toUInt64)) <<< bw.bitCount.toUInt64))
         (bw.bitCount.toNat + n) := by
-  rw [writeBits, flushBatched]
+  rw [writeBits]
   split
-  · rw [flushBytesWide_eq, flushAcc_eq]
-  · rfl
+  next h =>
+    refine (flushBatchedU_eq bw.data _ (bw.bitCount.toUInt32 + n.toUInt32)).trans ?_
+    congr 1
+    rw [UInt32.toNat_add, UInt8.toNat_toUInt32, Nat.toUInt32_eq, UInt32.toNat_ofNat']
+    have hb := UInt8.toNat_lt bw.bitCount
+    omega
+  next => rfl
 
 /-- Reverse all 16 bits of `x` (`bit i ↦ bit (15-i)`) with a branchless
     swap network — no per-bit loop. -/
@@ -191,15 +342,21 @@ def reverse16 (x : UInt16) : UInt16 :=
     The reversal is done in one shot: reverse all 16 bits, then shift the
     reversed code down by `16 - len` so its low `len` bits hold the code in
     packing order. (Widening to `UInt64` before the down-shift makes `len = 0`
-    yield `0` correctly, since `>>> 16` clears a 16-bit value.) -/
+    yield `0` correctly, since `>>> 16` clears a 16-bit value.)
+
+    The flush bookkeeping runs through the scalar `flushBatchedU` — the
+    `UInt32` total is exact for every input (`bitCount, len < 256`). -/
 def writeHuffCode (bw : BitWriter) (code : UInt16) (len : UInt8) : BitWriter :=
   let rev : UInt64 := (reverse16 code).toUInt64 >>> (16 - len.toUInt64)
   let acc : UInt64 := bw.bitBuf ||| (rev <<< bw.bitCount.toUInt64)
-  let total := bw.bitCount.toNat + len.toNat
-  if total ≥ flushThreshold then
-    ⟨flushBytesWide bw.data acc (total / 8), dropBytes acc (total / 8), (total % 8).toUInt8⟩
+  -- `flushBatchedU bw.data acc totalU`, hand-inlined so the result cell is a
+  -- literal ctor in each branch and reuse recycles `bw` on both paths.
+  let totalU : UInt32 := bw.bitCount.toUInt32 + len.toUInt32
+  if totalU ≥ 32 then
+    ⟨flushBytesWideU bw.data acc (totalU >>> 3), dropBytesU acc (totalU >>> 3),
+      (totalU &&& 7).toUInt8⟩
   else
-    ⟨bw.data, acc, total.toUInt8⟩
+    ⟨bw.data, acc, totalU.toUInt8⟩
 
 /-- `writeHuffCode` is `flushBatched` of the merged accumulator — the defining
     equation the spec proofs unfold to. -/
@@ -209,10 +366,13 @@ theorem writeHuffCode_def (bw : BitWriter) (code : UInt16) (len : UInt8) :
         (bw.bitBuf |||
           (((reverse16 code).toUInt64 >>> (16 - len.toUInt64)) <<< bw.bitCount.toUInt64))
         (bw.bitCount.toNat + len.toNat) := by
-  rw [writeHuffCode, flushBatched]
-  split
-  · rw [flushBytesWide_eq, flushAcc_eq]
-  · rfl
+  rw [writeHuffCode]
+  refine (flushBatchedU_eq bw.data _ (bw.bitCount.toUInt32 + len.toUInt32)).trans ?_
+  congr 1
+  rw [UInt32.toNat_add, UInt8.toNat_toUInt32, UInt8.toNat_toUInt32]
+  have hb := UInt8.toNat_lt bw.bitCount
+  have hl := UInt8.toNat_lt len
+  omega
 
 /-- Flush all pending bits, padding the final partial byte with zeros. Drains
     every whole pending byte (`bitCount` may hold up to 31 bits under batching),

--- a/Zip/Native/BitWriter.lean
+++ b/Zip/Native/BitWriter.lean
@@ -47,13 +47,13 @@ def bitLength (bw : BitWriter) : Nat := bw.data.size * 8 + bw.bitCount.toNat
     low bits, LSB-first. Pushes `total / 8` bytes to `data`; the remaining
     `total % 8` bits become the new partial byte.
 
-    Reference form only: the production writers use the split
-    `flushBytes`/`dropBytes` loops (equal by `flushAcc_eq`, which the
-    `writeBits_def`/`writeHuffCode_def` equations build on) so the `BitWriter`
-    cell is constructed in the caller, where the ctor-reuse optimization can
-    recycle the input writer instead of allocating a fresh cell per field
-    (measured at ~59%/~19% of `mi_malloc_small` calls on L1/L8 compress,
-    #2739). -/
+    Reference form only: the production writers use the split scalar
+    `flushBytesWideU`/`dropBytesU` forms (equal by `flushAcc_eq` via
+    `flushBatchedU_eq`, which the `writeBits_def`/`writeHuffCode_def`
+    equations build on) so the `BitWriter` cell is constructed in the caller,
+    where the ctor-reuse optimization can recycle the input writer instead of
+    allocating a fresh cell per field (measured at ~59%/~19% of
+    `mi_malloc_small` calls on L1/L8 compress, #2739). -/
 def flushAcc (data : ByteArray) (acc : UInt64) : Nat → BitWriter
   | total =>
     if total ≥ 8 then
@@ -93,7 +93,9 @@ private theorem toUSize_toNat_of_le_8 {k : Nat} (h : k ≤ 8) : k.toUSize.toNat 
     before a field, so `k = total / 8 ≤ (31 + 25) / 8 = 7 ≤ 8` — but the guard
     keeps the function total on all inputs, falling back to the push loop.
     Kernel-measured 1.4× over the push loop on a synthetic L1-like field
-    trace (`lake exe wide-store-bench`, issue #2631 step 0). -/
+    trace (`lake exe wide-store-bench`, issue #2631 step 0). `Nat`-count
+    reference form; the production writers use the `UInt32`-count
+    `flushBytesWideU`. -/
 @[inline] def flushBytesWide (data : ByteArray) (acc : UInt64) (k : Nat) : ByteArray :=
   if h : k ≤ 8 then
     data.pushUInt64LE acc k.toUSize (by rw [toUSize_toNat_of_le_8 h]; exact h)
@@ -373,6 +375,34 @@ theorem writeHuffCode_def (bw : BitWriter) (code : UInt16) (len : UInt8) :
   have hb := UInt8.toNat_lt bw.bitCount
   have hl := UInt8.toNat_lt len
   omega
+
+/-- Write a Huffman code whose bits are already in LSB-first packing order:
+    `rev` must be `reverse16 code >>> (16 - len)` (low `len` bits), which the
+    packed code tables precompute once per block (`packCodeEntry`). Skips the
+    per-symbol `reverse16` call and down-shift of `writeHuffCode`; equal to it
+    by `writeRevCode_eq`. -/
+def writeRevCode (bw : BitWriter) (rev : UInt16) (len : UInt8) : BitWriter :=
+  let acc : UInt64 := bw.bitBuf ||| (rev.toUInt64 <<< bw.bitCount.toUInt64)
+  -- `flushBatchedU bw.data acc totalU`, hand-inlined so the result cell is a
+  -- literal ctor in each branch and reuse recycles `bw` on both paths.
+  let totalU : UInt32 := bw.bitCount.toUInt32 + len.toUInt32
+  if totalU ≥ 32 then
+    ⟨flushBytesWideU bw.data acc (totalU >>> 3), dropBytesU acc (totalU >>> 3),
+      (totalU &&& 7).toUInt8⟩
+  else
+    ⟨bw.data, acc, totalU.toUInt8⟩
+
+/-- `writeRevCode` on the precomputed reversal is `writeHuffCode`: the
+    down-shifted reversal has at most 16 live bits, so the `UInt16` round-trip
+    through the packed table is lossless. -/
+theorem writeRevCode_eq (bw : BitWriter) (code : UInt16) (len : UInt8) :
+    bw.writeRevCode ((reverse16 code).toUInt64 >>> (16 - len.toUInt64)).toUInt16 len =
+      bw.writeHuffCode code len := by
+  unfold writeRevCode writeHuffCode
+  rw [show (((reverse16 code).toUInt64 >>> (16 - len.toUInt64)).toUInt16).toUInt64 =
+      (reverse16 code).toUInt64 >>> (16 - len.toUInt64) from by
+    generalize reverse16 code = r
+    bv_decide]
 
 /-- Flush all pending bits, padding the final partial byte with zeros. Drains
     every whole pending byte (`bitCount` may hold up to 31 bits under batching),

--- a/Zip/Native/DeflateDynamic.lean
+++ b/Zip/Native/DeflateDynamic.lean
@@ -115,19 +115,26 @@ termination_by tokens.size - i
 /-! ## Packed Huffman-code tables (#2827)
 
 `litCodes`/`distCodes` are `Array (UInt16 × UInt8)`: every per-token code
-lookup fetches a boxed `Prod` cell and chases it with two `lean_ctor_get`s —
-the second-largest per-token cost in the emit profile after the writer calls.
-Packing each entry into one `UInt32` (code in bits 0–15, bit length in bits
-16–23) turns the lookup into a single tagged-scalar array read plus two
-register ops. `emitTokensWithCodesPT` is the packed-table twin of
-`emitTokensWithCodesP` (equal by `emitTokensWithCodesPT_eq`,
-`Zip/Spec/EmitPackedCorrect.lean`); the block emitters pack the tables once
-per block (`packCodeTab`, ≤ 316 entries) before the token walk. -/
+lookup fetches a boxed `Prod` cell and chases it with two `lean_ctor_get`s,
+and every `writeHuffCode` re-reverses the code's bits (`reverse16`, an
+out-of-line call) and down-shifts them — per symbol, for values that are
+table constants. Packing each entry into one `UInt32` holding the
+**pre-reversed** code (`reverse16 code >>> (16 - len)`, bits 0–15) and the
+bit length (bits 16–23) turns the lookup into a single tagged-scalar array
+read plus two register ops, and lets the walk write through the leaner
+`BitWriter.writeRevCode` (no per-symbol reversal). `emitTokensWithCodesPT`
+is the packed-table twin of `emitTokensWithCodesP` (equal by
+`emitTokensWithCodesPT_eq`, `Zip/Spec/EmitPackedCorrect.lean`); the block
+emitters pack the tables once per block (`packCodeTab`, ≤ 316 entries)
+before the token walk. -/
 
 /-- Pack one canonical-code entry `(code, bitLength)` into a `UInt32`:
-    code in bits 0–15, bit length in bits 16–23. -/
+    the LSB-first packing-order reversal `reverse16 code >>> (16 - len)` in
+    bits 0–15 (always < 2¹⁶, so the `UInt16` round-trip is lossless), and the
+    bit length in bits 16–23. -/
 @[inline] def packCodeEntry (e : UInt16 × UInt8) : UInt32 :=
-  e.1.toUInt32 ||| (e.2.toUInt32 <<< 16)
+  ((BitWriter.reverse16 e.1).toUInt64 >>> (16 - e.2.toUInt64)).toUInt16.toUInt32 |||
+    (e.2.toUInt32 <<< 16)
 
 /-- Pack a canonical-code table for the emit loop (one `UInt32` per entry). -/
 def packCodeTab (t : Array (UInt16 × UInt8)) : Array UInt32 :=
@@ -138,7 +145,8 @@ def packCodeTab (t : Array (UInt16 × UInt8)) : Array UInt32 :=
 
 /-- Packed-table twin of `emitRefWithCodesP`: identical branch structure,
     with each `(code, len)` pair read replaced by one packed-word read
-    (`e.toUInt16` / `(e >>> 16).toUInt8`). Equal to `emitRefWithCodesP` over
+    (`e.toUInt16` / `(e >>> 16).toUInt8`) written through `writeRevCode`
+    (the table code is pre-reversed). Equal to `emitRefWithCodesP` over
     `packCodeTab` (`emitRefWithCodesPT_eq`). -/
 @[inline] def emitRefWithCodesPT (bw : BitWriter)
     (litT distT : Array UInt32) (w : UInt32) : BitWriter :=
@@ -146,13 +154,13 @@ def packCodeTab (t : Array (UInt16 × UInt8)) : Array UInt32 :=
   let idx := codeIdx lw
   if hlitlt : idx + 257 < litT.size then
     let e := litT[idx + 257]
-    let bw := bw.writeHuffCode e.toUInt16 (e >>> 16).toUInt8
+    let bw := bw.writeRevCode e.toUInt16 (e >>> 16).toUInt8
     let bw := bw.writeBits (codeExtra lw) (codeVal lw)
     let dw := distCodeWord ((w &&& 0xFFFF).toNat)
     let dIdx := codeIdx dw
     if hdistlt : dIdx < distT.size then
       let de := distT[dIdx]
-      let bw := bw.writeHuffCode de.toUInt16 (de >>> 16).toUInt8
+      let bw := bw.writeRevCode de.toUInt16 (de >>> 16).toUInt8
       bw.writeBits (codeExtra dw) (codeVal dw)
     else bw
   else bw
@@ -171,7 +179,7 @@ def emitTokensWithCodesPT (bw : BitWriter) (tokens : Array UInt32)
       have : w.toUInt8.toNat < litT.size := by
         have := UInt8.toNat_lt w.toUInt8; omega
       let e := litT[w.toUInt8.toNat]
-      emitTokensWithCodesPT (bw.writeHuffCode e.toUInt16 (e >>> 16).toUInt8) tokens litT distT
+      emitTokensWithCodesPT (bw.writeRevCode e.toUInt16 (e >>> 16).toUInt8) tokens litT distT
         hlit hdist (i + 1)
     else
       emitTokensWithCodesPT (emitRefWithCodesPT bw litT distT w) tokens litT distT

--- a/Zip/Native/DeflateDynamic.lean
+++ b/Zip/Native/DeflateDynamic.lean
@@ -112,6 +112,73 @@ def emitTokensWithCodesP (bw : BitWriter) (tokens : Array UInt32)
   else bw
 termination_by tokens.size - i
 
+/-! ## Packed Huffman-code tables (#2827)
+
+`litCodes`/`distCodes` are `Array (UInt16 × UInt8)`: every per-token code
+lookup fetches a boxed `Prod` cell and chases it with two `lean_ctor_get`s —
+the second-largest per-token cost in the emit profile after the writer calls.
+Packing each entry into one `UInt32` (code in bits 0–15, bit length in bits
+16–23) turns the lookup into a single tagged-scalar array read plus two
+register ops. `emitTokensWithCodesPT` is the packed-table twin of
+`emitTokensWithCodesP` (equal by `emitTokensWithCodesPT_eq`,
+`Zip/Spec/EmitPackedCorrect.lean`); the block emitters pack the tables once
+per block (`packCodeTab`, ≤ 316 entries) before the token walk. -/
+
+/-- Pack one canonical-code entry `(code, bitLength)` into a `UInt32`:
+    code in bits 0–15, bit length in bits 16–23. -/
+@[inline] def packCodeEntry (e : UInt16 × UInt8) : UInt32 :=
+  e.1.toUInt32 ||| (e.2.toUInt32 <<< 16)
+
+/-- Pack a canonical-code table for the emit loop (one `UInt32` per entry). -/
+def packCodeTab (t : Array (UInt16 × UInt8)) : Array UInt32 :=
+  t.map packCodeEntry
+
+@[simp] theorem packCodeTab_size (t : Array (UInt16 × UInt8)) :
+    (packCodeTab t).size = t.size := Array.size_map ..
+
+/-- Packed-table twin of `emitRefWithCodesP`: identical branch structure,
+    with each `(code, len)` pair read replaced by one packed-word read
+    (`e.toUInt16` / `(e >>> 16).toUInt8`). Equal to `emitRefWithCodesP` over
+    `packCodeTab` (`emitRefWithCodesPT_eq`). -/
+@[inline] def emitRefWithCodesPT (bw : BitWriter)
+    (litT distT : Array UInt32) (w : UInt32) : BitWriter :=
+  let lw := lenCodeWord (((w >>> 16) &&& 0x7FFF).toNat)
+  let idx := codeIdx lw
+  if hlitlt : idx + 257 < litT.size then
+    let e := litT[idx + 257]
+    let bw := bw.writeHuffCode e.toUInt16 (e >>> 16).toUInt8
+    let bw := bw.writeBits (codeExtra lw) (codeVal lw)
+    let dw := distCodeWord ((w &&& 0xFFFF).toNat)
+    let dIdx := codeIdx dw
+    if hdistlt : dIdx < distT.size then
+      let de := distT[dIdx]
+      let bw := bw.writeHuffCode de.toUInt16 (de >>> 16).toUInt8
+      bw.writeBits (codeExtra dw) (codeVal dw)
+    else bw
+  else bw
+
+/-- Packed-table twin of `emitTokensWithCodesP` (same size hypotheses, now on
+    the packed tables): walk the packed token stream reading Huffman codes
+    from `packCodeTab`-packed `UInt32` tables. Equal to `emitTokensWithCodesP`
+    for every word array (`emitTokensWithCodesPT_eq`). -/
+def emitTokensWithCodesPT (bw : BitWriter) (tokens : Array UInt32)
+    (litT distT : Array UInt32)
+    (hlit : litT.size ≥ 286) (hdist : distT.size ≥ 30)
+    (i : Nat) : BitWriter :=
+  if h : i < tokens.size then
+    let w := tokens[i]
+    if w &&& ((1 : UInt32) <<< 31) = 0 then
+      have : w.toUInt8.toNat < litT.size := by
+        have := UInt8.toNat_lt w.toUInt8; omega
+      let e := litT[w.toUInt8.toNat]
+      emitTokensWithCodesPT (bw.writeHuffCode e.toUInt16 (e >>> 16).toUInt8) tokens litT distT
+        hlit hdist (i + 1)
+    else
+      emitTokensWithCodesPT (emitRefWithCodesPT bw litT distT w) tokens litT distT
+        hlit hdist (i + 1)
+  else bw
+termination_by tokens.size - i
+
 
 /-- Write the dynamic Huffman tree header via BitWriter.
     This is the native equivalent of spec `encodeDynamicTrees`, writing
@@ -356,7 +423,12 @@ def deflateDynamicBlockCoreP (data : ByteArray) (tokens : Array UInt32)
     let bw := bw.writeHuffCode code len
     bw.flush
   else
-    let bw := emitTokensWithCodesP bw tokens litCodes distCodes hlit_size hdist_size 0
+    have hlitT_size : (packCodeTab litCodes).size ≥ 286 := by
+      rw [packCodeTab_size]; exact hlit_size
+    have hdistT_size : (packCodeTab distCodes).size ≥ 30 := by
+      rw [packCodeTab_size]; exact hdist_size
+    let bw := emitTokensWithCodesPT bw tokens (packCodeTab litCodes) (packCodeTab distCodes)
+      hlitT_size hdistT_size 0
     let (code, len) := litCodes[256]'h256
     let bw := bw.writeHuffCode code len
     bw.flush
@@ -394,7 +466,12 @@ def deflateDynamicBlockCorePWith (data : ByteArray) (tokens : Array UInt32)
     let bw := bw.writeHuffCode code len
     bw.flush
   else
-    let bw := emitTokensWithCodesP bw tokens litCodes distCodes hlit_size hdist_size 0
+    have hlitT_size : (packCodeTab litCodes).size ≥ 286 := by
+      rw [packCodeTab_size]; exact hlit_size
+    have hdistT_size : (packCodeTab distCodes).size ≥ 30 := by
+      rw [packCodeTab_size]; exact hdist_size
+    let bw := emitTokensWithCodesPT bw tokens (packCodeTab litCodes) (packCodeTab distCodes)
+      hlitT_size hdistT_size 0
     let (code, len) := litCodes[256]'h256
     let bw := bw.writeHuffCode code len
     bw.flush
@@ -1288,8 +1365,13 @@ def emitDynBlockP (bw : BitWriter) (data : ByteArray) (ptoks : Array UInt32)
   have h256 : 256 < litCodes.size := by
     show 256 < (canonicalCodes (litLens.toArray.map Nat.toUInt8)).size
     rw [canonicalCodes_size, Array.size_map, List.size_toArray]; omega
+  have hlitT_size : (packCodeTab litCodes).size ≥ 286 := by
+    rw [packCodeTab_size]; exact hlit_size
+  have hdistT_size : (packCodeTab distCodes).size ≥ 30 := by
+    rw [packCodeTab_size]; exact hdist_size
   let bw := if data.size == 0 then bw
-            else emitTokensWithCodesP bw ptoks litCodes distCodes hlit_size hdist_size 0
+            else emitTokensWithCodesPT bw ptoks (packCodeTab litCodes) (packCodeTab distCodes)
+              hlitT_size hdistT_size 0
   let (code, len) := litCodes[256]'h256
   bw.writeHuffCode code len
 

--- a/Zip/Spec/EmitPackedCorrect.lean
+++ b/Zip/Spec/EmitPackedCorrect.lean
@@ -259,19 +259,27 @@ theorem emitTokensWithCodesP_eq (bw : BitWriter) (ws : Array UInt32)
 
 /-! ## The packed-table emitter equals the pair-table one (#2827) -/
 
-/-- `packCodeEntry` keeps the code in the low 16 bits. -/
-private theorem packCodeEntry_code (e : UInt16 × UInt8) :
-    (packCodeEntry e).toUInt16 = e.1 := by
-  obtain ⟨c, l⟩ := e
-  unfold packCodeEntry
-  bv_decide
-
 /-- `packCodeEntry` keeps the bit length in bits 16–23. -/
 private theorem packCodeEntry_len (e : UInt16 × UInt8) :
     (packCodeEntry e >>> 16).toUInt8 = e.2 := by
   obtain ⟨c, l⟩ := e
   unfold packCodeEntry
+  generalize BitWriter.reverse16 c = r
   bv_decide
+
+/-- Writing a packed entry through `writeRevCode` is `writeHuffCode` of the
+    original pair: the packed code field is exactly the precomputed
+    LSB-first reversal `writeRevCode` expects. -/
+private theorem packCodeEntry_write (bw : BitWriter) (e : UInt16 × UInt8) :
+    bw.writeRevCode (packCodeEntry e).toUInt16 ((packCodeEntry e) >>> 16).toUInt8 =
+      bw.writeHuffCode e.1 e.2 := by
+  obtain ⟨c, l⟩ := e
+  have hcode : (packCodeEntry (c, l)).toUInt16 =
+      ((BitWriter.reverse16 c).toUInt64 >>> (16 - l.toUInt64)).toUInt16 := by
+    unfold packCodeEntry
+    generalize BitWriter.reverse16 c = r
+    bv_decide
+  rw [packCodeEntry_len, hcode, BitWriter.writeRevCode_eq]
 
 /-- The packed-table reference emit is the pair-table one over `packCodeTab`:
     identical branch structure, each table read recovered by
@@ -281,8 +289,7 @@ private theorem emitRefWithCodesPT_eq (bw : BitWriter)
     emitRefWithCodesPT bw (packCodeTab litCodes) (packCodeTab distCodes) w =
       emitRefWithCodesP bw litCodes distCodes w := by
   unfold emitRefWithCodesPT emitRefWithCodesP
-  simp only [packCodeTab, Array.size_map, Array.getElem_map,
-    packCodeEntry_code, packCodeEntry_len]
+  simp only [packCodeTab, Array.size_map, Array.getElem_map, packCodeEntry_write]
   rfl
 
 /-- The packed-table emit loop is the pair-table one over `packCodeTab`, for
@@ -301,8 +308,7 @@ theorem emitTokensWithCodesPT_eq (bw : BitWriter) (ws : Array UInt32)
     by_cases hi : i < ws.size
     · simp only [hi, ↓reduceDIte]
       by_cases hc : ws[i] &&& ((1 : UInt32) <<< 31) = 0
-      · simp only [hc, ↓reduceIte, packCodeTab, Array.getElem_map,
-          packCodeEntry_code, packCodeEntry_len]
+      · simp only [hc, ↓reduceIte, packCodeTab, Array.getElem_map, packCodeEntry_write]
         exact ih _ (by omega) _ _ rfl
       · simp only [hc, ↓reduceIte, emitRefWithCodesPT_eq]
         exact ih _ (by omega) _ _ rfl

--- a/Zip/Spec/EmitPackedCorrect.lean
+++ b/Zip/Spec/EmitPackedCorrect.lean
@@ -257,6 +257,57 @@ theorem emitTokensWithCodesP_eq (bw : BitWriter) (ws : Array UInt32)
           exact ih _ (by omega) _ _ rfl
     · simp only [Array.size_map, hi, ↓reduceDIte]
 
+/-! ## The packed-table emitter equals the pair-table one (#2827) -/
+
+/-- `packCodeEntry` keeps the code in the low 16 bits. -/
+private theorem packCodeEntry_code (e : UInt16 × UInt8) :
+    (packCodeEntry e).toUInt16 = e.1 := by
+  obtain ⟨c, l⟩ := e
+  unfold packCodeEntry
+  bv_decide
+
+/-- `packCodeEntry` keeps the bit length in bits 16–23. -/
+private theorem packCodeEntry_len (e : UInt16 × UInt8) :
+    (packCodeEntry e >>> 16).toUInt8 = e.2 := by
+  obtain ⟨c, l⟩ := e
+  unfold packCodeEntry
+  bv_decide
+
+/-- The packed-table reference emit is the pair-table one over `packCodeTab`:
+    identical branch structure, each table read recovered by
+    `packCodeEntry_code`/`packCodeEntry_len`. -/
+private theorem emitRefWithCodesPT_eq (bw : BitWriter)
+    (litCodes distCodes : Array (UInt16 × UInt8)) (w : UInt32) :
+    emitRefWithCodesPT bw (packCodeTab litCodes) (packCodeTab distCodes) w =
+      emitRefWithCodesP bw litCodes distCodes w := by
+  unfold emitRefWithCodesPT emitRefWithCodesP
+  simp only [packCodeTab, Array.size_map, Array.getElem_map,
+    packCodeEntry_code, packCodeEntry_len]
+  rfl
+
+/-- The packed-table emit loop is the pair-table one over `packCodeTab`, for
+    every word array — the lockstep induction of `emitTokensWithCodesP_eq`
+    with the table reads bridged per arm. -/
+theorem emitTokensWithCodesPT_eq (bw : BitWriter) (ws : Array UInt32)
+    (litCodes distCodes : Array (UInt16 × UInt8))
+    (hlitT : (packCodeTab litCodes).size ≥ 286)
+    (hdistT : (packCodeTab distCodes).size ≥ 30) (i : Nat) :
+    emitTokensWithCodesPT bw ws (packCodeTab litCodes) (packCodeTab distCodes) hlitT hdistT i =
+      emitTokensWithCodesP bw ws litCodes distCodes
+        (by simpa using hlitT) (by simpa using hdistT) i := by
+  induction h : ws.size - i using Nat.strongRecOn generalizing bw i with
+  | _ n ih =>
+    unfold emitTokensWithCodesPT emitTokensWithCodesP
+    by_cases hi : i < ws.size
+    · simp only [hi, ↓reduceDIte]
+      by_cases hc : ws[i] &&& ((1 : UInt32) <<< 31) = 0
+      · simp only [hc, ↓reduceIte, packCodeTab, Array.getElem_map,
+          packCodeEntry_code, packCodeEntry_len]
+        exact ih _ (by omega) _ _ rfl
+      · simp only [hc, ↓reduceIte, emitRefWithCodesPT_eq]
+        exact ih _ (by omega) _ _ rfl
+    · simp only [hi, ↓reduceDIte]
+
 /-! ## The packed single-block cores equal the boxed ones -/
 
 /-- The packed fixed-block core is the boxed one over the `unpackTok` view:
@@ -275,6 +326,6 @@ theorem deflateDynamicBlockCoreP_eq (data : ByteArray) (ptoks : Array UInt32)
     deflateDynamicBlockCoreP data ptoks litLens distLens hlit hdist =
       deflateDynamicBlockCore data (ptoks.map unpackTok) litLens distLens hlit hdist := by
   unfold deflateDynamicBlockCoreP deflateDynamicBlockCore
-  simp only [emitTokensWithCodesP_eq]
+  simp only [emitTokensWithCodesPT_eq, emitTokensWithCodesP_eq]
 
 end Zip.Native.Deflate

--- a/Zip/Spec/LZ77PackedCorrect.lean
+++ b/Zip/Spec/LZ77PackedCorrect.lean
@@ -258,7 +258,7 @@ theorem emitDynBlockP_eq (bw : BitWriter) (data : ByteArray) (ws : Array UInt32)
     emitDynBlockP bw data ws litLens distLens hlit hdist isFinal =
       emitDynBlock bw data (ws.map unpackTok) litLens distLens hlit hdist isFinal := by
   unfold emitDynBlockP emitDynBlock
-  simp only [emitTokensWithCodesP_eq]
+  simp only [emitTokensWithCodesPT_eq, emitTokensWithCodesP_eq]
 
 /-- The packed shared-window block emitter is the boxed one over the
     `unpackTok` view: the trees agree by `tokenFreqsP_eq`, the emit by

--- a/bench/graphs/canterbury_compress_heatmap.svg
+++ b/bench/graphs/canterbury_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#pcf23f6cf17)">
+   <g clip-path="url(#p823434621b)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJGUlEQVR4nO3Yv4qc5x2GYY00G0v2RggTy8YCEUiaQCBV3CS9ex9IjsCNj8FnYAzujcGFazcpQ5oEQoIIApGgyPqzu9qdnUlhyBHcL79ouK4jeD5evm/ueTf7H7463ODNcvFyesE6r4/z2Q6XF9MTltncvT89YY233p5esM7m5vSCNa6O9z071jM7PP3n9IRljvPEAAAGCSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgNj20ebp9IYlLq8vpics88G9n09PWOZ0f396whKb8+fTE5b5/vwv0xOW+PAn701PWOZ6v5uesMSL3dn0hGV2h+vpCUv89qcPpics4wYLACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYtvTk3vTG5bYb/fTE5Y5vXF7esI6zx5NL1jicP58esIyHz383fSEJc52x3tmr4702X55+uvpCctcbnbTE5Y4/ONP0xOWcYMFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAse2dW6fTG5a4uD6bnrDO5oi7+Pbd6QVLbI74zE52u+kJSxzzmb2zPc737Mnl4+kJy+z2l9MTlnjwzr3pCcsc7xcEAGCIwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAIDY5vrPnx2mR8D/7PfTC+BHN/3/fOP4fvB/xBcEACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYts//OvR9IYlnr++np6wzB8fv5iesMw3n/x+esIS7995OD1hmd988eX0hCU+/sW70xOW+dt/zqcnLHFne2t6wjJff/vX6QlLnH3+6fSEZdxgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQGyz2393mB6xwvV+Nz1hmZub4+3iWxdn0xPWuLWdXrDOq6fTC5a4vvfB9IRl9of99IQlTjbH+55dHY7zN+1kd5zPdeOGGywAgJzAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCIbV/vzqY3LHF1uJyesMzdFy+nJ6zz8t/TC5Y4XF5NT1hm8+BX0xOWuNof7zfk5dWz6QlL/Ozk/vSEZU7Onk1PWOLw5O/TE5ZxgwUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAACx/wJ81IjnCGZz2wAAAABJRU5ErkJggg==" id="image4d13dbdfa7" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJF0lEQVR4nO3YzaqdZx2H4axkbU3abQ2FxpLSIOhMoSOd2HnnPRCPwInH0DMoQuel0EHHThwWJwqiBAnEQhrzsbOz9/pwIHgE98PfLK7rCH4vD++77vVsDv/+4niDN8vli+kF67w+zWc7Xl1OT1hm88696Qlr/PCt6QXrbG5OL1jj+nTfs1M9s+OTf05PWOY0TwwAYJDAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCIbR9unkxvWOJqfzk9YZn37/50esIy54d70xOW2Lx6Nj1hmT+++sv0hCXu/+C96QnL7A+76QlLPN9dTE9YZnfcT09Y4lc/+mB6wjJusAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACC2PT+7O71hicP2MD1hmfMbt6cnrPP04fSCJY6vnk1PWObXD34zPWGJi93pntnLE322n5//cnrCMleb3fSEJY7/+HZ6wjJusAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACC2vXPrfHrDEpf7i+kJ62xOuItvvzO9YInNCZ/Z2W43PWGJUz6zt7en+Z49vno0PWGZ3eFqesISH7x9d3rCMqf7BQEAGCKwAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAILbZ//n3x+kR8D+Hw/QC+K+b/n++cXw/+D/iCwIAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAACx7W+/ezi9YYlnr/fTE5b506Pn0xOW+erTj6cnLPGTOw+mJyzz0ed/mJ6wxCc/e3d6wjJ/+/7V9IQl7mxvTU9Y5suv/zo9YYmLz343PWEZN1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQ2+wO3xynR6ywP+ymJyxzc3O6XXzr8mJ6whq3ttML1nn5ZHrBEvu7709PWOZwPExPWOJsc7rv2fXxNH/Tznan+Vw3brjBAgDICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgNj24vrZ9IYl9sfd9IRlfvzycnrCOs//Nb1giePV9fSEZTYf/mJ6whJX+9N9z15cP52esMR7t+9PT1jm7OXT6QlLHB//fXrCMm6wAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAIPYf212I7lRstEUAAAAASUVORK5CYII=" id="imageaa0de41442" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m652ee007da" d="M 0 0 
+       <path id="mb170d0d508" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m652ee007da" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb170d0d508" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m652ee007da" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb170d0d508" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m652ee007da" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb170d0d508" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m652ee007da" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb170d0d508" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m652ee007da" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb170d0d508" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m652ee007da" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb170d0d508" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m652ee007da" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb170d0d508" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m652ee007da" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb170d0d508" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m652ee007da" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb170d0d508" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m652ee007da" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb170d0d508" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m652ee007da" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb170d0d508" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="m2d4d093355" d="M 0 0 
+       <path id="m590a41a35e" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m2d4d093355" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m590a41a35e" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m2d4d093355" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m590a41a35e" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m2d4d093355" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m590a41a35e" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m2d4d093355" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m590a41a35e" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m2d4d093355" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m590a41a35e" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m2d4d093355" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m590a41a35e" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m2d4d093355" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m590a41a35e" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m2d4d093355" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m590a41a35e" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1303,7 +1303,7 @@ L 527.435033 49.4355
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_20">
-    <!-- +21 -->
+    <!-- +25 -->
     <g transform="translate(108.442626 68.904519) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-2b" d="M 2944 4013 
@@ -1324,11 +1324,11 @@ z
      </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_21">
-    <!-- +30 -->
+    <!-- +33 -->
     <g transform="translate(147.693424 68.904519) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-33" d="M 2597 2516 
@@ -1366,11 +1366,11 @@ z
      </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_22">
-    <!-- -47 -->
+    <!-- -46 -->
     <g transform="translate(188.495082 68.904519) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
@@ -1392,6 +1392,46 @@ L 313 1709
 L 2253 4666 
 z
 " transform="scale(0.015625)"/>
+      <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_23">
+    <!-- -78 -->
+    <g transform="translate(227.74588 68.904519) scale(0.065 -0.065)">
+     <defs>
       <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
 L 3525 4397 
@@ -1402,24 +1442,6 @@ L 525 4134
 L 525 4666 
 z
 " transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_23">
-    <!-- -79 -->
-    <g transform="translate(227.74588 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_24">
-    <!-- -89 -->
-    <g transform="translate(266.996679 68.904519) scale(0.065 -0.065)">
-     <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
 Q 1069 1734 1069 1313 
@@ -1461,55 +1483,63 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_24">
+    <!-- -89 -->
+    <g transform="translate(266.996679 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_25">
-    <!-- -23 -->
+    <!-- -20 -->
     <g transform="translate(306.247477 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_26">
-    <!-- +17 -->
+    <!-- +22 -->
     <g transform="translate(343.947416 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_27">
-    <!-- +41 -->
+    <!-- +46 -->
     <g transform="translate(383.198215 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_28">
-    <!-- -7 -->
+    <!-- -4 -->
     <g transform="translate(426.067685 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_29">
-    <!-- -37 -->
+    <!-- -36 -->
     <g transform="translate(463.250671 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_30">
-    <!-- -90 -->
+    <!-- -89 -->
     <g transform="translate(502.50147 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_31">
@@ -1634,38 +1664,6 @@ z
    <g id="text_46">
     <!-- +26 -->
     <g transform="translate(265.44582 139.606222) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-36" d="M 2113 2584 
-Q 1688 2584 1439 2293 
-Q 1191 2003 1191 1497 
-Q 1191 994 1439 701 
-Q 1688 409 2113 409 
-Q 2538 409 2786 701 
-Q 3034 994 3034 1497 
-Q 3034 2003 2786 2293 
-Q 2538 2584 2113 2584 
-z
-M 3366 4563 
-L 3366 3988 
-Q 3128 4100 2886 4159 
-Q 2644 4219 2406 4219 
-Q 1781 4219 1451 3797 
-Q 1122 3375 1075 2522 
-Q 1259 2794 1537 2939 
-Q 1816 3084 2150 3084 
-Q 2853 3084 3261 2657 
-Q 3669 2231 3669 1497 
-Q 3669 778 3244 343 
-Q 2819 -91 2113 -91 
-Q 1303 -91 875 529 
-Q 447 1150 447 2328 
-Q 447 3434 972 4092 
-Q 1497 4750 2381 4750 
-Q 2619 4750 2861 4703 
-Q 3103 4656 3366 4563 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
@@ -2180,18 +2178,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="image0505b1e670" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
+iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="image314f857a07" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="mfbc1bedf96" d="M 0 0 
+       <path id="m80aa4a1420" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mfbc1bedf96" x="547.779688" y="276.293905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m80aa4a1420" x="547.779688" y="276.293905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
@@ -2214,7 +2212,7 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#mfbc1bedf96" x="547.779688" y="247.808905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m80aa4a1420" x="547.779688" y="247.808905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
@@ -2228,7 +2226,7 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#mfbc1bedf96" x="547.779688" y="219.323905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m80aa4a1420" x="547.779688" y="219.323905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
@@ -2242,7 +2240,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#mfbc1bedf96" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m80aa4a1420" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
@@ -2255,7 +2253,7 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mfbc1bedf96" x="547.779688" y="162.353904" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m80aa4a1420" x="547.779688" y="162.353904" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_112">
@@ -2268,7 +2266,7 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#mfbc1bedf96" x="547.779688" y="133.868904" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m80aa4a1420" x="547.779688" y="133.868904" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
@@ -2281,7 +2279,7 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mfbc1bedf96" x="547.779688" y="105.383904" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m80aa4a1420" x="547.779688" y="105.383904" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
@@ -2942,8 +2940,8 @@ z
    </g>
   </g>
   <g id="text_117">
-   <!-- 2026-07-09T07:09:47Z  ·  Linux chungus2 x86_64  ·  commit b23a23be  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(16.545547 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-09T17:31:54Z  ·  Linux chungus2 x86_64  ·  commit 324f086c  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(17.677578 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -3012,14 +3010,14 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-39" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
     <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3059,109 +3057,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3135.351562 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3198.974609 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3262.597656 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3323.876953 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3387.5 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3451.123047 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3514.599609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3576.123047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3607.910156 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3639.697266 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3671.484375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3703.271484 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3735.058594 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3762.841797 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3824.365234 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3885.644531 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3949.023438 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4012.5 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4051.363281 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4112.544922 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4171.724609 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4233.248047 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4274.361328 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4308.052734 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4335.835938 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4397.359375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4458.638672 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4522.017578 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4585.640625 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4619.332031 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4678.511719 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4742.134766 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4773.921875 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4837.544922 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4901.167969 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4932.955078 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4996.578125 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5032.662109 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5071.525391 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5126.505859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5190.128906 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5221.916016 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5253.703125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5285.490234 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5317.277344 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5349.064453 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5388.273438 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5451.652344 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5490.515625 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5551.697266 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5615.076172 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5678.552734 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5741.931641 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5805.408203 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5868.787109 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5907.996094 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5939.783203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6023.572266 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6055.359375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6152.771484 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6214.294922 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6277.771484 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6305.554688 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6366.833984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6430.212891 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6462 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6514.099609 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6577.478516 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6638.757812 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6702.234375 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6754.333984 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6817.712891 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6878.894531 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6918.103516 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6951.794922 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6983.582031 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7024.695312 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7085.974609 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7125.183594 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7152.966797 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7214.148438 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7245.935547 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7273.71875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7325.818359 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7357.605469 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7421.082031 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7482.605469 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7521.814453 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7583.337891 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7622.701172 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7720.113281 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7747.896484 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7811.275391 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7839.058594 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7891.158203 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7930.367188 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7958.150391 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3262.744141 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3297.949219 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3361.572266 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3425.195312 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3488.818359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3543.798828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3575.585938 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3607.373047 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3639.160156 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3670.947266 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3702.734375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3730.517578 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3792.041016 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3853.320312 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3916.699219 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3980.175781 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4019.039062 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4080.220703 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4139.400391 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4200.923828 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4242.037109 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4275.728516 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4303.511719 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4365.035156 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4426.314453 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4489.693359 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4553.316406 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4587.007812 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4646.1875 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4709.810547 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4741.597656 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4805.220703 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4868.84375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4900.630859 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4964.253906 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5000.337891 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5039.201172 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5094.181641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5157.804688 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5189.591797 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5221.378906 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5253.166016 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5284.953125 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5316.740234 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5355.949219 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5419.328125 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5458.191406 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5519.373047 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5582.751953 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5646.228516 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5709.607422 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5773.083984 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5836.462891 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5875.671875 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5907.458984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5991.248047 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6023.035156 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6120.447266 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6181.970703 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6245.447266 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6273.230469 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6334.509766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6397.888672 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6429.675781 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6481.775391 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6545.154297 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6606.433594 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6669.910156 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6722.009766 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6785.388672 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6846.570312 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6885.779297 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6919.470703 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6951.257812 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6992.371094 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7053.650391 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7092.859375 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7120.642578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7181.824219 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7213.611328 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7241.394531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7293.494141 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7325.28125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7388.757812 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7450.28125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7489.490234 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7551.013672 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7590.376953 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7687.789062 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7715.572266 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7778.951172 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7806.734375 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7858.833984 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7898.042969 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7925.826172 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pcf23f6cf17">
+  <clipPath id="p823434621b">
    <rect x="95.67625" y="49.4355" width="431.758783" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_compress_pareto.svg
+++ b/bench/graphs/canterbury_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 79.118387 412.80375 
 L 79.118387 48.323125 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m0747f4ce58" d="M 0 0 
+       <path id="m44cfe20ad5" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m0747f4ce58" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m44cfe20ad5" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -161,11 +161,11 @@ z
      <g id="line2d_3">
       <path d="M 166.481434 412.80375 
 L 166.481434 48.323125 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m0747f4ce58" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m44cfe20ad5" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -216,11 +216,11 @@ z
      <g id="line2d_5">
       <path d="M 253.844481 412.80375 
 L 253.844481 48.323125 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m0747f4ce58" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m44cfe20ad5" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -237,11 +237,11 @@ L 253.844481 48.323125
      <g id="line2d_7">
       <path d="M 341.207528 412.80375 
 L 341.207528 48.323125 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m0747f4ce58" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m44cfe20ad5" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -279,11 +279,11 @@ z
      <g id="line2d_9">
       <path d="M 428.570575 412.80375 
 L 428.570575 48.323125 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m0747f4ce58" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m44cfe20ad5" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -332,11 +332,11 @@ z
      <g id="line2d_11">
       <path d="M 515.933622 412.80375 
 L 515.933622 48.323125 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m0747f4ce58" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m44cfe20ad5" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -353,11 +353,11 @@ L 515.933622 48.323125
      <g id="line2d_13">
       <path d="M 603.296669 412.80375 
 L 603.296669 48.323125 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m0747f4ce58" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m44cfe20ad5" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -854,16 +854,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 347.786382 
 L 637.2 347.786382 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="m18af61eeb6" d="M 0 0 
+       <path id="mf80b61b523" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m18af61eeb6" x="49.078125" y="347.786382" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf80b61b523" x="49.078125" y="347.786382" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -895,11 +895,11 @@ z
      <g id="line2d_17">
       <path d="M 49.078125 238.646289 
 L 637.2 238.646289 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m18af61eeb6" x="49.078125" y="238.646289" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf80b61b523" x="49.078125" y="238.646289" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -915,11 +915,11 @@ L 637.2 238.646289
      <g id="line2d_19">
       <path d="M 49.078125 129.506196 
 L 637.2 129.506196 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m18af61eeb6" x="49.078125" y="129.506196" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf80b61b523" x="49.078125" y="129.506196" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -935,16 +935,16 @@ L 637.2 129.506196
      <g id="line2d_21">
       <path d="M 49.078125 404.853417 
 L 637.2 404.853417 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="mcdfb370ebc" d="M 0 0 
+       <path id="m44e0f0e5c4" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#mcdfb370ebc" x="49.078125" y="404.853417" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m44e0f0e5c4" x="49.078125" y="404.853417" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -952,11 +952,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 391.217592 
 L 637.2 391.217592 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mcdfb370ebc" x="49.078125" y="391.217592" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m44e0f0e5c4" x="49.078125" y="391.217592" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -964,11 +964,11 @@ L 637.2 391.217592
      <g id="line2d_25">
       <path d="M 49.078125 380.640824 
 L 637.2 380.640824 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mcdfb370ebc" x="49.078125" y="380.640824" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m44e0f0e5c4" x="49.078125" y="380.640824" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -976,11 +976,11 @@ L 637.2 380.640824
      <g id="line2d_27">
       <path d="M 49.078125 371.998975 
 L 637.2 371.998975 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#mcdfb370ebc" x="49.078125" y="371.998975" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m44e0f0e5c4" x="49.078125" y="371.998975" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -988,11 +988,11 @@ L 637.2 371.998975
      <g id="line2d_29">
       <path d="M 49.078125 364.692396 
 L 637.2 364.692396 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#mcdfb370ebc" x="49.078125" y="364.692396" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m44e0f0e5c4" x="49.078125" y="364.692396" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1000,11 +1000,11 @@ L 637.2 364.692396
      <g id="line2d_31">
       <path d="M 49.078125 358.36315 
 L 637.2 358.36315 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#mcdfb370ebc" x="49.078125" y="358.36315" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m44e0f0e5c4" x="49.078125" y="358.36315" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1012,11 +1012,11 @@ L 637.2 358.36315
      <g id="line2d_33">
       <path d="M 49.078125 352.780359 
 L 637.2 352.780359 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#mcdfb370ebc" x="49.078125" y="352.780359" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m44e0f0e5c4" x="49.078125" y="352.780359" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1024,11 +1024,11 @@ L 637.2 352.780359
      <g id="line2d_35">
       <path d="M 49.078125 314.93194 
 L 637.2 314.93194 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#mcdfb370ebc" x="49.078125" y="314.93194" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m44e0f0e5c4" x="49.078125" y="314.93194" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1036,11 +1036,11 @@ L 637.2 314.93194
      <g id="line2d_37">
       <path d="M 49.078125 295.713324 
 L 637.2 295.713324 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#mcdfb370ebc" x="49.078125" y="295.713324" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m44e0f0e5c4" x="49.078125" y="295.713324" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1048,11 +1048,11 @@ L 637.2 295.713324
      <g id="line2d_39">
       <path d="M 49.078125 282.077499 
 L 637.2 282.077499 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#mcdfb370ebc" x="49.078125" y="282.077499" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m44e0f0e5c4" x="49.078125" y="282.077499" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1060,11 +1060,11 @@ L 637.2 282.077499
      <g id="line2d_41">
       <path d="M 49.078125 271.500731 
 L 637.2 271.500731 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#mcdfb370ebc" x="49.078125" y="271.500731" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m44e0f0e5c4" x="49.078125" y="271.500731" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1072,11 +1072,11 @@ L 637.2 271.500731
      <g id="line2d_43">
       <path d="M 49.078125 262.858882 
 L 637.2 262.858882 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#mcdfb370ebc" x="49.078125" y="262.858882" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m44e0f0e5c4" x="49.078125" y="262.858882" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1084,11 +1084,11 @@ L 637.2 262.858882
      <g id="line2d_45">
       <path d="M 49.078125 255.552304 
 L 637.2 255.552304 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#mcdfb370ebc" x="49.078125" y="255.552304" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m44e0f0e5c4" x="49.078125" y="255.552304" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1096,11 +1096,11 @@ L 637.2 255.552304
      <g id="line2d_47">
       <path d="M 49.078125 249.223057 
 L 637.2 249.223057 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#mcdfb370ebc" x="49.078125" y="249.223057" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m44e0f0e5c4" x="49.078125" y="249.223057" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1108,11 +1108,11 @@ L 637.2 249.223057
      <g id="line2d_49">
       <path d="M 49.078125 243.640266 
 L 637.2 243.640266 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#mcdfb370ebc" x="49.078125" y="243.640266" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m44e0f0e5c4" x="49.078125" y="243.640266" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1120,11 +1120,11 @@ L 637.2 243.640266
      <g id="line2d_51">
       <path d="M 49.078125 205.791848 
 L 637.2 205.791848 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#mcdfb370ebc" x="49.078125" y="205.791848" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m44e0f0e5c4" x="49.078125" y="205.791848" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1132,11 +1132,11 @@ L 637.2 205.791848
      <g id="line2d_53">
       <path d="M 49.078125 186.573231 
 L 637.2 186.573231 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#mcdfb370ebc" x="49.078125" y="186.573231" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m44e0f0e5c4" x="49.078125" y="186.573231" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1144,11 +1144,11 @@ L 637.2 186.573231
      <g id="line2d_55">
       <path d="M 49.078125 172.937406 
 L 637.2 172.937406 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#mcdfb370ebc" x="49.078125" y="172.937406" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m44e0f0e5c4" x="49.078125" y="172.937406" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1156,11 +1156,11 @@ L 637.2 172.937406
      <g id="line2d_57">
       <path d="M 49.078125 162.360638 
 L 637.2 162.360638 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#mcdfb370ebc" x="49.078125" y="162.360638" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m44e0f0e5c4" x="49.078125" y="162.360638" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1168,11 +1168,11 @@ L 637.2 162.360638
      <g id="line2d_59">
       <path d="M 49.078125 153.71879 
 L 637.2 153.71879 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#mcdfb370ebc" x="49.078125" y="153.71879" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m44e0f0e5c4" x="49.078125" y="153.71879" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1180,11 +1180,11 @@ L 637.2 153.71879
      <g id="line2d_61">
       <path d="M 49.078125 146.412211 
 L 637.2 146.412211 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#mcdfb370ebc" x="49.078125" y="146.412211" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m44e0f0e5c4" x="49.078125" y="146.412211" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1192,11 +1192,11 @@ L 637.2 146.412211
      <g id="line2d_63">
       <path d="M 49.078125 140.082964 
 L 637.2 140.082964 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#mcdfb370ebc" x="49.078125" y="140.082964" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m44e0f0e5c4" x="49.078125" y="140.082964" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1204,11 +1204,11 @@ L 637.2 140.082964
      <g id="line2d_65">
       <path d="M 49.078125 134.500173 
 L 637.2 134.500173 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#mcdfb370ebc" x="49.078125" y="134.500173" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m44e0f0e5c4" x="49.078125" y="134.500173" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1216,11 +1216,11 @@ L 637.2 134.500173
      <g id="line2d_67">
       <path d="M 49.078125 96.651755 
 L 637.2 96.651755 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_68">
       <g>
-       <use xlink:href="#mcdfb370ebc" x="49.078125" y="96.651755" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m44e0f0e5c4" x="49.078125" y="96.651755" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1228,11 +1228,11 @@ L 637.2 96.651755
      <g id="line2d_69">
       <path d="M 49.078125 77.433138 
 L 637.2 77.433138 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_70">
       <g>
-       <use xlink:href="#mcdfb370ebc" x="49.078125" y="77.433138" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m44e0f0e5c4" x="49.078125" y="77.433138" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1240,11 +1240,11 @@ L 637.2 77.433138
      <g id="line2d_71">
       <path d="M 49.078125 63.797313 
 L 637.2 63.797313 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_72">
       <g>
-       <use xlink:href="#mcdfb370ebc" x="49.078125" y="63.797313" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m44e0f0e5c4" x="49.078125" y="63.797313" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1252,11 +1252,11 @@ L 637.2 63.797313
      <g id="line2d_73">
       <path d="M 49.078125 53.220545 
 L 637.2 53.220545 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_74">
       <g>
-       <use xlink:href="#mcdfb370ebc" x="49.078125" y="53.220545" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m44e0f0e5c4" x="49.078125" y="53.220545" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1378,7 +1378,7 @@ L 637.2 48.323125
    </g>
    <g id="text_13">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(294.783126 142.213917) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(294.783126 139.387822) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1410,7 +1410,7 @@ z
    </g>
    <g id="text_14">
     <!-- L10 -->
-    <g style="fill: #d62728" transform="translate(104.775489 295.457249) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(104.775489 294.492401) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1732,23 +1732,23 @@ z
    </g>
    <g id="line2d_75">
     <defs>
-     <path id="ma3ad1cb385" d="M -2.5 2.5 
+     <path id="m2e38fef57b" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pb239c4b002)">
-     <use xlink:href="#ma3ad1cb385" x="355.479835" y="95.382063" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma3ad1cb385" x="308.273931" y="102.754513" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma3ad1cb385" x="271.230161" y="116.528062" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma3ad1cb385" x="217.83458" y="120.013651" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma3ad1cb385" x="177.077692" y="138.43462" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma3ad1cb385" x="162.880539" y="157.778627" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma3ad1cb385" x="160.741445" y="165.196647" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma3ad1cb385" x="153.966678" y="183.405761" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma3ad1cb385" x="151.589614" y="194.488118" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pa93c90c411)">
+     <use xlink:href="#m2e38fef57b" x="355.479835" y="95.382063" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2e38fef57b" x="308.273931" y="102.754513" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2e38fef57b" x="271.230161" y="116.528062" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2e38fef57b" x="217.83458" y="120.013651" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2e38fef57b" x="177.077692" y="138.43462" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2e38fef57b" x="162.880539" y="157.778627" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2e38fef57b" x="160.741445" y="165.196647" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2e38fef57b" x="153.966678" y="183.405761" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2e38fef57b" x="151.589614" y="194.488118" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_76">
@@ -1801,7 +1801,7 @@ L 311.2243 102.325849
 L 310.240844 102.469168 
 L 309.257387 102.612055 
 L 308.273931 102.754513 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_77">
     <path d="M 308.273931 102.754513 
@@ -1853,7 +1853,7 @@ L 273.545396 115.775058
 L 272.773651 116.027391 
 L 272.001906 116.278388 
 L 271.230161 116.528062 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_78">
     <path d="M 271.230161 116.528062 
@@ -1905,7 +1905,7 @@ L 221.171803 119.803152
 L 220.059395 119.873422 
 L 218.946988 119.943588 
 L 217.83458 120.013651 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_79">
     <path d="M 217.83458 120.013651 
@@ -1957,7 +1957,7 @@ L 179.624997 137.470928
 L 178.775895 137.79434 
 L 177.926794 138.115561 
 L 177.077692 138.43462 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_80">
     <path d="M 177.077692 138.43462 
@@ -2009,7 +2009,7 @@ L 163.767861 156.775388
 L 163.472087 157.112166 
 L 163.176313 157.446568 
 L 162.880539 157.778627 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_81">
     <path d="M 162.880539 157.778627 
@@ -2061,7 +2061,7 @@ L 160.875139 164.765525
 L 160.830574 164.909668 
 L 160.78601 165.053375 
 L 160.741445 165.196647 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_82">
     <path d="M 160.741445 165.196647 
@@ -2113,7 +2113,7 @@ L 154.390101 182.45125
 L 154.24896 182.771561 
 L 154.107819 183.089721 
 L 153.966678 183.405761 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_83">
     <path d="M 153.966678 183.405761 
@@ -2165,26 +2165,26 @@ L 151.73818 193.866427
 L 151.688658 194.074564 
 L 151.639136 194.281792 
 L 151.589614 194.488118 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_84">
     <defs>
-     <path id="mf74002dac0" d="M 0 -2.5 
+     <path id="m98c195fde7" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pb239c4b002)">
-     <use xlink:href="#mf74002dac0" x="531.649087" y="75.963093" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf74002dac0" x="283.721324" y="99.020035" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf74002dac0" x="218.882044" y="121.069315" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf74002dac0" x="187.447228" y="127.10685" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf74002dac0" x="176.342474" y="138.36311" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf74002dac0" x="163.054314" y="161.312135" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf74002dac0" x="162.210539" y="168.753955" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf74002dac0" x="159.303811" y="175.753345" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf74002dac0" x="157.793928" y="179.494802" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pa93c90c411)">
+     <use xlink:href="#m98c195fde7" x="531.649087" y="75.963093" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m98c195fde7" x="283.721324" y="99.020035" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m98c195fde7" x="218.882044" y="121.069315" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m98c195fde7" x="187.447228" y="127.10685" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m98c195fde7" x="176.342474" y="138.36311" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m98c195fde7" x="163.054314" y="161.312135" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m98c195fde7" x="162.210539" y="168.753955" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m98c195fde7" x="159.303811" y="175.753345" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m98c195fde7" x="157.793928" y="179.494802" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_85">
@@ -2237,7 +2237,7 @@ L 299.21681 97.864971
 L 294.051648 98.253128 
 L 288.886486 98.638133 
 L 283.721324 99.020035 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_86">
     <path d="M 283.721324 99.020035 
@@ -2289,7 +2289,7 @@ L 222.934499 119.954333
 L 221.583681 120.328916 
 L 220.232863 120.700561 
 L 218.882044 121.069315 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_87">
     <path d="M 218.882044 121.069315 
@@ -2341,7 +2341,7 @@ L 189.411904 126.751217
 L 188.757012 126.870058 
 L 188.10212 126.988602 
 L 187.447228 127.10685 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_88">
     <path d="M 187.447228 127.10685 
@@ -2393,7 +2393,7 @@ L 177.036521 137.732718
 L 176.805172 137.943781 
 L 176.573823 138.153909 
 L 176.342474 138.36311 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_89">
     <path d="M 176.342474 138.36311 
@@ -2445,7 +2445,7 @@ L 163.884824 160.161325
 L 163.607987 160.548041 
 L 163.33115 160.931628 
 L 163.054314 161.312135 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_90">
     <path d="M 163.054314 161.312135 
@@ -2497,7 +2497,7 @@ L 162.263275 168.321549
 L 162.245696 168.466124 
 L 162.228118 168.610258 
 L 162.210539 168.753955 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_91">
     <path d="M 162.210539 168.753955 
@@ -2549,7 +2549,7 @@ L 159.485481 175.344896
 L 159.424925 175.481437 
 L 159.364368 175.617586 
 L 159.303811 175.753345 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_92">
     <path d="M 159.303811 175.753345 
@@ -2601,30 +2601,30 @@ L 157.888296 179.269417
 L 157.85684 179.344665 
 L 157.825384 179.419793 
 L 157.793928 179.494802 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_93">
     <defs>
-     <path id="mf3d7ce576c" d="M -0 3.535534 
+     <path id="me47f981e49" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pb239c4b002)">
-     <use xlink:href="#mf3d7ce576c" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf3d7ce576c" x="203.775848" y="81.750179" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf3d7ce576c" x="186.982691" y="88.344921" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf3d7ce576c" x="179.779306" y="91.045312" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf3d7ce576c" x="157.610419" y="99.395085" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf3d7ce576c" x="148.722526" y="107.864022" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf3d7ce576c" x="144.388162" y="121.237794" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf3d7ce576c" x="127.071247" y="144.560664" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf3d7ce576c" x="124.491988" y="152.083585" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf3d7ce576c" x="92.613662" y="207.637263" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf3d7ce576c" x="87.348715" y="225.457654" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf3d7ce576c" x="86.053433" y="242.017529" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pa93c90c411)">
+     <use xlink:href="#me47f981e49" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me47f981e49" x="203.775848" y="81.750179" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me47f981e49" x="186.982691" y="88.344921" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me47f981e49" x="179.779306" y="91.045312" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me47f981e49" x="157.610419" y="99.395085" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me47f981e49" x="148.722526" y="107.864022" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me47f981e49" x="144.388162" y="121.237794" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me47f981e49" x="127.071247" y="144.560664" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me47f981e49" x="124.491988" y="152.083585" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me47f981e49" x="92.613662" y="207.637263" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me47f981e49" x="87.348715" y="225.457654" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me47f981e49" x="86.053433" y="242.017529" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_94">
@@ -2677,7 +2677,7 @@ L 206.762331 80.855075
 L 205.766837 81.155325 
 L 204.771342 81.453685 
 L 203.775848 81.750179 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_95">
     <path d="M 203.775848 81.750179 
@@ -2729,7 +2729,7 @@ L 188.032264 87.958568
 L 187.682406 88.087703 
 L 187.332549 88.216487 
 L 186.982691 88.344921 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_96">
     <path d="M 186.982691 88.344921 
@@ -2781,7 +2781,7 @@ L 180.229518 90.88097
 L 180.079447 90.935814 
 L 179.929376 90.990595 
 L 179.779306 91.045312 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_97">
     <path d="M 179.779306 91.045312 
@@ -2833,7 +2833,7 @@ L 158.995974 98.914174
 L 158.534122 99.075021 
 L 158.07227 99.235323 
 L 157.610419 99.395085 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_98">
     <path d="M 157.610419 99.395085 
@@ -2885,7 +2885,7 @@ L 149.27802 107.37681
 L 149.092855 107.539771 
 L 148.907691 107.702174 
 L 148.722526 107.864022 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_99">
     <path d="M 148.722526 107.864022 
@@ -2937,7 +2937,7 @@ L 144.65906 120.50385
 L 144.568761 120.749763 
 L 144.478462 120.994407 
 L 144.388162 121.237794 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_100">
     <path d="M 144.388162 121.237794 
@@ -2989,7 +2989,7 @@ L 128.153555 143.395158
 L 127.792786 143.786853 
 L 127.432016 144.175338 
 L 127.071247 144.560664 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_101">
     <path d="M 127.071247 144.560664 
@@ -3041,7 +3041,7 @@ L 124.653192 151.646811
 L 124.599457 151.79285 
 L 124.545723 151.93844 
 L 124.491988 152.083585 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_102">
     <path d="M 124.491988 152.083585 
@@ -3093,7 +3093,7 @@ L 94.606058 205.546972
 L 93.941926 206.254028 
 L 93.277794 206.950691 
 L 92.613662 207.637263 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_103">
     <path d="M 92.613662 207.637263 
@@ -3145,7 +3145,7 @@ L 87.677774 224.520091
 L 87.568088 224.834677 
 L 87.458402 225.147189 
 L 87.348715 225.457654 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_104">
     <path d="M 87.348715 225.457654 
@@ -3197,23 +3197,23 @@ L 86.134388 241.135848
 L 86.107403 241.431568 
 L 86.080418 241.725454 
 L 86.053433 242.017529 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_105">
     <defs>
-     <path id="maf5f7c5678" d="M -0 2.5 
+     <path id="med6a60f151" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pb239c4b002)">
-     <use xlink:href="#maf5f7c5678" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pa93c90c411)">
+     <use xlink:href="#med6a60f151" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_106">
     <defs>
-     <path id="m04d1a15967" d="M -0.833333 2.5 
+     <path id="mb6e0298424" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -3228,16 +3228,16 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pb239c4b002)">
-     <use xlink:href="#m04d1a15967" x="362.865999" y="115.428618" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m04d1a15967" x="278.798176" y="122.858526" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m04d1a15967" x="251.17632" y="128.261574" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m04d1a15967" x="200.806828" y="131.522849" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m04d1a15967" x="169.803221" y="147.931404" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m04d1a15967" x="161.916638" y="160.718659" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m04d1a15967" x="158.697104" y="167.705569" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m04d1a15967" x="154.26679" y="181.026105" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m04d1a15967" x="153.096464" y="191.924265" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pa93c90c411)">
+     <use xlink:href="#mb6e0298424" x="362.865999" y="115.428618" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb6e0298424" x="278.798176" y="122.858526" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb6e0298424" x="251.17632" y="128.261574" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb6e0298424" x="200.806828" y="131.522849" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb6e0298424" x="169.803221" y="147.931404" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb6e0298424" x="161.916638" y="160.718659" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb6e0298424" x="158.697104" y="167.705569" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb6e0298424" x="154.26679" y="181.026105" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb6e0298424" x="153.096464" y="191.924265" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_107">
@@ -3290,7 +3290,7 @@ L 284.052415 122.426763
 L 282.301002 122.571121 
 L 280.549589 122.715042 
 L 278.798176 122.858526 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_108">
     <path d="M 278.798176 122.858526 
@@ -3342,7 +3342,7 @@ L 252.902686 127.94134
 L 252.327231 128.048325 
 L 251.751776 128.155069 
 L 251.17632 128.261574 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_109">
     <path d="M 251.17632 128.261574 
@@ -3394,7 +3394,7 @@ L 203.954921 131.325463
 L 202.905557 131.39135 
 L 201.856192 131.457145 
 L 200.806828 131.522849 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_110">
     <path d="M 200.806828 131.522849 
@@ -3446,7 +3446,7 @@ L 171.740947 147.056528
 L 171.095038 147.349951 
 L 170.44913 147.64157 
 L 169.803221 147.931404 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_111">
     <path d="M 169.803221 147.931404 
@@ -3498,7 +3498,7 @@ L 162.409549 160.012958
 L 162.245246 160.249361 
 L 162.080942 160.484591 
 L 161.916638 160.718659 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_112">
     <path d="M 161.916638 160.718659 
@@ -3550,7 +3550,7 @@ L 158.898325 167.297798
 L 158.831251 167.434112 
 L 158.764178 167.570034 
 L 158.697104 167.705569 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_113">
     <path d="M 158.697104 167.705569 
@@ -3602,7 +3602,7 @@ L 154.543684 180.294711
 L 154.451386 180.539765 
 L 154.359088 180.783558 
 L 154.26679 181.026105 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_114">
     <path d="M 154.26679 181.026105 
@@ -3654,11 +3654,11 @@ L 153.16961 191.311823
 L 153.145228 191.516851 
 L 153.120846 191.720996 
 L 153.096464 191.924265 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_115">
     <defs>
-     <path id="maf7b1feefd" d="M -1.25 2.5 
+     <path id="m9b4e721c73" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -3673,16 +3673,16 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pb239c4b002)">
-     <use xlink:href="#maf7b1feefd" x="301.619021" y="150.561849" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#maf7b1feefd" x="250.236474" y="156.671134" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#maf7b1feefd" x="225.418659" y="160.842551" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#maf7b1feefd" x="212.328936" y="161.382211" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#maf7b1feefd" x="209.030149" y="166.25091" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#maf7b1feefd" x="197.547749" y="171.432451" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#maf7b1feefd" x="194.819287" y="175.129495" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#maf7b1feefd" x="193.12279" y="181.606362" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#maf7b1feefd" x="192.79794" y="189.451167" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pa93c90c411)">
+     <use xlink:href="#m9b4e721c73" x="301.619021" y="150.561849" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9b4e721c73" x="250.236474" y="156.671134" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9b4e721c73" x="225.418659" y="160.842551" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9b4e721c73" x="212.328936" y="161.382211" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9b4e721c73" x="209.030149" y="166.25091" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9b4e721c73" x="197.547749" y="171.432451" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9b4e721c73" x="194.819287" y="175.129495" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9b4e721c73" x="193.12279" y="181.606362" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9b4e721c73" x="192.79794" y="189.451167" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_116">
@@ -3735,7 +3735,7 @@ L 253.447883 156.311526
 L 252.377414 156.431699 
 L 251.306944 156.551567 
 L 250.236474 156.671134 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_117">
     <path d="M 250.236474 156.671134 
@@ -3787,7 +3787,7 @@ L 226.969772 160.592321
 L 226.452735 160.675878 
 L 225.935697 160.759287 
 L 225.418659 160.842551 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_118">
     <path d="M 225.418659 160.842551 
@@ -3839,7 +3839,7 @@ L 213.147044 161.348661
 L 212.874341 161.359847 
 L 212.601639 161.37103 
 L 212.328936 161.382211 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_119">
     <path d="M 212.328936 161.382211 
@@ -3891,7 +3891,7 @@ L 209.236323 165.960837
 L 209.167599 166.057725 
 L 209.098874 166.154416 
 L 209.030149 166.25091 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_120">
     <path d="M 209.030149 166.25091 
@@ -3943,7 +3943,7 @@ L 198.265399 171.124681
 L 198.026182 171.227493 
 L 197.786966 171.330083 
 L 197.547749 171.432451 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_121">
     <path d="M 197.547749 171.432451 
@@ -3995,7 +3995,7 @@ L 194.989815 174.906688
 L 194.932972 174.981074 
 L 194.876129 175.055342 
 L 194.819287 175.129495 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_122">
     <path d="M 194.819287 175.129495 
@@ -4047,7 +4047,7 @@ L 193.228821 181.226479
 L 193.193478 181.353445 
 L 193.158134 181.480072 
 L 193.12279 181.606362 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_123">
     <path d="M 193.12279 181.606362 
@@ -4099,11 +4099,11 @@ L 192.818243 188.997124
 L 192.811475 189.148955 
 L 192.804707 189.300302 
 L 192.79794 189.451167 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_124">
     <defs>
-     <path id="mf31a395a28" d="M 0 -2.5 
+     <path id="mf88fb2684f" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -4116,16 +4116,16 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#pb239c4b002)">
-     <use xlink:href="#mf31a395a28" x="206.45578" y="118.584066" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mf31a395a28" x="206.45578" y="118.258949" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mf31a395a28" x="206.45578" y="118.759361" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mf31a395a28" x="206.45578" y="118.234957" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mf31a395a28" x="171.767499" y="134.097889" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mf31a395a28" x="163.54283" y="144.663903" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mf31a395a28" x="160.174881" y="151.505345" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mf31a395a28" x="154.179217" y="169.303726" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mf31a395a28" x="152.4406" y="178.584542" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#pa93c90c411)">
+     <use xlink:href="#mf88fb2684f" x="206.45578" y="118.584066" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf88fb2684f" x="206.45578" y="118.258949" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf88fb2684f" x="206.45578" y="118.759361" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf88fb2684f" x="206.45578" y="118.234957" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf88fb2684f" x="171.767499" y="134.097889" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf88fb2684f" x="163.54283" y="144.663903" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf88fb2684f" x="160.174881" y="151.505345" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf88fb2684f" x="154.179217" y="169.303726" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf88fb2684f" x="152.4406" y="178.584542" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_125">
@@ -4178,7 +4178,7 @@ L 206.45578 118.279335
 L 206.45578 118.27254 
 L 206.45578 118.265745 
 L 206.45578 118.258949 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_126">
     <path d="M 206.45578 118.258949 
@@ -4230,7 +4230,7 @@ L 206.45578 118.728239
 L 206.45578 118.738615 
 L 206.45578 118.748989 
 L 206.45578 118.759361 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_127">
     <path d="M 206.45578 118.759361 
@@ -4282,7 +4282,7 @@ L 206.45578 118.267903
 L 206.45578 118.256924 
 L 206.45578 118.245942 
 L 206.45578 118.234957 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_128">
     <path d="M 206.45578 118.234957 
@@ -4334,7 +4334,7 @@ L 173.935517 133.247721
 L 173.212844 133.532808 
 L 172.490172 133.816191 
 L 171.767499 134.097889 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_129">
     <path d="M 171.767499 134.097889 
@@ -4386,7 +4386,7 @@ L 164.056872 144.068227
 L 163.885524 144.267619 
 L 163.714177 144.466175 
 L 163.54283 144.663903 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_130">
     <path d="M 163.54283 144.663903 
@@ -4438,7 +4438,7 @@ L 160.385378 151.105499
 L 160.315212 151.239156 
 L 160.245047 151.372438 
 L 160.174881 151.505345 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_131">
     <path d="M 160.174881 151.505345 
@@ -4490,7 +4490,7 @@ L 154.553946 168.367127
 L 154.429036 168.681387 
 L 154.304126 168.993578 
 L 154.179217 169.303726 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_132">
     <path d="M 154.179217 169.303726 
@@ -4542,11 +4542,11 @@ L 152.549264 178.054798
 L 152.513043 178.232038 
 L 152.476822 178.408618 
 L 152.4406 178.584542 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_133">
     <defs>
-     <path id="mea3b72276d" d="M 0 -2.5 
+     <path id="m186a731b9e" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -4555,16 +4555,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pb239c4b002)">
-     <use xlink:href="#mea3b72276d" x="610.467188" y="172.829682" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mea3b72276d" x="592.067397" y="173.763838" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mea3b72276d" x="534.807821" y="180.385179" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mea3b72276d" x="327.802209" y="176.172104" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mea3b72276d" x="275.83761" y="186.734601" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mea3b72276d" x="258.25125" y="198.783148" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mea3b72276d" x="256.777056" y="203.737732" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mea3b72276d" x="248.769854" y="217.74136" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mea3b72276d" x="246.264594" y="227.740017" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pa93c90c411)">
+     <use xlink:href="#m186a731b9e" x="610.467188" y="172.829682" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m186a731b9e" x="592.067397" y="173.763838" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m186a731b9e" x="534.807821" y="180.385179" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m186a731b9e" x="327.802209" y="176.172104" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m186a731b9e" x="275.83761" y="186.734601" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m186a731b9e" x="258.25125" y="198.783148" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m186a731b9e" x="256.777056" y="203.737732" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m186a731b9e" x="248.769854" y="217.74136" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m186a731b9e" x="246.264594" y="227.740017" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_134">
@@ -4617,7 +4617,7 @@ L 593.217384 173.705989
 L 592.834055 173.72528 
 L 592.450726 173.744563 
 L 592.067397 173.763838 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_135">
     <path d="M 592.067397 173.763838 
@@ -4669,7 +4669,7 @@ L 538.386544 179.997367
 L 537.193636 180.126991 
 L 536.000728 180.25626 
 L 534.807821 180.385179 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_136">
     <path d="M 534.807821 180.385179 
@@ -4721,7 +4721,7 @@ L 340.74006 176.446681
 L 336.427443 176.355332 
 L 332.114826 176.263806 
 L 327.802209 176.172104 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_137">
     <path d="M 327.802209 176.172104 
@@ -4773,7 +4773,7 @@ L 279.085397 186.139102
 L 278.002801 186.338434 
 L 276.920205 186.536931 
 L 275.83761 186.734601 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_138">
     <path d="M 275.83761 186.734601 
@@ -4825,7 +4825,7 @@ L 259.350398 198.113494
 L 258.984015 198.337765 
 L 258.617633 198.560979 
 L 258.25125 198.783148 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_139">
     <path d="M 258.25125 198.783148 
@@ -4877,7 +4877,7 @@ L 256.869193 203.442789
 L 256.838481 203.541307 
 L 256.807768 203.639621 
 L 256.777056 203.737732 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_140">
     <path d="M 256.777056 203.737732 
@@ -4929,7 +4929,7 @@ L 249.270304 216.977455
 L 249.103487 217.23346 
 L 248.93667 217.48809 
 L 248.769854 217.74136 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_141">
     <path d="M 248.769854 217.74136 
@@ -4981,7 +4981,7 @@ L 246.421172 227.173237
 L 246.368979 227.362918 
 L 246.316786 227.551842 
 L 246.264594 227.740017 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="legend_1">
     <g id="patch_7">
@@ -4999,7 +4999,7 @@ z
     </g>
     <g id="line2d_142">
      <defs>
-      <path id="mf38210ea7a" d="M 0 3.5 
+      <path id="m368a0b380d" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -5012,7 +5012,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#mf38210ea7a" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m368a0b380d" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -5071,7 +5071,7 @@ z
     </g>
     <g id="line2d_143">
      <g>
-      <use xlink:href="#ma3ad1cb385" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m2e38fef57b" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -5085,7 +5085,7 @@ z
     </g>
     <g id="line2d_144">
      <g>
-      <use xlink:href="#mf74002dac0" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m98c195fde7" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -5130,7 +5130,7 @@ z
     </g>
     <g id="line2d_145">
      <g>
-      <use xlink:href="#mf3d7ce576c" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#me47f981e49" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -5173,7 +5173,7 @@ z
     </g>
     <g id="line2d_146">
      <g>
-      <use xlink:href="#maf5f7c5678" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#med6a60f151" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -5189,7 +5189,7 @@ z
     </g>
     <g id="line2d_147">
      <g>
-      <use xlink:href="#m04d1a15967" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mb6e0298424" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -5243,7 +5243,7 @@ z
     </g>
     <g id="line2d_148">
      <g>
-      <use xlink:href="#maf7b1feefd" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m9b4e721c73" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -5308,7 +5308,7 @@ z
     </g>
     <g id="line2d_149">
      <g>
-      <use xlink:href="#mf31a395a28" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#mf88fb2684f" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -5346,7 +5346,7 @@ z
     </g>
     <g id="line2d_150">
      <g>
-      <use xlink:href="#mea3b72276d" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m186a731b9e" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -5416,486 +5416,486 @@ z
     </g>
    </g>
    <g id="line2d_151">
-    <g clip-path="url(#pb239c4b002)">
-     <use xlink:href="#mf38210ea7a" x="289.783126" y="147.213917" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mf38210ea7a" x="223.847406" y="155.071426" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mf38210ea7a" x="212.445767" y="159.097461" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mf38210ea7a" x="181.367844" y="170.234704" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mf38210ea7a" x="165.308999" y="179.010762" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mf38210ea7a" x="160.074948" y="185.882034" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mf38210ea7a" x="157.029538" y="188.998592" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mf38210ea7a" x="149.72506" y="197.808147" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mf38210ea7a" x="115.00257" y="274.102857" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mf38210ea7a" x="99.775489" y="300.457249" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <g clip-path="url(#pa93c90c411)">
+     <use xlink:href="#m368a0b380d" x="289.783126" y="144.387822" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m368a0b380d" x="223.847406" y="152.598403" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m368a0b380d" x="212.445767" y="156.86178" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m368a0b380d" x="181.367844" y="168.544499" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m368a0b380d" x="165.308999" y="177.922091" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m368a0b380d" x="160.074948" y="184.567562" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m368a0b380d" x="157.029538" y="187.747619" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m368a0b380d" x="149.72506" y="196.670382" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m368a0b380d" x="115.00257" y="273.714295" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m368a0b380d" x="99.775489" y="299.492401" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
    <g id="line2d_152">
-    <path d="M 289.783126 147.213917 
-L 288.409466 147.391631 
-L 287.035805 147.568682 
-L 285.662144 147.745075 
-L 284.288483 147.920813 
-L 282.914822 148.095902 
-L 281.541161 148.270346 
-L 280.167501 148.444151 
-L 278.79384 148.617321 
-L 277.420179 148.789861 
-L 276.046518 148.961775 
-L 274.672857 149.133067 
-L 273.299196 149.303743 
-L 271.925536 149.473806 
-L 270.551875 149.643262 
-L 269.178214 149.812113 
-L 267.804553 149.980366 
-L 266.430892 150.148023 
-L 265.057231 150.315089 
-L 263.68357 150.481569 
-L 262.30991 150.647465 
-L 260.936249 150.812784 
-L 259.562588 150.977527 
-L 258.188927 151.1417 
-L 256.815266 151.305306 
-L 255.441605 151.46835 
-L 254.067945 151.630835 
-L 252.694284 151.792764 
-L 251.320623 151.954142 
-L 249.946962 152.114973 
-L 248.573301 152.27526 
-L 247.19964 152.435006 
-L 245.82598 152.594216 
-L 244.452319 152.752893 
-L 243.078658 152.911041 
-L 241.704997 153.068662 
-L 240.331336 153.225761 
-L 238.957675 153.382342 
-L 237.584015 153.538406 
-L 236.210354 153.693959 
-L 234.836693 153.849002 
-L 233.463032 154.003541 
-L 232.089371 154.157577 
-L 230.71571 154.311114 
-L 229.34205 154.464155 
-L 227.968389 154.616704 
-L 226.594728 154.768763 
-L 225.221067 154.920336 
-L 223.847406 155.071426 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 289.783126 144.387822 
+L 288.409466 144.574218 
+L 287.035805 144.759883 
+L 285.662144 144.944825 
+L 284.288483 145.129047 
+L 282.914822 145.312556 
+L 281.541161 145.495358 
+L 280.167501 145.677457 
+L 278.79384 145.858859 
+L 277.420179 146.03957 
+L 276.046518 146.219594 
+L 274.672857 146.398938 
+L 273.299196 146.577605 
+L 271.925536 146.755601 
+L 270.551875 146.932931 
+L 269.178214 147.1096 
+L 267.804553 147.285614 
+L 266.430892 147.460976 
+L 265.057231 147.635691 
+L 263.68357 147.809765 
+L 262.30991 147.983202 
+L 260.936249 148.156007 
+L 259.562588 148.328184 
+L 258.188927 148.499738 
+L 256.815266 148.670673 
+L 255.441605 148.840994 
+L 254.067945 149.010705 
+L 252.694284 149.179811 
+L 251.320623 149.348315 
+L 249.946962 149.516223 
+L 248.573301 149.683538 
+L 247.19964 149.850264 
+L 245.82598 150.016406 
+L 244.452319 150.181968 
+L 243.078658 150.346953 
+L 241.704997 150.511366 
+L 240.331336 150.675211 
+L 238.957675 150.838491 
+L 237.584015 151.001211 
+L 236.210354 151.163374 
+L 234.836693 151.324984 
+L 233.463032 151.486045 
+L 232.089371 151.64656 
+L 230.71571 151.806534 
+L 229.34205 151.96597 
+L 227.968389 152.124871 
+L 226.594728 152.283241 
+L 225.221067 152.441084 
+L 223.847406 152.598403 
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_153">
-    <path d="M 223.847406 155.071426 
-L 223.609872 155.158886 
-L 223.372338 155.246185 
-L 223.134804 155.333324 
-L 222.89727 155.420303 
-L 222.659735 155.507122 
-L 222.422201 155.593783 
-L 222.184667 155.680285 
-L 221.947133 155.76663 
-L 221.709599 155.852818 
-L 221.472065 155.93885 
-L 221.23453 156.024725 
-L 220.996996 156.110445 
-L 220.759462 156.196011 
-L 220.521928 156.281422 
-L 220.284394 156.36668 
-L 220.04686 156.451785 
-L 219.809325 156.536737 
-L 219.571791 156.621537 
-L 219.334257 156.706186 
-L 219.096723 156.790684 
-L 218.859189 156.875031 
-L 218.621655 156.959229 
-L 218.38412 157.043277 
-L 218.146586 157.127177 
-L 217.909052 157.210928 
-L 217.671518 157.294531 
-L 217.433984 157.377988 
-L 217.19645 157.461298 
-L 216.958916 157.544461 
-L 216.721381 157.627479 
-L 216.483847 157.710352 
-L 216.246313 157.79308 
-L 216.008779 157.875664 
-L 215.771245 157.958104 
-L 215.533711 158.040401 
-L 215.296176 158.122556 
-L 215.058642 158.204568 
-L 214.821108 158.286439 
-L 214.583574 158.368168 
-L 214.34604 158.449757 
-L 214.108506 158.531206 
-L 213.870971 158.612515 
-L 213.633437 158.693684 
-L 213.395903 158.774715 
-L 213.158369 158.855608 
-L 212.920835 158.936363 
-L 212.683301 159.01698 
-L 212.445767 159.097461 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 223.847406 152.598403 
+L 223.609872 152.691249 
+L 223.372338 152.783914 
+L 223.134804 152.876398 
+L 222.89727 152.968702 
+L 222.659735 153.060827 
+L 222.422201 153.152773 
+L 222.184667 153.244541 
+L 221.947133 153.336131 
+L 221.709599 153.427545 
+L 221.472065 153.518783 
+L 221.23453 153.609846 
+L 220.996996 153.700734 
+L 220.759462 153.791448 
+L 220.521928 153.881989 
+L 220.284394 153.972357 
+L 220.04686 154.062553 
+L 219.809325 154.152578 
+L 219.571791 154.242432 
+L 219.334257 154.332116 
+L 219.096723 154.421631 
+L 218.859189 154.510977 
+L 218.621655 154.600156 
+L 218.38412 154.689166 
+L 218.146586 154.77801 
+L 217.909052 154.866687 
+L 217.671518 154.955199 
+L 217.433984 155.043546 
+L 217.19645 155.131729 
+L 216.958916 155.219748 
+L 216.721381 155.307603 
+L 216.483847 155.395296 
+L 216.246313 155.482828 
+L 216.008779 155.570197 
+L 215.771245 155.657406 
+L 215.533711 155.744455 
+L 215.296176 155.831345 
+L 215.058642 155.918075 
+L 214.821108 156.004647 
+L 214.583574 156.091061 
+L 214.34604 156.177318 
+L 214.108506 156.263418 
+L 213.870971 156.349362 
+L 213.633437 156.435151 
+L 213.395903 156.520784 
+L 213.158369 156.606263 
+L 212.920835 156.691589 
+L 212.683301 156.776761 
+L 212.445767 156.86178 
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_154">
-    <path d="M 212.445767 159.097461 
-L 211.79831 159.358294 
-L 211.150853 159.617699 
-L 210.503396 159.875692 
-L 209.85594 160.132289 
-L 209.208483 160.387504 
-L 208.561026 160.641352 
-L 207.913569 160.893848 
-L 207.266113 161.145007 
-L 206.618656 161.394841 
-L 205.971199 161.643365 
-L 205.323743 161.890593 
-L 204.676286 162.136538 
-L 204.028829 162.381214 
-L 203.381372 162.624633 
-L 202.733916 162.866809 
-L 202.086459 163.107753 
-L 201.439002 163.347479 
-L 200.791546 163.585998 
-L 200.144089 163.823323 
-L 199.496632 164.059466 
-L 198.849175 164.294438 
-L 198.201719 164.528251 
-L 197.554262 164.760916 
-L 196.906805 164.992445 
-L 196.259348 165.222848 
-L 195.611892 165.452137 
-L 194.964435 165.680322 
-L 194.316978 165.907414 
-L 193.669522 166.133423 
-L 193.022065 166.358359 
-L 192.374608 166.582233 
-L 191.727151 166.805054 
-L 191.079695 167.026833 
-L 190.432238 167.247579 
-L 189.784781 167.467302 
-L 189.137324 167.686011 
-L 188.489868 167.903715 
-L 187.842411 168.120424 
-L 187.194954 168.336147 
-L 186.547498 168.550893 
-L 185.900041 168.764669 
-L 185.252584 168.977486 
-L 184.605127 169.189352 
-L 183.957671 169.400275 
-L 183.310214 169.610263 
-L 182.662757 169.819326 
-L 182.015301 170.02747 
-L 181.367844 170.234704 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 212.445767 156.86178 
+L 211.79831 157.136988 
+L 211.150853 157.410608 
+L 210.503396 157.682657 
+L 209.85594 157.953154 
+L 209.208483 158.222116 
+L 208.561026 158.48956 
+L 207.913569 158.755504 
+L 207.266113 159.019963 
+L 206.618656 159.282956 
+L 205.971199 159.544497 
+L 205.323743 159.804603 
+L 204.676286 160.06329 
+L 204.028829 160.320572 
+L 203.381372 160.576465 
+L 202.733916 160.830985 
+L 202.086459 161.084145 
+L 201.439002 161.335959 
+L 200.791546 161.586444 
+L 200.144089 161.835611 
+L 199.496632 162.083475 
+L 198.849175 162.330051 
+L 198.201719 162.575349 
+L 197.554262 162.819385 
+L 196.906805 163.062171 
+L 196.259348 163.30372 
+L 195.611892 163.544044 
+L 194.964435 163.783156 
+L 194.316978 164.021067 
+L 193.669522 164.257791 
+L 193.022065 164.493338 
+L 192.374608 164.72772 
+L 191.727151 164.960948 
+L 191.079695 165.193035 
+L 190.432238 165.423991 
+L 189.784781 165.653827 
+L 189.137324 165.882554 
+L 188.489868 166.110183 
+L 187.842411 166.336724 
+L 187.194954 166.562187 
+L 186.547498 166.786582 
+L 185.900041 167.009921 
+L 185.252584 167.232211 
+L 184.605127 167.453465 
+L 183.957671 167.67369 
+L 183.310214 167.892897 
+L 182.662757 168.111094 
+L 182.015301 168.328292 
+L 181.367844 168.544499 
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_155">
-    <path d="M 181.367844 170.234704 
-L 181.033285 170.435135 
-L 180.698725 170.634723 
-L 180.364166 170.833473 
-L 180.029607 171.031393 
-L 179.695047 171.228491 
-L 179.360488 171.424772 
-L 179.025929 171.620244 
-L 178.69137 171.814913 
-L 178.35681 172.008785 
-L 178.022251 172.201868 
-L 177.687692 172.394168 
-L 177.353133 172.585691 
-L 177.018573 172.776442 
-L 176.684014 172.96643 
-L 176.349455 173.155658 
-L 176.014895 173.344135 
-L 175.680336 173.531865 
-L 175.345777 173.718854 
-L 175.011218 173.905108 
-L 174.676658 174.090634 
-L 174.342099 174.275436 
-L 174.00754 174.45952 
-L 173.672981 174.642892 
-L 173.338421 174.825558 
-L 173.003862 175.007522 
-L 172.669303 175.188791 
-L 172.334743 175.369368 
-L 172.000184 175.549261 
-L 171.665625 175.728473 
-L 171.331066 175.90701 
-L 170.996506 176.084878 
-L 170.661947 176.26208 
-L 170.327388 176.438622 
-L 169.992829 176.61451 
-L 169.658269 176.789747 
-L 169.32371 176.964338 
-L 168.989151 177.138289 
-L 168.654591 177.311603 
-L 168.320032 177.484287 
-L 167.985473 177.656343 
-L 167.650914 177.827777 
-L 167.316354 177.998593 
-L 166.981795 178.168796 
-L 166.647236 178.33839 
-L 166.312676 178.50738 
-L 165.978117 178.675768 
-L 165.643558 178.843561 
-L 165.308999 179.010762 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 181.367844 168.544499 
+L 181.033285 168.760041 
+L 180.698725 168.974607 
+L 180.364166 169.188206 
+L 180.029607 169.400847 
+L 179.695047 169.612539 
+L 179.360488 169.823289 
+L 179.025929 170.033106 
+L 178.69137 170.241998 
+L 178.35681 170.449974 
+L 178.022251 170.657041 
+L 177.687692 170.863208 
+L 177.353133 171.068482 
+L 177.018573 171.27287 
+L 176.684014 171.476381 
+L 176.349455 171.679022 
+L 176.014895 171.880801 
+L 175.680336 172.081724 
+L 175.345777 172.281798 
+L 175.011218 172.481032 
+L 174.676658 172.679432 
+L 174.342099 172.877005 
+L 174.00754 173.073758 
+L 173.672981 173.269697 
+L 173.338421 173.46483 
+L 173.003862 173.659163 
+L 172.669303 173.852702 
+L 172.334743 174.045455 
+L 172.000184 174.237426 
+L 171.665625 174.428623 
+L 171.331066 174.619052 
+L 170.996506 174.80872 
+L 170.661947 174.997631 
+L 170.327388 175.185792 
+L 169.992829 175.373209 
+L 169.658269 175.559888 
+L 169.32371 175.745835 
+L 168.989151 175.931055 
+L 168.654591 176.115554 
+L 168.320032 176.299338 
+L 167.985473 176.482412 
+L 167.650914 176.664781 
+L 167.316354 176.846452 
+L 166.981795 177.027429 
+L 166.647236 177.207717 
+L 166.312676 177.387322 
+L 165.978117 177.56625 
+L 165.643558 177.744504 
+L 165.308999 177.922091 
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_156">
-    <path d="M 165.308999 179.010762 
-L 165.199956 179.16456 
-L 165.090913 179.317861 
-L 164.98187 179.470667 
-L 164.872828 179.622982 
-L 164.763785 179.774809 
-L 164.654742 179.926152 
-L 164.5457 180.077013 
-L 164.436657 180.227395 
-L 164.327614 180.377302 
-L 164.218571 180.526736 
-L 164.109529 180.6757 
-L 164.000486 180.824198 
-L 163.891443 180.972232 
-L 163.782401 181.119805 
-L 163.673358 181.26692 
-L 163.564315 181.41358 
-L 163.455272 181.559787 
-L 163.34623 181.705545 
-L 163.237187 181.850856 
-L 163.128144 181.995722 
-L 163.019101 182.140148 
-L 162.910059 182.284135 
-L 162.801016 182.427685 
-L 162.691973 182.570802 
-L 162.582931 182.713489 
-L 162.473888 182.855747 
-L 162.364845 182.997579 
-L 162.255802 183.138988 
-L 162.14676 183.279977 
-L 162.037717 183.420548 
-L 161.928674 183.560702 
-L 161.819631 183.700444 
-L 161.710589 183.839775 
-L 161.601546 183.978697 
-L 161.492503 184.117214 
-L 161.383461 184.255327 
-L 161.274418 184.393038 
-L 161.165375 184.530351 
-L 161.056332 184.667267 
-L 160.94729 184.803789 
-L 160.838247 184.939919 
-L 160.729204 185.075658 
-L 160.620161 185.21101 
-L 160.511119 185.345977 
-L 160.402076 185.480561 
-L 160.293033 185.614763 
-L 160.183991 185.748587 
-L 160.074948 185.882034 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 165.308999 177.922091 
+L 165.199956 178.070481 
+L 165.090913 178.218408 
+L 164.98187 178.365875 
+L 164.872828 178.512884 
+L 164.763785 178.659439 
+L 164.654742 178.805542 
+L 164.5457 178.951196 
+L 164.436657 179.096404 
+L 164.327614 179.241168 
+L 164.218571 179.385492 
+L 164.109529 179.529378 
+L 164.000486 179.672828 
+L 163.891443 179.815845 
+L 163.782401 179.958432 
+L 163.673358 180.100591 
+L 163.564315 180.242326 
+L 163.455272 180.383637 
+L 163.34623 180.524529 
+L 163.237187 180.665003 
+L 163.128144 180.805062 
+L 163.019101 180.944708 
+L 162.910059 181.083945 
+L 162.801016 181.222773 
+L 162.691973 181.361196 
+L 162.582931 181.499216 
+L 162.473888 181.636835 
+L 162.364845 181.774055 
+L 162.255802 181.91088 
+L 162.14676 182.047311 
+L 162.037717 182.18335 
+L 161.928674 182.319 
+L 161.819631 182.454263 
+L 161.710589 182.58914 
+L 161.601546 182.723636 
+L 161.492503 182.85775 
+L 161.383461 182.991486 
+L 161.274418 183.124846 
+L 161.165375 183.257832 
+L 161.056332 183.390446 
+L 160.94729 183.522689 
+L 160.838247 183.654565 
+L 160.729204 183.786075 
+L 160.620161 183.917221 
+L 160.511119 184.048005 
+L 160.402076 184.178429 
+L 160.293033 184.308496 
+L 160.183991 184.438206 
+L 160.074948 184.567562 
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_157">
-    <path d="M 160.074948 185.882034 
-L 160.011502 185.949096 
-L 159.948056 186.016065 
-L 159.88461 186.082938 
-L 159.821164 186.149718 
-L 159.757718 186.216404 
-L 159.694272 186.282995 
-L 159.630826 186.349494 
-L 159.56738 186.415899 
-L 159.503933 186.482211 
-L 159.440487 186.548431 
-L 159.377041 186.614559 
-L 159.313595 186.680594 
-L 159.250149 186.746537 
-L 159.186703 186.812389 
-L 159.123257 186.878149 
-L 159.059811 186.943819 
-L 158.996365 187.009397 
-L 158.932919 187.074885 
-L 158.869473 187.140282 
-L 158.806027 187.20559 
-L 158.742581 187.270807 
-L 158.679135 187.335935 
-L 158.615689 187.400973 
-L 158.552243 187.465923 
-L 158.488797 187.530783 
-L 158.425351 187.595555 
-L 158.361905 187.660239 
-L 158.298459 187.724834 
-L 158.235013 187.789342 
-L 158.171567 187.853761 
-L 158.108121 187.918094 
-L 158.044675 187.982339 
-L 157.981229 188.046497 
-L 157.917783 188.110568 
-L 157.854337 188.174553 
-L 157.790891 188.238452 
-L 157.727444 188.302265 
-L 157.663998 188.365991 
-L 157.600552 188.429633 
-L 157.537106 188.493189 
-L 157.47366 188.55666 
-L 157.410214 188.620046 
-L 157.346768 188.683347 
-L 157.283322 188.746564 
-L 157.219876 188.809697 
-L 157.15643 188.872745 
-L 157.092984 188.93571 
-L 157.029538 188.998592 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 160.074948 184.567562 
+L 160.011502 184.636037 
+L 159.948056 184.704413 
+L 159.88461 184.77269 
+L 159.821164 184.84087 
+L 159.757718 184.908951 
+L 159.694272 184.976935 
+L 159.630826 185.044821 
+L 159.56738 185.11261 
+L 159.503933 185.180302 
+L 159.440487 185.247898 
+L 159.377041 185.315398 
+L 159.313595 185.382801 
+L 159.250149 185.450109 
+L 159.186703 185.517321 
+L 159.123257 185.584439 
+L 159.059811 185.651461 
+L 158.996365 185.718389 
+L 158.932919 185.785222 
+L 158.869473 185.851961 
+L 158.806027 185.918607 
+L 158.742581 185.985158 
+L 158.679135 186.051617 
+L 158.615689 186.117982 
+L 158.552243 186.184255 
+L 158.488797 186.250435 
+L 158.425351 186.316523 
+L 158.361905 186.382519 
+L 158.298459 186.448423 
+L 158.235013 186.514235 
+L 158.171567 186.579957 
+L 158.108121 186.645587 
+L 158.044675 186.711126 
+L 157.981229 186.776576 
+L 157.917783 186.841934 
+L 157.854337 186.907203 
+L 157.790891 186.972382 
+L 157.727444 187.037472 
+L 157.663998 187.102472 
+L 157.600552 187.167383 
+L 157.537106 187.232206 
+L 157.47366 187.29694 
+L 157.410214 187.361585 
+L 157.346768 187.426143 
+L 157.283322 187.490613 
+L 157.219876 187.554995 
+L 157.15643 187.61929 
+L 157.092984 187.683498 
+L 157.029538 187.747619 
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_158">
-    <path d="M 157.029538 188.998592 
-L 156.877361 189.199859 
-L 156.725185 189.400276 
-L 156.573008 189.599849 
-L 156.420832 189.798585 
-L 156.268655 189.996491 
-L 156.116478 190.193575 
-L 155.964302 190.389842 
-L 155.812125 190.5853 
-L 155.659949 190.779956 
-L 155.507772 190.973815 
-L 155.355595 191.166884 
-L 155.203419 191.35917 
-L 155.051242 191.55068 
-L 154.899065 191.741419 
-L 154.746889 191.931393 
-L 154.594712 192.120609 
-L 154.442536 192.309072 
-L 154.290359 192.496789 
-L 154.138182 192.683766 
-L 153.986006 192.870008 
-L 153.833829 193.055521 
-L 153.681652 193.240311 
-L 153.529476 193.424383 
-L 153.377299 193.607743 
-L 153.225123 193.790396 
-L 153.072946 193.972349 
-L 152.920769 194.153605 
-L 152.768593 194.334171 
-L 152.616416 194.514052 
-L 152.46424 194.693253 
-L 152.312063 194.871779 
-L 152.159886 195.049635 
-L 152.00771 195.226826 
-L 151.855533 195.403357 
-L 151.703356 195.579233 
-L 151.55118 195.754459 
-L 151.399003 195.929039 
-L 151.246827 196.102979 
-L 151.09465 196.276283 
-L 150.942473 196.448955 
-L 150.790297 196.621001 
-L 150.63812 196.792424 
-L 150.485943 196.96323 
-L 150.333767 197.133423 
-L 150.18159 197.303006 
-L 150.029414 197.471985 
-L 149.877237 197.640364 
-L 149.72506 197.808147 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 157.029538 187.747619 
+L 156.877361 187.951718 
+L 156.725185 188.154942 
+L 156.573008 188.357299 
+L 156.420832 188.558795 
+L 156.268655 188.759439 
+L 156.116478 188.959236 
+L 155.964302 189.158195 
+L 155.812125 189.356322 
+L 155.659949 189.553625 
+L 155.507772 189.75011 
+L 155.355595 189.945783 
+L 155.203419 190.140652 
+L 155.051242 190.334724 
+L 154.899065 190.528003 
+L 154.746889 190.720498 
+L 154.594712 190.912215 
+L 154.442536 191.103159 
+L 154.290359 191.293336 
+L 154.138182 191.482754 
+L 153.986006 191.671418 
+L 153.833829 191.859334 
+L 153.681652 192.046508 
+L 153.529476 192.232946 
+L 153.377299 192.418653 
+L 153.225123 192.603635 
+L 153.072946 192.787899 
+L 152.920769 192.971448 
+L 152.768593 193.15429 
+L 152.616416 193.336429 
+L 152.46424 193.517871 
+L 152.312063 193.698621 
+L 152.159886 193.878685 
+L 152.00771 194.058066 
+L 151.855533 194.236772 
+L 151.703356 194.414806 
+L 151.55118 194.592175 
+L 151.399003 194.768881 
+L 151.246827 194.944932 
+L 151.09465 195.120331 
+L 150.942473 195.295084 
+L 150.790297 195.469194 
+L 150.63812 195.642667 
+L 150.485943 195.815508 
+L 150.333767 195.987721 
+L 150.18159 196.15931 
+L 150.029414 196.33028 
+L 149.877237 196.500636 
+L 149.72506 196.670382 
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_159">
-    <path d="M 149.72506 197.808147 
-L 149.001675 201.602957 
-L 148.27829 205.116343 
-L 147.554905 208.387179 
-L 146.831519 211.446803 
-L 146.108134 214.320845 
-L 145.384749 217.030538 
-L 144.661364 219.593664 
-L 143.937979 222.025269 
-L 143.214593 224.338195 
-L 142.491208 226.543489 
-L 141.767823 228.650724 
-L 141.044438 230.66825 
-L 140.321052 232.603396 
-L 139.597667 234.462625 
-L 138.874282 236.25167 
-L 138.150897 237.975638 
-L 137.427512 239.639097 
-L 136.704126 241.246151 
-L 135.980741 242.800499 
-L 135.257356 244.305491 
-L 134.533971 245.764164 
-L 133.810585 247.179284 
-L 133.0872 248.553376 
-L 132.363815 249.888754 
-L 131.64043 251.187538 
-L 130.917045 252.451682 
-L 130.193659 253.682984 
-L 129.470274 254.883108 
-L 128.746889 256.053595 
-L 128.023504 257.195872 
-L 127.300118 258.311268 
-L 126.576733 259.401018 
-L 125.853348 260.466277 
-L 125.129963 261.508119 
-L 124.406577 262.527553 
-L 123.683192 263.525523 
-L 122.959807 264.502913 
-L 122.236422 265.460555 
-L 121.513037 266.399232 
-L 120.789651 267.31968 
-L 120.066266 268.222594 
-L 119.342881 269.108628 
-L 118.619496 269.978404 
-L 117.89611 270.832506 
-L 117.172725 271.67149 
-L 116.44934 272.495881 
-L 115.725955 273.306179 
-L 115.00257 274.102857 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 149.72506 196.670382 
+L 149.001675 200.537761 
+L 148.27829 204.113258 
+L 147.554905 207.437856 
+L 146.831519 210.54447 
+L 146.108134 213.459935 
+L 145.384749 216.206416 
+L 144.661364 218.802434 
+L 143.937979 221.263622 
+L 143.214593 223.603297 
+L 142.491208 225.832894 
+L 141.767823 227.962308 
+L 141.044438 230.000157 
+L 140.321052 231.953991 
+L 139.597667 233.830464 
+L 138.874282 235.63547 
+L 138.150897 237.374253 
+L 137.427512 239.051501 
+L 136.704126 240.671422 
+L 135.980741 242.237804 
+L 135.257356 243.754074 
+L 134.533971 245.223339 
+L 133.810585 246.648426 
+L 133.0872 248.031915 
+L 132.363815 249.376164 
+L 131.64043 250.683339 
+L 130.917045 251.95543 
+L 130.193659 253.194271 
+L 129.470274 254.401557 
+L 128.746889 255.578853 
+L 128.023504 256.727616 
+L 127.300118 257.849195 
+L 126.576733 258.944846 
+L 125.853348 260.015742 
+L 125.129963 261.062977 
+L 124.406577 262.087573 
+L 123.683192 263.090489 
+L 122.959807 264.072624 
+L 122.236422 265.03482 
+L 121.513037 265.977872 
+L 120.789651 266.902526 
+L 120.066266 267.809487 
+L 119.342881 268.699418 
+L 118.619496 269.572949 
+L 117.89611 270.430671 
+L 117.172725 271.273148 
+L 116.44934 272.100912 
+L 115.725955 272.914468 
+L 115.00257 273.714295 
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_160">
-    <path d="M 115.00257 274.102857 
-L 114.685339 274.831618 
-L 114.368108 275.549344 
-L 114.050877 276.256364 
-L 113.733646 276.952992 
-L 113.416415 277.639531 
-L 113.099184 278.316267 
-L 112.781954 278.983477 
-L 112.464723 279.641425 
-L 112.147492 280.290365 
-L 111.830261 280.93054 
-L 111.51303 281.562184 
-L 111.195799 282.185521 
-L 110.878569 282.800767 
-L 110.561338 283.40813 
-L 110.244107 284.007808 
-L 109.926876 284.599993 
-L 109.609645 285.184872 
-L 109.292414 285.762621 
-L 108.975184 286.333413 
-L 108.657953 286.897412 
-L 108.340722 287.45478 
-L 108.023491 288.005669 
-L 107.70626 288.55023 
-L 107.389029 289.088605 
-L 107.071799 289.620933 
-L 106.754568 290.14735 
-L 106.437337 290.667984 
-L 106.120106 291.182961 
-L 105.802875 291.692404 
-L 105.485644 292.196429 
-L 105.168414 292.695151 
-L 104.851183 293.18868 
-L 104.533952 293.677123 
-L 104.216721 294.160584 
-L 103.89949 294.639164 
-L 103.582259 295.11296 
-L 103.265028 295.582066 
-L 102.947798 296.046576 
-L 102.630567 296.506577 
-L 102.313336 296.962157 
-L 101.996105 297.413399 
-L 101.678874 297.860387 
-L 101.361643 298.303198 
-L 101.044413 298.741911 
-L 100.727182 299.1766 
-L 100.409951 299.607339 
-L 100.09272 300.034199 
-L 99.775489 300.457249 
-" clip-path="url(#pb239c4b002)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 115.00257 273.714295 
+L 114.685339 274.422561 
+L 114.368108 275.1204 
+L 114.050877 275.808113 
+L 113.733646 276.485991 
+L 113.416415 277.15431 
+L 113.099184 277.813337 
+L 112.781954 278.463327 
+L 112.464723 279.104524 
+L 112.147492 279.737163 
+L 111.830261 280.361468 
+L 111.51303 280.977658 
+L 111.195799 281.58594 
+L 110.878569 282.186514 
+L 110.561338 282.779574 
+L 110.244107 283.365305 
+L 109.926876 283.943886 
+L 109.609645 284.51549 
+L 109.292414 285.080282 
+L 108.975184 285.638424 
+L 108.657953 286.19007 
+L 108.340722 286.735369 
+L 108.023491 287.274467 
+L 107.70626 287.807501 
+L 107.389029 288.334608 
+L 107.071799 288.855918 
+L 106.754568 289.371556 
+L 106.437337 289.881646 
+L 106.120106 290.386304 
+L 105.802875 290.885646 
+L 105.485644 291.379782 
+L 105.168414 291.868819 
+L 104.851183 292.352863 
+L 104.533952 292.832013 
+L 104.216721 293.306368 
+L 103.89949 293.776023 
+L 103.582259 294.24107 
+L 103.265028 294.701599 
+L 102.947798 295.157696 
+L 102.630567 295.609446 
+L 102.313336 296.056931 
+L 101.996105 296.500231 
+L 101.678874 296.939423 
+L 101.361643 297.374583 
+L 101.044413 297.805784 
+L 100.727182 298.233098 
+L 100.409951 298.656594 
+L 100.09272 299.07634 
+L 99.775489 299.492401 
+" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
   </g>
   <g id="text_25">
@@ -6254,8 +6254,8 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-07-09T07:09:47Z  ·  Linux chungus2 x86_64  ·  commit b23a23be  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(43.545547 465.66) scale(0.07 -0.07)">
+   <!-- 2026-07-09T17:31:54Z  ·  Linux chungus2 x86_64  ·  commit 324f086c  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(44.677578 465.66) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -6319,6 +6319,31 @@ L 1409 3309
 L 1409 2516 
 L 750 2516 
 L 750 3309 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-b7" d="M 684 2619 
@@ -6418,14 +6443,14 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-39" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
     <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -6465,109 +6490,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3135.351562 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3198.974609 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3262.597656 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3323.876953 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3387.5 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3451.123047 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3514.599609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3576.123047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3607.910156 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3639.697266 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3671.484375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3703.271484 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3735.058594 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3762.841797 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3824.365234 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3885.644531 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3949.023438 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4012.5 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4051.363281 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4112.544922 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4171.724609 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4233.248047 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4274.361328 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4308.052734 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4335.835938 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4397.359375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4458.638672 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4522.017578 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4585.640625 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4619.332031 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4678.511719 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4742.134766 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4773.921875 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4837.544922 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4901.167969 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4932.955078 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4996.578125 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5032.662109 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5071.525391 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5126.505859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5190.128906 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5221.916016 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5253.703125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5285.490234 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5317.277344 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5349.064453 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5388.273438 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5451.652344 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5490.515625 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5551.697266 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5615.076172 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5678.552734 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5741.931641 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5805.408203 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5868.787109 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5907.996094 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5939.783203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6023.572266 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6055.359375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6152.771484 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6214.294922 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6277.771484 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6305.554688 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6366.833984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6430.212891 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6462 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6514.099609 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6577.478516 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6638.757812 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6702.234375 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6754.333984 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6817.712891 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6878.894531 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6918.103516 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6951.794922 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6983.582031 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7024.695312 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7085.974609 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7125.183594 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7152.966797 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7214.148438 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7245.935547 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7273.71875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7325.818359 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7357.605469 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7421.082031 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7482.605469 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7521.814453 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7583.337891 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7622.701172 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7720.113281 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7747.896484 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7811.275391 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7839.058594 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7891.158203 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7930.367188 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7958.150391 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3262.744141 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3297.949219 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3361.572266 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3425.195312 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3488.818359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3543.798828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3575.585938 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3607.373047 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3639.160156 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3670.947266 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3702.734375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3730.517578 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3792.041016 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3853.320312 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3916.699219 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3980.175781 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4019.039062 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4080.220703 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4139.400391 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4200.923828 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4242.037109 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4275.728516 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4303.511719 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4365.035156 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4426.314453 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4489.693359 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4553.316406 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4587.007812 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4646.1875 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4709.810547 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4741.597656 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4805.220703 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4868.84375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4900.630859 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4964.253906 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5000.337891 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5039.201172 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5094.181641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5157.804688 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5189.591797 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5221.378906 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5253.166016 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5284.953125 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5316.740234 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5355.949219 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5419.328125 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5458.191406 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5519.373047 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5582.751953 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5646.228516 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5709.607422 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5773.083984 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5836.462891 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5875.671875 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5907.458984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5991.248047 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6023.035156 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6120.447266 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6181.970703 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6245.447266 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6273.230469 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6334.509766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6397.888672 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6429.675781 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6481.775391 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6545.154297 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6606.433594 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6669.910156 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6722.009766 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6785.388672 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6846.570312 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6885.779297 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6919.470703 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6951.257812 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6992.371094 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7053.650391 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7092.859375 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7120.642578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7181.824219 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7213.611328 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7241.394531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7293.494141 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7325.28125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7388.757812 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7450.28125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7489.490234 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7551.013672 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7590.376953 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7687.789062 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7715.572266 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7778.951172 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7806.734375 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7858.833984 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7898.042969 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7925.826172 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pb239c4b002">
+  <clipPath id="pa93c90c411">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_ratio_heatmap.svg
+++ b/bench/graphs/canterbury_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p214fe99e80)">
+   <g clip-path="url(#pce3af741db)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAI/ElEQVR4nO3YwYqkVx2H4aqe7qZnxAFlEodZCu4kuMjG2bj2TnIFLsW91xG9AUFEdCOKGzfiTrILEmIyxnEmdNdUf+UlTIQT/lLv81zB71DU+V7OfvvXh6fduXn12fSCpU6fn9d5drvd7uOf/Gp6wlIf/fX19ITlfvSLH09PWG7/g/enJ6y1v5hesN7LT6YXrHfzeHrBUr/8zs+nJyx3hv8kAICvTgwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKTt746/Pk2PWO2026YnLLU/w2a9urienrDUYbudnrDc1d/+PD1hueP3n09PWOq4HaYnLPf6+HJ6wnJPzux6ePP4yfSE5c7vKwsA8D8QQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaZdXr7+Y3rDe3ZfTC9Y6bdML1nv4eHrBUtfTA74Gp5evpycsd/WfF9MTlrrajtMTlnt4jvfd7avpBUtdXZ7fjedlCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGn74/bb0/SI1U6nbXrCUtuZnWe32+2uLq6nJyx1fzpOT1juwasX0xPW++a70wuWerMdpics9/ntP6YnLPf07nJ6wlLbt55NT1jOyxAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkHb5l0//OL1huYvdfnrCUu88ejI9Ybn77Tg9YanrBzfTE5b74Pd/mJ6w3M9++L3pCUsdT9v0hOV++qe/T09Y7vmzb0xPWOqD955PT1jOyxAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDS9m/uf3OaHrHa4f52esJSD/c30xN4i8P+OD1huX/ffTY9Yblv3zydnrDUdtqmJyz3xd2n0xOWe3H3yfSEpb77+L3pCct5GQIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAEDaftt+d5oeAfwfOh6mF6x3eT29gLe4vf9yesJyNw8eTU/gLbwMAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIO1yd3+c3rDexZk13v7MzrPb7XZvbqcXrHVxOb1gucPFNj1huevpAaudzu83Om6H6QnL/fPwYnrCUu/cPJuesNwZfmUBAL46MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkPZfKmeKG6wY/4kAAAAASUVORK5CYII=" id="image5ae7ea062a" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAI/ElEQVR4nO3YwYqkVx2H4aqe7qZnxAFlEodZCu4kuMjG2bj2TnIFLsW91xG9AUFEdCOKGzfiTrILEmIyxnEmdNdUf+UlTIQT/lLv81zB71DU+V7OfvvXh6fduXn12fSCpU6fn9d5drvd7uOf/Gp6wlIf/fX19ITlfvSLH09PWG7/g/enJ6y1v5hesN7LT6YXrHfzeHrBUr/8zs+nJyx3hv8kAICvTgwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKTt746/Pk2PWO2026YnLLU/w2a9urienrDUYbudnrDc1d/+PD1hueP3n09PWOq4HaYnLPf6+HJ6wnJPzux6ePP4yfSE5c7vKwsA8D8QQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaZdXr7+Y3rDe3ZfTC9Y6bdML1nv4eHrBUtfTA74Gp5evpycsd/WfF9MTlrrajtMTlnt4jvfd7avpBUtdXZ7fjedlCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGn74/bb0/SI1U6nbXrCUtuZnWe32+2uLq6nJyx1fzpOT1juwasX0xPW++a70wuWerMdpics9/ntP6YnLPf07nJ6wlLbt55NT1jOyxAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkHb5l0//OL1huYvdfnrCUu88ejI9Ybn77Tg9YanrBzfTE5b74Pd/mJ6w3M9++L3pCUsdT9v0hOV++qe/T09Y7vmzb0xPWOqD955PT1jOyxAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDS9m/uf3OaHrHa4f52esJSD/c30xN4i8P+OD1huX/ffTY9Yblv3zydnrDUdtqmJyz3xd2n0xOWe3H3yfSEpb77+L3pCct5GQIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAEDaftt+d5oeAfwfOh6mF6x3eT29gLe4vf9yesJyNw8eTU/gLbwMAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIO1yd3+c3rDexZk13v7MzrPb7XZvbqcXrHVxOb1gucPFNj1huevpAaudzu83Om6H6QnL/fPwYnrCUu/cPJuesNwZfmUBAL46MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkPZfKmeKG6wY/4kAAAAASUVORK5CYII=" id="imagec337e14d61" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m965626cd06" d="M 0 0 
+       <path id="m050ca7c316" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m965626cd06" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m050ca7c316" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m965626cd06" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m050ca7c316" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m965626cd06" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m050ca7c316" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m965626cd06" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m050ca7c316" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m965626cd06" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m050ca7c316" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m965626cd06" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m050ca7c316" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m965626cd06" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m050ca7c316" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m965626cd06" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m050ca7c316" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m965626cd06" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m050ca7c316" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m965626cd06" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m050ca7c316" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m965626cd06" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m050ca7c316" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="mfa771d3a1b" d="M 0 0 
+       <path id="me9a9fedfb0" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mfa771d3a1b" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me9a9fedfb0" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#mfa771d3a1b" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me9a9fedfb0" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mfa771d3a1b" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me9a9fedfb0" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#mfa771d3a1b" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me9a9fedfb0" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#mfa771d3a1b" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me9a9fedfb0" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#mfa771d3a1b" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me9a9fedfb0" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mfa771d3a1b" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me9a9fedfb0" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#mfa771d3a1b" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me9a9fedfb0" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -2092,18 +2092,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="image85983c84ba" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
+iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="image8b65da8b18" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="m00153163a2" d="M 0 0 
+       <path id="mb4983ae5c3" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m00153163a2" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb4983ae5c3" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
@@ -2129,7 +2129,7 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m00153163a2" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb4983ae5c3" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
@@ -2146,7 +2146,7 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m00153163a2" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb4983ae5c3" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
@@ -2163,7 +2163,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m00153163a2" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb4983ae5c3" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
@@ -2180,7 +2180,7 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m00153163a2" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb4983ae5c3" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_112">
@@ -2196,7 +2196,7 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m00153163a2" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb4983ae5c3" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
@@ -2212,7 +2212,7 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m00153163a2" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb4983ae5c3" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
@@ -2228,7 +2228,7 @@ z
     <g id="ytick_16">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#m00153163a2" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb4983ae5c3" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_115">
@@ -2244,7 +2244,7 @@ z
     <g id="ytick_17">
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m00153163a2" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb4983ae5c3" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_116">
@@ -2882,8 +2882,8 @@ z
    </g>
   </g>
   <g id="text_119">
-   <!-- 2026-07-09T07:09:47Z  ·  Linux chungus2 x86_64  ·  commit b23a23be  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(16.545547 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-09T17:31:54Z  ·  Linux chungus2 x86_64  ·  commit 324f086c  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(17.677578 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2952,14 +2952,14 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-39" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
     <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2999,109 +2999,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3135.351562 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3198.974609 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3262.597656 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3323.876953 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3387.5 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3451.123047 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3514.599609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3576.123047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3607.910156 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3639.697266 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3671.484375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3703.271484 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3735.058594 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3762.841797 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3824.365234 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3885.644531 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3949.023438 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4012.5 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4051.363281 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4112.544922 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4171.724609 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4233.248047 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4274.361328 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4308.052734 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4335.835938 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4397.359375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4458.638672 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4522.017578 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4585.640625 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4619.332031 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4678.511719 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4742.134766 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4773.921875 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4837.544922 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4901.167969 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4932.955078 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4996.578125 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5032.662109 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5071.525391 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5126.505859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5190.128906 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5221.916016 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5253.703125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5285.490234 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5317.277344 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5349.064453 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5388.273438 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5451.652344 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5490.515625 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5551.697266 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5615.076172 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5678.552734 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5741.931641 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5805.408203 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5868.787109 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5907.996094 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5939.783203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6023.572266 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6055.359375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6152.771484 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6214.294922 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6277.771484 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6305.554688 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6366.833984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6430.212891 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6462 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6514.099609 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6577.478516 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6638.757812 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6702.234375 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6754.333984 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6817.712891 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6878.894531 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6918.103516 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6951.794922 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6983.582031 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7024.695312 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7085.974609 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7125.183594 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7152.966797 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7214.148438 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7245.935547 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7273.71875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7325.818359 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7357.605469 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7421.082031 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7482.605469 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7521.814453 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7583.337891 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7622.701172 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7720.113281 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7747.896484 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7811.275391 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7839.058594 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7891.158203 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7930.367188 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7958.150391 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3262.744141 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3297.949219 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3361.572266 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3425.195312 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3488.818359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3543.798828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3575.585938 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3607.373047 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3639.160156 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3670.947266 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3702.734375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3730.517578 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3792.041016 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3853.320312 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3916.699219 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3980.175781 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4019.039062 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4080.220703 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4139.400391 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4200.923828 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4242.037109 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4275.728516 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4303.511719 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4365.035156 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4426.314453 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4489.693359 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4553.316406 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4587.007812 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4646.1875 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4709.810547 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4741.597656 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4805.220703 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4868.84375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4900.630859 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4964.253906 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5000.337891 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5039.201172 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5094.181641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5157.804688 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5189.591797 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5221.378906 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5253.166016 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5284.953125 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5316.740234 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5355.949219 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5419.328125 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5458.191406 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5519.373047 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5582.751953 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5646.228516 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5709.607422 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5773.083984 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5836.462891 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5875.671875 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5907.458984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5991.248047 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6023.035156 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6120.447266 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6181.970703 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6245.447266 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6273.230469 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6334.509766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6397.888672 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6429.675781 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6481.775391 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6545.154297 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6606.433594 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6669.910156 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6722.009766 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6785.388672 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6846.570312 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6885.779297 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6919.470703 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6951.257812 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6992.371094 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7053.650391 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7092.859375 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7120.642578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7181.824219 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7213.611328 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7241.394531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7293.494141 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7325.28125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7388.757812 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7450.28125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7489.490234 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7551.013672 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7590.376953 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7687.789062 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7715.572266 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7778.951172 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7806.734375 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7858.833984 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7898.042969 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7925.826172 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p214fe99e80">
+  <clipPath id="pce3af741db">
    <rect x="95.67625" y="49.4355" width="416.571298" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_summary.svg
+++ b/bench/graphs/canterbury_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="575.308906pt" height="386.202469pt" viewBox="0 0 575.308906 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="573.044844pt" height="386.202469pt" viewBox="0 0 573.044844 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,232 +22,232 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 386.202469 
-L 575.308906 386.202469 
-L 575.308906 0 
+L 573.044844 386.202469 
+L 573.044844 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 189.779453 104.1264 
-L 294.404453 104.1264 
-L 294.404453 74.7432 
-L 189.779453 74.7432 
+    <path d="M 188.647422 104.1264 
+L 293.272422 104.1264 
+L 293.272422 74.7432 
+L 188.647422 74.7432 
 z
-" clip-path="url(#p9bc56fbad2)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p74712be3cf)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 294.404453 104.1264 
-L 399.029453 104.1264 
-L 399.029453 74.7432 
-L 294.404453 74.7432 
+    <path d="M 293.272422 104.1264 
+L 397.897422 104.1264 
+L 397.897422 74.7432 
+L 293.272422 74.7432 
 z
-" clip-path="url(#p9bc56fbad2)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p74712be3cf)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 399.029453 104.1264 
-L 503.654453 104.1264 
-L 503.654453 74.7432 
-L 399.029453 74.7432 
+    <path d="M 397.897422 104.1264 
+L 502.522422 104.1264 
+L 502.522422 74.7432 
+L 397.897422 74.7432 
 z
-" clip-path="url(#p9bc56fbad2)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p74712be3cf)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 189.779453 133.5096 
-L 294.404453 133.5096 
-L 294.404453 104.1264 
-L 189.779453 104.1264 
+    <path d="M 188.647422 133.5096 
+L 293.272422 133.5096 
+L 293.272422 104.1264 
+L 188.647422 104.1264 
 z
-" clip-path="url(#p9bc56fbad2)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p74712be3cf)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 294.404453 133.5096 
-L 399.029453 133.5096 
-L 399.029453 104.1264 
-L 294.404453 104.1264 
+    <path d="M 293.272422 133.5096 
+L 397.897422 133.5096 
+L 397.897422 104.1264 
+L 293.272422 104.1264 
 z
-" clip-path="url(#p9bc56fbad2)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p74712be3cf)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 399.029453 133.5096 
-L 503.654453 133.5096 
-L 503.654453 104.1264 
-L 399.029453 104.1264 
+    <path d="M 397.897422 133.5096 
+L 502.522422 133.5096 
+L 502.522422 104.1264 
+L 397.897422 104.1264 
 z
-" clip-path="url(#p9bc56fbad2)" style="fill: #fdb768; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p74712be3cf)" style="fill: #fdb768; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 189.779453 162.8928 
-L 294.404453 162.8928 
-L 294.404453 133.5096 
-L 189.779453 133.5096 
+    <path d="M 188.647422 162.8928 
+L 293.272422 162.8928 
+L 293.272422 133.5096 
+L 188.647422 133.5096 
 z
-" clip-path="url(#p9bc56fbad2)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p74712be3cf)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 294.404453 162.8928 
-L 399.029453 162.8928 
-L 399.029453 133.5096 
-L 294.404453 133.5096 
+    <path d="M 293.272422 162.8928 
+L 397.897422 162.8928 
+L 397.897422 133.5096 
+L 293.272422 133.5096 
 z
-" clip-path="url(#p9bc56fbad2)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p74712be3cf)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 399.029453 162.8928 
-L 503.654453 162.8928 
-L 503.654453 133.5096 
-L 399.029453 133.5096 
+    <path d="M 397.897422 162.8928 
+L 502.522422 162.8928 
+L 502.522422 133.5096 
+L 397.897422 133.5096 
 z
-" clip-path="url(#p9bc56fbad2)" style="fill: #bbe278; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p74712be3cf)" style="fill: #bbe278; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 189.779453 192.276 
-L 294.404453 192.276 
-L 294.404453 162.8928 
-L 189.779453 162.8928 
+    <path d="M 188.647422 192.276 
+L 293.272422 192.276 
+L 293.272422 162.8928 
+L 188.647422 162.8928 
 z
-" clip-path="url(#p9bc56fbad2)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p74712be3cf)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 294.404453 192.276 
-L 399.029453 192.276 
-L 399.029453 162.8928 
-L 294.404453 162.8928 
+    <path d="M 293.272422 192.276 
+L 397.897422 192.276 
+L 397.897422 162.8928 
+L 293.272422 162.8928 
 z
-" clip-path="url(#p9bc56fbad2)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p74712be3cf)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 399.029453 192.276 
-L 503.654453 192.276 
-L 503.654453 162.8928 
-L 399.029453 162.8928 
+    <path d="M 397.897422 192.276 
+L 502.522422 192.276 
+L 502.522422 162.8928 
+L 397.897422 162.8928 
 z
-" clip-path="url(#p9bc56fbad2)" style="fill: #fdc776; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p74712be3cf)" style="fill: #fdc776; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 189.779453 221.6592 
-L 294.404453 221.6592 
-L 294.404453 192.276 
-L 189.779453 192.276 
+    <path d="M 188.647422 221.6592 
+L 293.272422 221.6592 
+L 293.272422 192.276 
+L 188.647422 192.276 
 z
-" clip-path="url(#p9bc56fbad2)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p74712be3cf)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 294.404453 221.6592 
-L 399.029453 221.6592 
-L 399.029453 192.276 
-L 294.404453 192.276 
+    <path d="M 293.272422 221.6592 
+L 397.897422 221.6592 
+L 397.897422 192.276 
+L 293.272422 192.276 
 z
-" clip-path="url(#p9bc56fbad2)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p74712be3cf)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 399.029453 221.6592 
-L 503.654453 221.6592 
-L 503.654453 192.276 
-L 399.029453 192.276 
+    <path d="M 397.897422 221.6592 
+L 502.522422 221.6592 
+L 502.522422 192.276 
+L 397.897422 192.276 
 z
-" clip-path="url(#p9bc56fbad2)" style="fill: #addc6f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p74712be3cf)" style="fill: #addc6f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 189.779453 251.0424 
-L 294.404453 251.0424 
-L 294.404453 221.6592 
-L 189.779453 221.6592 
+    <path d="M 188.647422 251.0424 
+L 293.272422 251.0424 
+L 293.272422 221.6592 
+L 188.647422 221.6592 
 z
-" clip-path="url(#p9bc56fbad2)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p74712be3cf)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 294.404453 251.0424 
-L 399.029453 251.0424 
-L 399.029453 221.6592 
-L 294.404453 221.6592 
+    <path d="M 293.272422 251.0424 
+L 397.897422 251.0424 
+L 397.897422 221.6592 
+L 293.272422 221.6592 
 z
-" clip-path="url(#p9bc56fbad2)" style="fill: #fdbd6d; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p74712be3cf)" style="fill: #fdbd6d; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 399.029453 251.0424 
-L 503.654453 251.0424 
-L 503.654453 221.6592 
-L 399.029453 221.6592 
+    <path d="M 397.897422 251.0424 
+L 502.522422 251.0424 
+L 502.522422 221.6592 
+L 397.897422 221.6592 
 z
-" clip-path="url(#p9bc56fbad2)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p74712be3cf)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 189.779453 280.4256 
-L 294.404453 280.4256 
-L 294.404453 251.0424 
-L 189.779453 251.0424 
+    <path d="M 188.647422 280.4256 
+L 293.272422 280.4256 
+L 293.272422 251.0424 
+L 188.647422 251.0424 
 z
-" clip-path="url(#p9bc56fbad2)" style="fill: #f5fbb2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p74712be3cf)" style="fill: #f5fbb2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 294.404453 280.4256 
-L 399.029453 280.4256 
-L 399.029453 251.0424 
-L 294.404453 251.0424 
+    <path d="M 293.272422 280.4256 
+L 397.897422 280.4256 
+L 397.897422 251.0424 
+L 293.272422 251.0424 
 z
-" clip-path="url(#p9bc56fbad2)" style="fill: #fba35c; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p74712be3cf)" style="fill: #fca55d; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 399.029453 280.4256 
-L 503.654453 280.4256 
-L 503.654453 251.0424 
-L 399.029453 251.0424 
+    <path d="M 397.897422 280.4256 
+L 502.522422 280.4256 
+L 502.522422 251.0424 
+L 397.897422 251.0424 
 z
-" clip-path="url(#p9bc56fbad2)" style="fill: #fca55d; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p74712be3cf)" style="fill: #fca85e; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 189.779453 309.8088 
-L 294.404453 309.8088 
-L 294.404453 280.4256 
-L 189.779453 280.4256 
+    <path d="M 188.647422 309.8088 
+L 293.272422 309.8088 
+L 293.272422 280.4256 
+L 188.647422 280.4256 
 z
-" clip-path="url(#p9bc56fbad2)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p74712be3cf)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 294.404453 309.8088 
-L 399.029453 309.8088 
-L 399.029453 280.4256 
-L 294.404453 280.4256 
+    <path d="M 293.272422 309.8088 
+L 397.897422 309.8088 
+L 397.897422 280.4256 
+L 293.272422 280.4256 
 z
-" clip-path="url(#p9bc56fbad2)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p74712be3cf)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 399.029453 309.8088 
-L 503.654453 309.8088 
-L 503.654453 280.4256 
-L 399.029453 280.4256 
+    <path d="M 397.897422 309.8088 
+L 502.522422 309.8088 
+L 502.522422 280.4256 
+L 397.897422 280.4256 
 z
-" clip-path="url(#p9bc56fbad2)" style="fill: #ee613e; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p74712be3cf)" style="fill: #ee613e; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 189.779453 339.192 
-L 294.404453 339.192 
-L 294.404453 309.8088 
-L 189.779453 309.8088 
+    <path d="M 188.647422 339.192 
+L 293.272422 339.192 
+L 293.272422 309.8088 
+L 188.647422 309.8088 
 z
-" clip-path="url(#p9bc56fbad2)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p74712be3cf)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 294.404453 339.192 
-L 399.029453 339.192 
-L 399.029453 309.8088 
-L 294.404453 309.8088 
+    <path d="M 293.272422 339.192 
+L 397.897422 339.192 
+L 397.897422 309.8088 
+L 293.272422 309.8088 
 z
-" clip-path="url(#p9bc56fbad2)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p74712be3cf)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 399.029453 339.192 
-L 503.654453 339.192 
-L 503.654453 309.8088 
-L 399.029453 309.8088 
+    <path d="M 397.897422 339.192 
+L 502.522422 339.192 
+L 502.522422 309.8088 
+L 397.897422 309.8088 
 z
-" clip-path="url(#p9bc56fbad2)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p74712be3cf)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(122.766719 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(121.634688 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(230.050938 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(228.918906 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(308.623047 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(307.491016 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(406.974766 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(405.842734 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(118.704453 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(117.572422 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.296 -->
-    <g transform="translate(230.640703 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(229.508672 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -946,7 +946,7 @@ z
    </g>
    <g id="text_7">
     <!-- 158 -->
-    <g transform="translate(339.081953 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(337.949922 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -1034,7 +1034,7 @@ z
    </g>
    <g id="text_8">
     <!-- 925 -->
-    <g transform="translate(443.706953 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(442.574922 91.6423) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-39"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
@@ -1042,7 +1042,7 @@ z
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(113.342578 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(112.210547 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1141,7 +1141,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.299 -->
-    <g transform="translate(230.640703 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(229.508672 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1151,7 +1151,7 @@ z
    </g>
    <g id="text_11">
     <!-- 73 -->
-    <g transform="translate(341.626953 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(340.494922 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -1202,7 +1202,7 @@ z
    </g>
    <g id="text_12">
     <!-- 283 -->
-    <g transform="translate(443.706953 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(442.574922 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(127.246094 0)"/>
@@ -1210,7 +1210,7 @@ z
    </g>
    <g id="text_13">
     <!-- zlib -->
-    <g transform="translate(130.605703 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(129.473672 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1234,7 +1234,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.299 -->
-    <g transform="translate(230.640703 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(229.508672 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1244,14 +1244,14 @@ z
    </g>
    <g id="text_15">
     <!-- 55 -->
-    <g transform="translate(341.626953 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(340.494922 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
     <!-- 692 -->
-    <g transform="translate(443.706953 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(442.574922 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-36"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
@@ -1259,7 +1259,7 @@ z
    </g>
    <g id="text_17">
     <!-- Go compress/flate -->
-    <g transform="translate(101.035703 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(99.903672 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -1430,7 +1430,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.299 -->
-    <g transform="translate(230.640703 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(229.508672 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1440,14 +1440,14 @@ z
    </g>
    <g id="text_19">
     <!-- 52 -->
-    <g transform="translate(341.626953 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(340.494922 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
     <!-- 323 -->
-    <g transform="translate(443.706953 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(442.574922 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(127.246094 0)"/>
@@ -1455,7 +1455,7 @@ z
    </g>
    <g id="text_21">
     <!-- miniz_oxide -->
-    <g transform="translate(113.911953 209.06385) scale(0.08 -0.08)">
+    <g transform="translate(112.779922 209.06385) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6e" d="M 3513 2113 
 L 3513 0 
@@ -1514,7 +1514,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.299 -->
-    <g transform="translate(230.640703 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(229.508672 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1524,14 +1524,14 @@ z
    </g>
    <g id="text_23">
     <!-- 51 -->
-    <g transform="translate(341.626953 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(340.494922 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_24">
     <!-- 729 -->
-    <g transform="translate(443.706953 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(442.574922 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-37"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(127.246094 0)"/>
@@ -1539,7 +1539,7 @@ z
    </g>
    <g id="text_25">
     <!-- JS fflate -->
-    <g transform="translate(122.068203 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(120.936172 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1599,7 +1599,7 @@ z
    </g>
    <g id="text_26">
     <!-- 0.307 -->
-    <g transform="translate(230.640703 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(229.508672 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1609,7 +1609,7 @@ z
    </g>
    <g id="text_27">
     <!-- 41 -->
-    <g transform="translate(341.626953 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(340.494922 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1637,14 +1637,14 @@ z
    </g>
    <g id="text_28">
     <!-- 80 -->
-    <g transform="translate(446.251953 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(445.119922 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-38"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_29">
     <!-- lean-zip (native) -->
-    <g transform="translate(100.413828 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(99.281797 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1753,7 +1753,7 @@ z
    </g>
    <g id="text_30">
     <!-- 0.299 -->
-    <g transform="translate(229.440078 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(228.308047 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1844,8 +1844,8 @@ z
     </g>
    </g>
    <g id="text_31">
-    <!-- 30 -->
-    <g transform="translate(341.150703 267.9415) scale(0.08 -0.08)">
+    <!-- 31 -->
+    <g transform="translate(340.018672 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-33" d="M 2981 2516 
 Q 3453 2394 3698 2092 
@@ -1879,14 +1879,28 @@ Q 3834 3144 3618 2883
 Q 3403 2622 2981 2516 
 z
 " transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-31" d="M 750 831 
+L 1813 831 
+L 1813 3847 
+L 722 3622 
+L 722 4441 
+L 1806 4666 
+L 2950 4666 
+L 2950 831 
+L 4013 831 
+L 4013 0 
+L 750 0 
+L 750 831 
+z
+" transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-Bold-33"/>
-     <use xlink:href="#DejaVuSans-Bold-30" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-31" transform="translate(69.580078 0)"/>
     </g>
    </g>
    <g id="text_32">
-    <!-- 247 -->
-    <g transform="translate(442.992578 267.9415) scale(0.08 -0.08)">
+    <!-- 249 -->
+    <g transform="translate(441.860547 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-34" d="M 2356 3675 
 L 1038 1722 
@@ -1907,25 +1921,15 @@ L 288 1881
 L 2156 4666 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-37" d="M 428 4666 
-L 3944 4666 
-L 3944 3988 
-L 2125 0 
-L 953 0 
-L 2675 3781 
-L 428 3781 
-L 428 4666 
-z
-" transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-Bold-32"/>
      <use xlink:href="#DejaVuSans-Bold-34" transform="translate(69.580078 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-37" transform="translate(139.160156 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-39" transform="translate(139.160156 0)"/>
     </g>
    </g>
    <g id="text_33">
     <!-- OCaml decompress -->
-    <g transform="translate(98.528828 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(97.396797 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -1990,7 +1994,7 @@ z
    </g>
    <g id="text_34">
     <!-- 0.321 -->
-    <g transform="translate(230.640703 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(229.508672 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -2000,14 +2004,14 @@ z
    </g>
    <g id="text_35">
     <!-- 23 -->
-    <g transform="translate(341.626953 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(340.494922 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_36">
     <!-- 117 -->
-    <g transform="translate(443.706953 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(442.574922 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
@@ -2015,7 +2019,7 @@ z
    </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(126.750078 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(125.618047 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -2026,7 +2030,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.279 -->
-    <g transform="translate(230.640703 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(229.508672 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -2036,13 +2040,13 @@ z
    </g>
    <g id="text_39">
     <!-- 0 -->
-    <g transform="translate(344.171953 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(343.039922 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(447.341953 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(446.209922 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2058,7 +2062,7 @@ z
   </g>
   <g id="text_41">
    <!-- canterbury — geomean over files, level 6 -->
-   <g transform="translate(137.163203 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(136.031172 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-62" d="M 2400 722 
 Q 2759 722 2948 984 
@@ -2271,7 +2275,7 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-07-09T07:09:47Z  ·  Linux chungus2 x86_64  ·  commit b23a23be  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-07-09T17:31:54Z  ·  Linux chungus2 x86_64  ·  commit 324f086c  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2412,14 +2416,14 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-39" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
     <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2459,110 +2463,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3135.351562 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3198.974609 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3262.597656 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3323.876953 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3387.5 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3451.123047 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3514.599609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3576.123047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3607.910156 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3639.697266 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3671.484375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3703.271484 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3735.058594 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3762.841797 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3824.365234 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3885.644531 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3949.023438 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4012.5 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4051.363281 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4112.544922 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4171.724609 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4233.248047 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4274.361328 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4308.052734 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4335.835938 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4397.359375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4458.638672 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4522.017578 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4585.640625 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4619.332031 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4678.511719 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4742.134766 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4773.921875 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4837.544922 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4901.167969 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4932.955078 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4996.578125 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5032.662109 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5071.525391 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5126.505859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5190.128906 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5221.916016 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5253.703125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5285.490234 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5317.277344 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5349.064453 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5388.273438 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5451.652344 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5490.515625 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5551.697266 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5615.076172 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5678.552734 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5741.931641 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5805.408203 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5868.787109 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5907.996094 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5939.783203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6023.572266 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6055.359375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6152.771484 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6214.294922 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6277.771484 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6305.554688 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6366.833984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6430.212891 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6462 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6514.099609 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6577.478516 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6638.757812 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6702.234375 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6754.333984 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6817.712891 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6878.894531 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6918.103516 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6951.794922 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6983.582031 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7024.695312 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7085.974609 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7125.183594 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7152.966797 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7214.148438 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7245.935547 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7273.71875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7325.818359 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7357.605469 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7421.082031 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7482.605469 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7521.814453 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7583.337891 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7622.701172 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7720.113281 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7747.896484 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7811.275391 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7839.058594 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7891.158203 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7930.367188 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7958.150391 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3262.744141 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3297.949219 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3361.572266 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3425.195312 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3488.818359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3543.798828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3575.585938 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3607.373047 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3639.160156 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3670.947266 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3702.734375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3730.517578 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3792.041016 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3853.320312 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3916.699219 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3980.175781 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4019.039062 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4080.220703 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4139.400391 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4200.923828 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4242.037109 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4275.728516 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4303.511719 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4365.035156 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4426.314453 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4489.693359 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4553.316406 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4587.007812 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4646.1875 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4709.810547 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4741.597656 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4805.220703 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4868.84375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4900.630859 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4964.253906 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5000.337891 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5039.201172 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5094.181641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5157.804688 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5189.591797 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5221.378906 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5253.166016 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5284.953125 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5316.740234 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5355.949219 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5419.328125 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5458.191406 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5519.373047 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5582.751953 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5646.228516 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5709.607422 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5773.083984 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5836.462891 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5875.671875 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5907.458984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5991.248047 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6023.035156 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6120.447266 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6181.970703 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6245.447266 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6273.230469 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6334.509766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6397.888672 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6429.675781 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6481.775391 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6545.154297 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6606.433594 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6669.910156 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6722.009766 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6785.388672 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6846.570312 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6885.779297 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6919.470703 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6951.257812 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6992.371094 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7053.650391 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7092.859375 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7120.642578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7181.824219 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7213.611328 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7241.394531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7293.494141 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7325.28125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7388.757812 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7450.28125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7489.490234 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7551.013672 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7590.376953 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7687.789062 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7715.572266 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7778.951172 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7806.734375 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7858.833984 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7898.042969 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7925.826172 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p9bc56fbad2">
-   <rect x="85.154453" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="p74712be3cf">
+   <rect x="84.022422" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/graphs/silesia_compress_heatmap.svg
+++ b/bench/graphs/silesia_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.34175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p70b04d419f)">
+   <g clip-path="url(#pbc55d5b544)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAqAAAAGaCAYAAADQNfGTAAAJ+ElEQVR4nO3YQY5lZR2H4b51b1dXN6QDTajYhglOjHFAMCGGbbAOR05dgxtw5tAFOHDiwIEJTBgykgRQ04HQQVJpi6pbVS6CfO+/PHmeFfxOvnPuee/Z3X77x7sHW3b1anrBWruT6QVr3R6nF6y19fM7Xk0vWOvJG9ML1vrhYnoBP8b+dHrBWlu/Px+eTS9YauNvPwAA7hsBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBA6vDp8cvpDUudPjxMT1jq8ng1PWGp509/Oj1hqS++/2p6wlLH3c30hKV+8fjZ9ISljo/Opics9a+Lf05PWOr88fn0hKUuT4/TE5baPXg1PWEpX0ABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAIDU4fzJ+fSGpZ6/9rPpCUt9/erL6QlL/eRy2/+Rnr713vSEpU73Z9MTlrq5PU5PWGrr57f56zvZ9vUdTt6ZnrDU2eXl9ISltv12BwDg3hGgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkDo/2T6Y3LPXy8sX0hKW2fn43bz6bnrDUV999Oj1hqYvry+kJS33w5gfTE5a6ujtOT1jqi+8/n56w1C/f+tX0hKU+fvH36QlLvf/2ts/PF1AAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACA1O7mb7+9mx6x1O3t9AJ+jK2f34n/gDBm68+f38//b8fj9IKlNn56AADcNwIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAIDU4fzjz6Y3LLU/3U9PWOrrz76ZnrDUH37z/vSEpX7/ybbP78N3nk5PWOpPf/18esJSv/vo59MTlvrzP/4zPWGpd994PD1hqZf/vZ6esNSvnz+ZnrCUL6AAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBqd33zl7vpESvtr6+mJ6y1P51esNbxcnrBWoez6QVr7Q/TC9a6u51esNb1xp+/3ca/wZxs+/m73m37+Xt4PE5PWGrjTx8AAPeNAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAIHV4efliesNSb++fTU9Y6uL2YnrCUq9fH6cnrPXo9ekFa/2w7fvz5YNtX9+z68P0hLVe2/b74cFu29+YHn737+kJaz1+Or1gqW3fnQAA3DsCFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACA1P8AMBJ6x8RLlUEAAAAASUVORK5CYII=" id="image95ead97c2c" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="483.84" height="295.2"/>
+iVBORw0KGgoAAAANSUhEUgAAAqAAAAGaCAYAAADQNfGTAAAJ+0lEQVR4nO3YP25lZx3H4di+9ngcaTSZKNYMSgMNQhQoSFGUbWQdVLSsgQ3QUbIAijQUFEihSZmKSPmDFGVgBJPRxNjX11lE9H5+5uh5VvC9ev36fM45Ovz7j3dvbNn16+kFax0dTy9Y67CfXrDW1s9vfz29YK2Lx9ML1vrfq+kF/BgnZ9ML1tr63+fp+fSCpTb+9AMA4L4RoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApHaf7r+c3rDU2eluesJSV/vr6QlLPXv0k+kJS33x8qvpCUvtj26nJyz1i4dPpicstX9wPj1hqX+++np6wlKXDy+nJyx1dbafnrDU0Ruvpycs5QsoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQ2l1eXE5vWOrZmz+bnrDUt6+/nJ6w1NOrbb8jPXr7V9MTljo7OZ+esNTtYT89Yamtn9/mf9/xtn/f7vjd6QlLnV9dTU9YattPdwAA7h0BCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBAavfg5GJ6w1Ivrr6ZnrDU1s/v9q0n0xOW+uo/n05PWOrVzdX0hKXef+v96QlLXd/tpycs9cXLz6cnLPXLt389PWGpT7752/SEpd57Z9vn5wsoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQOro9q+/vZsesdThML2AH2Pr53fsHRDGbP3++f/5/22/n16w1MZPDwCA+0aAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQ2l1+8tn0hqVOzk6mJyz17WfPpycs9YffvDc9Yanf/33b5/fhu4+mJyz1p798Pj1hqd999PPpCUv9+R//nZ6w1E8fP5yesNSL72+mJyz1wbOL6QlL+QIKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkjm5uP76bHrHSyc319IS1Ts6mF6y1v5pesNbufHrBWie76QVr3R2mF6x1s/H7d7TxbzDH275/N0fbvn+n+/30hKU2fvsAALhvBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAAKnd8++/nt6w1NPTp9MTlnp5eDk9YalHtxt/R3qwm16w1s3V9IKlnu//NT1hqXcOF9MT1nrzyfSCpW4O19MTljr97sX0hLUuHk8vWGrjT3cAAO4bAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQOoHe0x9yWgI2DEAAAAASUVORK5CYII=" id="image12d7863257" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="483.84" height="295.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="ma4fa4fe0c6" d="M 0 0 
+       <path id="m48204cc8a4" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#ma4fa4fe0c6" x="115.814949" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m48204cc8a4" x="115.814949" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#ma4fa4fe0c6" x="156.092348" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m48204cc8a4" x="156.092348" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#ma4fa4fe0c6" x="196.369746" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m48204cc8a4" x="196.369746" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#ma4fa4fe0c6" x="236.647145" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m48204cc8a4" x="236.647145" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#ma4fa4fe0c6" x="276.924544" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m48204cc8a4" x="276.924544" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#ma4fa4fe0c6" x="317.201942" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m48204cc8a4" x="317.201942" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#ma4fa4fe0c6" x="357.479341" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m48204cc8a4" x="357.479341" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#ma4fa4fe0c6" x="397.756739" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m48204cc8a4" x="397.756739" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#ma4fa4fe0c6" x="438.034138" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m48204cc8a4" x="438.034138" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#ma4fa4fe0c6" x="478.311536" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m48204cc8a4" x="478.311536" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#ma4fa4fe0c6" x="518.588935" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m48204cc8a4" x="518.588935" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#ma4fa4fe0c6" x="558.866334" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m48204cc8a4" x="558.866334" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="m6df0a6bc5f" d="M 0 0 
+       <path id="mfd56e68120" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m6df0a6bc5f" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfd56e68120" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m6df0a6bc5f" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfd56e68120" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m6df0a6bc5f" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfd56e68120" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m6df0a6bc5f" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfd56e68120" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -836,7 +836,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m6df0a6bc5f" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfd56e68120" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -899,7 +899,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m6df0a6bc5f" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfd56e68120" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -966,7 +966,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m6df0a6bc5f" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfd56e68120" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1047,7 +1047,7 @@ z
     <g id="ytick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m6df0a6bc5f" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfd56e68120" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -1138,7 +1138,7 @@ L 579.005033 49.34175
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_21">
-    <!-- +34 -->
+    <!-- +39 -->
     <g transform="translate(108.955926 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-2b" d="M 2944 4013 
@@ -1188,59 +1188,6 @@ Q 3450 3153 3228 2886
 Q 3006 2619 2597 2516 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-34" d="M 2419 4116 
-L 825 1625 
-L 2419 1625 
-L 2419 4116 
-z
-M 2253 4666 
-L 3047 4666 
-L 3047 1625 
-L 3713 1625 
-L 3713 1100 
-L 3047 1100 
-L 3047 0 
-L 2419 0 
-L 2419 1100 
-L 313 1100 
-L 313 1709 
-L 2253 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_22">
-    <!-- -14 -->
-    <g transform="translate(150.784184 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-31" d="M 794 531 
-L 1825 531 
-L 1825 4091 
-L 703 3866 
-L 703 4441 
-L 1819 4666 
-L 2450 4666 
-L 2450 531 
-L 3481 531 
-L 3481 0 
-L 794 0 
-L 794 531 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_23">
-    <!-- +19 -->
-    <g transform="translate(189.510723 69.553235) scale(0.065 -0.065)">
-     <defs>
       <path id="DejaVuSans-39" d="M 703 97 
 L 703 672 
 Q 941 559 1184 500 
@@ -1273,14 +1220,28 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
     </g>
    </g>
-   <g id="text_24">
-    <!-- -25 -->
-    <g transform="translate(231.338981 69.553235) scale(0.065 -0.065)">
+   <g id="text_22">
+    <!-- -12 -->
+    <g transform="translate(150.784184 69.553235) scale(0.065 -0.065)">
      <defs>
+      <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
       <path id="DejaVuSans-32" d="M 1228 531 
 L 3431 531 
 L 3431 0 
@@ -1305,6 +1266,143 @@ Q 2828 2175 2409 1742
 Q 1991 1309 1228 531 
 z
 " transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_23">
+    <!-- +23 -->
+    <g transform="translate(189.510723 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_24">
+    <!-- -20 -->
+    <g transform="translate(231.338981 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_25">
+    <!-- +0 -->
+    <g transform="translate(272.133333 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_26">
+    <!-- -10 -->
+    <g transform="translate(311.893778 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_27">
+    <!-- +33 -->
+    <g transform="translate(350.620317 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_28">
+    <!-- -22 -->
+    <g transform="translate(392.448575 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_29">
+    <!-- -0 -->
+    <g transform="translate(434.793786 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_30">
+    <!-- +7 -->
+    <g transform="translate(473.520325 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_31">
+    <!-- -29 -->
+    <g transform="translate(513.280771 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_32">
+    <!-- -11 -->
+    <g transform="translate(553.558169 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_33">
+    <!-- +7 -->
+    <g transform="translate(111.023738 106.389018) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_34">
+    <!-- -13 -->
+    <g transform="translate(150.784184 106.389018) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_35">
+    <!-- -5 -->
+    <g transform="translate(193.129395 106.389018) scale(0.065 -0.065)">
+     <defs>
       <path id="DejaVuSans-35" d="M 691 4666 
 L 3169 4666 
 L 3169 4134 
@@ -1331,102 +1429,6 @@ L 691 4666
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_25">
-    <!-- -2 -->
-    <g transform="translate(273.684192 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_26">
-    <!-- -14 -->
-    <g transform="translate(311.893778 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_27">
-    <!-- +29 -->
-    <g transform="translate(350.620317 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_28">
-    <!-- -25 -->
-    <g transform="translate(392.448575 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_29">
-    <!-- -4 -->
-    <g transform="translate(434.793786 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_30">
-    <!-- +2 -->
-    <g transform="translate(473.520325 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_31">
-    <!-- -32 -->
-    <g transform="translate(513.280771 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_32">
-    <!-- -15 -->
-    <g transform="translate(553.558169 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_33">
-    <!-- +7 -->
-    <g transform="translate(111.023738 106.389018) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_34">
-    <!-- -13 -->
-    <g transform="translate(150.784184 106.389018) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_35">
-    <!-- -5 -->
-    <g transform="translate(193.129395 106.389018) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
     </g>
@@ -1481,29 +1483,6 @@ z
    <g id="text_38">
     <!-- -0 -->
     <g transform="translate(313.961591 106.389018) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-30" d="M 2034 4250 
-Q 1547 4250 1301 3770 
-Q 1056 3291 1056 2328 
-Q 1056 1369 1301 889 
-Q 1547 409 2034 409 
-Q 2525 409 2770 889 
-Q 3016 1369 3016 2328 
-Q 3016 3291 2770 3770 
-Q 2525 4250 2034 4250 
-z
-M 2034 4750 
-Q 2819 4750 3233 4129 
-Q 3647 3509 3647 2328 
-Q 3647 1150 3233 529 
-Q 2819 -91 2034 -91 
-Q 1250 -91 836 529 
-Q 422 1150 422 2328 
-Q 422 3509 836 4129 
-Q 1250 4750 2034 4750 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(36.083984 0)"/>
     </g>
@@ -1511,6 +1490,27 @@ z
    <g id="text_39">
     <!-- -4 -->
     <g transform="translate(354.238989 106.389018) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
     </g>
@@ -2191,18 +2191,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB1ElEQVR4nO2b0a3DMAwD7cSzvM3fmI47gvpxCK6ENABhnkQ5aZH5P/7OAGpdFyEzBiQDnija2qSEghnZhIIZCa3NyWQkmZFOKJhRsDXsOopmJJwjaEPOmxHirE3MWjOqhSBr2EAGMyKtMVpc+ynYwe3viNQVbA0LrZDRFbxGbNbWyM3auG0RGbo1Qp0IZCSMiG2OgtNvbL+Oke6BvddIWaQ1qP3RjGSTLXypwdaIMP2ctWb0olAzKkr4LhLMCPvnOJiRbo6CrTWjF4WCGYHWJtU1TKgZvSZkfNAKZhRsDftFa96MkJCRrf29ausyWrOtWiMjmxDH6FAfDJzzIEKctQc60ToDEqJOBLbfZs04RxQjobWOSFXrjM0IdURqIaG1jkhVPmvGOUqOCPLJMdh+6kRk+zFGMtjKOdK13zbZ2EBGMxLOkSz90YygK9tozSbUa6Qu4RxtRifZ2np0jDY32YiOc44gIQo2aI1ZkB2Rb4SiIyJbtcr0Q0IPdCQyIpCQDnZHpC5uQ27uOtJFBBptH2zlHOnab+uaMSK29htXrW2NKK0hOtlrxLaPjIxys4a99x9dRKgTgUK69gsZ9RxVFWzNyIi6RZIZtbXfE+qI1BU8R5i1D2e5X2tFkZmlAAAAAElFTkSuQmCC" id="imagecb33c5b1f7" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-69.84" width="12.96" height="253.44"/>
+iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB1ElEQVR4nO2b0a3DMAwD7cSzvM3fmI47gvpxCK6ENABhnkQ5aZH5P/7OAGpdFyEzBiQDnija2qSEghnZhIIZCa3NyWQkmZFOKJhRsDXsOopmJJwjaEPOmxHirE3MWjOqhSBr2EAGMyKtMVpc+ynYwe3viNQVbA0LrZDRFbxGbNbWyM3auG0RGbo1Qp0IZCSMiG2OgtNvbL+Oke6BvddIWaQ1qP3RjGSTLXypwdaIMP2ctWb0olAzKkr4LhLMCPvnOJiRbo6CrTWjF4WCGYHWJtU1TKgZvSZkfNAKZhRsDftFa96MkJCRrf29ausyWrOtWiMjmxDH6FAfDJzzIEKctQc60ToDEqJOBLbfZs04RxQjobWOSFXrjM0IdURqIaG1jkhVPmvGOUqOCPLJMdh+6kRk+zFGMtjKOdK13zbZ2EBGMxLOkSz90YygK9tozSbUa6Qu4RxtRifZ2np0jDY32YiOc44gIQo2aI1ZkB2Rb4SiIyJbtcr0Q0IPdCQyIpCQDnZHpC5uQ27uOtJFBBptH2zlHOnab+uaMSK29htXrW2NKK0hOtlrxLaPjIxys4a99x9dRKgTgUK69gsZ9RxVFWzNyIi6RZIZtbXfE+qI1BU8R5i1D2e5X2tFkZmlAAAAAElFTkSuQmCC" id="image2a02c79209" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-69.84" width="12.96" height="253.44"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_21">
       <defs>
-       <path id="mf013a2df42" d="M 0 0 
+       <path id="m2abed29570" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mf013a2df42" x="601.779688" y="322.507463" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2abed29570" x="601.779688" y="322.507463" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_117">
@@ -2225,7 +2225,7 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#mf013a2df42" x="601.779688" y="280.566603" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2abed29570" x="601.779688" y="280.566603" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_118">
@@ -2239,7 +2239,7 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#mf013a2df42" x="601.779688" y="238.625742" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2abed29570" x="601.779688" y="238.625742" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_119">
@@ -2253,7 +2253,7 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mf013a2df42" x="601.779688" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2abed29570" x="601.779688" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_120">
@@ -2266,7 +2266,7 @@ z
     <g id="ytick_13">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#mf013a2df42" x="601.779688" y="154.74402" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2abed29570" x="601.779688" y="154.74402" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_121">
@@ -2279,7 +2279,7 @@ z
     <g id="ytick_14">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mf013a2df42" x="601.779688" y="112.803159" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2abed29570" x="601.779688" y="112.803159" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_122">
@@ -2292,7 +2292,7 @@ z
     <g id="ytick_15">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#mf013a2df42" x="601.779688" y="70.862298" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2abed29570" x="601.779688" y="70.862298" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_123">
@@ -2908,8 +2908,8 @@ z
    </g>
   </g>
   <g id="text_126">
-   <!-- 2026-07-09T07:09:47Z  ·  Linux chungus2 x86_64  ·  commit b23a23be  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(43.545547 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-09T17:31:54Z  ·  Linux chungus2 x86_64  ·  commit 324f086c  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(44.677578 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -3000,14 +3000,14 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-39" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
     <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3047,109 +3047,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3135.351562 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3198.974609 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3262.597656 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3323.876953 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3387.5 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3451.123047 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3514.599609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3576.123047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3607.910156 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3639.697266 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3671.484375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3703.271484 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3735.058594 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3762.841797 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3824.365234 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3885.644531 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3949.023438 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4012.5 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4051.363281 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4112.544922 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4171.724609 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4233.248047 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4274.361328 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4308.052734 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4335.835938 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4397.359375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4458.638672 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4522.017578 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4585.640625 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4619.332031 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4678.511719 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4742.134766 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4773.921875 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4837.544922 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4901.167969 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4932.955078 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4996.578125 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5032.662109 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5071.525391 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5126.505859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5190.128906 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5221.916016 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5253.703125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5285.490234 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5317.277344 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5349.064453 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5388.273438 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5451.652344 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5490.515625 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5551.697266 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5615.076172 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5678.552734 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5741.931641 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5805.408203 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5868.787109 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5907.996094 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5939.783203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6023.572266 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6055.359375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6152.771484 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6214.294922 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6277.771484 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6305.554688 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6366.833984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6430.212891 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6462 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6514.099609 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6577.478516 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6638.757812 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6702.234375 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6754.333984 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6817.712891 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6878.894531 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6918.103516 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6951.794922 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6983.582031 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7024.695312 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7085.974609 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7125.183594 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7152.966797 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7214.148438 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7245.935547 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7273.71875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7325.818359 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7357.605469 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7421.082031 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7482.605469 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7521.814453 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7583.337891 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7622.701172 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7720.113281 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7747.896484 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7811.275391 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7839.058594 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7891.158203 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7930.367188 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7958.150391 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3262.744141 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3297.949219 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3361.572266 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3425.195312 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3488.818359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3543.798828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3575.585938 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3607.373047 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3639.160156 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3670.947266 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3702.734375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3730.517578 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3792.041016 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3853.320312 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3916.699219 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3980.175781 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4019.039062 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4080.220703 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4139.400391 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4200.923828 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4242.037109 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4275.728516 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4303.511719 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4365.035156 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4426.314453 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4489.693359 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4553.316406 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4587.007812 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4646.1875 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4709.810547 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4741.597656 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4805.220703 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4868.84375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4900.630859 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4964.253906 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5000.337891 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5039.201172 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5094.181641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5157.804688 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5189.591797 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5221.378906 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5253.166016 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5284.953125 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5316.740234 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5355.949219 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5419.328125 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5458.191406 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5519.373047 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5582.751953 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5646.228516 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5709.607422 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5773.083984 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5836.462891 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5875.671875 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5907.458984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5991.248047 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6023.035156 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6120.447266 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6181.970703 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6245.447266 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6273.230469 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6334.509766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6397.888672 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6429.675781 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6481.775391 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6545.154297 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6606.433594 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6669.910156 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6722.009766 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6785.388672 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6846.570312 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6885.779297 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6919.470703 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6951.257812 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6992.371094 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7053.650391 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7092.859375 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7120.642578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7181.824219 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7213.611328 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7241.394531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7293.494141 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7325.28125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7388.757812 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7450.28125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7489.490234 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7551.013672 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7590.376953 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7687.789062 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7715.572266 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7778.951172 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7806.734375 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7858.833984 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7898.042969 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7925.826172 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p70b04d419f">
+  <clipPath id="pbc55d5b544">
    <rect x="95.67625" y="49.34175" width="483.328783" height="294.686261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_compress_pareto.svg
+++ b/bench/graphs/silesia_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 61.085542 412.80375 
 L 61.085542 48.323125 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m9155527b6b" d="M 0 0 
+       <path id="m49613c94fa" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m9155527b6b" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m49613c94fa" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -130,11 +130,11 @@ z
      <g id="line2d_3">
       <path d="M 145.270284 412.80375 
 L 145.270284 48.323125 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m9155527b6b" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m49613c94fa" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -177,11 +177,11 @@ z
      <g id="line2d_5">
       <path d="M 229.455026 412.80375 
 L 229.455026 48.323125 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m9155527b6b" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m49613c94fa" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -219,11 +219,11 @@ z
      <g id="line2d_7">
       <path d="M 313.639768 412.80375 
 L 313.639768 48.323125 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m9155527b6b" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m49613c94fa" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -272,11 +272,11 @@ z
      <g id="line2d_9">
       <path d="M 397.82451 412.80375 
 L 397.82451 48.323125 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m9155527b6b" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m49613c94fa" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -334,11 +334,11 @@ z
      <g id="line2d_11">
       <path d="M 482.009253 412.80375 
 L 482.009253 48.323125 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m9155527b6b" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m49613c94fa" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -355,11 +355,11 @@ L 482.009253 48.323125
      <g id="line2d_13">
       <path d="M 566.193995 412.80375 
 L 566.193995 48.323125 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m9155527b6b" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m49613c94fa" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -856,16 +856,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 368.08164 
 L 637.2 368.08164 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="mb42cf5b180" d="M 0 0 
+       <path id="m13ec08a276" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mb42cf5b180" x="49.078125" y="368.08164" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m13ec08a276" x="49.078125" y="368.08164" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -897,11 +897,11 @@ z
      <g id="line2d_17">
       <path d="M 49.078125 243.439835 
 L 637.2 243.439835 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mb42cf5b180" x="49.078125" y="243.439835" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m13ec08a276" x="49.078125" y="243.439835" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -917,11 +917,11 @@ L 637.2 243.439835
      <g id="line2d_19">
       <path d="M 49.078125 118.798029 
 L 637.2 118.798029 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#mb42cf5b180" x="49.078125" y="118.798029" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m13ec08a276" x="49.078125" y="118.798029" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -937,16 +937,16 @@ L 637.2 118.798029
      <g id="line2d_21">
       <path d="M 49.078125 405.602562 
 L 637.2 405.602562 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="mb03835ccb1" d="M 0 0 
+       <path id="mdaf5a0b89b" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#mb03835ccb1" x="49.078125" y="405.602562" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdaf5a0b89b" x="49.078125" y="405.602562" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -954,11 +954,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 395.733268 
 L 637.2 395.733268 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mb03835ccb1" x="49.078125" y="395.733268" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdaf5a0b89b" x="49.078125" y="395.733268" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -966,11 +966,11 @@ L 637.2 395.733268
      <g id="line2d_25">
       <path d="M 49.078125 387.3889 
 L 637.2 387.3889 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mb03835ccb1" x="49.078125" y="387.3889" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdaf5a0b89b" x="49.078125" y="387.3889" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -978,11 +978,11 @@ L 637.2 387.3889
      <g id="line2d_27">
       <path d="M 49.078125 380.160679 
 L 637.2 380.160679 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#mb03835ccb1" x="49.078125" y="380.160679" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdaf5a0b89b" x="49.078125" y="380.160679" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -990,11 +990,11 @@ L 637.2 380.160679
      <g id="line2d_29">
       <path d="M 49.078125 373.784936 
 L 637.2 373.784936 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#mb03835ccb1" x="49.078125" y="373.784936" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdaf5a0b89b" x="49.078125" y="373.784936" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1002,11 +1002,11 @@ L 637.2 373.784936
      <g id="line2d_31">
       <path d="M 49.078125 330.560718 
 L 637.2 330.560718 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#mb03835ccb1" x="49.078125" y="330.560718" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdaf5a0b89b" x="49.078125" y="330.560718" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1014,11 +1014,11 @@ L 637.2 330.560718
      <g id="line2d_33">
       <path d="M 49.078125 308.612385 
 L 637.2 308.612385 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#mb03835ccb1" x="49.078125" y="308.612385" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdaf5a0b89b" x="49.078125" y="308.612385" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1026,11 +1026,11 @@ L 637.2 308.612385
      <g id="line2d_35">
       <path d="M 49.078125 293.039796 
 L 637.2 293.039796 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#mb03835ccb1" x="49.078125" y="293.039796" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdaf5a0b89b" x="49.078125" y="293.039796" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1038,11 +1038,11 @@ L 637.2 293.039796
      <g id="line2d_37">
       <path d="M 49.078125 280.960757 
 L 637.2 280.960757 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#mb03835ccb1" x="49.078125" y="280.960757" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdaf5a0b89b" x="49.078125" y="280.960757" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1050,11 +1050,11 @@ L 637.2 280.960757
      <g id="line2d_39">
       <path d="M 49.078125 271.091463 
 L 637.2 271.091463 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#mb03835ccb1" x="49.078125" y="271.091463" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdaf5a0b89b" x="49.078125" y="271.091463" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1062,11 +1062,11 @@ L 637.2 271.091463
      <g id="line2d_41">
       <path d="M 49.078125 262.747094 
 L 637.2 262.747094 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#mb03835ccb1" x="49.078125" y="262.747094" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdaf5a0b89b" x="49.078125" y="262.747094" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1074,11 +1074,11 @@ L 637.2 262.747094
      <g id="line2d_43">
       <path d="M 49.078125 255.518874 
 L 637.2 255.518874 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#mb03835ccb1" x="49.078125" y="255.518874" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdaf5a0b89b" x="49.078125" y="255.518874" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1086,11 +1086,11 @@ L 637.2 255.518874
      <g id="line2d_45">
       <path d="M 49.078125 249.143131 
 L 637.2 249.143131 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#mb03835ccb1" x="49.078125" y="249.143131" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdaf5a0b89b" x="49.078125" y="249.143131" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1098,11 +1098,11 @@ L 637.2 249.143131
      <g id="line2d_47">
       <path d="M 49.078125 205.918912 
 L 637.2 205.918912 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#mb03835ccb1" x="49.078125" y="205.918912" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdaf5a0b89b" x="49.078125" y="205.918912" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1110,11 +1110,11 @@ L 637.2 205.918912
      <g id="line2d_49">
       <path d="M 49.078125 183.97058 
 L 637.2 183.97058 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#mb03835ccb1" x="49.078125" y="183.97058" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdaf5a0b89b" x="49.078125" y="183.97058" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1122,11 +1122,11 @@ L 637.2 183.97058
      <g id="line2d_51">
       <path d="M 49.078125 168.39799 
 L 637.2 168.39799 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#mb03835ccb1" x="49.078125" y="168.39799" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdaf5a0b89b" x="49.078125" y="168.39799" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1134,11 +1134,11 @@ L 637.2 168.39799
      <g id="line2d_53">
       <path d="M 49.078125 156.318951 
 L 637.2 156.318951 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#mb03835ccb1" x="49.078125" y="156.318951" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdaf5a0b89b" x="49.078125" y="156.318951" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1146,11 +1146,11 @@ L 637.2 156.318951
      <g id="line2d_55">
       <path d="M 49.078125 146.449658 
 L 637.2 146.449658 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#mb03835ccb1" x="49.078125" y="146.449658" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdaf5a0b89b" x="49.078125" y="146.449658" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1158,11 +1158,11 @@ L 637.2 146.449658
      <g id="line2d_57">
       <path d="M 49.078125 138.105289 
 L 637.2 138.105289 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#mb03835ccb1" x="49.078125" y="138.105289" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdaf5a0b89b" x="49.078125" y="138.105289" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1170,11 +1170,11 @@ L 637.2 138.105289
      <g id="line2d_59">
       <path d="M 49.078125 130.877068 
 L 637.2 130.877068 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#mb03835ccb1" x="49.078125" y="130.877068" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdaf5a0b89b" x="49.078125" y="130.877068" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1182,11 +1182,11 @@ L 637.2 130.877068
      <g id="line2d_61">
       <path d="M 49.078125 124.501326 
 L 637.2 124.501326 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#mb03835ccb1" x="49.078125" y="124.501326" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdaf5a0b89b" x="49.078125" y="124.501326" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1194,11 +1194,11 @@ L 637.2 124.501326
      <g id="line2d_63">
       <path d="M 49.078125 81.277107 
 L 637.2 81.277107 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#mb03835ccb1" x="49.078125" y="81.277107" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdaf5a0b89b" x="49.078125" y="81.277107" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1206,11 +1206,11 @@ L 637.2 81.277107
      <g id="line2d_65">
       <path d="M 49.078125 59.328775 
 L 637.2 59.328775 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#mb03835ccb1" x="49.078125" y="59.328775" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdaf5a0b89b" x="49.078125" y="59.328775" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1332,7 +1332,7 @@ L 637.2 48.323125
    </g>
    <g id="text_13">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(324.643112 116.395074) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(324.643112 112.176023) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1364,7 +1364,7 @@ z
    </g>
    <g id="text_14">
     <!-- L10 -->
-    <g style="fill: #d62728" transform="translate(102.814287 309.137023) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(102.814287 308.360586) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1686,23 +1686,23 @@ z
    </g>
    <g id="line2d_67">
     <defs>
-     <path id="m7a3ce87474" d="M -2.5 2.5 
+     <path id="m709da15e7e" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p2a283bbcdd)">
-     <use xlink:href="#m7a3ce87474" x="377.110281" y="104.685421" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7a3ce87474" x="323.801439" y="110.409833" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7a3ce87474" x="272.665744" y="126.308323" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7a3ce87474" x="235.168828" y="128.026741" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7a3ce87474" x="186.228265" y="149.377587" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7a3ce87474" x="158.303164" y="171.457731" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7a3ce87474" x="149.489547" y="182.192614" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7a3ce87474" x="140.563162" y="202.482797" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7a3ce87474" x="138.984853" y="209.328911" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p49dad874ee)">
+     <use xlink:href="#m709da15e7e" x="377.110281" y="104.685421" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m709da15e7e" x="323.801439" y="110.409833" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m709da15e7e" x="272.665744" y="126.308323" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m709da15e7e" x="235.168828" y="128.026741" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m709da15e7e" x="186.228265" y="149.377587" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m709da15e7e" x="158.303164" y="171.457731" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m709da15e7e" x="149.489547" y="182.192614" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m709da15e7e" x="140.563162" y="202.482797" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m709da15e7e" x="138.984853" y="209.328911" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_68">
@@ -1755,7 +1755,7 @@ L 327.133241 110.069256
 L 326.02264 110.18302 
 L 324.91204 110.296545 
 L 323.801439 110.409833 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_69">
     <path d="M 323.801439 110.409833 
@@ -1807,7 +1807,7 @@ L 275.861725 125.44037
 L 274.796398 125.731236 
 L 273.731071 126.020548 
 L 272.665744 126.308323 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_70">
     <path d="M 272.665744 126.308323 
@@ -1859,7 +1859,7 @@ L 237.512385 127.920923
 L 236.7312 127.956219 
 L 235.950014 127.991491 
 L 235.168828 128.026741 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_71">
     <path d="M 235.168828 128.026741 
@@ -1911,7 +1911,7 @@ L 189.28705 148.263499
 L 188.267455 148.637415 
 L 187.24786 149.008766 
 L 186.228265 149.377587 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_72">
     <path d="M 186.228265 149.377587 
@@ -1963,7 +1963,7 @@ L 160.048483 170.312481
 L 159.46671 170.696929 
 L 158.884937 171.078667 
 L 158.303164 171.457731 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_73">
     <path d="M 158.303164 171.457731 
@@ -2015,7 +2015,7 @@ L 150.040398 181.580576
 L 149.856781 181.785359 
 L 149.673164 181.989369 
 L 149.489547 182.192614 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_74">
     <path d="M 149.489547 182.192614 
@@ -2067,7 +2067,7 @@ L 141.121061 201.414753
 L 140.935095 201.773114 
 L 140.749129 202.129119 
 L 140.563162 202.482797 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_75">
     <path d="M 140.563162 202.482797 
@@ -2119,26 +2119,26 @@ L 139.083497 208.925481
 L 139.050616 209.060292 
 L 139.017734 209.194768 
 L 138.984853 209.328911 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_76">
     <defs>
-     <path id="m347b73ce0a" d="M 0 -2.5 
+     <path id="m8323a7be1f" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p2a283bbcdd)">
-     <use xlink:href="#m347b73ce0a" x="610.467187" y="71.939349" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m347b73ce0a" x="319.880958" y="101.884157" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m347b73ce0a" x="210.281253" y="129.778154" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m347b73ce0a" x="196.287076" y="133.586625" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m347b73ce0a" x="176.054419" y="147.38645" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m347b73ce0a" x="152.161413" y="174.753272" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m347b73ce0a" x="146.720208" y="186.587648" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m347b73ce0a" x="143.994022" y="196.356323" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m347b73ce0a" x="142.666037" y="200.180971" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p49dad874ee)">
+     <use xlink:href="#m8323a7be1f" x="610.467187" y="71.939349" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8323a7be1f" x="319.880958" y="101.884157" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8323a7be1f" x="210.281253" y="129.778154" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8323a7be1f" x="196.287076" y="133.586625" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8323a7be1f" x="176.054419" y="147.38645" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8323a7be1f" x="152.161413" y="174.753272" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8323a7be1f" x="146.720208" y="186.587648" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8323a7be1f" x="143.994022" y="196.356323" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8323a7be1f" x="142.666037" y="200.180971" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_77">
@@ -2191,7 +2191,7 @@ L 338.042598 100.427247
 L 331.988718 100.917253 
 L 325.934838 101.402864 
 L 319.880958 101.884157 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_78">
     <path d="M 319.880958 101.884157 
@@ -2243,7 +2243,7 @@ L 217.131235 128.398367
 L 214.847908 128.862215 
 L 212.564581 129.322122 
 L 210.281253 129.778154 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_79">
     <path d="M 210.281253 129.778154 
@@ -2295,7 +2295,7 @@ L 197.161712 133.356286
 L 196.870166 133.433175 
 L 196.578621 133.509954 
 L 196.287076 133.586625 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_80">
     <path d="M 196.287076 133.586625 
@@ -2347,7 +2347,7 @@ L 177.31896 146.619719
 L 176.897447 146.876504 
 L 176.475933 147.132078 
 L 176.054419 147.38645 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_81">
     <path d="M 176.054419 147.38645 
@@ -2399,7 +2399,7 @@ L 153.654726 173.393769
 L 153.156955 173.850741 
 L 152.659184 174.303887 
 L 152.161413 174.753272 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_82">
     <path d="M 152.161413 174.753272 
@@ -2451,7 +2451,7 @@ L 147.060283 185.919158
 L 146.946925 186.142906 
 L 146.833566 186.365734 
 L 146.720208 186.587648 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_83">
     <path d="M 146.720208 186.587648 
@@ -2503,7 +2503,7 @@ L 144.164409 195.794799
 L 144.107613 195.982622 
 L 144.050817 196.169795 
 L 143.994022 196.356323 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_84">
     <path d="M 143.994022 196.356323 
@@ -2555,30 +2555,30 @@ L 142.749036 199.949687
 L 142.72137 200.026891 
 L 142.693704 200.103986 
 L 142.666037 200.180971 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_85">
     <defs>
-     <path id="mc35308547c" d="M -0 3.535534 
+     <path id="m0ead7fa3ab" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p2a283bbcdd)">
-     <use xlink:href="#mc35308547c" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc35308547c" x="242.839153" y="80.778898" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc35308547c" x="218.251194" y="86.377096" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc35308547c" x="197.814984" y="90.309617" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc35308547c" x="166.378359" y="99.066934" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc35308547c" x="145.830392" y="110.431955" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc35308547c" x="134.598477" y="126.026287" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc35308547c" x="124.077268" y="149.033155" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc35308547c" x="122.462976" y="157.476606" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc35308547c" x="81.012077" y="220.06889" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc35308547c" x="77.44276" y="239.652656" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc35308547c" x="76.953425" y="252.706566" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p49dad874ee)">
+     <use xlink:href="#m0ead7fa3ab" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0ead7fa3ab" x="242.839153" y="80.778898" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0ead7fa3ab" x="218.251194" y="86.377096" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0ead7fa3ab" x="197.814984" y="90.309617" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0ead7fa3ab" x="166.378359" y="99.066934" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0ead7fa3ab" x="145.830392" y="110.431955" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0ead7fa3ab" x="134.598477" y="126.026287" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0ead7fa3ab" x="124.077268" y="149.033155" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0ead7fa3ab" x="122.462976" y="157.476606" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0ead7fa3ab" x="81.012077" y="220.06889" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0ead7fa3ab" x="77.44276" y="239.652656" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0ead7fa3ab" x="76.953425" y="252.706566" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_86">
@@ -2631,7 +2631,7 @@ L 245.91379 79.91142
 L 244.888911 80.202126 
 L 243.864032 80.49128 
 L 242.839153 80.778898 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_87">
     <path d="M 242.839153 80.778898 
@@ -2683,7 +2683,7 @@ L 219.787941 86.043669
 L 219.275692 86.155039 
 L 218.763443 86.266182 
 L 218.251194 86.377096 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_88">
     <path d="M 218.251194 86.377096 
@@ -2735,7 +2735,7 @@ L 199.092247 90.072029
 L 198.666492 90.151341 
 L 198.240738 90.230537 
 L 197.814984 90.309617 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_89">
     <path d="M 197.814984 90.309617 
@@ -2787,7 +2787,7 @@ L 168.343148 98.559208
 L 167.688219 98.72898 
 L 167.033289 98.898221 
 L 166.378359 99.066934 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_90">
     <path d="M 166.378359 99.066934 
@@ -2839,7 +2839,7 @@ L 147.11464 109.78743
 L 146.686557 110.003126 
 L 146.258475 110.217965 
 L 145.830392 110.431955 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_91">
     <path d="M 145.830392 110.431955 
@@ -2891,7 +2891,7 @@ L 135.300472 125.172774
 L 135.066474 125.458776 
 L 134.832476 125.743276 
 L 134.598477 126.026287 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_92">
     <path d="M 134.598477 126.026287 
@@ -2943,7 +2943,7 @@ L 124.734843 147.848882
 L 124.515652 148.246526 
 L 124.29646 148.641269 
 L 124.077268 149.033155 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_93">
     <path d="M 124.077268 149.033155 
@@ -2995,7 +2995,7 @@ L 122.56387 156.985769
 L 122.530239 157.149876 
 L 122.496607 157.313488 
 L 122.462976 157.476606 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_94">
     <path d="M 122.462976 157.476606 
@@ -3047,7 +3047,7 @@ L 83.602758 217.699074
 L 82.739198 218.500595 
 L 81.875637 219.290422 
 L 81.012077 220.06889 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_95">
     <path d="M 81.012077 220.06889 
@@ -3099,7 +3099,7 @@ L 77.665842 238.615761
 L 77.591481 238.963605 
 L 77.517121 239.309227 
 L 77.44276 239.652656 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_96">
     <path d="M 77.44276 239.652656 
@@ -3151,23 +3151,23 @@ L 76.984008 251.97672
 L 76.973814 252.221097 
 L 76.96362 252.464376 
 L 76.953425 252.706566 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_97">
     <defs>
-     <path id="m050d0d9fab" d="M -0 2.5 
+     <path id="m42903246a3" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p2a283bbcdd)">
-     <use xlink:href="#m050d0d9fab" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p49dad874ee)">
+     <use xlink:href="#m42903246a3" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_98">
     <defs>
-     <path id="m9f94d41229" d="M -0.833333 2.5 
+     <path id="mca89382c6b" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -3182,16 +3182,16 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p2a283bbcdd)">
-     <use xlink:href="#m9f94d41229" x="432.495268" y="96.067622" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9f94d41229" x="300.62247" y="112.493412" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9f94d41229" x="266.967623" y="120.8136" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9f94d41229" x="226.040946" y="122.099593" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9f94d41229" x="180.985721" y="141.85872" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9f94d41229" x="164.441833" y="156.106179" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9f94d41229" x="157.761315" y="165.23787" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9f94d41229" x="151.269082" y="178.700983" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9f94d41229" x="150.327087" y="185.23695" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p49dad874ee)">
+     <use xlink:href="#mca89382c6b" x="432.495268" y="96.067622" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mca89382c6b" x="300.62247" y="112.493412" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mca89382c6b" x="266.967623" y="120.8136" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mca89382c6b" x="226.040946" y="122.099593" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mca89382c6b" x="180.985721" y="141.85872" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mca89382c6b" x="164.441833" y="156.106179" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mca89382c6b" x="157.761315" y="165.23787" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mca89382c6b" x="151.269082" y="178.700983" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mca89382c6b" x="150.327087" y="185.23695" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_99">
@@ -3244,7 +3244,7 @@ L 308.86452 111.600609
 L 306.11717 111.899849 
 L 303.36982 112.197444 
 L 300.62247 112.493412 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_100">
     <path d="M 300.62247 112.493412 
@@ -3296,7 +3296,7 @@ L 269.071051 120.329422
 L 268.369908 120.491297 
 L 267.668766 120.652688 
 L 266.967623 120.8136 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_101">
     <path d="M 266.967623 120.8136 
@@ -3348,7 +3348,7 @@ L 228.598863 122.020108
 L 227.746224 122.046616 
 L 226.893585 122.073111 
 L 226.040946 122.099593 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_102">
     <path d="M 226.040946 122.099593 
@@ -3400,7 +3400,7 @@ L 183.801673 140.814056
 L 182.863022 141.164522 
 L 181.924372 141.512734 
 L 180.985721 141.85872 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_103">
     <path d="M 180.985721 141.85872 
@@ -3452,7 +3452,7 @@ L 165.475826 155.317544
 L 165.131161 155.581701 
 L 164.786497 155.844575 
 L 164.441833 156.106179 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_104">
     <path d="M 164.441833 156.106179 
@@ -3504,7 +3504,7 @@ L 158.178848 164.710119
 L 158.03967 164.886608 
 L 157.900493 165.062524 
 L 157.761315 165.23787 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_105">
     <path d="M 157.761315 165.23787 
@@ -3556,7 +3556,7 @@ L 151.674847 177.950842
 L 151.539592 178.202046 
 L 151.404337 178.452089 
 L 151.269082 178.700983 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_106">
     <path d="M 151.269082 178.700983 
@@ -3608,11 +3608,11 @@ L 150.385962 184.850776
 L 150.366337 184.979807 
 L 150.346712 185.108531 
 L 150.327087 185.23695 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_107">
     <defs>
-     <path id="m830fa6b107" d="M -1.25 2.5 
+     <path id="m45cfdb7b80" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -3627,16 +3627,16 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p2a283bbcdd)">
-     <use xlink:href="#m830fa6b107" x="345.030867" y="136.859359" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m830fa6b107" x="273.364924" y="143.571257" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m830fa6b107" x="240.719951" y="149.310846" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m830fa6b107" x="221.353978" y="154.160538" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m830fa6b107" x="207.129625" y="156.092215" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m830fa6b107" x="181.064802" y="166.758473" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m830fa6b107" x="179.282169" y="170.289343" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m830fa6b107" x="177.719335" y="175.489948" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m830fa6b107" x="177.643939" y="181.552088" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p49dad874ee)">
+     <use xlink:href="#m45cfdb7b80" x="345.030867" y="136.859359" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m45cfdb7b80" x="273.364924" y="143.571257" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m45cfdb7b80" x="240.719951" y="149.310846" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m45cfdb7b80" x="221.353978" y="154.160538" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m45cfdb7b80" x="207.129625" y="156.092215" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m45cfdb7b80" x="181.064802" y="166.758473" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m45cfdb7b80" x="179.282169" y="170.289343" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m45cfdb7b80" x="177.719335" y="175.489948" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m45cfdb7b80" x="177.643939" y="181.552088" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_108">
@@ -3689,7 +3689,7 @@ L 277.844045 143.175283
 L 276.351005 143.307597 
 L 274.857964 143.439587 
 L 273.364924 143.571257 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_109">
     <path d="M 273.364924 143.571257 
@@ -3741,7 +3741,7 @@ L 242.760262 148.96941
 L 242.080158 149.083462 
 L 241.400055 149.197273 
 L 240.719951 149.310846 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_110">
     <path d="M 240.719951 149.310846 
@@ -3793,7 +3793,7 @@ L 222.564351 153.869835
 L 222.160893 153.966909 
 L 221.757435 154.06381 
 L 221.353978 154.160538 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_111">
     <path d="M 221.353978 154.160538 
@@ -3845,7 +3845,7 @@ L 208.018647 155.973483
 L 207.722306 156.013089 
 L 207.425965 156.052666 
 L 207.129625 156.092215 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_112">
     <path d="M 207.129625 156.092215 
@@ -3897,7 +3897,7 @@ L 182.693853 166.149994
 L 182.150836 166.353581 
 L 181.607819 166.556405 
 L 181.064802 166.758473 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_113">
     <path d="M 181.064802 166.758473 
@@ -3949,7 +3949,7 @@ L 179.393584 170.075284
 L 179.356445 170.146731 
 L 179.319307 170.218084 
 L 179.282169 170.289343 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_114">
     <path d="M 179.282169 170.289343 
@@ -4001,7 +4001,7 @@ L 177.817012 175.179146
 L 177.784453 175.282945 
 L 177.751894 175.386546 
 L 177.719335 175.489948 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_115">
     <path d="M 177.719335 175.489948 
@@ -4053,11 +4053,11 @@ L 177.648651 181.192458
 L 177.64708 181.3126 
 L 177.645509 181.432477 
 L 177.643939 181.552088 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_116">
     <defs>
-     <path id="mdd0cd7491f" d="M 0 -2.5 
+     <path id="mec2cc8893d" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -4070,16 +4070,16 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p2a283bbcdd)">
-     <use xlink:href="#mdd0cd7491f" x="226.871027" y="113.224491" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mdd0cd7491f" x="226.871027" y="113.066324" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mdd0cd7491f" x="226.871027" y="113.178221" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mdd0cd7491f" x="226.871027" y="113.089884" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mdd0cd7491f" x="177.768423" y="132.327899" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mdd0cd7491f" x="160.37503" y="145.652356" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mdd0cd7491f" x="153.995779" y="152.678629" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mdd0cd7491f" x="147.106887" y="168.143801" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mdd0cd7491f" x="145.871703" y="175.118358" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p49dad874ee)">
+     <use xlink:href="#mec2cc8893d" x="226.871027" y="113.224491" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mec2cc8893d" x="226.871027" y="113.066324" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mec2cc8893d" x="226.871027" y="113.178221" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mec2cc8893d" x="226.871027" y="113.089884" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mec2cc8893d" x="177.768423" y="132.327899" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mec2cc8893d" x="160.37503" y="145.652356" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mec2cc8893d" x="153.995779" y="152.678629" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mec2cc8893d" x="147.106887" y="168.143801" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mec2cc8893d" x="145.871703" y="175.118358" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_117">
@@ -4132,7 +4132,7 @@ L 226.871027 113.076223
 L 226.871027 113.072924 
 L 226.871027 113.069624 
 L 226.871027 113.066324 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_118">
     <path d="M 226.871027 113.066324 
@@ -4184,7 +4184,7 @@ L 226.871027 113.171234
 L 226.871027 113.173563 
 L 226.871027 113.175892 
 L 226.871027 113.178221 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_119">
     <path d="M 226.871027 113.178221 
@@ -4236,7 +4236,7 @@ L 226.871027 113.09541
 L 226.871027 113.093568 
 L 226.871027 113.091726 
 L 226.871027 113.089884 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_120">
     <path d="M 226.871027 113.089884 
@@ -4288,7 +4288,7 @@ L 180.837336 131.306392
 L 179.814365 131.649041 
 L 178.791394 131.989534 
 L 177.768423 132.327899 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_121">
     <path d="M 177.768423 132.327899 
@@ -4340,7 +4340,7 @@ L 161.462117 144.909076
 L 161.099755 145.157972 
 L 160.737393 145.405728 
 L 160.37503 145.652356 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_122">
     <path d="M 160.37503 145.652356 
@@ -4392,7 +4392,7 @@ L 154.394483 152.265218
 L 154.261581 152.403373 
 L 154.12868 152.541176 
 L 153.995779 152.678629 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_123">
     <path d="M 153.995779 152.678629 
@@ -4444,7 +4444,7 @@ L 147.537442 167.296442
 L 147.393924 167.580372 
 L 147.250405 167.862819 
 L 147.106887 168.143801 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_124">
     <path d="M 147.106887 168.143801 
@@ -4496,11 +4496,11 @@ L 145.948902 174.70781
 L 145.923169 174.845005 
 L 145.897436 174.981854 
 L 145.871703 175.118358 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_125">
     <defs>
-     <path id="mebe388d71f" d="M 0 -2.5 
+     <path id="mae17d241f7" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -4509,16 +4509,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p2a283bbcdd)">
-     <use xlink:href="#mebe388d71f" x="585.66883" y="173.051371" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mebe388d71f" x="527.144592" y="175.326465" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mebe388d71f" x="457.339427" y="183.688849" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mebe388d71f" x="292.124837" y="178.486631" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mebe388d71f" x="243.129344" y="190.369032" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mebe388d71f" x="213.541392" y="204.43395" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mebe388d71f" x="204.551957" y="212.140784" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mebe388d71f" x="195.860087" y="228.582256" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mebe388d71f" x="194.019853" y="234.294862" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p49dad874ee)">
+     <use xlink:href="#mae17d241f7" x="585.66883" y="173.051371" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mae17d241f7" x="527.144592" y="175.326465" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mae17d241f7" x="457.339427" y="183.688849" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mae17d241f7" x="292.124837" y="178.486631" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mae17d241f7" x="243.129344" y="190.369032" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mae17d241f7" x="213.541392" y="204.43395" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mae17d241f7" x="204.551957" y="212.140784" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mae17d241f7" x="195.860087" y="228.582256" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mae17d241f7" x="194.019853" y="234.294862" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_126">
@@ -4571,7 +4571,7 @@ L 530.802357 175.187039
 L 529.583102 175.233554 
 L 528.363847 175.28003 
 L 527.144592 175.326465 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_127">
     <path d="M 527.144592 175.326465 
@@ -4623,7 +4623,7 @@ L 461.70225 183.20239
 L 460.247976 183.36503 
 L 458.793701 183.527182 
 L 457.339427 183.688849 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_128">
     <path d="M 457.339427 183.688849 
@@ -4675,7 +4675,7 @@ L 302.450749 178.826834
 L 299.008779 178.713671 
 L 295.566808 178.60027 
 L 292.124837 178.486631 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_129">
     <path d="M 292.124837 178.486631 
@@ -4727,7 +4727,7 @@ L 246.191563 189.6981
 L 245.170823 189.922669 
 L 244.150084 190.146311 
 L 243.129344 190.369032 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_130">
     <path d="M 243.129344 190.369032 
@@ -4779,7 +4779,7 @@ L 215.390639 203.654226
 L 214.774224 203.915384 
 L 214.157808 204.175288 
 L 213.541392 204.43395 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_131">
     <path d="M 213.541392 204.43395 
@@ -4831,7 +4831,7 @@ L 205.113797 211.689953
 L 204.926517 211.840648 
 L 204.739237 211.990924 
 L 204.551957 212.140784 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_132">
     <path d="M 204.551957 212.140784 
@@ -4883,7 +4883,7 @@ L 196.403329 227.688717
 L 196.222248 227.988205 
 L 196.041168 228.286045 
 L 195.860087 228.582256 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_133">
     <path d="M 195.860087 228.582256 
@@ -4935,7 +4935,7 @@ L 194.134867 233.954953
 L 194.096529 234.068494 
 L 194.058191 234.181796 
 L 194.019853 234.294862 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="legend_1">
     <g id="patch_7">
@@ -4953,7 +4953,7 @@ z
     </g>
     <g id="line2d_134">
      <defs>
-      <path id="ma5924d740c" d="M 0 3.5 
+      <path id="m34154200ec" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -4966,7 +4966,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#ma5924d740c" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m34154200ec" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -5025,7 +5025,7 @@ z
     </g>
     <g id="line2d_135">
      <g>
-      <use xlink:href="#m7a3ce87474" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m709da15e7e" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -5039,7 +5039,7 @@ z
     </g>
     <g id="line2d_136">
      <g>
-      <use xlink:href="#m347b73ce0a" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m8323a7be1f" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -5084,7 +5084,7 @@ z
     </g>
     <g id="line2d_137">
      <g>
-      <use xlink:href="#mc35308547c" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m0ead7fa3ab" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -5127,7 +5127,7 @@ z
     </g>
     <g id="line2d_138">
      <g>
-      <use xlink:href="#m050d0d9fab" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m42903246a3" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -5143,7 +5143,7 @@ z
     </g>
     <g id="line2d_139">
      <g>
-      <use xlink:href="#m9f94d41229" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mca89382c6b" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -5197,7 +5197,7 @@ z
     </g>
     <g id="line2d_140">
      <g>
-      <use xlink:href="#m830fa6b107" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m45cfdb7b80" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -5262,7 +5262,7 @@ z
     </g>
     <g id="line2d_141">
      <g>
-      <use xlink:href="#mdd0cd7491f" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#mec2cc8893d" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -5300,7 +5300,7 @@ z
     </g>
     <g id="line2d_142">
      <g>
-      <use xlink:href="#mebe388d71f" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mae17d241f7" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -5370,486 +5370,486 @@ z
     </g>
    </g>
    <g id="line2d_143">
-    <g clip-path="url(#p2a283bbcdd)">
-     <use xlink:href="#ma5924d740c" x="319.643112" y="121.395074" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#ma5924d740c" x="269.129958" y="133.594619" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#ma5924d740c" x="247.452898" y="138.864449" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#ma5924d740c" x="192.820547" y="154.384156" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#ma5924d740c" x="180.389901" y="165.599093" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#ma5924d740c" x="155.351585" y="174.870052" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#ma5924d740c" x="149.634124" y="178.809574" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#ma5924d740c" x="139.514773" y="191.860315" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#ma5924d740c" x="119.666036" y="285.753115" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#ma5924d740c" x="97.814287" y="314.137023" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <g clip-path="url(#p49dad874ee)">
+     <use xlink:href="#m34154200ec" x="319.643112" y="117.176023" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m34154200ec" x="269.129958" y="129.719036" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m34154200ec" x="247.452898" y="135.539692" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m34154200ec" x="192.820547" y="151.842181" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m34154200ec" x="180.389901" y="163.51492" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m34154200ec" x="155.351585" y="172.655677" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m34154200ec" x="149.634124" y="177.205842" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m34154200ec" x="139.514773" y="190.541672" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m34154200ec" x="119.666036" y="285.81942" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m34154200ec" x="97.814287" y="313.360586" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
    <g id="line2d_144">
-    <path d="M 319.643112 121.395074 
-L 318.590755 121.679401 
-L 317.538397 121.962243 
-L 316.48604 122.243614 
-L 315.433682 122.523531 
-L 314.381325 122.802007 
-L 313.328968 123.079058 
-L 312.27661 123.354699 
-L 311.224253 123.628942 
-L 310.171896 123.901804 
-L 309.119538 124.173297 
-L 308.067181 124.443435 
-L 307.014823 124.712231 
-L 305.962466 124.9797 
-L 304.910109 125.245853 
-L 303.857751 125.510705 
-L 302.805394 125.774266 
-L 301.753037 126.036551 
-L 300.700679 126.297571 
-L 299.648322 126.557338 
-L 298.595965 126.815864 
-L 297.543607 127.073162 
-L 296.49125 127.329243 
-L 295.438892 127.584118 
-L 294.386535 127.837798 
-L 293.334178 128.090295 
-L 292.28182 128.34162 
-L 291.229463 128.591783 
-L 290.177106 128.840795 
-L 289.124748 129.088668 
-L 288.072391 129.33541 
-L 287.020033 129.581033 
-L 285.967676 129.825546 
-L 284.915319 130.06896 
-L 283.862961 130.311284 
-L 282.810604 130.552528 
-L 281.758247 130.792702 
-L 280.705889 131.031815 
-L 279.653532 131.269876 
-L 278.601175 131.506895 
-L 277.548817 131.74288 
-L 276.49646 131.977842 
-L 275.444102 132.211787 
-L 274.391745 132.444726 
-L 273.339388 132.676667 
-L 272.28703 132.907619 
-L 271.234673 133.137589 
-L 270.182316 133.366587 
-L 269.129958 133.594619 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 319.643112 117.176023 
+L 318.590755 117.469295 
+L 317.538397 117.760987 
+L 316.48604 118.051115 
+L 315.433682 118.339697 
+L 314.381325 118.626749 
+L 313.328968 118.912286 
+L 312.27661 119.196325 
+L 311.224253 119.478882 
+L 310.171896 119.759971 
+L 309.119538 120.039608 
+L 308.067181 120.317808 
+L 307.014823 120.594585 
+L 305.962466 120.869955 
+L 304.910109 121.143931 
+L 303.857751 121.416527 
+L 302.805394 121.687757 
+L 301.753037 121.957635 
+L 300.700679 122.226174 
+L 299.648322 122.493387 
+L 298.595965 122.759288 
+L 297.543607 123.023889 
+L 296.49125 123.287203 
+L 295.438892 123.549243 
+L 294.386535 123.81002 
+L 293.334178 124.069546 
+L 292.28182 124.327835 
+L 291.229463 124.584896 
+L 290.177106 124.840743 
+L 289.124748 125.095386 
+L 288.072391 125.348837 
+L 287.020033 125.601107 
+L 285.967676 125.852207 
+L 284.915319 126.102147 
+L 283.862961 126.350938 
+L 282.810604 126.598591 
+L 281.758247 126.845117 
+L 280.705889 127.090524 
+L 279.653532 127.334825 
+L 278.601175 127.578027 
+L 277.548817 127.820142 
+L 276.49646 128.061179 
+L 275.444102 128.301147 
+L 274.391745 128.540056 
+L 273.339388 128.777915 
+L 272.28703 129.014733 
+L 271.234673 129.250521 
+L 270.182316 129.485285 
+L 269.129958 129.719036 
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_145">
-    <path d="M 269.129958 133.594619 
-L 268.678353 133.709807 
-L 268.226747 133.824749 
-L 267.775142 133.939448 
-L 267.323537 134.053905 
-L 266.871931 134.16812 
-L 266.420326 134.282095 
-L 265.96872 134.39583 
-L 265.517115 134.509327 
-L 265.065509 134.622586 
-L 264.613904 134.735609 
-L 264.162299 134.848396 
-L 263.710693 134.960949 
-L 263.259088 135.073268 
-L 262.807482 135.185355 
-L 262.355877 135.29721 
-L 261.904271 135.408834 
-L 261.452666 135.520229 
-L 261.001061 135.631394 
-L 260.549455 135.742333 
-L 260.09785 135.853044 
-L 259.646244 135.963529 
-L 259.194639 136.073789 
-L 258.743034 136.183825 
-L 258.291428 136.293638 
-L 257.839823 136.403228 
-L 257.388217 136.512597 
-L 256.936612 136.621746 
-L 256.485006 136.730675 
-L 256.033401 136.839385 
-L 255.581796 136.947877 
-L 255.13019 137.056153 
-L 254.678585 137.164212 
-L 254.226979 137.272055 
-L 253.775374 137.379685 
-L 253.323769 137.487101 
-L 252.872163 137.594304 
-L 252.420558 137.701295 
-L 251.968952 137.808075 
-L 251.517347 137.914645 
-L 251.065741 138.021005 
-L 250.614136 138.127157 
-L 250.162531 138.233102 
-L 249.710925 138.338839 
-L 249.25932 138.44437 
-L 248.807714 138.549696 
-L 248.356109 138.654817 
-L 247.904503 138.759734 
-L 247.452898 138.864449 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 269.129958 129.719036 
+L 268.678353 129.846908 
+L 268.226747 129.974479 
+L 267.775142 130.10175 
+L 267.323537 130.228722 
+L 266.871931 130.355398 
+L 266.420326 130.481777 
+L 265.96872 130.607862 
+L 265.517115 130.733655 
+L 265.065509 130.859155 
+L 264.613904 130.984365 
+L 264.162299 131.109287 
+L 263.710693 131.23392 
+L 263.259088 131.358268 
+L 262.807482 131.48233 
+L 262.355877 131.606109 
+L 261.904271 131.729605 
+L 261.452666 131.85282 
+L 261.001061 131.975756 
+L 260.549455 132.098413 
+L 260.09785 132.220792 
+L 259.646244 132.342896 
+L 259.194639 132.464724 
+L 258.743034 132.586279 
+L 258.291428 132.707562 
+L 257.839823 132.828574 
+L 257.388217 132.949315 
+L 256.936612 133.069788 
+L 256.485006 133.189994 
+L 256.033401 133.309933 
+L 255.581796 133.429607 
+L 255.13019 133.549017 
+L 254.678585 133.668164 
+L 254.226979 133.787049 
+L 253.775374 133.905674 
+L 253.323769 134.02404 
+L 252.872163 134.142147 
+L 252.420558 134.259997 
+L 251.968952 134.377591 
+L 251.517347 134.49493 
+L 251.065741 134.612016 
+L 250.614136 134.728848 
+L 250.162531 134.845429 
+L 249.710925 134.96176 
+L 249.25932 135.077841 
+L 248.807714 135.193674 
+L 248.356109 135.309259 
+L 247.904503 135.424598 
+L 247.452898 135.539692 
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_146">
-    <path d="M 247.452898 138.864449 
-L 246.314724 139.237603 
-L 245.17655 139.608202 
-L 244.038376 139.976282 
-L 242.900202 140.341875 
-L 241.762028 140.705016 
-L 240.623854 141.065737 
-L 239.48568 141.42407 
-L 238.347506 141.780046 
-L 237.209332 142.133697 
-L 236.071158 142.485052 
-L 234.932984 142.834142 
-L 233.79481 143.180995 
-L 232.656636 143.525639 
-L 231.518462 143.868103 
-L 230.380288 144.208414 
-L 229.242114 144.546598 
-L 228.10394 144.882683 
-L 226.965766 145.216695 
-L 225.827592 145.548658 
-L 224.689418 145.878597 
-L 223.551244 146.206538 
-L 222.41307 146.532504 
-L 221.274896 146.856519 
-L 220.136722 147.178605 
-L 218.998548 147.498787 
-L 217.860374 147.817086 
-L 216.7222 148.133524 
-L 215.584026 148.448124 
-L 214.445852 148.760905 
-L 213.307678 149.071889 
-L 212.169505 149.381097 
-L 211.031331 149.688549 
-L 209.893157 149.994265 
-L 208.754983 150.298263 
-L 207.616809 150.600564 
-L 206.478635 150.901186 
-L 205.340461 151.200148 
-L 204.202287 151.497467 
-L 203.064113 151.793163 
-L 201.925939 152.087252 
-L 200.787765 152.379751 
-L 199.649591 152.670679 
-L 198.511417 152.960052 
-L 197.373243 153.247886 
-L 196.235069 153.534197 
-L 195.096895 153.819002 
-L 193.958721 154.102317 
-L 192.820547 154.384156 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 247.452898 135.539692 
+L 246.314724 135.934572 
+L 245.17655 136.326592 
+L 244.038376 136.715794 
+L 242.900202 137.102217 
+L 241.762028 137.485901 
+L 240.623854 137.866885 
+L 239.48568 138.245206 
+L 238.347506 138.620901 
+L 237.209332 138.994007 
+L 236.071158 139.364559 
+L 234.932984 139.732591 
+L 233.79481 140.098138 
+L 232.656636 140.461233 
+L 231.518462 140.821909 
+L 230.380288 141.180197 
+L 229.242114 141.53613 
+L 228.10394 141.889737 
+L 226.965766 142.24105 
+L 225.827592 142.590097 
+L 224.689418 142.936908 
+L 223.551244 143.281511 
+L 222.41307 143.623934 
+L 221.274896 143.964205 
+L 220.136722 144.30235 
+L 218.998548 144.638396 
+L 217.860374 144.972369 
+L 216.7222 145.304294 
+L 215.584026 145.634195 
+L 214.445852 145.962099 
+L 213.307678 146.288028 
+L 212.169505 146.612006 
+L 211.031331 146.934057 
+L 209.893157 147.254203 
+L 208.754983 147.572467 
+L 207.616809 147.888871 
+L 206.478635 148.203436 
+L 205.340461 148.516183 
+L 204.202287 148.827134 
+L 203.064113 149.136309 
+L 201.925939 149.443728 
+L 200.787765 149.749411 
+L 199.649591 150.053377 
+L 198.511417 150.355647 
+L 197.373243 150.656237 
+L 196.235069 150.955168 
+L 195.096895 151.252457 
+L 193.958721 151.548122 
+L 192.820547 151.842181 
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_147">
-    <path d="M 192.820547 154.384156 
-L 192.561575 154.643145 
-L 192.302603 154.900901 
-L 192.043631 155.157435 
-L 191.78466 155.412759 
-L 191.525688 155.666885 
-L 191.266716 155.919823 
-L 191.007744 156.171585 
-L 190.748773 156.422181 
-L 190.489801 156.671623 
-L 190.230829 156.91992 
-L 189.971857 157.167083 
-L 189.712885 157.413123 
-L 189.453914 157.65805 
-L 189.194942 157.901874 
-L 188.93597 158.144604 
-L 188.676998 158.386251 
-L 188.418027 158.626824 
-L 188.159055 158.866332 
-L 187.900083 159.104786 
-L 187.641111 159.342193 
-L 187.382139 159.578564 
-L 187.123168 159.813907 
-L 186.864196 160.048231 
-L 186.605224 160.281546 
-L 186.346252 160.513859 
-L 186.087281 160.745179 
-L 185.828309 160.975515 
-L 185.569337 161.204876 
-L 185.310365 161.433268 
-L 185.051393 161.660701 
-L 184.792422 161.887182 
-L 184.53345 162.11272 
-L 184.274478 162.337321 
-L 184.015506 162.560995 
-L 183.756535 162.783748 
-L 183.497563 163.005589 
-L 183.238591 163.226524 
-L 182.979619 163.446561 
-L 182.720647 163.665707 
-L 182.461676 163.883969 
-L 182.202704 164.101355 
-L 181.943732 164.317872 
-L 181.68476 164.533525 
-L 181.425789 164.748324 
-L 181.166817 164.962273 
-L 180.907845 165.17538 
-L 180.648873 165.387651 
-L 180.389901 165.599093 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 192.820547 151.842181 
+L 192.561575 152.112895 
+L 192.302603 152.382263 
+L 192.043631 152.650296 
+L 191.78466 152.917009 
+L 191.525688 153.182414 
+L 191.266716 153.446524 
+L 191.007744 153.709352 
+L 190.748773 153.97091 
+L 190.489801 154.23121 
+L 190.230829 154.490265 
+L 189.971857 154.748085 
+L 189.712885 155.004684 
+L 189.453914 155.260072 
+L 189.194942 155.51426 
+L 188.93597 155.767261 
+L 188.676998 156.019084 
+L 188.418027 156.269742 
+L 188.159055 156.519244 
+L 187.900083 156.767601 
+L 187.641111 157.014824 
+L 187.382139 157.260924 
+L 187.123168 157.505909 
+L 186.864196 157.749791 
+L 186.605224 157.992578 
+L 186.346252 158.234282 
+L 186.087281 158.474911 
+L 185.828309 158.714476 
+L 185.569337 158.952984 
+L 185.310365 159.190447 
+L 185.051393 159.426872 
+L 184.792422 159.662269 
+L 184.53345 159.896647 
+L 184.274478 160.130015 
+L 184.015506 160.362381 
+L 183.756535 160.593753 
+L 183.497563 160.824141 
+L 183.238591 161.053552 
+L 182.979619 161.281996 
+L 182.720647 161.509479 
+L 182.461676 161.73601 
+L 182.202704 161.961597 
+L 181.943732 162.186248 
+L 181.68476 162.409971 
+L 181.425789 162.632772 
+L 181.166817 162.854661 
+L 180.907845 163.075643 
+L 180.648873 163.295728 
+L 180.389901 163.51492 
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_148">
-    <path d="M 180.389901 165.599093 
-L 179.86827 165.809355 
-L 179.346638 166.018803 
-L 178.825007 166.227444 
-L 178.303375 166.435284 
-L 177.781744 166.642329 
-L 177.260112 166.848586 
-L 176.73848 167.054059 
-L 176.216849 167.258755 
-L 175.695217 167.46268 
-L 175.173586 167.66584 
-L 174.651954 167.86824 
-L 174.130322 168.069886 
-L 173.608691 168.270784 
-L 173.087059 168.470939 
-L 172.565428 168.670357 
-L 172.043796 168.869042 
-L 171.522165 169.067002 
-L 171.000533 169.264239 
-L 170.478901 169.460761 
-L 169.95727 169.656572 
-L 169.435638 169.851677 
-L 168.914007 170.046081 
-L 168.392375 170.23979 
-L 167.870743 170.432808 
-L 167.349112 170.62514 
-L 166.82748 170.816791 
-L 166.305849 171.007766 
-L 165.784217 171.19807 
-L 165.262586 171.387707 
-L 164.740954 171.576682 
-L 164.219322 171.764999 
-L 163.697691 171.952664 
-L 163.176059 172.13968 
-L 162.654428 172.326053 
-L 162.132796 172.511786 
-L 161.611164 172.696883 
-L 161.089533 172.88135 
-L 160.567901 173.065191 
-L 160.04627 173.248409 
-L 159.524638 173.43101 
-L 159.003007 173.612996 
-L 158.481375 173.794373 
-L 157.959743 173.975144 
-L 157.438112 174.155313 
-L 156.91648 174.334884 
-L 156.394849 174.513862 
-L 155.873217 174.69225 
-L 155.351585 174.870052 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 180.389901 163.51492 
+L 179.86827 163.721979 
+L 179.346638 163.928249 
+L 178.825007 164.133736 
+L 178.303375 164.338446 
+L 177.781744 164.542385 
+L 177.260112 164.745558 
+L 176.73848 164.947971 
+L 176.216849 165.14963 
+L 175.695217 165.350541 
+L 175.173586 165.550709 
+L 174.651954 165.75014 
+L 174.130322 165.948838 
+L 173.608691 166.14681 
+L 173.087059 166.34406 
+L 172.565428 166.540594 
+L 172.043796 166.736418 
+L 171.522165 166.931535 
+L 171.000533 167.125951 
+L 170.478901 167.319672 
+L 169.95727 167.512702 
+L 169.435638 167.705046 
+L 168.914007 167.896709 
+L 168.392375 168.087696 
+L 167.870743 168.278012 
+L 167.349112 168.46766 
+L 166.82748 168.656647 
+L 166.305849 168.844976 
+L 165.784217 169.032652 
+L 165.262586 169.219679 
+L 164.740954 169.406063 
+L 164.219322 169.591807 
+L 163.697691 169.776916 
+L 163.176059 169.961394 
+L 162.654428 170.145246 
+L 162.132796 170.328475 
+L 161.611164 170.511086 
+L 161.089533 170.693083 
+L 160.567901 170.87447 
+L 160.04627 171.055252 
+L 159.524638 171.235431 
+L 159.003007 171.415013 
+L 158.481375 171.594001 
+L 157.959743 171.7724 
+L 157.438112 171.950212 
+L 156.91648 172.127442 
+L 156.394849 172.304094 
+L 155.873217 172.480171 
+L 155.351585 172.655677 
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_149">
-    <path d="M 155.351585 174.870052 
-L 155.232472 174.955119 
-L 155.113358 175.040052 
-L 154.994244 175.124853 
-L 154.87513 175.20952 
-L 154.756017 175.294056 
-L 154.636903 175.378459 
-L 154.517789 175.462732 
-L 154.398675 175.546873 
-L 154.279561 175.630883 
-L 154.160448 175.714764 
-L 154.041334 175.798515 
-L 153.92222 175.882136 
-L 153.803106 175.965628 
-L 153.683992 176.048992 
-L 153.564879 176.132227 
-L 153.445765 176.215335 
-L 153.326651 176.298316 
-L 153.207537 176.381169 
-L 153.088424 176.463896 
-L 152.96931 176.546496 
-L 152.850196 176.628971 
-L 152.731082 176.71132 
-L 152.611968 176.793544 
-L 152.492855 176.875644 
-L 152.373741 176.957619 
-L 152.254627 177.03947 
-L 152.135513 177.121197 
-L 152.016399 177.202802 
-L 151.897286 177.284283 
-L 151.778172 177.365642 
-L 151.659058 177.446879 
-L 151.539944 177.527994 
-L 151.420831 177.608988 
-L 151.301717 177.689861 
-L 151.182603 177.770613 
-L 151.063489 177.851245 
-L 150.944375 177.931757 
-L 150.825262 178.012149 
-L 150.706148 178.092422 
-L 150.587034 178.172577 
-L 150.46792 178.252613 
-L 150.348806 178.33253 
-L 150.229693 178.41233 
-L 150.110579 178.492012 
-L 149.991465 178.571578 
-L 149.872351 178.651026 
-L 149.753238 178.730358 
-L 149.634124 178.809574 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 155.351585 172.655677 
+L 155.232472 172.75448 
+L 155.113358 172.853103 
+L 154.994244 172.951547 
+L 154.87513 173.049812 
+L 154.756017 173.147899 
+L 154.636903 173.245808 
+L 154.517789 173.343541 
+L 154.398675 173.441097 
+L 154.279561 173.538478 
+L 154.160448 173.635685 
+L 154.041334 173.732717 
+L 153.92222 173.829575 
+L 153.803106 173.92626 
+L 153.683992 174.022773 
+L 153.564879 174.119114 
+L 153.445765 174.215284 
+L 153.326651 174.311284 
+L 153.207537 174.407113 
+L 153.088424 174.502774 
+L 152.96931 174.598265 
+L 152.850196 174.693588 
+L 152.731082 174.788744 
+L 152.611968 174.883733 
+L 152.492855 174.978555 
+L 152.373741 175.073212 
+L 152.254627 175.167703 
+L 152.135513 175.262029 
+L 152.016399 175.356192 
+L 151.897286 175.450191 
+L 151.778172 175.544027 
+L 151.659058 175.637701 
+L 151.539944 175.731213 
+L 151.420831 175.824563 
+L 151.301717 175.917753 
+L 151.182603 176.010783 
+L 151.063489 176.103653 
+L 150.944375 176.196364 
+L 150.825262 176.288917 
+L 150.706148 176.381311 
+L 150.587034 176.473549 
+L 150.46792 176.565629 
+L 150.348806 176.657553 
+L 150.229693 176.749321 
+L 150.110579 176.840933 
+L 149.991465 176.932391 
+L 149.872351 177.023695 
+L 149.753238 177.114845 
+L 149.634124 177.205842 
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_150">
-    <path d="M 149.634124 178.809574 
-L 149.423304 179.116171 
-L 149.212484 179.421041 
-L 149.001664 179.724204 
-L 148.790845 180.025678 
-L 148.580025 180.325483 
-L 148.369205 180.623636 
-L 148.158385 180.920156 
-L 147.947565 181.21506 
-L 147.736745 181.508367 
-L 147.525926 181.800093 
-L 147.315106 182.090255 
-L 147.104286 182.37887 
-L 146.893466 182.665955 
-L 146.682646 182.951525 
-L 146.471827 183.235596 
-L 146.261007 183.518184 
-L 146.050187 183.799305 
-L 145.839367 184.078973 
-L 145.628547 184.357204 
-L 145.417728 184.634012 
-L 145.206908 184.909412 
-L 144.996088 185.183418 
-L 144.785268 185.456044 
-L 144.574448 185.727303 
-L 144.363629 185.99721 
-L 144.152809 186.265778 
-L 143.941989 186.53302 
-L 143.731169 186.798949 
-L 143.520349 187.063578 
-L 143.30953 187.32692 
-L 143.09871 187.588987 
-L 142.88789 187.849791 
-L 142.67707 188.109344 
-L 142.46625 188.367659 
-L 142.25543 188.624748 
-L 142.044611 188.880621 
-L 141.833791 189.13529 
-L 141.622971 189.388766 
-L 141.412151 189.641062 
-L 141.201331 189.892186 
-L 140.990512 190.142151 
-L 140.779692 190.390968 
-L 140.568872 190.638645 
-L 140.358052 190.885195 
-L 140.147232 191.130627 
-L 139.936413 191.374951 
-L 139.725593 191.618177 
-L 139.514773 191.860315 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 149.634124 177.205842 
+L 149.423304 177.519974 
+L 149.212484 177.832294 
+L 149.001664 178.142822 
+L 148.790845 178.451579 
+L 148.580025 178.758584 
+L 148.369205 179.063859 
+L 148.158385 179.367421 
+L 147.947565 179.669291 
+L 147.736745 179.969486 
+L 147.525926 180.268026 
+L 147.315106 180.564929 
+L 147.104286 180.860211 
+L 146.893466 181.153892 
+L 146.682646 181.445988 
+L 146.471827 181.736517 
+L 146.261007 182.025494 
+L 146.050187 182.312937 
+L 145.839367 182.598862 
+L 145.628547 182.883284 
+L 145.417728 183.16622 
+L 145.206908 183.447684 
+L 144.996088 183.727692 
+L 144.785268 184.00626 
+L 144.574448 184.283401 
+L 144.363629 184.559131 
+L 144.152809 184.833463 
+L 143.941989 185.106412 
+L 143.731169 185.377992 
+L 143.520349 185.648216 
+L 143.30953 185.917097 
+L 143.09871 186.18465 
+L 142.88789 186.450886 
+L 142.67707 186.71582 
+L 142.46625 186.979463 
+L 142.25543 187.241829 
+L 142.044611 187.502929 
+L 141.833791 187.762775 
+L 141.622971 188.02138 
+L 141.412151 188.278756 
+L 141.201331 188.534914 
+L 140.990512 188.789865 
+L 140.779692 189.043621 
+L 140.568872 189.296193 
+L 140.358052 189.547592 
+L 140.147232 189.797829 
+L 139.936413 190.046914 
+L 139.725593 190.294858 
+L 139.514773 190.541672 
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_151">
-    <path d="M 139.514773 191.860315 
-L 139.101258 196.882349 
-L 138.687742 201.477763 
-L 138.274227 205.713398 
-L 137.860712 209.641521 
-L 137.447196 213.303778 
-L 137.033681 216.733888 
-L 136.620165 219.959535 
-L 136.20665 223.00373 
-L 135.793135 225.885805 
-L 135.379619 228.622157 
-L 134.966104 231.226816 
-L 134.552589 233.711878 
-L 134.139073 236.087845 
-L 133.725558 238.363896 
-L 133.312043 240.548094 
-L 132.898527 242.647568 
-L 132.485012 244.668644 
-L 132.071496 246.616969 
-L 131.657981 248.497598 
-L 131.244466 250.315079 
-L 130.83095 252.073513 
-L 130.417435 253.776618 
-L 130.00392 255.427769 
-L 129.590404 257.030043 
-L 129.176889 258.586251 
-L 128.763374 260.098967 
-L 128.349858 261.570556 
-L 127.936343 263.003195 
-L 127.522827 264.398894 
-L 127.109312 265.759509 
-L 126.695797 267.086762 
-L 126.282281 268.382249 
-L 125.868766 269.647455 
-L 125.455251 270.883763 
-L 125.041735 272.092465 
-L 124.62822 273.274766 
-L 124.214705 274.431795 
-L 123.801189 275.56461 
-L 123.387674 276.674203 
-L 122.974158 277.761507 
-L 122.560643 278.827401 
-L 122.147128 279.872711 
-L 121.733612 280.898218 
-L 121.320097 281.904656 
-L 120.906582 282.892724 
-L 120.493066 283.863079 
-L 120.079551 284.816346 
-L 119.666036 285.753115 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 139.514773 190.541672 
+L 139.101258 195.714424 
+L 138.687742 200.435699 
+L 138.274227 204.778021 
+L 137.860712 208.797728 
+L 137.447196 212.539461 
+L 137.033681 216.03919 
+L 136.620165 219.326328 
+L 136.20665 222.42523 
+L 135.793135 225.35629 
+L 135.379619 228.136762 
+L 134.966104 230.781363 
+L 134.552589 233.302758 
+L 134.139073 235.711916 
+L 133.725558 238.018406 
+L 133.312043 240.230622 
+L 132.898527 242.355968 
+L 132.485012 244.40101 
+L 132.071496 246.371596 
+L 131.657981 248.272957 
+L 131.244466 250.109794 
+L 130.83095 251.886341 
+L 130.417435 253.606431 
+L 130.00392 255.273542 
+L 129.590404 256.890841 
+L 129.176889 258.461217 
+L 128.763374 259.987318 
+L 128.349858 261.471571 
+L 127.936343 262.91621 
+L 127.522827 264.323295 
+L 127.109312 265.694729 
+L 126.695797 267.032274 
+L 126.282281 268.337565 
+L 125.868766 269.61212 
+L 125.455251 270.857355 
+L 125.041735 272.074586 
+L 124.62822 273.265048 
+L 124.214705 274.42989 
+L 123.801189 275.570194 
+L 123.387674 276.686972 
+L 122.974158 277.781174 
+L 122.560643 278.853696 
+L 122.147128 279.90538 
+L 121.733612 280.93702 
+L 121.320097 281.949366 
+L 120.906582 282.943126 
+L 120.493066 283.918971 
+L 120.079551 284.877535 
+L 119.666036 285.81942 
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_152">
-    <path d="M 119.666036 285.753115 
-L 119.210791 286.525007 
-L 118.755546 287.286047 
-L 118.300301 288.036536 
-L 117.845056 288.776762 
-L 117.389812 289.507001 
-L 116.934567 290.227521 
-L 116.479322 290.938576 
-L 116.024077 291.640412 
-L 115.568833 292.333264 
-L 115.113588 293.017361 
-L 114.658343 293.692919 
-L 114.203098 294.360151 
-L 113.747854 295.019258 
-L 113.292609 295.670436 
-L 112.837364 296.313874 
-L 112.382119 296.949753 
-L 111.926875 297.578249 
-L 111.47163 298.199532 
-L 111.016385 298.813765 
-L 110.56114 299.421106 
-L 110.105895 300.021708 
-L 109.650651 300.61572 
-L 109.195406 301.203284 
-L 108.740161 301.784539 
-L 108.284916 302.359618 
-L 107.829672 302.928652 
-L 107.374427 303.491767 
-L 106.919182 304.049084 
-L 106.463937 304.600721 
-L 106.008693 305.146794 
-L 105.553448 305.687412 
-L 105.098203 306.222685 
-L 104.642958 306.752717 
-L 104.187713 307.277609 
-L 103.732469 307.79746 
-L 103.277224 308.312366 
-L 102.821979 308.82242 
-L 102.366734 309.327714 
-L 101.91149 309.828334 
-L 101.456245 310.324366 
-L 101.001 310.815895 
-L 100.545755 311.303 
-L 100.090511 311.785761 
-L 99.635266 312.264255 
-L 99.180021 312.738556 
-L 98.724776 313.208738 
-L 98.269531 313.67487 
-L 97.814287 314.137023 
-" clip-path="url(#p2a283bbcdd)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 119.666036 285.81942 
+L 119.210791 286.56229 
+L 118.755546 287.295104 
+L 118.300301 288.018129 
+L 117.845056 288.731624 
+L 117.389812 289.435837 
+L 116.934567 290.131006 
+L 116.479322 290.817361 
+L 116.024077 291.495122 
+L 115.568833 292.164501 
+L 115.113588 292.825704 
+L 114.658343 293.478928 
+L 114.203098 294.124364 
+L 113.747854 294.762194 
+L 113.292609 295.392595 
+L 112.837364 296.01574 
+L 112.382119 296.631793 
+L 111.926875 297.240913 
+L 111.47163 297.843256 
+L 111.016385 298.43897 
+L 110.56114 299.028199 
+L 110.105895 299.611083 
+L 109.650651 300.187757 
+L 109.195406 300.758353 
+L 108.740161 301.322997 
+L 108.284916 301.881812 
+L 107.829672 302.434917 
+L 107.374427 302.982427 
+L 106.919182 303.524455 
+L 106.463937 304.06111 
+L 106.008693 304.592496 
+L 105.553448 305.118716 
+L 105.098203 305.63987 
+L 104.642958 306.156055 
+L 104.187713 306.667363 
+L 103.732469 307.173888 
+L 103.277224 307.675716 
+L 102.821979 308.172935 
+L 102.366734 308.665628 
+L 101.91149 309.153877 
+L 101.456245 309.637762 
+L 101.001 310.117359 
+L 100.545755 310.592745 
+L 100.090511 311.063992 
+L 99.635266 311.531172 
+L 99.180021 311.994354 
+L 98.724776 312.453607 
+L 98.269531 312.908996 
+L 97.814287 313.360586 
+" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
   </g>
   <g id="text_25">
@@ -6166,8 +6166,8 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-07-09T07:09:47Z  ·  Linux chungus2 x86_64  ·  commit b23a23be  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(43.545547 465.66) scale(0.07 -0.07)">
+   <!-- 2026-07-09T17:31:54Z  ·  Linux chungus2 x86_64  ·  commit 324f086c  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(44.677578 465.66) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -6231,6 +6231,31 @@ L 1409 3309
 L 1409 2516 
 L 750 2516 
 L 750 3309 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-b7" d="M 684 2619 
@@ -6330,14 +6355,14 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-39" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
     <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -6377,109 +6402,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3135.351562 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3198.974609 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3262.597656 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3323.876953 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3387.5 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3451.123047 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3514.599609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3576.123047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3607.910156 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3639.697266 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3671.484375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3703.271484 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3735.058594 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3762.841797 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3824.365234 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3885.644531 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3949.023438 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4012.5 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4051.363281 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4112.544922 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4171.724609 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4233.248047 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4274.361328 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4308.052734 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4335.835938 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4397.359375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4458.638672 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4522.017578 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4585.640625 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4619.332031 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4678.511719 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4742.134766 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4773.921875 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4837.544922 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4901.167969 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4932.955078 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4996.578125 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5032.662109 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5071.525391 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5126.505859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5190.128906 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5221.916016 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5253.703125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5285.490234 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5317.277344 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5349.064453 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5388.273438 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5451.652344 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5490.515625 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5551.697266 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5615.076172 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5678.552734 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5741.931641 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5805.408203 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5868.787109 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5907.996094 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5939.783203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6023.572266 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6055.359375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6152.771484 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6214.294922 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6277.771484 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6305.554688 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6366.833984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6430.212891 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6462 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6514.099609 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6577.478516 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6638.757812 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6702.234375 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6754.333984 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6817.712891 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6878.894531 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6918.103516 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6951.794922 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6983.582031 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7024.695312 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7085.974609 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7125.183594 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7152.966797 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7214.148438 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7245.935547 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7273.71875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7325.818359 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7357.605469 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7421.082031 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7482.605469 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7521.814453 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7583.337891 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7622.701172 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7720.113281 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7747.896484 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7811.275391 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7839.058594 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7891.158203 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7930.367188 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7958.150391 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3262.744141 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3297.949219 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3361.572266 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3425.195312 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3488.818359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3543.798828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3575.585938 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3607.373047 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3639.160156 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3670.947266 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3702.734375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3730.517578 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3792.041016 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3853.320312 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3916.699219 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3980.175781 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4019.039062 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4080.220703 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4139.400391 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4200.923828 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4242.037109 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4275.728516 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4303.511719 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4365.035156 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4426.314453 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4489.693359 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4553.316406 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4587.007812 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4646.1875 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4709.810547 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4741.597656 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4805.220703 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4868.84375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4900.630859 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4964.253906 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5000.337891 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5039.201172 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5094.181641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5157.804688 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5189.591797 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5221.378906 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5253.166016 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5284.953125 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5316.740234 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5355.949219 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5419.328125 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5458.191406 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5519.373047 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5582.751953 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5646.228516 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5709.607422 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5773.083984 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5836.462891 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5875.671875 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5907.458984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5991.248047 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6023.035156 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6120.447266 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6181.970703 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6245.447266 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6273.230469 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6334.509766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6397.888672 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6429.675781 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6481.775391 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6545.154297 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6606.433594 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6669.910156 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6722.009766 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6785.388672 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6846.570312 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6885.779297 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6919.470703 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6951.257812 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6992.371094 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7053.650391 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7092.859375 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7120.642578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7181.824219 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7213.611328 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7241.394531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7293.494141 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7325.28125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7388.757812 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7450.28125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7489.490234 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7551.013672 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7590.376953 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7687.789062 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7715.572266 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7778.951172 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7806.734375 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7858.833984 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7898.042969 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7925.826172 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p2a283bbcdd">
+  <clipPath id="p49dad874ee">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_decode_density.svg
+++ b/bench/graphs/silesia_decode_density.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 82.373685 412.80375 
 L 82.373685 47.3475 
-" clip-path="url(#p601f9e3509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p828f705f24)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m335593e028" d="M 0 0 
+       <path id="m8a7c3a19a5" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m335593e028" x="82.373685" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8a7c3a19a5" x="82.373685" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -111,11 +111,11 @@ z
      <g id="line2d_3">
       <path d="M 165.44644 412.80375 
 L 165.44644 47.3475 
-" clip-path="url(#p601f9e3509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p828f705f24)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m335593e028" x="165.44644" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8a7c3a19a5" x="165.44644" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -157,11 +157,11 @@ z
      <g id="line2d_5">
       <path d="M 248.519195 412.80375 
 L 248.519195 47.3475 
-" clip-path="url(#p601f9e3509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p828f705f24)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m335593e028" x="248.519195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8a7c3a19a5" x="248.519195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -211,11 +211,11 @@ z
      <g id="line2d_7">
       <path d="M 331.59195 412.80375 
 L 331.59195 47.3475 
-" clip-path="url(#p601f9e3509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p828f705f24)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m335593e028" x="331.59195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8a7c3a19a5" x="331.59195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -252,11 +252,11 @@ z
      <g id="line2d_9">
       <path d="M 414.664704 412.80375 
 L 414.664704 47.3475 
-" clip-path="url(#p601f9e3509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p828f705f24)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m335593e028" x="414.664704" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8a7c3a19a5" x="414.664704" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -299,11 +299,11 @@ z
      <g id="line2d_11">
       <path d="M 497.737459 412.80375 
 L 497.737459 47.3475 
-" clip-path="url(#p601f9e3509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p828f705f24)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m335593e028" x="497.737459" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8a7c3a19a5" x="497.737459" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -351,11 +351,11 @@ z
      <g id="line2d_13">
       <path d="M 580.810214 412.80375 
 L 580.810214 47.3475 
-" clip-path="url(#p601f9e3509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p828f705f24)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m335593e028" x="580.810214" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8a7c3a19a5" x="580.810214" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -897,16 +897,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 391.33747 
 L 637.2 391.33747 
-" clip-path="url(#p601f9e3509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p828f705f24)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="m78d23eb5bf" d="M 0 0 
+       <path id="m409263b295" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m78d23eb5bf" x="49.078125" y="391.33747" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m409263b295" x="49.078125" y="391.33747" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -922,11 +922,11 @@ L -3.5 0
      <g id="line2d_17">
       <path d="M 49.078125 263.934445 
 L 637.2 263.934445 
-" clip-path="url(#p601f9e3509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p828f705f24)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m78d23eb5bf" x="49.078125" y="263.934445" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m409263b295" x="49.078125" y="263.934445" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -942,11 +942,11 @@ L 637.2 263.934445
      <g id="line2d_19">
       <path d="M 49.078125 136.53142 
 L 637.2 136.53142 
-" clip-path="url(#p601f9e3509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p828f705f24)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m78d23eb5bf" x="49.078125" y="136.53142" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m409263b295" x="49.078125" y="136.53142" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -962,16 +962,16 @@ L 637.2 136.53142
      <g id="line2d_21">
       <path d="M 49.078125 411.072449 
 L 637.2 411.072449 
-" clip-path="url(#p601f9e3509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p828f705f24)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="m6c26a07714" d="M 0 0 
+       <path id="mc6b54a5c44" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m6c26a07714" x="49.078125" y="411.072449" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc6b54a5c44" x="49.078125" y="411.072449" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -979,11 +979,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 403.684099 
 L 637.2 403.684099 
-" clip-path="url(#p601f9e3509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p828f705f24)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m6c26a07714" x="49.078125" y="403.684099" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc6b54a5c44" x="49.078125" y="403.684099" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -991,11 +991,11 @@ L 637.2 403.684099
      <g id="line2d_25">
       <path d="M 49.078125 397.167113 
 L 637.2 397.167113 
-" clip-path="url(#p601f9e3509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p828f705f24)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m6c26a07714" x="49.078125" y="397.167113" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc6b54a5c44" x="49.078125" y="397.167113" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1003,11 +1003,11 @@ L 637.2 397.167113
      <g id="line2d_27">
       <path d="M 49.078125 352.985338 
 L 637.2 352.985338 
-" clip-path="url(#p601f9e3509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p828f705f24)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m6c26a07714" x="49.078125" y="352.985338" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc6b54a5c44" x="49.078125" y="352.985338" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1015,11 +1015,11 @@ L 637.2 352.985338
      <g id="line2d_29">
       <path d="M 49.078125 330.550779 
 L 637.2 330.550779 
-" clip-path="url(#p601f9e3509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p828f705f24)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m6c26a07714" x="49.078125" y="330.550779" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc6b54a5c44" x="49.078125" y="330.550779" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1027,11 +1027,11 @@ L 637.2 330.550779
      <g id="line2d_31">
       <path d="M 49.078125 314.633206 
 L 637.2 314.633206 
-" clip-path="url(#p601f9e3509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p828f705f24)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m6c26a07714" x="49.078125" y="314.633206" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc6b54a5c44" x="49.078125" y="314.633206" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1039,11 +1039,11 @@ L 637.2 314.633206
      <g id="line2d_33">
       <path d="M 49.078125 302.286577 
 L 637.2 302.286577 
-" clip-path="url(#p601f9e3509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p828f705f24)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m6c26a07714" x="49.078125" y="302.286577" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc6b54a5c44" x="49.078125" y="302.286577" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1051,11 +1051,11 @@ L 637.2 302.286577
      <g id="line2d_35">
       <path d="M 49.078125 292.198647 
 L 637.2 292.198647 
-" clip-path="url(#p601f9e3509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p828f705f24)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m6c26a07714" x="49.078125" y="292.198647" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc6b54a5c44" x="49.078125" y="292.198647" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1063,11 +1063,11 @@ L 637.2 292.198647
      <g id="line2d_37">
       <path d="M 49.078125 283.669424 
 L 637.2 283.669424 
-" clip-path="url(#p601f9e3509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p828f705f24)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m6c26a07714" x="49.078125" y="283.669424" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc6b54a5c44" x="49.078125" y="283.669424" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1075,11 +1075,11 @@ L 637.2 283.669424
      <g id="line2d_39">
       <path d="M 49.078125 276.281074 
 L 637.2 276.281074 
-" clip-path="url(#p601f9e3509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p828f705f24)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m6c26a07714" x="49.078125" y="276.281074" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc6b54a5c44" x="49.078125" y="276.281074" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1087,11 +1087,11 @@ L 637.2 276.281074
      <g id="line2d_41">
       <path d="M 49.078125 269.764088 
 L 637.2 269.764088 
-" clip-path="url(#p601f9e3509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p828f705f24)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m6c26a07714" x="49.078125" y="269.764088" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc6b54a5c44" x="49.078125" y="269.764088" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1099,11 +1099,11 @@ L 637.2 269.764088
      <g id="line2d_43">
       <path d="M 49.078125 225.582313 
 L 637.2 225.582313 
-" clip-path="url(#p601f9e3509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p828f705f24)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m6c26a07714" x="49.078125" y="225.582313" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc6b54a5c44" x="49.078125" y="225.582313" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1111,11 +1111,11 @@ L 637.2 225.582313
      <g id="line2d_45">
       <path d="M 49.078125 203.147754 
 L 637.2 203.147754 
-" clip-path="url(#p601f9e3509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p828f705f24)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m6c26a07714" x="49.078125" y="203.147754" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc6b54a5c44" x="49.078125" y="203.147754" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1123,11 +1123,11 @@ L 637.2 203.147754
      <g id="line2d_47">
       <path d="M 49.078125 187.230181 
 L 637.2 187.230181 
-" clip-path="url(#p601f9e3509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p828f705f24)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m6c26a07714" x="49.078125" y="187.230181" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc6b54a5c44" x="49.078125" y="187.230181" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1135,11 +1135,11 @@ L 637.2 187.230181
      <g id="line2d_49">
       <path d="M 49.078125 174.883552 
 L 637.2 174.883552 
-" clip-path="url(#p601f9e3509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p828f705f24)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m6c26a07714" x="49.078125" y="174.883552" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc6b54a5c44" x="49.078125" y="174.883552" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1147,11 +1147,11 @@ L 637.2 174.883552
      <g id="line2d_51">
       <path d="M 49.078125 164.795622 
 L 637.2 164.795622 
-" clip-path="url(#p601f9e3509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p828f705f24)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m6c26a07714" x="49.078125" y="164.795622" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc6b54a5c44" x="49.078125" y="164.795622" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1159,11 +1159,11 @@ L 637.2 164.795622
      <g id="line2d_53">
       <path d="M 49.078125 156.266399 
 L 637.2 156.266399 
-" clip-path="url(#p601f9e3509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p828f705f24)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#m6c26a07714" x="49.078125" y="156.266399" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc6b54a5c44" x="49.078125" y="156.266399" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1171,11 +1171,11 @@ L 637.2 156.266399
      <g id="line2d_55">
       <path d="M 49.078125 148.878049 
 L 637.2 148.878049 
-" clip-path="url(#p601f9e3509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p828f705f24)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#m6c26a07714" x="49.078125" y="148.878049" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc6b54a5c44" x="49.078125" y="148.878049" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1183,11 +1183,11 @@ L 637.2 148.878049
      <g id="line2d_57">
       <path d="M 49.078125 142.361063 
 L 637.2 142.361063 
-" clip-path="url(#p601f9e3509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p828f705f24)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#m6c26a07714" x="49.078125" y="142.361063" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc6b54a5c44" x="49.078125" y="142.361063" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1195,11 +1195,11 @@ L 637.2 142.361063
      <g id="line2d_59">
       <path d="M 49.078125 98.179288 
 L 637.2 98.179288 
-" clip-path="url(#p601f9e3509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p828f705f24)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#m6c26a07714" x="49.078125" y="98.179288" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc6b54a5c44" x="49.078125" y="98.179288" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1207,11 +1207,11 @@ L 637.2 98.179288
      <g id="line2d_61">
       <path d="M 49.078125 75.744729 
 L 637.2 75.744729 
-" clip-path="url(#p601f9e3509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p828f705f24)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#m6c26a07714" x="49.078125" y="75.744729" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc6b54a5c44" x="49.078125" y="75.744729" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1219,11 +1219,11 @@ L 637.2 75.744729
      <g id="line2d_63">
       <path d="M 49.078125 59.827156 
 L 637.2 59.827156 
-" clip-path="url(#p601f9e3509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p828f705f24)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#m6c26a07714" x="49.078125" y="59.827156" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc6b54a5c44" x="49.078125" y="59.827156" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1231,11 +1231,11 @@ L 637.2 59.827156
      <g id="line2d_65">
       <path d="M 49.078125 47.480527 
 L 637.2 47.480527 
-" clip-path="url(#p601f9e3509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p828f705f24)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#m6c26a07714" x="49.078125" y="47.480527" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc6b54a5c44" x="49.078125" y="47.480527" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1398,7 +1398,7 @@ z
    <g id="line2d_67">
     <path d="M 49.078125 63.959148 
 L 637.2 63.959148 
-" clip-path="url(#p601f9e3509)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
+" clip-path="url(#p828f705f24)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
    </g>
    <g id="patch_3">
     <path d="M 49.078125 412.80375 
@@ -1762,78 +1762,78 @@ z
    </g>
    <g id="line2d_68">
     <defs>
-     <path id="ma73dffa4df" d="M -2.5 2.5 
+     <path id="m27d7d46dae" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p601f9e3509)">
-     <use xlink:href="#ma73dffa4df" x="75.810937" y="263.190298" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma73dffa4df" x="105.634056" y="267.887378" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma73dffa4df" x="204.490635" y="300.240046" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma73dffa4df" x="234.479899" y="306.367428" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma73dffa4df" x="242.537956" y="316.909198" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma73dffa4df" x="300.771958" y="297.352079" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma73dffa4df" x="303.26414" y="310.698625" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma73dffa4df" x="304.261013" y="317.548512" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma73dffa4df" x="313.897453" y="317.953886" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma73dffa4df" x="414.166268" y="334.149272" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma73dffa4df" x="587.289889" y="327.780982" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma73dffa4df" x="610.467187" y="318.981257" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p828f705f24)">
+     <use xlink:href="#m27d7d46dae" x="75.810937" y="263.190298" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m27d7d46dae" x="105.634056" y="267.887378" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m27d7d46dae" x="204.490635" y="300.240046" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m27d7d46dae" x="234.479899" y="306.367428" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m27d7d46dae" x="242.537956" y="316.909198" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m27d7d46dae" x="300.771958" y="297.352079" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m27d7d46dae" x="303.26414" y="310.698625" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m27d7d46dae" x="304.261013" y="317.548512" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m27d7d46dae" x="313.897453" y="317.953886" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m27d7d46dae" x="414.166268" y="334.149272" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m27d7d46dae" x="587.289889" y="327.780982" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m27d7d46dae" x="610.467187" y="318.981257" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_69">
     <defs>
-     <path id="md0a06f05c7" d="M 0 -2.5 
+     <path id="m64205cd5eb" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p601f9e3509)">
-     <use xlink:href="#md0a06f05c7" x="75.810937" y="260.629553" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md0a06f05c7" x="105.634056" y="253.888028" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md0a06f05c7" x="204.490635" y="301.454063" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md0a06f05c7" x="234.479899" y="296.198152" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md0a06f05c7" x="242.537956" y="306.497434" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md0a06f05c7" x="300.771958" y="285.157082" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md0a06f05c7" x="303.26414" y="299.127298" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md0a06f05c7" x="304.261013" y="312.289143" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md0a06f05c7" x="313.897453" y="305.55147" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md0a06f05c7" x="414.166268" y="323.799851" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md0a06f05c7" x="587.289889" y="327.192921" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md0a06f05c7" x="610.467187" y="316.49707" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p828f705f24)">
+     <use xlink:href="#m64205cd5eb" x="75.810937" y="260.629553" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m64205cd5eb" x="105.634056" y="253.888028" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m64205cd5eb" x="204.490635" y="301.454063" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m64205cd5eb" x="234.479899" y="296.198152" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m64205cd5eb" x="242.537956" y="306.497434" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m64205cd5eb" x="300.771958" y="285.157082" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m64205cd5eb" x="303.26414" y="299.127298" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m64205cd5eb" x="304.261013" y="312.289143" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m64205cd5eb" x="313.897453" y="305.55147" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m64205cd5eb" x="414.166268" y="323.799851" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m64205cd5eb" x="587.289889" y="327.192921" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m64205cd5eb" x="610.467187" y="316.49707" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_70">
     <defs>
-     <path id="m034e78e8c1" d="M -0 3.535534 
+     <path id="m450b86a470" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p601f9e3509)">
-     <use xlink:href="#m034e78e8c1" x="75.810937" y="229.675972" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m034e78e8c1" x="105.634056" y="230.807252" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m034e78e8c1" x="204.490635" y="262.817606" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m034e78e8c1" x="234.479899" y="260.308889" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m034e78e8c1" x="242.537956" y="274.651617" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m034e78e8c1" x="300.771958" y="258.820574" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m034e78e8c1" x="303.26414" y="270.569757" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m034e78e8c1" x="304.261013" y="279.042037" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m034e78e8c1" x="313.897453" y="275.908162" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m034e78e8c1" x="414.166268" y="294.938772" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m034e78e8c1" x="587.289889" y="301.872049" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m034e78e8c1" x="610.467187" y="298.545064" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p828f705f24)">
+     <use xlink:href="#m450b86a470" x="75.810937" y="229.675972" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m450b86a470" x="105.634056" y="230.807252" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m450b86a470" x="204.490635" y="262.817606" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m450b86a470" x="234.479899" y="260.308889" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m450b86a470" x="242.537956" y="274.651617" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m450b86a470" x="300.771958" y="258.820574" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m450b86a470" x="303.26414" y="270.569757" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m450b86a470" x="304.261013" y="279.042037" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m450b86a470" x="313.897453" y="275.908162" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m450b86a470" x="414.166268" y="294.938772" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m450b86a470" x="587.289889" y="301.872049" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m450b86a470" x="610.467187" y="298.545064" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_71">
     <defs>
-     <path id="m354abaac06" d="M -0.833333 2.5 
+     <path id="m6a23b2edcd" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -1848,24 +1848,24 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p601f9e3509)">
-     <use xlink:href="#m354abaac06" x="75.810937" y="286.028664" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m354abaac06" x="105.634056" y="293.887771" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m354abaac06" x="204.490635" y="326.335201" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m354abaac06" x="234.479899" y="337.903307" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m354abaac06" x="242.537956" y="341.092058" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m354abaac06" x="300.771958" y="336.485034" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m354abaac06" x="303.26414" y="344.754119" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m354abaac06" x="304.261013" y="344.606502" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m354abaac06" x="313.897453" y="351.527394" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m354abaac06" x="414.166268" y="363.295034" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m354abaac06" x="587.289889" y="368.159128" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m354abaac06" x="610.467187" y="356.976913" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p828f705f24)">
+     <use xlink:href="#m6a23b2edcd" x="75.810937" y="286.028664" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a23b2edcd" x="105.634056" y="293.887771" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a23b2edcd" x="204.490635" y="326.335201" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a23b2edcd" x="234.479899" y="337.903307" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a23b2edcd" x="242.537956" y="341.092058" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a23b2edcd" x="300.771958" y="336.485034" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a23b2edcd" x="303.26414" y="344.754119" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a23b2edcd" x="304.261013" y="344.606502" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a23b2edcd" x="313.897453" y="351.527394" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a23b2edcd" x="414.166268" y="363.295034" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a23b2edcd" x="587.289889" y="368.159128" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a23b2edcd" x="610.467187" y="356.976913" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_72">
     <defs>
-     <path id="ma3ceb8cba4" d="M -1.25 2.5 
+     <path id="ma39df6705a" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -1880,24 +1880,24 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p601f9e3509)">
-     <use xlink:href="#ma3ceb8cba4" x="75.810937" y="327.723121" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma3ceb8cba4" x="105.634056" y="342.646685" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma3ceb8cba4" x="204.490635" y="362.850184" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma3ceb8cba4" x="234.479899" y="371.338643" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma3ceb8cba4" x="242.537956" y="367.245927" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma3ceb8cba4" x="300.771958" y="360.026985" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma3ceb8cba4" x="303.26414" y="374.683393" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma3ceb8cba4" x="304.261013" y="357.457726" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma3ceb8cba4" x="313.897453" y="374.58929" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma3ceb8cba4" x="414.166268" y="385.027438" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma3ceb8cba4" x="587.289889" y="394.333029" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma3ceb8cba4" x="610.467187" y="391.249012" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p828f705f24)">
+     <use xlink:href="#ma39df6705a" x="75.810937" y="327.723121" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma39df6705a" x="105.634056" y="342.646685" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma39df6705a" x="204.490635" y="362.850184" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma39df6705a" x="234.479899" y="371.338643" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma39df6705a" x="242.537956" y="367.245927" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma39df6705a" x="300.771958" y="360.026985" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma39df6705a" x="303.26414" y="374.683393" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma39df6705a" x="304.261013" y="357.457726" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma39df6705a" x="313.897453" y="374.58929" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma39df6705a" x="414.166268" y="385.027438" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma39df6705a" x="587.289889" y="394.333029" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma39df6705a" x="610.467187" y="391.249012" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_73">
     <defs>
-     <path id="mae745fda07" d="M 0 -2.5 
+     <path id="m0b1c8772e1" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -1910,24 +1910,24 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p601f9e3509)">
-     <use xlink:href="#mae745fda07" x="75.810937" y="273.778134" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mae745fda07" x="105.634056" y="286.227815" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mae745fda07" x="204.490635" y="319.608779" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mae745fda07" x="234.479899" y="321.188418" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mae745fda07" x="242.537956" y="325.921453" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mae745fda07" x="300.771958" y="333.05015" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mae745fda07" x="303.26414" y="336.951003" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mae745fda07" x="304.261013" y="345.759761" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mae745fda07" x="313.897453" y="336.754653" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mae745fda07" x="414.166268" y="357.454726" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mae745fda07" x="587.289889" y="366.280671" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mae745fda07" x="610.467187" y="360.878702" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p828f705f24)">
+     <use xlink:href="#m0b1c8772e1" x="75.810937" y="273.778134" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m0b1c8772e1" x="105.634056" y="286.227815" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m0b1c8772e1" x="204.490635" y="319.608779" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m0b1c8772e1" x="234.479899" y="321.188418" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m0b1c8772e1" x="242.537956" y="325.921453" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m0b1c8772e1" x="300.771958" y="333.05015" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m0b1c8772e1" x="303.26414" y="336.951003" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m0b1c8772e1" x="304.261013" y="345.759761" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m0b1c8772e1" x="313.897453" y="336.754653" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m0b1c8772e1" x="414.166268" y="357.454726" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m0b1c8772e1" x="587.289889" y="366.280671" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m0b1c8772e1" x="610.467187" y="360.878702" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_74">
     <defs>
-     <path id="mf02be561d3" d="M 0 -2.5 
+     <path id="m359336e8e1" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -1936,19 +1936,19 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p601f9e3509)">
-     <use xlink:href="#mf02be561d3" x="75.810937" y="347.176172" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf02be561d3" x="105.634056" y="348.704001" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf02be561d3" x="204.490635" y="367.31757" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf02be561d3" x="234.479899" y="373.033423" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf02be561d3" x="242.537956" y="380.00037" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf02be561d3" x="300.771958" y="370.53122" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf02be561d3" x="303.26414" y="375.375651" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf02be561d3" x="304.261013" y="383.030012" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf02be561d3" x="313.897453" y="385.215351" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf02be561d3" x="414.166268" y="391.648192" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf02be561d3" x="587.289889" y="396.192102" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf02be561d3" x="610.467187" y="383.710333" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p828f705f24)">
+     <use xlink:href="#m359336e8e1" x="75.810937" y="347.176172" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m359336e8e1" x="105.634056" y="348.704001" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m359336e8e1" x="204.490635" y="367.31757" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m359336e8e1" x="234.479899" y="373.033423" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m359336e8e1" x="242.537956" y="380.00037" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m359336e8e1" x="300.771958" y="370.53122" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m359336e8e1" x="303.26414" y="375.375651" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m359336e8e1" x="304.261013" y="383.030012" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m359336e8e1" x="313.897453" y="385.215351" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m359336e8e1" x="414.166268" y="391.648192" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m359336e8e1" x="587.289889" y="396.192102" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m359336e8e1" x="610.467187" y="383.710333" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="legend_1">
@@ -1967,7 +1967,7 @@ z
     </g>
     <g id="line2d_75">
      <defs>
-      <path id="m942412aadf" d="M 0 3.5 
+      <path id="m9e13b04e6c" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -1980,7 +1980,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m942412aadf" x="434.04625" y="211.758125" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m9e13b04e6c" x="434.04625" y="211.758125" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_15">
@@ -2039,7 +2039,7 @@ z
     </g>
     <g id="line2d_76">
      <g>
-      <use xlink:href="#ma73dffa4df" x="434.04625" y="223.500625" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m27d7d46dae" x="434.04625" y="223.500625" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_16">
@@ -2053,7 +2053,7 @@ z
     </g>
     <g id="line2d_77">
      <g>
-      <use xlink:href="#md0a06f05c7" x="434.04625" y="235.243125" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m64205cd5eb" x="434.04625" y="235.243125" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -2098,7 +2098,7 @@ z
     </g>
     <g id="line2d_78">
      <g>
-      <use xlink:href="#m034e78e8c1" x="434.04625" y="247.208125" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m450b86a470" x="434.04625" y="247.208125" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -2118,7 +2118,7 @@ z
     </g>
     <g id="line2d_79">
      <g>
-      <use xlink:href="#m354abaac06" x="537.72375" y="211.758125" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m6a23b2edcd" x="537.72375" y="211.758125" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -2145,7 +2145,7 @@ z
     </g>
     <g id="line2d_80">
      <g>
-      <use xlink:href="#ma3ceb8cba4" x="537.72375" y="223.500625" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#ma39df6705a" x="537.72375" y="223.500625" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -2210,7 +2210,7 @@ z
     </g>
     <g id="line2d_81">
      <g>
-      <use xlink:href="#mae745fda07" x="537.72375" y="235.243125" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#m0b1c8772e1" x="537.72375" y="235.243125" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_21">
@@ -2248,7 +2248,7 @@ z
     </g>
     <g id="line2d_82">
      <g>
-      <use xlink:href="#mf02be561d3" x="537.72375" y="246.985625" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m359336e8e1" x="537.72375" y="246.985625" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -2318,19 +2318,19 @@ z
     </g>
    </g>
    <g id="line2d_83">
-    <g clip-path="url(#p601f9e3509)">
-     <use xlink:href="#m942412aadf" x="75.810937" y="272.143954" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m942412aadf" x="105.634056" y="288.399073" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m942412aadf" x="204.490635" y="322.103822" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m942412aadf" x="234.479899" y="324.29343" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m942412aadf" x="242.537956" y="324.418753" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m942412aadf" x="300.771958" y="312.453798" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m942412aadf" x="303.26414" y="333.249253" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m942412aadf" x="304.261013" y="351.748791" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m942412aadf" x="313.897453" y="337.048403" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m942412aadf" x="414.166268" y="356.441315" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m942412aadf" x="587.289889" y="359.296601" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m942412aadf" x="610.467187" y="343.193293" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <g clip-path="url(#p828f705f24)">
+     <use xlink:href="#m9e13b04e6c" x="75.810937" y="272.143954" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m9e13b04e6c" x="105.634056" y="288.399073" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m9e13b04e6c" x="204.490635" y="322.103822" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m9e13b04e6c" x="234.479899" y="324.29343" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m9e13b04e6c" x="242.537956" y="324.418753" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m9e13b04e6c" x="300.771958" y="312.453798" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m9e13b04e6c" x="303.26414" y="333.249253" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m9e13b04e6c" x="304.261013" y="351.748791" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m9e13b04e6c" x="313.897453" y="337.048403" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m9e13b04e6c" x="414.166268" y="356.441315" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m9e13b04e6c" x="587.289889" y="359.296601" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m9e13b04e6c" x="610.467187" y="343.193293" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
   </g>
@@ -3154,7 +3154,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p601f9e3509">
+  <clipPath id="p828f705f24">
    <rect x="49.078125" y="47.3475" width="588.121875" height="365.45625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_decode_ranking.svg
+++ b/bench/graphs/silesia_decode_ranking.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 292.269187 308.04375 
 L 292.269187 56.7075 
-" clip-path="url(#pb94ee70ab2)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p398923bc0b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="me144741b7a" d="M 0 0 
+       <path id="m613f197692" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#me144741b7a" x="292.269187" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m613f197692" x="292.269187" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -136,11 +136,11 @@ z
      <g id="line2d_3">
       <path d="M 449.991563 308.04375 
 L 449.991563 56.7075 
-" clip-path="url(#pb94ee70ab2)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p398923bc0b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#me144741b7a" x="449.991563" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m613f197692" x="449.991563" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -177,16 +177,16 @@ z
      <g id="line2d_5">
       <path d="M 182.025977 308.04375 
 L 182.025977 56.7075 
-" clip-path="url(#pb94ee70ab2)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p398923bc0b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <defs>
-       <path id="m84956248ff" d="M 0 0 
+       <path id="m63c3cce68d" d="M 0 0 
 L 0 2 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m84956248ff" x="182.025977" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m63c3cce68d" x="182.025977" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -194,11 +194,11 @@ L 0 2
      <g id="line2d_7">
       <path d="M 209.799509 308.04375 
 L 209.799509 56.7075 
-" clip-path="url(#pb94ee70ab2)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p398923bc0b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m84956248ff" x="209.799509" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m63c3cce68d" x="209.799509" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -206,11 +206,11 @@ L 209.799509 56.7075
      <g id="line2d_9">
       <path d="M 229.505143 308.04375 
 L 229.505143 56.7075 
-" clip-path="url(#pb94ee70ab2)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p398923bc0b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m84956248ff" x="229.505143" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m63c3cce68d" x="229.505143" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -218,11 +218,11 @@ L 229.505143 56.7075
      <g id="line2d_11">
       <path d="M 244.790021 308.04375 
 L 244.790021 56.7075 
-" clip-path="url(#pb94ee70ab2)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p398923bc0b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m84956248ff" x="244.790021" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m63c3cce68d" x="244.790021" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -230,11 +230,11 @@ L 244.790021 56.7075
      <g id="line2d_13">
       <path d="M 257.278675 308.04375 
 L 257.278675 56.7075 
-" clip-path="url(#pb94ee70ab2)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p398923bc0b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m84956248ff" x="257.278675" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m63c3cce68d" x="257.278675" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -242,11 +242,11 @@ L 257.278675 56.7075
      <g id="line2d_15">
       <path d="M 267.837682 308.04375 
 L 267.837682 56.7075 
-" clip-path="url(#pb94ee70ab2)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p398923bc0b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m84956248ff" x="267.837682" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m63c3cce68d" x="267.837682" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -254,11 +254,11 @@ L 267.837682 56.7075
      <g id="line2d_17">
       <path d="M 276.984309 308.04375 
 L 276.984309 56.7075 
-" clip-path="url(#pb94ee70ab2)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p398923bc0b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m84956248ff" x="276.984309" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m63c3cce68d" x="276.984309" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -266,11 +266,11 @@ L 276.984309 56.7075
      <g id="line2d_19">
       <path d="M 285.052207 308.04375 
 L 285.052207 56.7075 
-" clip-path="url(#pb94ee70ab2)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p398923bc0b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m84956248ff" x="285.052207" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m63c3cce68d" x="285.052207" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -278,11 +278,11 @@ L 285.052207 56.7075
      <g id="line2d_21">
       <path d="M 339.748353 308.04375 
 L 339.748353 56.7075 
-" clip-path="url(#pb94ee70ab2)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p398923bc0b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m84956248ff" x="339.748353" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m63c3cce68d" x="339.748353" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -290,11 +290,11 @@ L 339.748353 56.7075
      <g id="line2d_23">
       <path d="M 367.521885 308.04375 
 L 367.521885 56.7075 
-" clip-path="url(#pb94ee70ab2)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p398923bc0b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m84956248ff" x="367.521885" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m63c3cce68d" x="367.521885" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -302,11 +302,11 @@ L 367.521885 56.7075
      <g id="line2d_25">
       <path d="M 387.227519 308.04375 
 L 387.227519 56.7075 
-" clip-path="url(#pb94ee70ab2)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p398923bc0b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m84956248ff" x="387.227519" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m63c3cce68d" x="387.227519" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -314,11 +314,11 @@ L 387.227519 56.7075
      <g id="line2d_27">
       <path d="M 402.512397 308.04375 
 L 402.512397 56.7075 
-" clip-path="url(#pb94ee70ab2)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p398923bc0b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m84956248ff" x="402.512397" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m63c3cce68d" x="402.512397" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -326,11 +326,11 @@ L 402.512397 56.7075
      <g id="line2d_29">
       <path d="M 415.001051 308.04375 
 L 415.001051 56.7075 
-" clip-path="url(#pb94ee70ab2)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p398923bc0b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m84956248ff" x="415.001051" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m63c3cce68d" x="415.001051" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -338,11 +338,11 @@ L 415.001051 56.7075
      <g id="line2d_31">
       <path d="M 425.560057 308.04375 
 L 425.560057 56.7075 
-" clip-path="url(#pb94ee70ab2)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p398923bc0b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m84956248ff" x="425.560057" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m63c3cce68d" x="425.560057" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -350,11 +350,11 @@ L 425.560057 56.7075
      <g id="line2d_33">
       <path d="M 434.706685 308.04375 
 L 434.706685 56.7075 
-" clip-path="url(#pb94ee70ab2)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p398923bc0b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m84956248ff" x="434.706685" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m63c3cce68d" x="434.706685" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -362,11 +362,11 @@ L 434.706685 56.7075
      <g id="line2d_35">
       <path d="M 442.774583 308.04375 
 L 442.774583 56.7075 
-" clip-path="url(#pb94ee70ab2)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p398923bc0b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m84956248ff" x="442.774583" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m63c3cce68d" x="442.774583" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -374,11 +374,11 @@ L 442.774583 56.7075
      <g id="line2d_37">
       <path d="M 497.470729 308.04375 
 L 497.470729 56.7075 
-" clip-path="url(#pb94ee70ab2)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p398923bc0b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m84956248ff" x="497.470729" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m63c3cce68d" x="497.470729" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -386,11 +386,11 @@ L 497.470729 56.7075
      <g id="line2d_39">
       <path d="M 525.24426 308.04375 
 L 525.24426 56.7075 
-" clip-path="url(#pb94ee70ab2)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p398923bc0b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m84956248ff" x="525.24426" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m63c3cce68d" x="525.24426" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -398,11 +398,11 @@ L 525.24426 56.7075
      <g id="line2d_41">
       <path d="M 544.949895 308.04375 
 L 544.949895 56.7075 
-" clip-path="url(#pb94ee70ab2)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p398923bc0b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m84956248ff" x="544.949895" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m63c3cce68d" x="544.949895" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -410,11 +410,11 @@ L 544.949895 56.7075
      <g id="line2d_43">
       <path d="M 560.234772 308.04375 
 L 560.234772 56.7075 
-" clip-path="url(#pb94ee70ab2)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p398923bc0b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m84956248ff" x="560.234772" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m63c3cce68d" x="560.234772" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1016,12 +1016,12 @@ z
     <g id="ytick_1">
      <g id="line2d_45">
       <defs>
-       <path id="m06f41147fe" d="M 0 0 
+       <path id="m45d753604a" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m06f41147fe" x="139.360469" y="296.619375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m45d753604a" x="139.360469" y="296.619375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -1093,7 +1093,7 @@ z
     <g id="ytick_2">
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m06f41147fe" x="139.360469" y="263.978304" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m45d753604a" x="139.360469" y="263.978304" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -1160,7 +1160,7 @@ z
     <g id="ytick_3">
      <g id="line2d_47">
       <g>
-       <use xlink:href="#m06f41147fe" x="139.360469" y="231.337232" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m45d753604a" x="139.360469" y="231.337232" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -1216,7 +1216,7 @@ z
     <g id="ytick_4">
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m06f41147fe" x="139.360469" y="198.696161" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m45d753604a" x="139.360469" y="198.696161" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -1263,7 +1263,7 @@ z
     <g id="ytick_5">
      <g id="line2d_49">
       <g>
-       <use xlink:href="#m06f41147fe" x="139.360469" y="166.055089" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m45d753604a" x="139.360469" y="166.055089" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -1376,7 +1376,7 @@ z
     <g id="ytick_6">
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m06f41147fe" x="139.360469" y="133.414018" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m45d753604a" x="139.360469" y="133.414018" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -1392,7 +1392,7 @@ z
     <g id="ytick_7">
      <g id="line2d_51">
       <g>
-       <use xlink:href="#m06f41147fe" x="139.360469" y="100.772946" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m45d753604a" x="139.360469" y="100.772946" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -1439,7 +1439,7 @@ z
     <g id="ytick_8">
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m06f41147fe" x="139.360469" y="68.131875" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m45d753604a" x="139.360469" y="68.131875" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -1462,47 +1462,47 @@ z
    <g id="LineCollection_1">
     <path d="M 139.360469 296.619375 
 L 154.645346 296.619375 
-" clip-path="url(#pb94ee70ab2)" style="fill: none; stroke: #17becf; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p398923bc0b)" style="fill: none; stroke: #17becf; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_2">
     <path d="M 139.360469 263.978304 
 L 161.142927 263.978304 
-" clip-path="url(#pb94ee70ab2)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p398923bc0b)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_3">
     <path d="M 139.360469 231.337232 
 L 200.65327 231.337232 
-" clip-path="url(#pb94ee70ab2)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p398923bc0b)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_4">
     <path d="M 139.360469 198.696161 
 L 208.426981 198.696161 
-" clip-path="url(#pb94ee70ab2)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p398923bc0b)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_5">
     <path d="M 139.360469 166.055089 
 L 212.673671 166.055089 
-" clip-path="url(#pb94ee70ab2)" style="fill: none; stroke: #d62728; stroke-opacity: 0.9; stroke-width: 2.4"/>
+" clip-path="url(#p398923bc0b)" style="fill: none; stroke: #d62728; stroke-opacity: 0.9; stroke-width: 2.4"/>
    </g>
    <g id="LineCollection_6">
     <path d="M 139.360469 133.414018 
 L 239.878265 133.414018 
-" clip-path="url(#pb94ee70ab2)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p398923bc0b)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_7">
     <path d="M 139.360469 100.772946 
 L 248.943982 100.772946 
-" clip-path="url(#pb94ee70ab2)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p398923bc0b)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_8">
     <path d="M 139.360469 68.131875 
 L 284.774562 68.131875 
-" clip-path="url(#pb94ee70ab2)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p398923bc0b)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="line2d_53">
     <path d="M 542.152339 308.04375 
 L 542.152339 56.7075 
-" clip-path="url(#pb94ee70ab2)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
+" clip-path="url(#p398923bc0b)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
    </g>
    <g id="patch_3">
     <path d="M 139.360469 308.04375 
@@ -1888,7 +1888,7 @@ z
    </g>
    <g id="line2d_54">
     <defs>
-     <path id="m8e93d7240d" d="M 0 3 
+     <path id="m97922aba73" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1900,13 +1900,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #17becf"/>
     </defs>
-    <g clip-path="url(#pb94ee70ab2)">
-     <use xlink:href="#m8e93d7240d" x="154.645346" y="296.619375" style="fill: #17becf; stroke: #17becf"/>
+    <g clip-path="url(#p398923bc0b)">
+     <use xlink:href="#m97922aba73" x="154.645346" y="296.619375" style="fill: #17becf; stroke: #17becf"/>
     </g>
    </g>
    <g id="line2d_55">
     <defs>
-     <path id="m89300f779a" d="M 0 3 
+     <path id="m7dbf2a5378" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1918,13 +1918,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #e377c2"/>
     </defs>
-    <g clip-path="url(#pb94ee70ab2)">
-     <use xlink:href="#m89300f779a" x="161.142927" y="263.978304" style="fill: #e377c2; stroke: #e377c2"/>
+    <g clip-path="url(#p398923bc0b)">
+     <use xlink:href="#m7dbf2a5378" x="161.142927" y="263.978304" style="fill: #e377c2; stroke: #e377c2"/>
     </g>
    </g>
    <g id="line2d_56">
     <defs>
-     <path id="m6e443d603e" d="M 0 3 
+     <path id="m75a88064a1" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1936,13 +1936,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #8c564b"/>
     </defs>
-    <g clip-path="url(#pb94ee70ab2)">
-     <use xlink:href="#m6e443d603e" x="200.65327" y="231.337232" style="fill: #8c564b; stroke: #8c564b"/>
+    <g clip-path="url(#p398923bc0b)">
+     <use xlink:href="#m75a88064a1" x="200.65327" y="231.337232" style="fill: #8c564b; stroke: #8c564b"/>
     </g>
    </g>
    <g id="line2d_57">
     <defs>
-     <path id="m1c8d311feb" d="M 0 3 
+     <path id="ma72a4a66a3" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1954,13 +1954,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #bcbd22"/>
     </defs>
-    <g clip-path="url(#pb94ee70ab2)">
-     <use xlink:href="#m1c8d311feb" x="208.426981" y="198.696161" style="fill: #bcbd22; stroke: #bcbd22"/>
+    <g clip-path="url(#p398923bc0b)">
+     <use xlink:href="#ma72a4a66a3" x="208.426981" y="198.696161" style="fill: #bcbd22; stroke: #bcbd22"/>
     </g>
    </g>
    <g id="line2d_58">
     <defs>
-     <path id="mb559d315b9" d="M 0 5 
+     <path id="ma7e1dec914" d="M 0 5 
 C 1.326016 5 2.597899 4.473168 3.535534 3.535534 
 C 4.473168 2.597899 5 1.326016 5 0 
 C 5 -1.326016 4.473168 -2.597899 3.535534 -3.535534 
@@ -1972,13 +1972,13 @@ C -2.597899 4.473168 -1.326016 5 0 5
 z
 " style="stroke: #d62728"/>
     </defs>
-    <g clip-path="url(#pb94ee70ab2)">
-     <use xlink:href="#mb559d315b9" x="212.673671" y="166.055089" style="fill: #d62728; stroke: #d62728"/>
+    <g clip-path="url(#p398923bc0b)">
+     <use xlink:href="#ma7e1dec914" x="212.673671" y="166.055089" style="fill: #d62728; stroke: #d62728"/>
     </g>
    </g>
    <g id="line2d_59">
     <defs>
-     <path id="m0ffd89ee45" d="M 0 3 
+     <path id="mfdad4e2ec3" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1990,13 +1990,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #1f77b4"/>
     </defs>
-    <g clip-path="url(#pb94ee70ab2)">
-     <use xlink:href="#m0ffd89ee45" x="239.878265" y="133.414018" style="fill: #1f77b4; stroke: #1f77b4"/>
+    <g clip-path="url(#p398923bc0b)">
+     <use xlink:href="#mfdad4e2ec3" x="239.878265" y="133.414018" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_60">
     <defs>
-     <path id="mc1dc2926f9" d="M 0 3 
+     <path id="m2c644d6cb3" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -2008,13 +2008,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #2ca02c"/>
     </defs>
-    <g clip-path="url(#pb94ee70ab2)">
-     <use xlink:href="#mc1dc2926f9" x="248.943982" y="100.772946" style="fill: #2ca02c; stroke: #2ca02c"/>
+    <g clip-path="url(#p398923bc0b)">
+     <use xlink:href="#m2c644d6cb3" x="248.943982" y="100.772946" style="fill: #2ca02c; stroke: #2ca02c"/>
     </g>
    </g>
    <g id="line2d_61">
     <defs>
-     <path id="md473ae3b5c" d="M 0 3 
+     <path id="m605554a70c" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -2026,8 +2026,8 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #9467bd"/>
     </defs>
-    <g clip-path="url(#pb94ee70ab2)">
-     <use xlink:href="#md473ae3b5c" x="284.774562" y="68.131875" style="fill: #9467bd; stroke: #9467bd"/>
+    <g clip-path="url(#p398923bc0b)">
+     <use xlink:href="#m605554a70c" x="284.774562" y="68.131875" style="fill: #9467bd; stroke: #9467bd"/>
     </g>
    </g>
   </g>
@@ -2967,7 +2967,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="pb94ee70ab2">
+  <clipPath id="p398923bc0b">
    <rect x="139.360469" y="56.7075" width="425.839531" height="251.33625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_ratio_heatmap.svg
+++ b/bench/graphs/silesia_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.34175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#pb96a9ce219)">
+   <g clip-path="url(#pab5eac449f)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAosAAAGaCAYAAABniAm0AAAJ80lEQVR4nO3YO44dZhnH4TOe8UUe22NbECICAuGIghAoUSioUiEoWAMroKGiQuyAig3QoYjSTUqkcCdURISLuMgaYnzBcuzxzBxW8CtQ9OlFR8+zgr80Z97zO9/e+b0fbTc76OTHd6cnLHHxzdenJyyz99Inpycssf3t76YnLLH3pdemJyyxffp4esIyx999a3rCEi/94BvTE5bYu/2J6QlrnDydXrDM+c93895fmB4AAMD/L7EIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEDa+8/JW9vpESsc/vt4esISH9y4Oj1hmQ9Pn0xPWOLTj06mJyzx6OMvT09Y4nx7Pj1hmVsHt6cnrHH/L9MLlnh8azf/Xtf//IfpCctsP/+V6QlLeFkEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACAdHN6/N71hjas3pxcssd2eTE9Y5lNv/3J6whpvfn16wRJHH/xzesIa56fTC9Y53NH7cfna9IIlbvxrN7+fH3zmzvSEZW797d3pCUt4WQQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAADS3ouzu9vpESvsH/9pesIS965fmp6wzJMXD6cnLHHnrw+nJyxx+sWvTk9Y4unp4+kJyxzt35yesMT2/V9MT1ji2eden56wxJV335mesMzzL78xPWEJL4sAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA2vvp+9/ZTo9Y4faVw+kJS7z38P70hGW+/cNfT09Y4jff/+b0hCWOLh9NT1jiez/71fSEZb72ypXpCUt8684b0xOWePvv70xPWOLaxd38HG42m81P/vhgesISXhYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAtPfi7O52esQKD54fT09Y4vDgxvSEZd57+PvpCUu8evO16QlLbLfn0xOWuHa6u7+h/3G+m3fxlcNXpycs8ezs6fSEJXb1dmw2m83+hYPpCUvs7lUEAOAjE4sAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAOtjfO5jesMTH9m9PT1hj/9L0gmWOLh9NT1ji8ODG9IQlzran0xOWOL+4u7+hX95enZ7A/2BXv59Pts+mJyzz+Pnx9IQldvcqAgDwkYlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAADSwWZ7Pr1hiUfbJ9MTljg4uzQ9YZnPXv/C9IQlzran0xOW+PB0N//Hrm2uTE9Y5tmF3bz3+9MDFrm4v5v3fv/CwfSEZQ73rk5PWMLLIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJD+C2EVlmm8G2EiAAAAAElFTkSuQmCC" id="image9a0a56e040" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="468.72" height="295.2"/>
+iVBORw0KGgoAAAANSUhEUgAAAosAAAGaCAYAAABniAm0AAAJ80lEQVR4nO3YO44dZhnH4TOe8UUe22NbECICAuGIghAoUSioUiEoWAMroKGiQuyAig3QoYjSTUqkcCdURISLuMgaYnzBcuzxzBxW8CtQ9OlFR8+zgr80Z97zO9/e+b0fbTc76OTHd6cnLHHxzdenJyyz99Inpycssf3t76YnLLH3pdemJyyxffp4esIyx999a3rCEi/94BvTE5bYu/2J6QlrnDydXrDM+c93895fmB4AAMD/L7EIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEDa+8/JW9vpESsc/vt4esISH9y4Oj1hmQ9Pn0xPWOLTj06mJyzx6OMvT09Y4nx7Pj1hmVsHt6cnrHH/L9MLlnh8azf/Xtf//IfpCctsP/+V6QlLeFkEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACAdHN6/N71hjas3pxcssd2eTE9Y5lNv/3J6whpvfn16wRJHH/xzesIa56fTC9Y53NH7cfna9IIlbvxrN7+fH3zmzvSEZW797d3pCUt4WQQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAADS3ouzu9vpESvsH/9pesIS965fmp6wzJMXD6cnLHHnrw+nJyxx+sWvTk9Y4unp4+kJyxzt35yesMT2/V9MT1ji2eden56wxJV335mesMzzL78xPWEJL4sAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA2vvp+9/ZTo9Y4faVw+kJS7z38P70hGW+/cNfT09Y4jff/+b0hCWOLh9NT1jiez/71fSEZb72ypXpCUt8684b0xOWePvv70xPWOLaxd38HG42m81P/vhgesISXhYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAtPfi7O52esQKD54fT09Y4vDgxvSEZd57+PvpCUu8evO16QlLbLfn0xOWuHa6u7+h/3G+m3fxlcNXpycs8ezs6fSEJXb1dmw2m83+hYPpCUvs7lUEAOAjE4sAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAOtjfO5jesMTH9m9PT1hj/9L0gmWOLh9NT1ji8ODG9IQlzran0xOWOL+4u7+hX95enZ7A/2BXv59Pts+mJyzz+Pnx9IQldvcqAgDwkYlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAADSwWZ7Pr1hiUfbJ9MTljg4uzQ9YZnPXv/C9IQlzran0xOW+PB0N//Hrm2uTE9Y5tmF3bz3+9MDFrm4v5v3fv/CwfSEZQ73rk5PWMLLIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJD+C2EVlmm8G2EiAAAAAElFTkSuQmCC" id="imageb5b3f040bd" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="468.72" height="295.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="mc11272acd7" d="M 0 0 
+       <path id="me2d8feb9da" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mc11272acd7" x="115.182137" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me2d8feb9da" x="115.182137" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#mc11272acd7" x="154.193912" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me2d8feb9da" x="154.193912" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#mc11272acd7" x="193.205687" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me2d8feb9da" x="193.205687" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mc11272acd7" x="232.217462" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me2d8feb9da" x="232.217462" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#mc11272acd7" x="271.229237" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me2d8feb9da" x="271.229237" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#mc11272acd7" x="310.241012" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me2d8feb9da" x="310.241012" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#mc11272acd7" x="349.252787" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me2d8feb9da" x="349.252787" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#mc11272acd7" x="388.264562" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me2d8feb9da" x="388.264562" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#mc11272acd7" x="427.276336" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me2d8feb9da" x="427.276336" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#mc11272acd7" x="466.288111" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me2d8feb9da" x="466.288111" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#mc11272acd7" x="505.299886" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me2d8feb9da" x="505.299886" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#mc11272acd7" x="544.311661" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me2d8feb9da" x="544.311661" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="m3c6d3e7cc6" d="M 0 0 
+       <path id="mca8875d409" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m3c6d3e7cc6" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mca8875d409" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m3c6d3e7cc6" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mca8875d409" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m3c6d3e7cc6" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mca8875d409" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m3c6d3e7cc6" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mca8875d409" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -836,7 +836,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m3c6d3e7cc6" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mca8875d409" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -899,7 +899,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m3c6d3e7cc6" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mca8875d409" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -966,7 +966,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m3c6d3e7cc6" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mca8875d409" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1047,7 +1047,7 @@ z
     <g id="ytick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m3c6d3e7cc6" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mca8875d409" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -2060,18 +2060,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABEAAAFUCAYAAADCj9eRAAAB2ElEQVR4nO2aQY7EIAwEIeFP+6X9/33C3MPcKKSS1TygZRftNlLS2//fbJtn9KvvajAi17ZCM7Uzeg+TEyJhsh4TE8D25ZhYRMJkPSYmmZ0zIhfQEMPkJq74JpgQlUBMABkIrOV2KLMRItXMhrQjqcQUSszsbGuomFSbHULEAlblE0klor1zMaG0XwnDBDAsBVY0O4CIBizlE4ntEbCijK3mE8vKUPkEEIF8YslYje2RZFP5BJkdCxOonf1i6jEhRICOyjEBzFaPiWd2iChoYbKKhMkqgmSsh4kkHkU+6UyeACJEJaLZ6QQTzy7WtGPyicX2Kp/c+yKaATTliSWoTXsnPllEEtTLGX37f+7WRpuPQ4RhomlntCdMTohATIDbKceEaGfOD1BJZueIiImJZQBNTCxgw2Q91N7Zf7RBsxMmR0TqMdmvxPRmI0TmDJNVJExWkTBZRcJkFSnFZH6Q5aVhQrQzkYUOVEIxIXxSjAnRDjQ7mndsZud9VEwsPtFcsWjvaNZofHKoEpFPELCPJmORdqblMWxiYjEbw+QJk/dR+SQD+BbROFbEJAP4Q4RgQpiNCupKIhAT4gewakws7YTJIREoY4FPeNWYaNoJk18iQNqXY1LKJ1/07Ct/l+QCQgAAAABJRU5ErkJggg==" id="image486cbf1fb4" transform="scale(1 -1) translate(0 -244.8)" x="573.84" y="-74.16" width="12.24" height="244.8"/>
+iVBORw0KGgoAAAANSUhEUgAAABEAAAFUCAYAAADCj9eRAAAB2ElEQVR4nO2aQY7EIAwEIeFP+6X9/33C3MPcKKSS1TygZRftNlLS2//fbJtn9KvvajAi17ZCM7Uzeg+TEyJhsh4TE8D25ZhYRMJkPSYmmZ0zIhfQEMPkJq74JpgQlUBMABkIrOV2KLMRItXMhrQjqcQUSszsbGuomFSbHULEAlblE0klor1zMaG0XwnDBDAsBVY0O4CIBizlE4ntEbCijK3mE8vKUPkEEIF8YslYje2RZFP5BJkdCxOonf1i6jEhRICOyjEBzFaPiWd2iChoYbKKhMkqgmSsh4kkHkU+6UyeACJEJaLZ6QQTzy7WtGPyicX2Kp/c+yKaATTliSWoTXsnPllEEtTLGX37f+7WRpuPQ4RhomlntCdMTohATIDbKceEaGfOD1BJZueIiImJZQBNTCxgw2Q91N7Zf7RBsxMmR0TqMdmvxPRmI0TmDJNVJExWkTBZRcJkFSnFZH6Q5aVhQrQzkYUOVEIxIXxSjAnRDjQ7mndsZud9VEwsPtFcsWjvaNZofHKoEpFPELCPJmORdqblMWxiYjEbw+QJk/dR+SQD+BbROFbEJAP4Q4RgQpiNCupKIhAT4gewakws7YTJIREoY4FPeNWYaNoJk18iQNqXY1LKJ1/07Ct/l+QCQgAAAABJRU5ErkJggg==" id="image2386148777" transform="scale(1 -1) translate(0 -244.8)" x="573.84" y="-74.16" width="12.24" height="244.8"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_21">
       <defs>
-       <path id="m971a764be9" d="M 0 0 
+       <path id="maeaf339fe3" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m971a764be9" x="585.876562" y="282.022672" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#maeaf339fe3" x="585.876562" y="282.022672" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_117">
@@ -2097,7 +2097,7 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m971a764be9" x="585.876562" y="239.353777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#maeaf339fe3" x="585.876562" y="239.353777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_118">
@@ -2114,7 +2114,7 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m971a764be9" x="585.876562" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#maeaf339fe3" x="585.876562" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_119">
@@ -2130,7 +2130,7 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m971a764be9" x="585.876562" y="154.015985" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#maeaf339fe3" x="585.876562" y="154.015985" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_120">
@@ -2146,7 +2146,7 @@ z
     <g id="ytick_13">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m971a764be9" x="585.876562" y="111.347089" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#maeaf339fe3" x="585.876562" y="111.347089" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_121">
@@ -2739,8 +2739,8 @@ z
    </g>
   </g>
   <g id="text_124">
-   <!-- 2026-07-09T07:09:47Z  ·  Linux chungus2 x86_64  ·  commit b23a23be  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(43.545547 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-09T17:31:54Z  ·  Linux chungus2 x86_64  ·  commit 324f086c  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(44.677578 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2870,14 +2870,14 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-39" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
     <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2917,109 +2917,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3135.351562 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3198.974609 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3262.597656 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3323.876953 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3387.5 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3451.123047 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3514.599609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3576.123047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3607.910156 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3639.697266 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3671.484375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3703.271484 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3735.058594 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3762.841797 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3824.365234 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3885.644531 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3949.023438 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4012.5 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4051.363281 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4112.544922 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4171.724609 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4233.248047 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4274.361328 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4308.052734 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4335.835938 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4397.359375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4458.638672 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4522.017578 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4585.640625 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4619.332031 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4678.511719 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4742.134766 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4773.921875 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4837.544922 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4901.167969 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4932.955078 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4996.578125 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5032.662109 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5071.525391 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5126.505859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5190.128906 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5221.916016 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5253.703125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5285.490234 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5317.277344 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5349.064453 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5388.273438 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5451.652344 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5490.515625 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5551.697266 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5615.076172 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5678.552734 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5741.931641 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5805.408203 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5868.787109 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5907.996094 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5939.783203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6023.572266 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6055.359375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6152.771484 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6214.294922 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6277.771484 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6305.554688 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6366.833984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6430.212891 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6462 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6514.099609 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6577.478516 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6638.757812 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6702.234375 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6754.333984 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6817.712891 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6878.894531 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6918.103516 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6951.794922 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6983.582031 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7024.695312 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7085.974609 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7125.183594 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7152.966797 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7214.148438 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7245.935547 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7273.71875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7325.818359 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7357.605469 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7421.082031 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7482.605469 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7521.814453 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7583.337891 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7622.701172 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7720.113281 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7747.896484 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7811.275391 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7839.058594 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7891.158203 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7930.367188 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7958.150391 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3262.744141 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3297.949219 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3361.572266 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3425.195312 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3488.818359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3543.798828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3575.585938 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3607.373047 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3639.160156 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3670.947266 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3702.734375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3730.517578 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3792.041016 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3853.320312 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3916.699219 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3980.175781 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4019.039062 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4080.220703 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4139.400391 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4200.923828 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4242.037109 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4275.728516 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4303.511719 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4365.035156 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4426.314453 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4489.693359 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4553.316406 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4587.007812 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4646.1875 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4709.810547 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4741.597656 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4805.220703 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4868.84375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4900.630859 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4964.253906 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5000.337891 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5039.201172 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5094.181641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5157.804688 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5189.591797 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5221.378906 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5253.166016 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5284.953125 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5316.740234 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5355.949219 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5419.328125 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5458.191406 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5519.373047 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5582.751953 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5646.228516 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5709.607422 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5773.083984 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5836.462891 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5875.671875 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5907.458984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5991.248047 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6023.035156 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6120.447266 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6181.970703 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6245.447266 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6273.230469 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6334.509766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6397.888672 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6429.675781 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6481.775391 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6545.154297 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6606.433594 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6669.910156 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6722.009766 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6785.388672 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6846.570312 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6885.779297 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6919.470703 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6951.257812 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6992.371094 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7053.650391 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7092.859375 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7120.642578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7181.824219 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7213.611328 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7241.394531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7293.494141 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7325.28125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7388.757812 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7450.28125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7489.490234 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7551.013672 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7590.376953 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7687.789062 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7715.572266 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7778.951172 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7806.734375 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7858.833984 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7898.042969 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7925.826172 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pb96a9ce219">
+  <clipPath id="pab5eac449f">
    <rect x="95.67625" y="49.34175" width="468.141298" height="294.686261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_summary.svg
+++ b/bench/graphs/silesia_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="575.308906pt" height="386.202469pt" viewBox="0 0 575.308906 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="573.044844pt" height="386.202469pt" viewBox="0 0 573.044844 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,232 +22,232 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 386.202469 
-L 575.308906 386.202469 
-L 575.308906 0 
+L 573.044844 386.202469 
+L 573.044844 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 189.779453 104.1264 
-L 294.404453 104.1264 
-L 294.404453 74.7432 
-L 189.779453 74.7432 
+    <path d="M 188.647422 104.1264 
+L 293.272422 104.1264 
+L 293.272422 74.7432 
+L 188.647422 74.7432 
 z
-" clip-path="url(#pc747ff9fbd)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc5033f41c3)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 294.404453 104.1264 
-L 399.029453 104.1264 
-L 399.029453 74.7432 
-L 294.404453 74.7432 
+    <path d="M 293.272422 104.1264 
+L 397.897422 104.1264 
+L 397.897422 74.7432 
+L 293.272422 74.7432 
 z
-" clip-path="url(#pc747ff9fbd)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc5033f41c3)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 399.029453 104.1264 
-L 503.654453 104.1264 
-L 503.654453 74.7432 
-L 399.029453 74.7432 
+    <path d="M 397.897422 104.1264 
+L 502.522422 104.1264 
+L 502.522422 74.7432 
+L 397.897422 74.7432 
 z
-" clip-path="url(#pc747ff9fbd)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc5033f41c3)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 189.779453 133.5096 
-L 294.404453 133.5096 
-L 294.404453 104.1264 
-L 189.779453 104.1264 
+    <path d="M 188.647422 133.5096 
+L 293.272422 133.5096 
+L 293.272422 104.1264 
+L 188.647422 104.1264 
 z
-" clip-path="url(#pc747ff9fbd)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc5033f41c3)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 294.404453 133.5096 
-L 399.029453 133.5096 
-L 399.029453 104.1264 
-L 294.404453 104.1264 
+    <path d="M 293.272422 133.5096 
+L 397.897422 133.5096 
+L 397.897422 104.1264 
+L 293.272422 104.1264 
 z
-" clip-path="url(#pc747ff9fbd)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc5033f41c3)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 399.029453 133.5096 
-L 503.654453 133.5096 
-L 503.654453 104.1264 
-L 399.029453 104.1264 
+    <path d="M 397.897422 133.5096 
+L 502.522422 133.5096 
+L 502.522422 104.1264 
+L 397.897422 104.1264 
 z
-" clip-path="url(#pc747ff9fbd)" style="fill: #fece7c; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc5033f41c3)" style="fill: #fece7c; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 189.779453 162.8928 
-L 294.404453 162.8928 
-L 294.404453 133.5096 
-L 189.779453 133.5096 
+    <path d="M 188.647422 162.8928 
+L 293.272422 162.8928 
+L 293.272422 133.5096 
+L 188.647422 133.5096 
 z
-" clip-path="url(#pc747ff9fbd)" style="fill: #fee08b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc5033f41c3)" style="fill: #fee08b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 294.404453 162.8928 
-L 399.029453 162.8928 
-L 399.029453 133.5096 
-L 294.404453 133.5096 
+    <path d="M 293.272422 162.8928 
+L 397.897422 162.8928 
+L 397.897422 133.5096 
+L 293.272422 133.5096 
 z
-" clip-path="url(#pc747ff9fbd)" style="fill: #feefa3; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc5033f41c3)" style="fill: #feefa3; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 399.029453 162.8928 
-L 503.654453 162.8928 
-L 503.654453 133.5096 
-L 399.029453 133.5096 
+    <path d="M 397.897422 162.8928 
+L 502.522422 162.8928 
+L 502.522422 133.5096 
+L 397.897422 133.5096 
 z
-" clip-path="url(#pc747ff9fbd)" style="fill: #fdbf6f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc5033f41c3)" style="fill: #fdbf6f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 189.779453 192.276 
-L 294.404453 192.276 
-L 294.404453 162.8928 
-L 189.779453 162.8928 
+    <path d="M 188.647422 192.276 
+L 293.272422 192.276 
+L 293.272422 162.8928 
+L 188.647422 162.8928 
 z
-" clip-path="url(#pc747ff9fbd)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc5033f41c3)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 294.404453 192.276 
-L 399.029453 192.276 
-L 399.029453 162.8928 
-L 294.404453 162.8928 
+    <path d="M 293.272422 192.276 
+L 397.897422 192.276 
+L 397.897422 162.8928 
+L 293.272422 162.8928 
 z
-" clip-path="url(#pc747ff9fbd)" style="fill: #fede89; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc5033f41c3)" style="fill: #fede89; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 399.029453 192.276 
-L 503.654453 192.276 
-L 503.654453 162.8928 
-L 399.029453 162.8928 
+    <path d="M 397.897422 192.276 
+L 502.522422 192.276 
+L 502.522422 162.8928 
+L 397.897422 162.8928 
 z
-" clip-path="url(#pc747ff9fbd)" style="fill: #f7814c; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc5033f41c3)" style="fill: #f7814c; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 189.779453 221.6592 
-L 294.404453 221.6592 
-L 294.404453 192.276 
-L 189.779453 192.276 
+    <path d="M 188.647422 221.6592 
+L 293.272422 221.6592 
+L 293.272422 192.276 
+L 188.647422 192.276 
 z
-" clip-path="url(#pc747ff9fbd)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc5033f41c3)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 294.404453 221.6592 
-L 399.029453 221.6592 
-L 399.029453 192.276 
-L 294.404453 192.276 
+    <path d="M 293.272422 221.6592 
+L 397.897422 221.6592 
+L 397.897422 192.276 
+L 293.272422 192.276 
 z
-" clip-path="url(#pc747ff9fbd)" style="fill: #fed27f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc5033f41c3)" style="fill: #fed27f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 399.029453 221.6592 
-L 503.654453 221.6592 
-L 503.654453 192.276 
-L 399.029453 192.276 
+    <path d="M 397.897422 221.6592 
+L 502.522422 221.6592 
+L 502.522422 192.276 
+L 397.897422 192.276 
 z
-" clip-path="url(#pc747ff9fbd)" style="fill: #fffcba; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc5033f41c3)" style="fill: #fffcba; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 189.779453 251.0424 
-L 294.404453 251.0424 
-L 294.404453 221.6592 
-L 189.779453 221.6592 
+    <path d="M 188.647422 251.0424 
+L 293.272422 251.0424 
+L 293.272422 221.6592 
+L 188.647422 221.6592 
 z
-" clip-path="url(#pc747ff9fbd)" style="fill: #fff3ac; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc5033f41c3)" style="fill: #feefa3; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 294.404453 251.0424 
-L 399.029453 251.0424 
-L 399.029453 221.6592 
-L 294.404453 221.6592 
+    <path d="M 293.272422 251.0424 
+L 397.897422 251.0424 
+L 397.897422 221.6592 
+L 293.272422 221.6592 
 z
-" clip-path="url(#pc747ff9fbd)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc5033f41c3)" style="fill: #fed07e; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 399.029453 251.0424 
-L 503.654453 251.0424 
-L 503.654453 221.6592 
-L 399.029453 221.6592 
+    <path d="M 397.897422 251.0424 
+L 502.522422 251.0424 
+L 502.522422 221.6592 
+L 397.897422 221.6592 
 z
-" clip-path="url(#pc747ff9fbd)" style="fill: #e8f59f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc5033f41c3)" style="fill: #fec877; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 189.779453 280.4256 
-L 294.404453 280.4256 
-L 294.404453 251.0424 
-L 189.779453 251.0424 
+    <path d="M 188.647422 280.4256 
+L 293.272422 280.4256 
+L 293.272422 251.0424 
+L 188.647422 251.0424 
 z
-" clip-path="url(#pc747ff9fbd)" style="fill: #feefa3; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc5033f41c3)" style="fill: #fff3ac; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 294.404453 280.4256 
-L 399.029453 280.4256 
-L 399.029453 251.0424 
-L 294.404453 251.0424 
+    <path d="M 293.272422 280.4256 
+L 397.897422 280.4256 
+L 397.897422 251.0424 
+L 293.272422 251.0424 
 z
-" clip-path="url(#pc747ff9fbd)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc5033f41c3)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 399.029453 280.4256 
-L 503.654453 280.4256 
-L 503.654453 251.0424 
-L 399.029453 251.0424 
+    <path d="M 397.897422 280.4256 
+L 502.522422 280.4256 
+L 502.522422 251.0424 
+L 397.897422 251.0424 
 z
-" clip-path="url(#pc747ff9fbd)" style="fill: #fec877; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc5033f41c3)" style="fill: #e8f59f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 189.779453 309.8088 
-L 294.404453 309.8088 
-L 294.404453 280.4256 
-L 189.779453 280.4256 
+    <path d="M 188.647422 309.8088 
+L 293.272422 309.8088 
+L 293.272422 280.4256 
+L 188.647422 280.4256 
 z
-" clip-path="url(#pc747ff9fbd)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc5033f41c3)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 294.404453 309.8088 
-L 399.029453 309.8088 
-L 399.029453 280.4256 
-L 294.404453 280.4256 
+    <path d="M 293.272422 309.8088 
+L 397.897422 309.8088 
+L 397.897422 280.4256 
+L 293.272422 280.4256 
 z
-" clip-path="url(#pc747ff9fbd)" style="fill: #fa9b58; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc5033f41c3)" style="fill: #fa9b58; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 399.029453 309.8088 
-L 503.654453 309.8088 
-L 503.654453 280.4256 
-L 399.029453 280.4256 
+    <path d="M 397.897422 309.8088 
+L 502.522422 309.8088 
+L 502.522422 280.4256 
+L 397.897422 280.4256 
 z
-" clip-path="url(#pc747ff9fbd)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc5033f41c3)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 189.779453 339.192 
-L 294.404453 339.192 
-L 294.404453 309.8088 
-L 189.779453 309.8088 
+    <path d="M 188.647422 339.192 
+L 293.272422 339.192 
+L 293.272422 309.8088 
+L 188.647422 309.8088 
 z
-" clip-path="url(#pc747ff9fbd)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc5033f41c3)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 294.404453 339.192 
-L 399.029453 339.192 
-L 399.029453 309.8088 
-L 294.404453 309.8088 
+    <path d="M 293.272422 339.192 
+L 397.897422 339.192 
+L 397.897422 309.8088 
+L 293.272422 309.8088 
 z
-" clip-path="url(#pc747ff9fbd)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc5033f41c3)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 399.029453 339.192 
-L 503.654453 339.192 
-L 503.654453 309.8088 
-L 399.029453 309.8088 
+    <path d="M 397.897422 339.192 
+L 502.522422 339.192 
+L 502.522422 309.8088 
+L 397.897422 309.8088 
 z
-" clip-path="url(#pc747ff9fbd)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc5033f41c3)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(122.766719 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(121.634688 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(230.050938 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(228.918906 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(308.623047 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(307.491016 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(406.974766 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(405.842734 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(118.704453 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(117.572422 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.320 -->
-    <g transform="translate(230.640703 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(229.508672 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -918,7 +918,7 @@ z
    </g>
    <g id="text_7">
     <!-- 117 -->
-    <g transform="translate(339.081953 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(337.949922 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -952,7 +952,7 @@ z
    </g>
    <g id="text_8">
     <!-- 852 -->
-    <g transform="translate(443.706953 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(442.574922 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -1026,7 +1026,7 @@ z
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(113.342578 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(112.210547 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1125,7 +1125,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.324 -->
-    <g transform="translate(230.640703 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(229.508672 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1156,7 +1156,7 @@ z
    </g>
    <g id="text_11">
     <!-- 61 -->
-    <g transform="translate(341.626953 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(340.494922 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -1195,7 +1195,7 @@ z
    </g>
    <g id="text_12">
     <!-- 312 -->
-    <g transform="translate(443.706953 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(442.574922 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
@@ -1203,7 +1203,7 @@ z
    </g>
    <g id="text_13">
     <!-- Go compress/flate -->
-    <g transform="translate(101.035703 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(99.903672 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -1374,7 +1374,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.325 -->
-    <g transform="translate(230.640703 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(229.508672 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1384,14 +1384,14 @@ z
    </g>
    <g id="text_15">
     <!-- 50 -->
-    <g transform="translate(341.626953 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(340.494922 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
     <!-- 275 -->
-    <g transform="translate(443.706953 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(442.574922 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
@@ -1399,7 +1399,7 @@ z
    </g>
    <g id="text_17">
     <!-- JS fflate -->
-    <g transform="translate(122.068203 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(120.936172 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1459,7 +1459,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.329 -->
-    <g transform="translate(230.640703 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(229.508672 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-39" d="M 703 97 
 L 703 672 
@@ -1501,14 +1501,14 @@ z
    </g>
    <g id="text_19">
     <!-- 41 -->
-    <g transform="translate(341.626953 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(340.494922 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
     <!-- 160 -->
-    <g transform="translate(443.706953 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(442.574922 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -1516,7 +1516,7 @@ z
    </g>
    <g id="text_21">
     <!-- zlib -->
-    <g transform="translate(130.605703 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(129.473672 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1540,7 +1540,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.323 -->
-    <g transform="translate(230.640703 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(229.508672 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1550,106 +1550,22 @@ z
    </g>
    <g id="text_23">
     <!-- 38 -->
-    <g transform="translate(341.626953 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(340.494922 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_24">
     <!-- 448 -->
-    <g transform="translate(443.706953 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(442.574922 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_25">
-    <!-- miniz_oxide -->
-    <g transform="translate(113.911953 238.44705) scale(0.08 -0.08)">
-     <defs>
-      <path id="DejaVuSans-6e" d="M 3513 2113 
-L 3513 0 
-L 2938 0 
-L 2938 2094 
-Q 2938 2591 2744 2837 
-Q 2550 3084 2163 3084 
-Q 1697 3084 1428 2787 
-Q 1159 2491 1159 1978 
-L 1159 0 
-L 581 0 
-L 581 3500 
-L 1159 3500 
-L 1159 2956 
-Q 1366 3272 1645 3428 
-Q 1925 3584 2291 3584 
-Q 2894 3584 3203 3211 
-Q 3513 2838 3513 2113 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-5f" d="M 3263 -1063 
-L 3263 -1509 
-L -63 -1509 
-L -63 -1063 
-L 3263 -1063 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-78" d="M 3513 3500 
-L 2247 1797 
-L 3578 0 
-L 2900 0 
-L 1881 1375 
-L 863 0 
-L 184 0 
-L 1544 1831 
-L 300 3500 
-L 978 3500 
-L 1906 2253 
-L 2834 3500 
-L 3513 3500 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-6d"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(97.412109 0)"/>
-     <use xlink:href="#DejaVuSans-6e" transform="translate(125.195312 0)"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(188.574219 0)"/>
-     <use xlink:href="#DejaVuSans-7a" transform="translate(216.357422 0)"/>
-     <use xlink:href="#DejaVuSans-5f" transform="translate(268.847656 0)"/>
-     <use xlink:href="#DejaVuSans-6f" transform="translate(318.847656 0)"/>
-     <use xlink:href="#DejaVuSans-78" transform="translate(376.904297 0)"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(436.083984 0)"/>
-     <use xlink:href="#DejaVuSans-64" transform="translate(463.867188 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(527.34375 0)"/>
-    </g>
-   </g>
-   <g id="text_26">
-    <!-- 0.322 -->
-    <g transform="translate(230.640703 238.5583) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-30"/>
-     <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(159.033203 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(222.65625 0)"/>
-    </g>
-   </g>
-   <g id="text_27">
-    <!-- 36 -->
-    <g transform="translate(341.626953 238.5583) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-33"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
-    </g>
-   </g>
-   <g id="text_28">
-    <!-- 527 -->
-    <g transform="translate(443.706953 238.5583) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
-    </g>
-   </g>
-   <g id="text_29">
     <!-- lean-zip (native) -->
-    <g transform="translate(100.413828 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(99.281797 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1756,9 +1672,9 @@ z
      <use xlink:href="#DejaVuSans-Bold-29" transform="translate(880.615234 0)"/>
     </g>
    </g>
-   <g id="text_30">
+   <g id="text_26">
     <!-- 0.322 -->
-    <g transform="translate(229.440078 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(228.308047 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1850,43 +1766,28 @@ z
      <use xlink:href="#DejaVuSans-Bold-32" transform="translate(246.728516 0)"/>
     </g>
    </g>
-   <g id="text_31">
-    <!-- 35 -->
-    <g transform="translate(341.150703 267.9415) scale(0.08 -0.08)">
+   <g id="text_27">
+    <!-- 37 -->
+    <g transform="translate(340.018672 238.5583) scale(0.08 -0.08)">
      <defs>
-      <path id="DejaVuSans-Bold-35" d="M 678 4666 
-L 3669 4666 
-L 3669 3781 
-L 1638 3781 
-L 1638 3059 
-Q 1775 3097 1914 3117 
-Q 2053 3138 2203 3138 
-Q 3056 3138 3531 2711 
-Q 4006 2284 4006 1522 
-Q 4006 766 3489 337 
-Q 2972 -91 2053 -91 
-Q 1656 -91 1267 -14 
-Q 878 63 494 219 
-L 494 1166 
-Q 875 947 1217 837 
-Q 1559 728 1863 728 
-Q 2300 728 2551 942 
-Q 2803 1156 2803 1522 
-Q 2803 1891 2551 2103 
-Q 2300 2316 1863 2316 
-Q 1603 2316 1309 2248 
-Q 1016 2181 678 2041 
-L 678 4666 
+      <path id="DejaVuSans-Bold-37" d="M 428 4666 
+L 3944 4666 
+L 3944 3988 
+L 2125 0 
+L 953 0 
+L 2675 3781 
+L 428 3781 
+L 428 4666 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-Bold-33"/>
-     <use xlink:href="#DejaVuSans-Bold-35" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-37" transform="translate(69.580078 0)"/>
     </g>
    </g>
-   <g id="text_32">
-    <!-- 299 -->
-    <g transform="translate(442.992578 267.9415) scale(0.08 -0.08)">
+   <g id="text_28">
+    <!-- 295 -->
+    <g transform="translate(441.860547 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-39" d="M 641 103 
 L 641 966 
@@ -1918,15 +1819,124 @@ Q 1491 2759 1650 2554
 Q 1809 2350 2125 2350 
 z
 " transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-35" d="M 678 4666 
+L 3669 4666 
+L 3669 3781 
+L 1638 3781 
+L 1638 3059 
+Q 1775 3097 1914 3117 
+Q 2053 3138 2203 3138 
+Q 3056 3138 3531 2711 
+Q 4006 2284 4006 1522 
+Q 4006 766 3489 337 
+Q 2972 -91 2053 -91 
+Q 1656 -91 1267 -14 
+Q 878 63 494 219 
+L 494 1166 
+Q 875 947 1217 837 
+Q 1559 728 1863 728 
+Q 2300 728 2551 942 
+Q 2803 1156 2803 1522 
+Q 2803 1891 2551 2103 
+Q 2300 2316 1863 2316 
+Q 1603 2316 1309 2248 
+Q 1016 2181 678 2041 
+L 678 4666 
+z
+" transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-Bold-32"/>
      <use xlink:href="#DejaVuSans-Bold-39" transform="translate(69.580078 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-39" transform="translate(139.160156 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-35" transform="translate(139.160156 0)"/>
+    </g>
+   </g>
+   <g id="text_29">
+    <!-- miniz_oxide -->
+    <g transform="translate(112.779922 267.83025) scale(0.08 -0.08)">
+     <defs>
+      <path id="DejaVuSans-6e" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-5f" d="M 3263 -1063 
+L 3263 -1509 
+L -63 -1509 
+L -63 -1063 
+L 3263 -1063 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-78" d="M 3513 3500 
+L 2247 1797 
+L 3578 0 
+L 2900 0 
+L 1881 1375 
+L 863 0 
+L 184 0 
+L 1544 1831 
+L 300 3500 
+L 978 3500 
+L 1906 2253 
+L 2834 3500 
+L 3513 3500 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-6d"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(97.412109 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(125.195312 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(188.574219 0)"/>
+     <use xlink:href="#DejaVuSans-7a" transform="translate(216.357422 0)"/>
+     <use xlink:href="#DejaVuSans-5f" transform="translate(268.847656 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(318.847656 0)"/>
+     <use xlink:href="#DejaVuSans-78" transform="translate(376.904297 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(436.083984 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(463.867188 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(527.34375 0)"/>
+    </g>
+   </g>
+   <g id="text_30">
+    <!-- 0.322 -->
+    <g transform="translate(229.508672 267.9415) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-30"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(159.033203 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(222.65625 0)"/>
+    </g>
+   </g>
+   <g id="text_31">
+    <!-- 36 -->
+    <g transform="translate(340.494922 267.9415) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-33"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
+    </g>
+   </g>
+   <g id="text_32">
+    <!-- 527 -->
+    <g transform="translate(442.574922 267.9415) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-35"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_33">
     <!-- OCaml decompress -->
-    <g transform="translate(98.528828 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(97.396797 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -1991,7 +2001,7 @@ z
    </g>
    <g id="text_34">
     <!-- 0.336 -->
-    <g transform="translate(230.640703 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(229.508672 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -2001,21 +2011,21 @@ z
    </g>
    <g id="text_35">
     <!-- 21 -->
-    <g transform="translate(341.626953 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(340.494922 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_36">
     <!-- 69 -->
-    <g transform="translate(446.251953 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(445.119922 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-36"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(126.750078 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(125.618047 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -2026,7 +2036,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.303 -->
-    <g transform="translate(230.640703 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(229.508672 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -2036,13 +2046,13 @@ z
    </g>
    <g id="text_39">
     <!-- 1 -->
-    <g transform="translate(344.171953 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(343.039922 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(447.341953 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(446.209922 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2058,7 +2068,7 @@ z
   </g>
   <g id="text_41">
    <!-- silesia — geomean over files, level 6 -->
-   <g transform="translate(154.256172 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(153.124141 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-2014" d="M 344 2156 
 L 6056 2156 
@@ -2202,7 +2212,7 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-07-09T07:09:47Z  ·  Linux chungus2 x86_64  ·  commit b23a23be  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-07-09T17:31:54Z  ·  Linux chungus2 x86_64  ·  commit 324f086c  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2343,14 +2353,14 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-39" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
     <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2390,110 +2400,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3135.351562 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3198.974609 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3262.597656 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3323.876953 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3387.5 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3451.123047 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3514.599609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3576.123047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3607.910156 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3639.697266 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3671.484375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3703.271484 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3735.058594 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3762.841797 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3824.365234 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3885.644531 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3949.023438 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4012.5 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4051.363281 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4112.544922 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4171.724609 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4233.248047 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4274.361328 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4308.052734 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4335.835938 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4397.359375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4458.638672 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4522.017578 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4585.640625 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4619.332031 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4678.511719 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4742.134766 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4773.921875 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4837.544922 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4901.167969 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4932.955078 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4996.578125 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5032.662109 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5071.525391 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5126.505859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5190.128906 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5221.916016 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5253.703125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5285.490234 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5317.277344 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5349.064453 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5388.273438 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5451.652344 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5490.515625 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5551.697266 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5615.076172 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5678.552734 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5741.931641 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5805.408203 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5868.787109 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5907.996094 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5939.783203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6023.572266 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6055.359375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6152.771484 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6214.294922 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6277.771484 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6305.554688 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6366.833984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6430.212891 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6462 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6514.099609 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6577.478516 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6638.757812 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6702.234375 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6754.333984 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6817.712891 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6878.894531 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6918.103516 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6951.794922 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6983.582031 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7024.695312 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7085.974609 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7125.183594 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7152.966797 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7214.148438 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7245.935547 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7273.71875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7325.818359 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7357.605469 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7421.082031 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7482.605469 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7521.814453 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7583.337891 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7622.701172 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7720.113281 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7747.896484 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7811.275391 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7839.058594 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7891.158203 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7930.367188 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7958.150391 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3262.744141 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3297.949219 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3361.572266 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3425.195312 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3488.818359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3543.798828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3575.585938 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3607.373047 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3639.160156 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3670.947266 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3702.734375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3730.517578 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3792.041016 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3853.320312 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3916.699219 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3980.175781 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4019.039062 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4080.220703 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4139.400391 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4200.923828 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4242.037109 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4275.728516 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4303.511719 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4365.035156 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4426.314453 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4489.693359 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4553.316406 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4587.007812 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4646.1875 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4709.810547 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4741.597656 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4805.220703 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4868.84375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4900.630859 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4964.253906 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5000.337891 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5039.201172 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5094.181641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5157.804688 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5189.591797 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5221.378906 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5253.166016 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5284.953125 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5316.740234 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5355.949219 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5419.328125 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5458.191406 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5519.373047 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5582.751953 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5646.228516 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5709.607422 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5773.083984 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5836.462891 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5875.671875 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5907.458984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5991.248047 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6023.035156 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6120.447266 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6181.970703 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6245.447266 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6273.230469 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6334.509766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6397.888672 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6429.675781 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6481.775391 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6545.154297 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6606.433594 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6669.910156 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6722.009766 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6785.388672 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6846.570312 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6885.779297 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6919.470703 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6951.257812 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6992.371094 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7053.650391 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7092.859375 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7120.642578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7181.824219 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7213.611328 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7241.394531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7293.494141 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7325.28125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7388.757812 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7450.28125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7489.490234 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7551.013672 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7590.376953 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7687.789062 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7715.572266 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7778.951172 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7806.734375 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7858.833984 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7898.042969 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7925.826172 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pc747ff9fbd">
-   <rect x="85.154453" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="pc5033f41c3">
+   <rect x="84.022422" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/results/latest.json
+++ b/bench/results/latest.json
@@ -1,8 +1,8 @@
 {
  "meta": {
-  "date": "2026-07-09T07:09:47Z",
+  "date": "2026-07-09T17:31:54Z",
   "machine": "Linux chungus2 x86_64",
-  "git_commit": "b23a23be",
+  "git_commit": "324f086c",
   "toolchain": "leanprover/lean4:v4.30.0-rc2",
   "note": "compress_mbps/decompress_mbps are a median-of-5 snapshot on the machine above; ratio is deterministic"
  },
@@ -14,8 +14,8 @@
    "level": 1,
    "out_size": 60455,
    "ratio": 0.3975,
-   "compress_mbps": 74.28,
-   "decompress_mbps": 213.59
+   "compress_mbps": 82.64,
+   "decompress_mbps": 215.57
   },
   {
    "compressor": "native",
@@ -24,8 +24,8 @@
    "level": 2,
    "out_size": 56316,
    "ratio": 0.3703,
-   "compress_mbps": 58.7,
-   "decompress_mbps": 244.6
+   "compress_mbps": 61.84,
+   "decompress_mbps": 246.97
   },
   {
    "compressor": "native",
@@ -34,8 +34,8 @@
    "level": 3,
    "out_size": 55646,
    "ratio": 0.3659,
-   "compress_mbps": 51.6,
-   "decompress_mbps": 265.32
+   "compress_mbps": 53.84,
+   "decompress_mbps": 268.91
   },
   {
    "compressor": "native",
@@ -44,8 +44,8 @@
    "level": 4,
    "out_size": 54357,
    "ratio": 0.3574,
-   "compress_mbps": 37.58,
-   "decompress_mbps": 271.53
+   "compress_mbps": 38.5,
+   "decompress_mbps": 273.01
   },
   {
    "compressor": "native",
@@ -54,8 +54,8 @@
    "level": 5,
    "out_size": 54078,
    "ratio": 0.3556,
-   "compress_mbps": 30.31,
-   "decompress_mbps": 272.26
+   "compress_mbps": 30.84,
+   "decompress_mbps": 273.3
   },
   {
    "compressor": "native",
@@ -64,8 +64,8 @@
    "level": 6,
    "out_size": 54593,
    "ratio": 0.359,
-   "compress_mbps": 30.95,
-   "decompress_mbps": 279.8
+   "compress_mbps": 31.88,
+   "decompress_mbps": 280.09
   },
   {
    "compressor": "native",
@@ -74,8 +74,8 @@
    "level": 7,
    "out_size": 54469,
    "ratio": 0.3581,
-   "compress_mbps": 27.94,
-   "decompress_mbps": 279.18
+   "compress_mbps": 28.61,
+   "decompress_mbps": 280.24
   },
   {
    "compressor": "native",
@@ -84,8 +84,8 @@
    "level": 8,
    "out_size": 54216,
    "ratio": 0.3565,
-   "compress_mbps": 22.35,
-   "decompress_mbps": 281.19
+   "compress_mbps": 22.79,
+   "decompress_mbps": 280.41
   },
   {
    "compressor": "native",
@@ -94,8 +94,8 @@
    "level": 9,
    "out_size": 52732,
    "ratio": 0.3467,
-   "compress_mbps": 4.27,
-   "decompress_mbps": 280.58
+   "compress_mbps": 4.3,
+   "decompress_mbps": 281.43
   },
   {
    "compressor": "native",
@@ -104,7 +104,7 @@
    "level": 10,
    "out_size": 52078,
    "ratio": 0.3424,
-   "compress_mbps": 2.39,
+   "compress_mbps": 2.42,
    "decompress_mbps": null
   },
   {
@@ -114,8 +114,8 @@
    "level": 1,
    "out_size": 53135,
    "ratio": 0.4245,
-   "compress_mbps": 70.13,
-   "decompress_mbps": 207.32
+   "compress_mbps": 75.19,
+   "decompress_mbps": 208.45
   },
   {
    "compressor": "native",
@@ -124,8 +124,8 @@
    "level": 2,
    "out_size": 50187,
    "ratio": 0.4009,
-   "compress_mbps": 54.63,
-   "decompress_mbps": 225.66
+   "compress_mbps": 57.65,
+   "decompress_mbps": 226.82
   },
   {
    "compressor": "native",
@@ -134,8 +134,8 @@
    "level": 3,
    "out_size": 49810,
    "ratio": 0.3979,
-   "compress_mbps": 48.83,
-   "decompress_mbps": 246.3
+   "compress_mbps": 51.31,
+   "decompress_mbps": 248.39
   },
   {
    "compressor": "native",
@@ -144,8 +144,8 @@
    "level": 4,
    "out_size": 48687,
    "ratio": 0.3889,
-   "compress_mbps": 35.33,
-   "decompress_mbps": 250.05
+   "compress_mbps": 36.08,
+   "decompress_mbps": 250.72
   },
   {
    "compressor": "native",
@@ -154,8 +154,8 @@
    "level": 5,
    "out_size": 48586,
    "ratio": 0.3881,
-   "compress_mbps": 30.49,
-   "decompress_mbps": 250.31
+   "compress_mbps": 30.88,
+   "decompress_mbps": 251.53
   },
   {
    "compressor": "native",
@@ -164,8 +164,8 @@
    "level": 6,
    "out_size": 49005,
    "ratio": 0.3915,
-   "compress_mbps": 29.74,
-   "decompress_mbps": 254.28
+   "compress_mbps": 30.31,
+   "decompress_mbps": 255.89
   },
   {
    "compressor": "native",
@@ -174,8 +174,8 @@
    "level": 7,
    "out_size": 48910,
    "ratio": 0.3907,
-   "compress_mbps": 26.98,
-   "decompress_mbps": 255.42
+   "compress_mbps": 27.56,
+   "decompress_mbps": 256.45
   },
   {
    "compressor": "native",
@@ -184,8 +184,8 @@
    "level": 8,
    "out_size": 48839,
    "ratio": 0.3902,
-   "compress_mbps": 24.2,
-   "decompress_mbps": 256.78
+   "compress_mbps": 24.83,
+   "decompress_mbps": 256.58
   },
   {
    "compressor": "native",
@@ -194,8 +194,8 @@
    "level": 9,
    "out_size": 47433,
    "ratio": 0.3789,
-   "compress_mbps": 4.62,
-   "decompress_mbps": 257.11
+   "compress_mbps": 4.68,
+   "decompress_mbps": 256.75
   },
   {
    "compressor": "native",
@@ -204,7 +204,7 @@
    "level": 10,
    "out_size": 46866,
    "ratio": 0.3744,
-   "compress_mbps": 2.79,
+   "compress_mbps": 2.84,
    "decompress_mbps": null
   },
   {
@@ -214,8 +214,8 @@
    "level": 1,
    "out_size": 8476,
    "ratio": 0.3445,
-   "compress_mbps": 67.13,
-   "decompress_mbps": 272.69
+   "compress_mbps": 69.76,
+   "decompress_mbps": 275.19
   },
   {
    "compressor": "native",
@@ -224,8 +224,8 @@
    "level": 2,
    "out_size": 8271,
    "ratio": 0.3362,
-   "compress_mbps": 59.19,
-   "decompress_mbps": 283.22
+   "compress_mbps": 61.83,
+   "decompress_mbps": 284.53
   },
   {
    "compressor": "native",
@@ -234,8 +234,8 @@
    "level": 3,
    "out_size": 8159,
    "ratio": 0.3316,
-   "compress_mbps": 56.95,
-   "decompress_mbps": 287.41
+   "compress_mbps": 59.7,
+   "decompress_mbps": 285.91
   },
   {
    "compressor": "native",
@@ -244,8 +244,8 @@
    "level": 4,
    "out_size": 7948,
    "ratio": 0.3231,
-   "compress_mbps": 47.94,
-   "decompress_mbps": 294.02
+   "compress_mbps": 49.31,
+   "decompress_mbps": 295.89
   },
   {
    "compressor": "native",
@@ -254,8 +254,8 @@
    "level": 5,
    "out_size": 7899,
    "ratio": 0.3211,
-   "compress_mbps": 41.04,
-   "decompress_mbps": 301.16
+   "compress_mbps": 41.89,
+   "decompress_mbps": 302.73
   },
   {
    "compressor": "native",
@@ -264,8 +264,8 @@
    "level": 6,
    "out_size": 7962,
    "ratio": 0.3236,
-   "compress_mbps": 36.47,
-   "decompress_mbps": 301.15
+   "compress_mbps": 37.27,
+   "decompress_mbps": 301.65
   },
   {
    "compressor": "native",
@@ -274,8 +274,8 @@
    "level": 7,
    "out_size": 7950,
    "ratio": 0.3231,
-   "compress_mbps": 34.61,
-   "decompress_mbps": 306.65
+   "compress_mbps": 35.36,
+   "decompress_mbps": 307.03
   },
   {
    "compressor": "native",
@@ -284,8 +284,8 @@
    "level": 8,
    "out_size": 7934,
    "ratio": 0.3225,
-   "compress_mbps": 31.31,
-   "decompress_mbps": 307.66
+   "compress_mbps": 32.21,
+   "decompress_mbps": 306.43
   },
   {
    "compressor": "native",
@@ -294,8 +294,8 @@
    "level": 9,
    "out_size": 7803,
    "ratio": 0.3172,
-   "compress_mbps": 4.98,
-   "decompress_mbps": 305.49
+   "compress_mbps": 5.03,
+   "decompress_mbps": 306.41
   },
   {
    "compressor": "native",
@@ -304,7 +304,7 @@
    "level": 10,
    "out_size": 7737,
    "ratio": 0.3145,
-   "compress_mbps": 2.93,
+   "compress_mbps": 2.99,
    "decompress_mbps": null
   },
   {
@@ -314,8 +314,8 @@
    "level": 1,
    "out_size": 3509,
    "ratio": 0.3147,
-   "compress_mbps": 50.77,
-   "decompress_mbps": 186.46
+   "compress_mbps": 52.89,
+   "decompress_mbps": 185.68
   },
   {
    "compressor": "native",
@@ -324,8 +324,8 @@
    "level": 2,
    "out_size": 3269,
    "ratio": 0.2932,
-   "compress_mbps": 46.8,
-   "decompress_mbps": 188.63
+   "compress_mbps": 48.72,
+   "decompress_mbps": 188.3
   },
   {
    "compressor": "native",
@@ -334,8 +334,8 @@
    "level": 3,
    "out_size": 3209,
    "ratio": 0.2878,
-   "compress_mbps": 45.62,
-   "decompress_mbps": 192.61
+   "compress_mbps": 47.49,
+   "decompress_mbps": 191.69
   },
   {
    "compressor": "native",
@@ -344,8 +344,8 @@
    "level": 4,
    "out_size": 3128,
    "ratio": 0.2805,
-   "compress_mbps": 39.21,
-   "decompress_mbps": 196.51
+   "compress_mbps": 40.66,
+   "decompress_mbps": 196.88
   },
   {
    "compressor": "native",
@@ -354,8 +354,8 @@
    "level": 5,
    "out_size": 3112,
    "ratio": 0.2791,
-   "compress_mbps": 35.38,
-   "decompress_mbps": 197.41
+   "compress_mbps": 36.44,
+   "decompress_mbps": 197.69
   },
   {
    "compressor": "native",
@@ -364,8 +364,8 @@
    "level": 6,
    "out_size": 3136,
    "ratio": 0.2813,
-   "compress_mbps": 33.01,
-   "decompress_mbps": 197.96
+   "compress_mbps": 33.94,
+   "decompress_mbps": 198.09
   },
   {
    "compressor": "native",
@@ -374,8 +374,8 @@
    "level": 7,
    "out_size": 3122,
    "ratio": 0.28,
-   "compress_mbps": 32.02,
-   "decompress_mbps": 198.37
+   "compress_mbps": 32.53,
+   "decompress_mbps": 198.84
   },
   {
    "compressor": "native",
@@ -384,8 +384,8 @@
    "level": 8,
    "out_size": 3117,
    "ratio": 0.2796,
-   "compress_mbps": 29.73,
-   "decompress_mbps": 198.72
+   "compress_mbps": 30.45,
+   "decompress_mbps": 197.17
   },
   {
    "compressor": "native",
@@ -394,8 +394,8 @@
    "level": 9,
    "out_size": 3056,
    "ratio": 0.2741,
-   "compress_mbps": 5.47,
-   "decompress_mbps": 197.88
+   "compress_mbps": 5.49,
+   "decompress_mbps": 197.42
   },
   {
    "compressor": "native",
@@ -404,7 +404,7 @@
    "level": 10,
    "out_size": 3031,
    "ratio": 0.2718,
-   "compress_mbps": 3.07,
+   "compress_mbps": 3.1,
    "decompress_mbps": null
   },
   {
@@ -414,8 +414,8 @@
    "level": 1,
    "out_size": 1283,
    "ratio": 0.3448,
-   "compress_mbps": 25.31,
-   "decompress_mbps": 85.1
+   "compress_mbps": 25.95,
+   "decompress_mbps": 84.68
   },
   {
    "compressor": "native",
@@ -424,8 +424,8 @@
    "level": 2,
    "out_size": 1225,
    "ratio": 0.3292,
-   "compress_mbps": 24.64,
-   "decompress_mbps": 86.32
+   "compress_mbps": 25.41,
+   "decompress_mbps": 85.61
   },
   {
    "compressor": "native",
@@ -434,8 +434,8 @@
    "level": 3,
    "out_size": 1222,
    "ratio": 0.3284,
-   "compress_mbps": 24.35,
-   "decompress_mbps": 86.08
+   "compress_mbps": 25.06,
+   "decompress_mbps": 85.95
   },
   {
    "compressor": "native",
@@ -444,8 +444,8 @@
    "level": 4,
    "out_size": 1213,
    "ratio": 0.326,
-   "compress_mbps": 21.49,
-   "decompress_mbps": 85.93
+   "compress_mbps": 22.01,
+   "decompress_mbps": 86.55
   },
   {
    "compressor": "native",
@@ -454,8 +454,8 @@
    "level": 5,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 20.9,
-   "decompress_mbps": 86.57
+   "compress_mbps": 21.43,
+   "decompress_mbps": 87.0
   },
   {
    "compressor": "native",
@@ -464,8 +464,8 @@
    "level": 6,
    "out_size": 1220,
    "ratio": 0.3279,
-   "compress_mbps": 19.25,
-   "decompress_mbps": 86.88
+   "compress_mbps": 19.63,
+   "decompress_mbps": 86.83
   },
   {
    "compressor": "native",
@@ -474,8 +474,8 @@
    "level": 7,
    "out_size": 1219,
    "ratio": 0.3276,
-   "compress_mbps": 19.11,
-   "decompress_mbps": 86.9
+   "compress_mbps": 19.45,
+   "decompress_mbps": 86.91
   },
   {
    "compressor": "native",
@@ -484,8 +484,8 @@
    "level": 8,
    "out_size": 1219,
    "ratio": 0.3276,
-   "compress_mbps": 18.81,
-   "decompress_mbps": 86.8
+   "compress_mbps": 19.29,
+   "decompress_mbps": 86.67
   },
   {
    "compressor": "native",
@@ -494,8 +494,8 @@
    "level": 9,
    "out_size": 1205,
    "ratio": 0.3238,
-   "compress_mbps": 4.92,
-   "decompress_mbps": 86.82
+   "compress_mbps": 4.95,
+   "decompress_mbps": 86.12
   },
   {
    "compressor": "native",
@@ -504,7 +504,7 @@
    "level": 10,
    "out_size": 1191,
    "ratio": 0.3201,
-   "compress_mbps": 2.94,
+   "compress_mbps": 3.0,
    "decompress_mbps": null
   },
   {
@@ -514,8 +514,8 @@
    "level": 1,
    "out_size": 251793,
    "ratio": 0.2445,
-   "compress_mbps": 155.52,
-   "decompress_mbps": 398.07
+   "compress_mbps": 170.66,
+   "decompress_mbps": 401.3
   },
   {
    "compressor": "native",
@@ -524,8 +524,8 @@
    "level": 2,
    "out_size": 242565,
    "ratio": 0.2356,
-   "compress_mbps": 127.48,
-   "decompress_mbps": 427.01
+   "compress_mbps": 140.65,
+   "decompress_mbps": 430.39
   },
   {
    "compressor": "native",
@@ -534,8 +534,8 @@
    "level": 3,
    "out_size": 242532,
    "ratio": 0.2355,
-   "compress_mbps": 105.66,
-   "decompress_mbps": 454.16
+   "compress_mbps": 114.28,
+   "decompress_mbps": 457.5
   },
   {
    "compressor": "native",
@@ -544,8 +544,8 @@
    "level": 4,
    "out_size": 239953,
    "ratio": 0.233,
-   "compress_mbps": 93.03,
-   "decompress_mbps": 481.72
+   "compress_mbps": 100.69,
+   "decompress_mbps": 486.6
   },
   {
    "compressor": "native",
@@ -554,8 +554,8 @@
    "level": 5,
    "out_size": 218565,
    "ratio": 0.2123,
-   "compress_mbps": 52.85,
-   "decompress_mbps": 465.86
+   "compress_mbps": 54.34,
+   "decompress_mbps": 468.69
   },
   {
    "compressor": "native",
@@ -564,8 +564,8 @@
    "level": 6,
    "out_size": 202437,
    "ratio": 0.1966,
-   "compress_mbps": 38.5,
-   "decompress_mbps": 484.57
+   "compress_mbps": 39.8,
+   "decompress_mbps": 485.51
   },
   {
    "compressor": "native",
@@ -574,8 +574,8 @@
    "level": 7,
    "out_size": 201821,
    "ratio": 0.196,
-   "compress_mbps": 35.4,
-   "decompress_mbps": 489.09
+   "compress_mbps": 36.84,
+   "decompress_mbps": 488.48
   },
   {
    "compressor": "native",
@@ -584,8 +584,8 @@
    "level": 8,
    "out_size": 200869,
    "ratio": 0.1951,
-   "compress_mbps": 21.08,
-   "decompress_mbps": 498.54
+   "compress_mbps": 21.57,
+   "decompress_mbps": 498.72
   },
   {
    "compressor": "native",
@@ -594,8 +594,8 @@
    "level": 9,
    "out_size": 182511,
    "ratio": 0.1772,
-   "compress_mbps": 3.45,
-   "decompress_mbps": 495.43
+   "compress_mbps": 3.5,
+   "decompress_mbps": 500.1
   },
   {
    "compressor": "native",
@@ -604,7 +604,7 @@
    "level": 10,
    "out_size": 178069,
    "ratio": 0.1729,
-   "compress_mbps": 1.45,
+   "compress_mbps": 1.49,
    "decompress_mbps": null
   },
   {
@@ -614,8 +614,8 @@
    "level": 1,
    "out_size": 160674,
    "ratio": 0.3765,
-   "compress_mbps": 83.98,
-   "decompress_mbps": 222.33
+   "compress_mbps": 90.62,
+   "decompress_mbps": 222.37
   },
   {
    "compressor": "native",
@@ -624,8 +624,8 @@
    "level": 2,
    "out_size": 149787,
    "ratio": 0.351,
-   "compress_mbps": 63.66,
-   "decompress_mbps": 241.26
+   "compress_mbps": 67.6,
+   "decompress_mbps": 241.62
   },
   {
    "compressor": "native",
@@ -634,8 +634,8 @@
    "level": 3,
    "out_size": 148055,
    "ratio": 0.3469,
-   "compress_mbps": 55.55,
-   "decompress_mbps": 268.14
+   "compress_mbps": 58.43,
+   "decompress_mbps": 269.75
   },
   {
    "compressor": "native",
@@ -644,8 +644,8 @@
    "level": 4,
    "out_size": 144750,
    "ratio": 0.3392,
-   "compress_mbps": 40.94,
-   "decompress_mbps": 272.92
+   "compress_mbps": 42.3,
+   "decompress_mbps": 272.7
   },
   {
    "compressor": "native",
@@ -654,8 +654,8 @@
    "level": 5,
    "out_size": 144408,
    "ratio": 0.3384,
-   "compress_mbps": 33.31,
-   "decompress_mbps": 273.47
+   "compress_mbps": 33.9,
+   "decompress_mbps": 273.59
   },
   {
    "compressor": "native",
@@ -664,8 +664,8 @@
    "level": 6,
    "out_size": 144872,
    "ratio": 0.3395,
-   "compress_mbps": 30.72,
-   "decompress_mbps": 277.65
+   "compress_mbps": 31.97,
+   "decompress_mbps": 279.6
   },
   {
    "compressor": "native",
@@ -674,8 +674,8 @@
    "level": 7,
    "out_size": 144583,
    "ratio": 0.3388,
-   "compress_mbps": 27.81,
-   "decompress_mbps": 279.14
+   "compress_mbps": 29.16,
+   "decompress_mbps": 280.16
   },
   {
    "compressor": "native",
@@ -684,8 +684,8 @@
    "level": 8,
    "out_size": 144045,
    "ratio": 0.3375,
-   "compress_mbps": 23.31,
-   "decompress_mbps": 280.3
+   "compress_mbps": 23.95,
+   "decompress_mbps": 280.66
   },
   {
    "compressor": "native",
@@ -694,7 +694,7 @@
    "level": 9,
    "out_size": 140323,
    "ratio": 0.3288,
-   "compress_mbps": 4.24,
+   "compress_mbps": 4.25,
    "decompress_mbps": 280.11
   },
   {
@@ -704,7 +704,7 @@
    "level": 10,
    "out_size": 138833,
    "ratio": 0.3253,
-   "compress_mbps": 2.48,
+   "compress_mbps": 2.55,
    "decompress_mbps": null
   },
   {
@@ -714,8 +714,8 @@
    "level": 1,
    "out_size": 212588,
    "ratio": 0.4412,
-   "compress_mbps": 71.28,
-   "decompress_mbps": 191.67
+   "compress_mbps": 77.47,
+   "decompress_mbps": 192.5
   },
   {
    "compressor": "native",
@@ -724,8 +724,8 @@
    "level": 2,
    "out_size": 199981,
    "ratio": 0.415,
-   "compress_mbps": 53.36,
-   "decompress_mbps": 214.51
+   "compress_mbps": 56.65,
+   "decompress_mbps": 215.02
   },
   {
    "compressor": "native",
@@ -734,8 +734,8 @@
    "level": 3,
    "out_size": 198551,
    "ratio": 0.4121,
-   "compress_mbps": 46.99,
-   "decompress_mbps": 236.74
+   "compress_mbps": 49.21,
+   "decompress_mbps": 237.97
   },
   {
    "compressor": "native",
@@ -744,8 +744,8 @@
    "level": 4,
    "out_size": 193783,
    "ratio": 0.4022,
-   "compress_mbps": 31.69,
-   "decompress_mbps": 241.05
+   "compress_mbps": 32.85,
+   "decompress_mbps": 241.58
   },
   {
    "compressor": "native",
@@ -754,8 +754,8 @@
    "level": 5,
    "out_size": 193223,
    "ratio": 0.401,
-   "compress_mbps": 26.59,
-   "decompress_mbps": 237.12
+   "compress_mbps": 27.32,
+   "decompress_mbps": 237.52
   },
   {
    "compressor": "native",
@@ -764,8 +764,8 @@
    "level": 6,
    "out_size": 195643,
    "ratio": 0.406,
-   "compress_mbps": 27.26,
-   "decompress_mbps": 241.26
+   "compress_mbps": 28.15,
+   "decompress_mbps": 242.16
   },
   {
    "compressor": "native",
@@ -774,8 +774,8 @@
    "level": 7,
    "out_size": 195104,
    "ratio": 0.4049,
-   "compress_mbps": 24.22,
-   "decompress_mbps": 241.51
+   "compress_mbps": 25.2,
+   "decompress_mbps": 242.18
   },
   {
    "compressor": "native",
@@ -784,8 +784,8 @@
    "level": 8,
    "out_size": 194355,
    "ratio": 0.4033,
-   "compress_mbps": 19.85,
-   "decompress_mbps": 241.8
+   "compress_mbps": 20.44,
+   "decompress_mbps": 241.39
   },
   {
    "compressor": "native",
@@ -794,8 +794,8 @@
    "level": 9,
    "out_size": 189368,
    "ratio": 0.393,
-   "compress_mbps": 4.03,
-   "decompress_mbps": 241.75
+   "compress_mbps": 4.05,
+   "decompress_mbps": 242.31
   },
   {
    "compressor": "native",
@@ -804,7 +804,7 @@
    "level": 10,
    "out_size": 186146,
    "ratio": 0.3863,
-   "compress_mbps": 2.41,
+   "compress_mbps": 2.47,
    "decompress_mbps": null
   },
   {
@@ -814,8 +814,8 @@
    "level": 1,
    "out_size": 60161,
    "ratio": 0.1172,
-   "compress_mbps": 239.12,
-   "decompress_mbps": 584.88
+   "compress_mbps": 249.72,
+   "decompress_mbps": 590.55
   },
   {
    "compressor": "native",
@@ -824,8 +824,8 @@
    "level": 2,
    "out_size": 58873,
    "ratio": 0.1147,
-   "compress_mbps": 195.71,
-   "decompress_mbps": 615.87
+   "compress_mbps": 202.94,
+   "decompress_mbps": 618.29
   },
   {
    "compressor": "native",
@@ -834,8 +834,8 @@
    "level": 3,
    "out_size": 58327,
    "ratio": 0.1137,
-   "compress_mbps": 172.82,
-   "decompress_mbps": 643.86
+   "compress_mbps": 180.16,
+   "decompress_mbps": 648.7
   },
   {
    "compressor": "native",
@@ -844,8 +844,8 @@
    "level": 4,
    "out_size": 55586,
    "ratio": 0.1083,
-   "compress_mbps": 117.07,
-   "decompress_mbps": 661.71
+   "compress_mbps": 121.32,
+   "decompress_mbps": 666.08
   },
   {
    "compressor": "native",
@@ -854,8 +854,8 @@
    "level": 5,
    "out_size": 55097,
    "ratio": 0.1074,
-   "compress_mbps": 88.03,
-   "decompress_mbps": 685.17
+   "compress_mbps": 89.47,
+   "decompress_mbps": 693.44
   },
   {
    "compressor": "native",
@@ -864,8 +864,8 @@
    "level": 6,
    "out_size": 55674,
    "ratio": 0.1085,
-   "compress_mbps": 71.51,
-   "decompress_mbps": 706.03
+   "compress_mbps": 74.13,
+   "decompress_mbps": 711.47
   },
   {
    "compressor": "native",
@@ -874,8 +874,8 @@
    "level": 7,
    "out_size": 55495,
    "ratio": 0.1081,
-   "compress_mbps": 64.9,
-   "decompress_mbps": 722.61
+   "compress_mbps": 66.31,
+   "decompress_mbps": 727.38
   },
   {
    "compressor": "native",
@@ -884,8 +884,8 @@
    "level": 8,
    "out_size": 53384,
    "ratio": 0.104,
-   "compress_mbps": 41.79,
-   "decompress_mbps": 746.41
+   "compress_mbps": 42.25,
+   "decompress_mbps": 749.07
   },
   {
    "compressor": "native",
@@ -894,8 +894,8 @@
    "level": 9,
    "out_size": 52603,
    "ratio": 0.1025,
-   "compress_mbps": 5.83,
-   "decompress_mbps": 759.23
+   "compress_mbps": 5.87,
+   "decompress_mbps": 769.0
   },
   {
    "compressor": "native",
@@ -904,7 +904,7 @@
    "level": 10,
    "out_size": 52236,
    "ratio": 0.1018,
-   "compress_mbps": 3.79,
+   "compress_mbps": 3.87,
    "decompress_mbps": null
   },
   {
@@ -914,8 +914,8 @@
    "level": 1,
    "out_size": 14249,
    "ratio": 0.3726,
-   "compress_mbps": 60.94,
-   "decompress_mbps": 238.65
+   "compress_mbps": 63.9,
+   "decompress_mbps": 240.81
   },
   {
    "compressor": "native",
@@ -924,8 +924,8 @@
    "level": 2,
    "out_size": 13825,
    "ratio": 0.3615,
-   "compress_mbps": 54.83,
-   "decompress_mbps": 248.35
+   "compress_mbps": 57.93,
+   "decompress_mbps": 251.05
   },
   {
    "compressor": "native",
@@ -934,8 +934,8 @@
    "level": 3,
    "out_size": 13751,
    "ratio": 0.3596,
-   "compress_mbps": 52.55,
-   "decompress_mbps": 246.29
+   "compress_mbps": 55.68,
+   "decompress_mbps": 253.35
   },
   {
    "compressor": "native",
@@ -944,8 +944,8 @@
    "level": 4,
    "out_size": 13290,
    "ratio": 0.3475,
-   "compress_mbps": 44.63,
-   "decompress_mbps": 257.12
+   "compress_mbps": 46.38,
+   "decompress_mbps": 260.76
   },
   {
    "compressor": "native",
@@ -954,8 +954,8 @@
    "level": 5,
    "out_size": 13244,
    "ratio": 0.3463,
-   "compress_mbps": 38.53,
-   "decompress_mbps": 262.75
+   "compress_mbps": 39.51,
+   "decompress_mbps": 269.99
   },
   {
    "compressor": "native",
@@ -964,8 +964,8 @@
    "level": 6,
    "out_size": 12675,
    "ratio": 0.3315,
-   "compress_mbps": 20.78,
-   "decompress_mbps": 268.16
+   "compress_mbps": 21.15,
+   "decompress_mbps": 272.21
   },
   {
    "compressor": "native",
@@ -974,8 +974,8 @@
    "level": 7,
    "out_size": 12653,
    "ratio": 0.3309,
-   "compress_mbps": 20.07,
-   "decompress_mbps": 269.59
+   "compress_mbps": 20.42,
+   "decompress_mbps": 276.27
   },
   {
    "compressor": "native",
@@ -984,8 +984,8 @@
    "level": 8,
    "out_size": 12632,
    "ratio": 0.3303,
-   "compress_mbps": 16.66,
-   "decompress_mbps": 270.77
+   "compress_mbps": 17.03,
+   "decompress_mbps": 276.97
   },
   {
    "compressor": "native",
@@ -994,8 +994,8 @@
    "level": 9,
    "out_size": 12427,
    "ratio": 0.325,
-   "compress_mbps": 5.43,
-   "decompress_mbps": 274.18
+   "compress_mbps": 5.47,
+   "decompress_mbps": 278.65
   },
   {
    "compressor": "native",
@@ -1004,7 +1004,7 @@
    "level": 10,
    "out_size": 12273,
    "ratio": 0.3209,
-   "compress_mbps": 3.12,
+   "compress_mbps": 3.16,
    "decompress_mbps": null
   },
   {
@@ -1014,8 +1014,8 @@
    "level": 1,
    "out_size": 1800,
    "ratio": 0.4258,
-   "compress_mbps": 26.93,
-   "decompress_mbps": 92.19
+   "compress_mbps": 27.81,
+   "decompress_mbps": 93.67
   },
   {
    "compressor": "native",
@@ -1024,8 +1024,8 @@
    "level": 2,
    "out_size": 1750,
    "ratio": 0.414,
-   "compress_mbps": 26.06,
-   "decompress_mbps": 92.19
+   "compress_mbps": 27.23,
+   "decompress_mbps": 93.92
   },
   {
    "compressor": "native",
@@ -1034,8 +1034,8 @@
    "level": 3,
    "out_size": 1742,
    "ratio": 0.4121,
-   "compress_mbps": 26.08,
-   "decompress_mbps": 92.09
+   "compress_mbps": 27.04,
+   "decompress_mbps": 93.49
   },
   {
    "compressor": "native",
@@ -1044,8 +1044,8 @@
    "level": 4,
    "out_size": 1726,
    "ratio": 0.4083,
-   "compress_mbps": 23.22,
-   "decompress_mbps": 93.52
+   "compress_mbps": 24.09,
+   "decompress_mbps": 94.82
   },
   {
    "compressor": "native",
@@ -1054,8 +1054,8 @@
    "level": 5,
    "out_size": 1722,
    "ratio": 0.4074,
-   "compress_mbps": 23.01,
-   "decompress_mbps": 93.64
+   "compress_mbps": 23.8,
+   "decompress_mbps": 95.41
   },
   {
    "compressor": "native",
@@ -1064,8 +1064,8 @@
    "level": 6,
    "out_size": 1735,
    "ratio": 0.4105,
-   "compress_mbps": 20.35,
-   "decompress_mbps": 93.52
+   "compress_mbps": 20.94,
+   "decompress_mbps": 95.1
   },
   {
    "compressor": "native",
@@ -1074,8 +1074,8 @@
    "level": 7,
    "out_size": 1734,
    "ratio": 0.4102,
-   "compress_mbps": 20.35,
-   "decompress_mbps": 93.57
+   "compress_mbps": 20.86,
+   "decompress_mbps": 95.13
   },
   {
    "compressor": "native",
@@ -1084,8 +1084,8 @@
    "level": 8,
    "out_size": 1734,
    "ratio": 0.4102,
-   "compress_mbps": 20.31,
-   "decompress_mbps": 93.32
+   "compress_mbps": 20.91,
+   "decompress_mbps": 95.13
   },
   {
    "compressor": "native",
@@ -1094,8 +1094,8 @@
    "level": 9,
    "out_size": 1708,
    "ratio": 0.4041,
-   "compress_mbps": 5.41,
-   "decompress_mbps": 93.7
+   "compress_mbps": 5.49,
+   "decompress_mbps": 95.23
   },
   {
    "compressor": "native",
@@ -1104,7 +1104,7 @@
    "level": 10,
    "out_size": 1693,
    "ratio": 0.4005,
-   "compress_mbps": 3.26,
+   "compress_mbps": 3.36,
    "decompress_mbps": null
   },
   {
@@ -4414,8 +4414,8 @@
    "level": 1,
    "out_size": 4259644,
    "ratio": 0.4179,
-   "compress_mbps": 73.86,
-   "decompress_mbps": 194.65
+   "compress_mbps": 80.38,
+   "decompress_mbps": 195.94
   },
   {
    "compressor": "native",
@@ -4424,8 +4424,8 @@
    "level": 2,
    "out_size": 3977395,
    "ratio": 0.3902,
-   "compress_mbps": 55.26,
-   "decompress_mbps": 212.79
+   "compress_mbps": 58.6,
+   "decompress_mbps": 214.72
   },
   {
    "compressor": "native",
@@ -4434,8 +4434,8 @@
    "level": 3,
    "out_size": 3945296,
    "ratio": 0.3871,
-   "compress_mbps": 48.25,
-   "decompress_mbps": 235.47
+   "compress_mbps": 50.94,
+   "decompress_mbps": 236.13
   },
   {
    "compressor": "native",
@@ -4444,8 +4444,8 @@
    "level": 4,
    "out_size": 3851998,
    "ratio": 0.3779,
-   "compress_mbps": 33.86,
-   "decompress_mbps": 238.75
+   "compress_mbps": 35.02,
+   "decompress_mbps": 239.43
   },
   {
    "compressor": "native",
@@ -4454,8 +4454,8 @@
    "level": 5,
    "out_size": 3840481,
    "ratio": 0.3768,
-   "compress_mbps": 28.55,
-   "decompress_mbps": 234.3
+   "compress_mbps": 29.43,
+   "decompress_mbps": 238.07
   },
   {
    "compressor": "native",
@@ -4464,8 +4464,8 @@
    "level": 6,
    "out_size": 3878125,
    "ratio": 0.3805,
-   "compress_mbps": 28.32,
-   "decompress_mbps": 242.79
+   "compress_mbps": 29.47,
+   "decompress_mbps": 241.16
   },
   {
    "compressor": "native",
@@ -4474,8 +4474,8 @@
    "level": 7,
    "out_size": 3868436,
    "ratio": 0.3795,
-   "compress_mbps": 25.74,
-   "decompress_mbps": 254.64
+   "compress_mbps": 26.31,
+   "decompress_mbps": 242.1
   },
   {
    "compressor": "native",
@@ -4484,8 +4484,8 @@
    "level": 8,
    "out_size": 3854820,
    "ratio": 0.3782,
-   "compress_mbps": 20.92,
-   "decompress_mbps": 244.32
+   "compress_mbps": 21.33,
+   "decompress_mbps": 242.75
   },
   {
    "compressor": "native",
@@ -4494,8 +4494,8 @@
    "level": 9,
    "out_size": 3766619,
    "ratio": 0.3696,
-   "compress_mbps": 4.19,
-   "decompress_mbps": 252.61
+   "compress_mbps": 4.17,
+   "decompress_mbps": 253.02
   },
   {
    "compressor": "native",
@@ -4504,7 +4504,7 @@
    "level": 10,
    "out_size": 3711208,
    "ratio": 0.3641,
-   "compress_mbps": 2.45,
+   "compress_mbps": 2.47,
    "decompress_mbps": null
   },
   {
@@ -4514,8 +4514,8 @@
    "level": 1,
    "out_size": 21267086,
    "ratio": 0.4152,
-   "compress_mbps": 88.71,
-   "decompress_mbps": 211.84
+   "compress_mbps": 95.36,
+   "decompress_mbps": 213.1
   },
   {
    "compressor": "native",
@@ -4524,8 +4524,8 @@
    "level": 2,
    "out_size": 20802983,
    "ratio": 0.4061,
-   "compress_mbps": 74.93,
-   "decompress_mbps": 226.29
+   "compress_mbps": 79.75,
+   "decompress_mbps": 229.45
   },
   {
    "compressor": "native",
@@ -4534,8 +4534,8 @@
    "level": 3,
    "out_size": 20665485,
    "ratio": 0.4035,
-   "compress_mbps": 69.26,
-   "decompress_mbps": 235.58
+   "compress_mbps": 73.9,
+   "decompress_mbps": 233.44
   },
   {
    "compressor": "native",
@@ -4544,8 +4544,8 @@
    "level": 4,
    "out_size": 20356893,
    "ratio": 0.3974,
-   "compress_mbps": 53.26,
-   "decompress_mbps": 245.1
+   "compress_mbps": 56.11,
+   "decompress_mbps": 244.52
   },
   {
    "compressor": "native",
@@ -4554,8 +4554,8 @@
    "level": 5,
    "out_size": 20209289,
    "ratio": 0.3946,
-   "compress_mbps": 39.24,
-   "decompress_mbps": 246.11
+   "compress_mbps": 41.97,
+   "decompress_mbps": 254.77
   },
   {
    "compressor": "native",
@@ -4564,8 +4564,8 @@
    "level": 6,
    "out_size": 18875267,
    "ratio": 0.3685,
-   "compress_mbps": 29.57,
-   "decompress_mbps": 256.75
+   "compress_mbps": 30.31,
+   "decompress_mbps": 253.15
   },
   {
    "compressor": "native",
@@ -4574,8 +4574,8 @@
    "level": 7,
    "out_size": 18835212,
    "ratio": 0.3677,
-   "compress_mbps": 27.28,
-   "decompress_mbps": 258.24
+   "compress_mbps": 28.3,
+   "decompress_mbps": 258.91
   },
   {
    "compressor": "native",
@@ -4584,8 +4584,8 @@
    "level": 8,
    "out_size": 18777212,
    "ratio": 0.3666,
-   "compress_mbps": 19.2,
-   "decompress_mbps": 258.85
+   "compress_mbps": 19.49,
+   "decompress_mbps": 259.84
   },
   {
    "compressor": "native",
@@ -4594,8 +4594,8 @@
    "level": 9,
    "out_size": 18688252,
    "ratio": 0.3649,
-   "compress_mbps": 4.4,
-   "decompress_mbps": 259.53
+   "compress_mbps": 4.41,
+   "decompress_mbps": 257.94
   },
   {
    "compressor": "native",
@@ -4604,7 +4604,7 @@
    "level": 10,
    "out_size": 18541040,
    "ratio": 0.362,
-   "compress_mbps": 2.33,
+   "compress_mbps": 2.36,
    "decompress_mbps": null
   },
   {
@@ -4614,8 +4614,8 @@
    "level": 1,
    "out_size": 3864163,
    "ratio": 0.3876,
-   "compress_mbps": 90.66,
-   "decompress_mbps": 242.33
+   "compress_mbps": 99.83,
+   "decompress_mbps": 243.62
   },
   {
    "compressor": "native",
@@ -4624,8 +4624,8 @@
    "level": 2,
    "out_size": 3734957,
    "ratio": 0.3746,
-   "compress_mbps": 71.1,
-   "decompress_mbps": 249.48
+   "compress_mbps": 76.98,
+   "decompress_mbps": 250.94
   },
   {
    "compressor": "native",
@@ -4634,8 +4634,8 @@
    "level": 3,
    "out_size": 3708443,
    "ratio": 0.3719,
-   "compress_mbps": 59.82,
-   "decompress_mbps": 260.29
+   "compress_mbps": 64.27,
+   "decompress_mbps": 261.64
   },
   {
    "compressor": "native",
@@ -4644,8 +4644,8 @@
    "level": 4,
    "out_size": 3683603,
    "ratio": 0.3694,
-   "compress_mbps": 40.56,
-   "decompress_mbps": 246.89
+   "compress_mbps": 42.69,
+   "decompress_mbps": 249.68
   },
   {
    "compressor": "native",
@@ -4654,8 +4654,8 @@
    "level": 5,
    "out_size": 3677014,
    "ratio": 0.3688,
-   "compress_mbps": 32.62,
-   "decompress_mbps": 227.38
+   "compress_mbps": 33.91,
+   "decompress_mbps": 231.34
   },
   {
    "compressor": "native",
@@ -4664,8 +4664,8 @@
    "level": 6,
    "out_size": 3646607,
    "ratio": 0.3657,
-   "compress_mbps": 31.19,
-   "decompress_mbps": 247.55
+   "compress_mbps": 32.38,
+   "decompress_mbps": 249.6
   },
   {
    "compressor": "native",
@@ -4674,8 +4674,8 @@
    "level": 7,
    "out_size": 3642579,
    "ratio": 0.3653,
-   "compress_mbps": 28.68,
-   "decompress_mbps": 248.62
+   "compress_mbps": 29.38,
+   "decompress_mbps": 249.37
   },
   {
    "compressor": "native",
@@ -4684,8 +4684,8 @@
    "level": 8,
    "out_size": 3634763,
    "ratio": 0.3645,
-   "compress_mbps": 22.01,
-   "decompress_mbps": 254.14
+   "compress_mbps": 22.56,
+   "decompress_mbps": 255.16
   },
   {
    "compressor": "native",
@@ -4694,8 +4694,8 @@
    "level": 9,
    "out_size": 3581643,
    "ratio": 0.3592,
-   "compress_mbps": 4.82,
-   "decompress_mbps": 265.2
+   "compress_mbps": 4.83,
+   "decompress_mbps": 266.58
   },
   {
    "compressor": "native",
@@ -4704,7 +4704,7 @@
    "level": 10,
    "out_size": 3513006,
    "ratio": 0.3523,
-   "compress_mbps": 2.92,
+   "compress_mbps": 3.0,
    "decompress_mbps": null
   },
   {
@@ -4714,8 +4714,8 @@
    "level": 1,
    "out_size": 3785443,
    "ratio": 0.1128,
-   "compress_mbps": 279.67,
-   "decompress_mbps": 673.31
+   "compress_mbps": 299.73,
+   "decompress_mbps": 674.78
   },
   {
    "compressor": "native",
@@ -4724,8 +4724,8 @@
    "level": 2,
    "out_size": 3761560,
    "ratio": 0.1121,
-   "compress_mbps": 205.13,
-   "decompress_mbps": 745.53
+   "compress_mbps": 223.67,
+   "decompress_mbps": 749.0
   },
   {
    "compressor": "native",
@@ -4734,8 +4734,8 @@
    "level": 3,
    "out_size": 3606997,
    "ratio": 0.1075,
-   "compress_mbps": 176.49,
-   "decompress_mbps": 829.69
+   "compress_mbps": 194.16,
+   "decompress_mbps": 833.32
   },
   {
    "compressor": "native",
@@ -4744,8 +4744,8 @@
    "level": 4,
    "out_size": 3201209,
    "ratio": 0.0954,
-   "compress_mbps": 131.46,
-   "decompress_mbps": 844.07
+   "compress_mbps": 138.79,
+   "decompress_mbps": 847.75
   },
   {
    "compressor": "native",
@@ -4754,8 +4754,8 @@
    "level": 5,
    "out_size": 3091564,
    "ratio": 0.0921,
-   "compress_mbps": 91.91,
-   "decompress_mbps": 919.88
+   "compress_mbps": 94.45,
+   "decompress_mbps": 909.95
   },
   {
    "compressor": "native",
@@ -4764,8 +4764,8 @@
    "level": 6,
    "out_size": 3205217,
    "ratio": 0.0955,
-   "compress_mbps": 85.5,
-   "decompress_mbps": 971.57
+   "compress_mbps": 91.23,
+   "decompress_mbps": 968.43
   },
   {
    "compressor": "native",
@@ -4774,8 +4774,8 @@
    "level": 7,
    "out_size": 3146242,
    "ratio": 0.0938,
-   "compress_mbps": 77.97,
-   "decompress_mbps": 987.54
+   "compress_mbps": 80.58,
+   "decompress_mbps": 973.29
   },
   {
    "compressor": "native",
@@ -4784,8 +4784,8 @@
    "level": 8,
    "out_size": 3078031,
    "ratio": 0.0917,
-   "compress_mbps": 49.35,
-   "decompress_mbps": 990.94
+   "compress_mbps": 50.69,
+   "decompress_mbps": 993.93
   },
   {
    "compressor": "native",
@@ -4795,7 +4795,7 @@
    "out_size": 3031645,
    "ratio": 0.0904,
    "compress_mbps": 3.56,
-   "decompress_mbps": 1012.27
+   "decompress_mbps": 1012.4
   },
   {
    "compressor": "native",
@@ -4804,7 +4804,7 @@
    "level": 10,
    "out_size": 2902212,
    "ratio": 0.0865,
-   "compress_mbps": 2.02,
+   "compress_mbps": 2.04,
    "decompress_mbps": null
   },
   {
@@ -4814,8 +4814,8 @@
    "level": 1,
    "out_size": 3357083,
    "ratio": 0.5457,
-   "compress_mbps": 62.01,
-   "decompress_mbps": 146.43
+   "compress_mbps": 66.52,
+   "decompress_mbps": 146.59
   },
   {
    "compressor": "native",
@@ -4824,8 +4824,8 @@
    "level": 2,
    "out_size": 3285077,
    "ratio": 0.534,
-   "compress_mbps": 52.32,
-   "decompress_mbps": 148.38
+   "compress_mbps": 55.71,
+   "decompress_mbps": 149.65
   },
   {
    "compressor": "native",
@@ -4834,8 +4834,8 @@
    "level": 3,
    "out_size": 3272746,
    "ratio": 0.532,
-   "compress_mbps": 50.18,
-   "decompress_mbps": 153.35
+   "compress_mbps": 53.25,
+   "decompress_mbps": 155.03
   },
   {
    "compressor": "native",
@@ -4844,8 +4844,8 @@
    "level": 4,
    "out_size": 3228052,
    "ratio": 0.5247,
-   "compress_mbps": 40.04,
-   "decompress_mbps": 164.34
+   "compress_mbps": 41.78,
+   "decompress_mbps": 166.0
   },
   {
    "compressor": "native",
@@ -4854,8 +4854,8 @@
    "level": 5,
    "out_size": 3223415,
    "ratio": 0.5239,
-   "compress_mbps": 36.1,
-   "decompress_mbps": 170.27
+   "compress_mbps": 37.9,
+   "decompress_mbps": 171.73
   },
   {
    "compressor": "native",
@@ -4864,8 +4864,8 @@
    "level": 6,
    "out_size": 3087517,
    "ratio": 0.5019,
-   "compress_mbps": 25.84,
-   "decompress_mbps": 171.89
+   "compress_mbps": 26.5,
+   "decompress_mbps": 173.41
   },
   {
    "compressor": "native",
@@ -4874,8 +4874,8 @@
    "level": 7,
    "out_size": 3082738,
    "ratio": 0.5011,
-   "compress_mbps": 24.63,
-   "decompress_mbps": 172.67
+   "compress_mbps": 25.11,
+   "decompress_mbps": 173.76
   },
   {
    "compressor": "native",
@@ -4884,8 +4884,8 @@
    "level": 8,
    "out_size": 3078530,
    "ratio": 0.5004,
-   "compress_mbps": 21.94,
-   "decompress_mbps": 173.88
+   "compress_mbps": 22.5,
+   "decompress_mbps": 175.21
   },
   {
    "compressor": "native",
@@ -4895,7 +4895,7 @@
    "out_size": 3049028,
    "ratio": 0.4956,
    "compress_mbps": 5.14,
-   "decompress_mbps": 177.35
+   "decompress_mbps": 175.71
   },
   {
    "compressor": "native",
@@ -4904,7 +4904,7 @@
    "level": 10,
    "out_size": 3022127,
    "ratio": 0.4912,
-   "compress_mbps": 3.22,
+   "compress_mbps": 3.25,
    "decompress_mbps": null
   },
   {
@@ -4914,8 +4914,8 @@
    "level": 1,
    "out_size": 3838828,
    "ratio": 0.3806,
-   "compress_mbps": 101.32,
-   "decompress_mbps": 266.47
+   "compress_mbps": 108.54,
+   "decompress_mbps": 253.08
   },
   {
    "compressor": "native",
@@ -4924,8 +4924,8 @@
    "level": 2,
    "out_size": 3792520,
    "ratio": 0.376,
-   "compress_mbps": 80.76,
-   "decompress_mbps": 273.9
+   "compress_mbps": 88.49,
+   "decompress_mbps": 259.86
   },
   {
    "compressor": "native",
@@ -4934,8 +4934,8 @@
    "level": 3,
    "out_size": 3783171,
    "ratio": 0.3751,
-   "compress_mbps": 78.06,
-   "decompress_mbps": 281.28
+   "compress_mbps": 84.2,
+   "decompress_mbps": 264.1
   },
   {
    "compressor": "native",
@@ -4944,8 +4944,8 @@
    "level": 4,
    "out_size": 3648458,
    "ratio": 0.3617,
-   "compress_mbps": 64.77,
-   "decompress_mbps": 294.48
+   "compress_mbps": 70.85,
+   "decompress_mbps": 279.08
   },
   {
    "compressor": "native",
@@ -4954,8 +4954,8 @@
    "level": 5,
    "out_size": 3648472,
    "ratio": 0.3617,
-   "compress_mbps": 61.08,
-   "decompress_mbps": 297.48
+   "compress_mbps": 65.46,
+   "decompress_mbps": 281.31
   },
   {
    "compressor": "native",
@@ -4964,8 +4964,8 @@
    "level": 6,
    "out_size": 3661305,
    "ratio": 0.363,
-   "compress_mbps": 42.54,
-   "decompress_mbps": 309.26
+   "compress_mbps": 44.76,
+   "decompress_mbps": 287.85
   },
   {
    "compressor": "native",
@@ -4974,8 +4974,8 @@
    "level": 7,
    "out_size": 3659614,
    "ratio": 0.3629,
-   "compress_mbps": 40.99,
-   "decompress_mbps": 312.56
+   "compress_mbps": 42.57,
+   "decompress_mbps": 296.96
   },
   {
    "compressor": "native",
@@ -4984,8 +4984,8 @@
    "level": 8,
    "out_size": 3659136,
    "ratio": 0.3628,
-   "compress_mbps": 40.98,
-   "decompress_mbps": 314.36
+   "compress_mbps": 42.64,
+   "decompress_mbps": 296.49
   },
   {
    "compressor": "native",
@@ -4994,8 +4994,8 @@
    "level": 9,
    "out_size": 3648156,
    "ratio": 0.3617,
-   "compress_mbps": 6.06,
-   "decompress_mbps": 305.25
+   "compress_mbps": 6.09,
+   "decompress_mbps": 308.44
   },
   {
    "compressor": "native",
@@ -5004,7 +5004,7 @@
    "level": 10,
    "out_size": 3647385,
    "ratio": 0.3616,
-   "compress_mbps": 3.41,
+   "compress_mbps": 3.5,
    "decompress_mbps": null
   },
   {
@@ -5014,8 +5014,8 @@
    "level": 1,
    "out_size": 2254442,
    "ratio": 0.3402,
-   "compress_mbps": 96.16,
-   "decompress_mbps": 247.74
+   "compress_mbps": 104.1,
+   "decompress_mbps": 249.35
   },
   {
    "compressor": "native",
@@ -5024,8 +5024,8 @@
    "level": 2,
    "out_size": 2044843,
    "ratio": 0.3086,
-   "compress_mbps": 69.05,
-   "decompress_mbps": 267.69
+   "compress_mbps": 73.01,
+   "decompress_mbps": 265.96
   },
   {
    "compressor": "native",
@@ -5034,8 +5034,8 @@
    "level": 3,
    "out_size": 1992105,
    "ratio": 0.3006,
-   "compress_mbps": 54.87,
-   "decompress_mbps": 306.64
+   "compress_mbps": 57.34,
+   "decompress_mbps": 290.92
   },
   {
    "compressor": "native",
@@ -5044,8 +5044,8 @@
    "level": 4,
    "out_size": 1890729,
    "ratio": 0.2853,
-   "compress_mbps": 35.07,
-   "decompress_mbps": 297.3
+   "compress_mbps": 35.18,
+   "decompress_mbps": 296.72
   },
   {
    "compressor": "native",
@@ -5054,8 +5054,8 @@
    "level": 5,
    "out_size": 1858234,
    "ratio": 0.2804,
-   "compress_mbps": 22.52,
-   "decompress_mbps": 308.28
+   "compress_mbps": 22.48,
+   "decompress_mbps": 294.55
   },
   {
    "compressor": "native",
@@ -5064,8 +5064,8 @@
    "level": 6,
    "out_size": 1869426,
    "ratio": 0.2821,
-   "compress_mbps": 29.57,
-   "decompress_mbps": 307.72
+   "compress_mbps": 30.46,
+   "decompress_mbps": 309.76
   },
   {
    "compressor": "native",
@@ -5074,8 +5074,8 @@
    "level": 7,
    "out_size": 1860657,
    "ratio": 0.2808,
-   "compress_mbps": 25.06,
-   "decompress_mbps": 327.77
+   "compress_mbps": 25.58,
+   "decompress_mbps": 329.07
   },
   {
    "compressor": "native",
@@ -5084,8 +5084,8 @@
    "level": 8,
    "out_size": 1826296,
    "ratio": 0.2756,
-   "compress_mbps": 13.93,
-   "decompress_mbps": 310.88
+   "compress_mbps": 14.07,
+   "decompress_mbps": 314.24
   },
   {
    "compressor": "native",
@@ -5094,8 +5094,8 @@
    "level": 9,
    "out_size": 1773469,
    "ratio": 0.2676,
-   "compress_mbps": 2.96,
-   "decompress_mbps": 324.95
+   "compress_mbps": 2.94,
+   "decompress_mbps": 325.21
   },
   {
    "compressor": "native",
@@ -5104,7 +5104,7 @@
    "level": 10,
    "out_size": 1718509,
    "ratio": 0.2593,
-   "compress_mbps": 1.59,
+   "compress_mbps": 1.6,
    "decompress_mbps": null
   },
   {
@@ -5114,8 +5114,8 @@
    "level": 1,
    "out_size": 6406301,
    "ratio": 0.2965,
-   "compress_mbps": 124.24,
-   "decompress_mbps": 338.87
+   "compress_mbps": 134.32,
+   "decompress_mbps": 341.7
   },
   {
    "compressor": "native",
@@ -5124,8 +5124,8 @@
    "level": 2,
    "out_size": 6102377,
    "ratio": 0.2824,
-   "compress_mbps": 100.98,
-   "decompress_mbps": 360.63
+   "compress_mbps": 108.16,
+   "decompress_mbps": 361.23
   },
   {
    "compressor": "native",
@@ -5134,8 +5134,8 @@
    "level": 3,
    "out_size": 6022184,
    "ratio": 0.2787,
-   "compress_mbps": 91.57,
-   "decompress_mbps": 374.51
+   "compress_mbps": 96.55,
+   "decompress_mbps": 374.52
   },
   {
    "compressor": "native",
@@ -5144,8 +5144,8 @@
    "level": 4,
    "out_size": 5880892,
    "ratio": 0.2722,
-   "compress_mbps": 67.35,
-   "decompress_mbps": 391.89
+   "compress_mbps": 70.35,
+   "decompress_mbps": 393.36
   },
   {
    "compressor": "native",
@@ -5154,8 +5154,8 @@
    "level": 5,
    "out_size": 5834363,
    "ratio": 0.27,
-   "compress_mbps": 52.59,
-   "decompress_mbps": 401.12
+   "compress_mbps": 54.21,
+   "decompress_mbps": 400.98
   },
   {
    "compressor": "native",
@@ -5164,8 +5164,8 @@
    "level": 6,
    "out_size": 5418390,
    "ratio": 0.2508,
-   "compress_mbps": 42.52,
-   "decompress_mbps": 406.36
+   "compress_mbps": 44.09,
+   "decompress_mbps": 406.9
   },
   {
    "compressor": "native",
@@ -5174,8 +5174,8 @@
    "level": 7,
    "out_size": 5406915,
    "ratio": 0.2502,
-   "compress_mbps": 39.17,
-   "decompress_mbps": 403.02
+   "compress_mbps": 40.66,
+   "decompress_mbps": 400.39
   },
   {
    "compressor": "native",
@@ -5184,8 +5184,8 @@
    "level": 8,
    "out_size": 5387415,
    "ratio": 0.2493,
-   "compress_mbps": 31.37,
-   "decompress_mbps": 406.43
+   "compress_mbps": 31.85,
+   "decompress_mbps": 409.45
   },
   {
    "compressor": "native",
@@ -5194,7 +5194,7 @@
    "level": 9,
    "out_size": 5236015,
    "ratio": 0.2423,
-   "compress_mbps": 4.84,
+   "compress_mbps": 4.82,
    "decompress_mbps": 409.96
   },
   {
@@ -5204,7 +5204,7 @@
    "level": 10,
    "out_size": 5177683,
    "ratio": 0.2396,
-   "compress_mbps": 2.59,
+   "compress_mbps": 2.64,
    "decompress_mbps": null
   },
   {
@@ -5214,8 +5214,8 @@
    "level": 1,
    "out_size": 5612204,
    "ratio": 0.7739,
-   "compress_mbps": 51.75,
-   "decompress_mbps": 147.88
+   "compress_mbps": 55.98,
+   "decompress_mbps": 148.32
   },
   {
    "compressor": "native",
@@ -5224,8 +5224,8 @@
    "level": 2,
    "out_size": 5533875,
    "ratio": 0.7631,
-   "compress_mbps": 43.31,
-   "decompress_mbps": 154.17
+   "compress_mbps": 46.15,
+   "decompress_mbps": 154.62
   },
   {
    "compressor": "native",
@@ -5234,8 +5234,8 @@
    "level": 3,
    "out_size": 5522436,
    "ratio": 0.7615,
-   "compress_mbps": 40.63,
-   "decompress_mbps": 159.06
+   "compress_mbps": 42.79,
+   "decompress_mbps": 158.1
   },
   {
    "compressor": "native",
@@ -5244,8 +5244,8 @@
    "level": 4,
    "out_size": 5494383,
    "ratio": 0.7576,
-   "compress_mbps": 33.38,
-   "decompress_mbps": 164.02
+   "compress_mbps": 35.03,
+   "decompress_mbps": 164.88
   },
   {
    "compressor": "native",
@@ -5254,8 +5254,8 @@
    "level": 5,
    "out_size": 5489807,
    "ratio": 0.757,
-   "compress_mbps": 31.62,
-   "decompress_mbps": 162.18
+   "compress_mbps": 32.95,
+   "decompress_mbps": 162.23
   },
   {
    "compressor": "native",
@@ -5264,8 +5264,8 @@
    "level": 6,
    "out_size": 5346796,
    "ratio": 0.7373,
-   "compress_mbps": 22.14,
-   "decompress_mbps": 164.15
+   "compress_mbps": 22.94,
+   "decompress_mbps": 164.43
   },
   {
    "compressor": "native",
@@ -5274,8 +5274,8 @@
    "level": 7,
    "out_size": 5336745,
    "ratio": 0.7359,
-   "compress_mbps": 21.48,
-   "decompress_mbps": 164.06
+   "compress_mbps": 21.87,
+   "decompress_mbps": 164.79
   },
   {
    "compressor": "native",
@@ -5284,8 +5284,8 @@
    "level": 8,
    "out_size": 5330972,
    "ratio": 0.7351,
-   "compress_mbps": 20.16,
-   "decompress_mbps": 164.41
+   "compress_mbps": 20.73,
+   "decompress_mbps": 163.54
   },
   {
    "compressor": "native",
@@ -5294,8 +5294,8 @@
    "level": 9,
    "out_size": 5284606,
    "ratio": 0.7287,
-   "compress_mbps": 5.36,
-   "decompress_mbps": 162.91
+   "compress_mbps": 5.29,
+   "decompress_mbps": 162.88
   },
   {
    "compressor": "native",
@@ -5304,7 +5304,7 @@
    "level": 10,
    "out_size": 5262387,
    "ratio": 0.7257,
-   "compress_mbps": 3.78,
+   "compress_mbps": 3.74,
    "decompress_mbps": null
   },
   {
@@ -5314,8 +5314,8 @@
    "level": 1,
    "out_size": 13727247,
    "ratio": 0.3311,
-   "compress_mbps": 94.01,
-   "decompress_mbps": 250.83
+   "compress_mbps": 100.98,
+   "decompress_mbps": 251.17
   },
   {
    "compressor": "native",
@@ -5324,8 +5324,8 @@
    "level": 2,
    "out_size": 12940398,
    "ratio": 0.3121,
-   "compress_mbps": 74.18,
-   "decompress_mbps": 273.71
+   "compress_mbps": 79.33,
+   "decompress_mbps": 272.8
   },
   {
    "compressor": "native",
@@ -5334,8 +5334,8 @@
    "level": 3,
    "out_size": 12703756,
    "ratio": 0.3064,
-   "compress_mbps": 67.98,
-   "decompress_mbps": 295.64
+   "compress_mbps": 70.88,
+   "decompress_mbps": 294.47
   },
   {
    "compressor": "native",
@@ -5344,8 +5344,8 @@
    "level": 4,
    "out_size": 12177338,
    "ratio": 0.2937,
-   "compress_mbps": 48.86,
-   "decompress_mbps": 299.03
+   "compress_mbps": 50.5,
+   "decompress_mbps": 298.6
   },
   {
    "compressor": "native",
@@ -5354,8 +5354,8 @@
    "level": 5,
    "out_size": 12051075,
    "ratio": 0.2907,
-   "compress_mbps": 37.82,
-   "decompress_mbps": 302.61
+   "compress_mbps": 38.04,
+   "decompress_mbps": 303.95
   },
   {
    "compressor": "native",
@@ -5364,8 +5364,8 @@
    "level": 6,
    "out_size": 12220199,
    "ratio": 0.2948,
-   "compress_mbps": 36.93,
-   "decompress_mbps": 310.07
+   "compress_mbps": 38.94,
+   "decompress_mbps": 311.71
   },
   {
    "compressor": "native",
@@ -5374,8 +5374,8 @@
    "level": 7,
    "out_size": 12178598,
    "ratio": 0.2938,
-   "compress_mbps": 33.95,
-   "decompress_mbps": 311.55
+   "compress_mbps": 34.99,
+   "decompress_mbps": 313.5
   },
   {
    "compressor": "native",
@@ -5384,8 +5384,8 @@
    "level": 8,
    "out_size": 12096772,
    "ratio": 0.2918,
-   "compress_mbps": 25.94,
-   "decompress_mbps": 300.49
+   "compress_mbps": 26.56,
+   "decompress_mbps": 298.97
   },
   {
    "compressor": "native",
@@ -5394,8 +5394,8 @@
    "level": 9,
    "out_size": 11806641,
    "ratio": 0.2848,
-   "compress_mbps": 3.94,
-   "decompress_mbps": 312.72
+   "compress_mbps": 3.89,
+   "decompress_mbps": 313.82
   },
   {
    "compressor": "native",
@@ -5404,7 +5404,7 @@
    "level": 10,
    "out_size": 11636945,
    "ratio": 0.2807,
-   "compress_mbps": 2.01,
+   "compress_mbps": 2.04,
    "decompress_mbps": null
   },
   {
@@ -5414,8 +5414,8 @@
    "level": 1,
    "out_size": 6438176,
    "ratio": 0.7597,
-   "compress_mbps": 45.4,
-   "decompress_mbps": 143.59
+   "compress_mbps": 49.5,
+   "decompress_mbps": 144.36
   },
   {
    "compressor": "native",
@@ -5424,8 +5424,8 @@
    "level": 2,
    "out_size": 6392101,
    "ratio": 0.7543,
-   "compress_mbps": 44.09,
-   "decompress_mbps": 145.94
+   "compress_mbps": 47.82,
+   "decompress_mbps": 146.2
   },
   {
    "compressor": "native",
@@ -5434,8 +5434,8 @@
    "level": 3,
    "out_size": 6392124,
    "ratio": 0.7543,
-   "compress_mbps": 44.19,
-   "decompress_mbps": 147.52
+   "compress_mbps": 47.92,
+   "decompress_mbps": 144.34
   },
   {
    "compressor": "native",
@@ -5444,8 +5444,8 @@
    "level": 4,
    "out_size": 6360604,
    "ratio": 0.7506,
-   "compress_mbps": 39.56,
-   "decompress_mbps": 132.48
+   "compress_mbps": 42.99,
+   "decompress_mbps": 133.73
   },
   {
    "compressor": "native",
@@ -5454,8 +5454,8 @@
    "level": 5,
    "out_size": 6360567,
    "ratio": 0.7506,
-   "compress_mbps": 39.79,
-   "decompress_mbps": 134.0
+   "compress_mbps": 43.27,
+   "decompress_mbps": 136.04
   },
   {
    "compressor": "native",
@@ -5464,8 +5464,8 @@
    "level": 6,
    "out_size": 6036758,
    "ratio": 0.7124,
-   "compress_mbps": 23.5,
-   "decompress_mbps": 136.18
+   "compress_mbps": 24.74,
+   "decompress_mbps": 137.48
   },
   {
    "compressor": "native",
@@ -5474,8 +5474,8 @@
    "level": 7,
    "out_size": 6036620,
    "ratio": 0.7123,
-   "compress_mbps": 23.8,
-   "decompress_mbps": 136.97
+   "compress_mbps": 24.81,
+   "decompress_mbps": 136.27
   },
   {
    "compressor": "native",
@@ -5484,8 +5484,8 @@
    "level": 8,
    "out_size": 6036614,
    "ratio": 0.7123,
-   "compress_mbps": 23.91,
-   "decompress_mbps": 137.13
+   "compress_mbps": 24.66,
+   "decompress_mbps": 137.46
   },
   {
    "compressor": "native",
@@ -5494,8 +5494,8 @@
    "level": 9,
    "out_size": 5952975,
    "ratio": 0.7025,
-   "compress_mbps": 6.18,
-   "decompress_mbps": 140.62
+   "compress_mbps": 6.29,
+   "decompress_mbps": 139.68
   },
   {
    "compressor": "native",
@@ -5504,7 +5504,7 @@
    "level": 10,
    "out_size": 5849157,
    "ratio": 0.6902,
-   "compress_mbps": 4.47,
+   "compress_mbps": 4.62,
    "decompress_mbps": null
   },
   {
@@ -5514,8 +5514,8 @@
    "level": 1,
    "out_size": 858525,
    "ratio": 0.1606,
-   "compress_mbps": 204.16,
-   "decompress_mbps": 394.06
+   "compress_mbps": 221.13,
+   "decompress_mbps": 507.04
   },
   {
    "compressor": "native",
@@ -5524,8 +5524,8 @@
    "level": 2,
    "out_size": 846807,
    "ratio": 0.1584,
-   "compress_mbps": 149.28,
-   "decompress_mbps": 520.58
+   "compress_mbps": 161.98,
+   "decompress_mbps": 568.6
   },
   {
    "compressor": "native",
@@ -5534,8 +5534,8 @@
    "level": 3,
    "out_size": 806798,
    "ratio": 0.1509,
-   "compress_mbps": 138.02,
-   "decompress_mbps": 634.04
+   "compress_mbps": 144.24,
+   "decompress_mbps": 630.14
   },
   {
    "compressor": "native",
@@ -5544,8 +5544,8 @@
    "level": 4,
    "out_size": 717301,
    "ratio": 0.1342,
-   "compress_mbps": 98.65,
-   "decompress_mbps": 626.47
+   "compress_mbps": 101.54,
+   "decompress_mbps": 623.92
   },
   {
    "compressor": "native",
@@ -5554,8 +5554,8 @@
    "level": 5,
    "out_size": 701552,
    "ratio": 0.1312,
-   "compress_mbps": 74.76,
-   "decompress_mbps": 674.27
+   "compress_mbps": 76.35,
+   "decompress_mbps": 606.55
   },
   {
    "compressor": "native",
@@ -5564,8 +5564,8 @@
    "level": 6,
    "out_size": 689796,
    "ratio": 0.129,
-   "compress_mbps": 67.38,
-   "decompress_mbps": 725.73
+   "compress_mbps": 70.28,
+   "decompress_mbps": 655.56
   },
   {
    "compressor": "native",
@@ -5574,8 +5574,8 @@
    "level": 7,
    "out_size": 680793,
    "ratio": 0.1274,
-   "compress_mbps": 61.78,
-   "decompress_mbps": 726.73
+   "compress_mbps": 63.99,
+   "decompress_mbps": 740.67
   },
   {
    "compressor": "native",
@@ -5584,8 +5584,8 @@
    "level": 8,
    "out_size": 662896,
    "ratio": 0.124,
-   "compress_mbps": 43.13,
-   "decompress_mbps": 752.75
+   "compress_mbps": 44.62,
+   "decompress_mbps": 751.59
   },
   {
    "compressor": "native",
@@ -5595,7 +5595,7 @@
    "out_size": 659422,
    "ratio": 0.1234,
    "compress_mbps": 4.58,
-   "decompress_mbps": 634.75
+   "decompress_mbps": 658.58
   },
   {
    "compressor": "native",
@@ -5604,7 +5604,7 @@
    "level": 10,
    "out_size": 643101,
    "ratio": 0.1203,
-   "compress_mbps": 3.02,
+   "compress_mbps": 3.07,
    "decompress_mbps": null
   },
   {


### PR DESCRIPTION
This PR cut the dynamic-emit path's per-token cost (24-27% of L1 compress time) in three output-byte-identical steps. The Huffman code tables were `Array (UInt16 × UInt8)` — a boxed `Prod` chase per token — and `writeHuffCode` re-reversed the code's bits on every symbol even though the reversed form is a per-block constant: `packCodeTab` now packs each entry as one `UInt32` holding the pre-reversed code plus length (one scalar array read per token), written through the new `BitWriter.writeRevCode`. The `writeBits`/`writeHuffCode` flush bookkeeping also moves from tagged-`Nat` arithmetic (`nat_add`/`nat_mod`/recursive `dropBytes` per flush) to UInt32/UInt64 register ops, with the `_def` equations' statements unchanged so no downstream spec proof moves. Byte-identity is machine-checked end-to-end (`writeRevCode_eq`, `packCodeEntry_write`, `emitTokensWithCodesPT_eq`); no `sorry`.

Measured (chungus2, pinned, interleaved medians of 7, from-scratch baseline after ruling out a stale-cache layout phantom — see below): dickens L1 +6.1%, mozilla L1 +6.2%, xml L1 +5.7%, dickens L2 +4.2%, xml L6 +0.4%; the emit share of dickens L1 drops 26.2% → 20.1%. Two measurement hazards found on the way, worth their own note: inlining a branch into the hot FBIP flush arm made the ctor-reuse pass pick the wrong reuse site (−10-14% — verify `del_object` placement in the generated C after touching hot writers), and a baseline linked from stale `.lake` objects carried a luckier GCC inline layout for the untouched matcher (check `nm` for hot-symbol presence before trusting an A/B).

🤖 Prepared with Claude Code