### PR TITLE
perf: re-grid L2/L3 for the merged-greedy + packed-emit cost structure

### DIFF
--- a/Zip/Native/DeflateDynamic.lean
+++ b/Zip/Native/DeflateDynamic.lean
@@ -662,6 +662,13 @@ attribute [irreducible] symbolBitCount fixedBlockBytes dynBlockBytes dynBlockByt
     so the deep-chain point fell inside the new frontier and L7 adopts the old
     L6 config wholesale. L8 keeps 512; past that the chain saturates.
 
+    **L2/L3 dropped to 8/16 in the greedy re-grid** (`l1-sweep2`, run after the
+    merged-greedy-loop and packed-emit landings shifted the tier's cost
+    balance): with the `niceLen` cutoff disabled (see there), (chain 8, cap 8)
+    matches the old L2's weighted-Silesia ratio exactly at +12% speed, and
+    (chain 16, cap 32) beats the old L3 on both axes — the old rows sat ~10%
+    below the greedy-band mixing frontier.
+
     Level 1 is the `deflate_fast` corner (#2726): depth `4` is exactly zlib
     `-1`'s `max_chain`. A tokens-held-constant attribution on Silesia (see
     `ZipL1Attrib`/`ZipL1Sweep`) showed L1 is emit-bound — the token walk +
@@ -677,8 +684,8 @@ attribute [irreducible] symbolBitCount fixedBlockBytes dynBlockBytes dynBlockByt
     conservative point (+15% e2e at ratio 0.356, worst file +6.3%). -/
 def chainDepth (level : UInt8) : Nat :=
   if level ≤ 1 then 4
-  else if level ≤ 2 then 16
-  else if level ≤ 3 then 32
+  else if level ≤ 2 then 8
+  else if level ≤ 3 then 16
   else if level ≤ 4 then 64
   else if level ≤ 5 then 128
   else if level ≤ 7 then 64
@@ -693,12 +700,14 @@ def chainDepth (level : UInt8) : Nat :=
     counterproductive") no longer holds for the packed emit path — at chain depth
     4, `cap = 2` is +12% end-to-end vs `cap = 16` because the interior-insertion
     saving outweighs the slightly higher token count the worse ratio produces
-    (the emit walk is the bound, not the cap). The chain is a heuristic, so any
-    cap stays correct (`lz77ChainIter_resolves` holds ∀ cap). -/
+    (the emit walk is the bound, not the cap). L2/L3 dropped to 8/32 with the
+    greedy re-grid (`l1-sweep2`), paired with their new chain depths. The chain
+    is a heuristic, so any cap stays correct (`lz77ChainIter_resolves` holds
+    ∀ cap). -/
 def insertCap (level : UInt8) : Nat :=
   if level ≤ 1 then 2
-  else if level ≤ 2 then 32
-  else if level ≤ 3 then 64
+  else if level ≤ 2 then 8
+  else if level ≤ 3 then 32
   else 1000000000
 
 /-- Lazy `good_match` threshold (zlib-style): the lazy matcher skips the
@@ -721,10 +730,13 @@ def goodMatch (level : UInt8) : Nat :=
 /-- Per-level `niceLen` cutoff (libdeflate `nice_match_length`, `deflate_compress.c`):
     the chain walk stops as soon as the best match reaches this length, since a
     match this long is already good enough — burning the rest of the depth budget
-    to lengthen it further rarely pays for itself. L2/L3 keep libdeflate's values
-    (10/14, #2744); level 1 keeps `258` (no early-out) to leave the measured
-    `deflate_fast` corner (#2726) untouched — at chain depth 4 the walk is
-    already short, so a cutoff buys little there.
+    to lengthen it further rarely pays for itself. **L2/L3 disable the cutoff
+    since the greedy re-grid** (`l1-sweep2`, post merged-greedy-loop +
+    packed-emit landings): the libdeflate values (10/14, #2744) were costing
+    ~0.5pp weighted-Silesia ratio for speed better bought by shallowing the
+    chain instead — both old mid rows sat ~10% below the greedy-band mixing
+    frontier. Level 1 keeps `258` (no early-out) as before — at chain depth 4
+    the walk is already short, so a cutoff buys little there.
 
     The mid-band values were re-gridded for the #2737 remapped ladder
     (`mid-sweep --time`, Silesia): **L4 disables the cutoff** — at chain 64
@@ -743,10 +755,7 @@ def goodMatch (level : UInt8) : Nat :=
     cutoff never enters correctness — the chain is a heuristic re-verified at
     emission — so any value keeps the encoder contracts. -/
 def niceLen (level : UInt8) : Nat :=
-  if level ≤ 1 then 258
-  else if level ≤ 2 then 10
-  else if level ≤ 3 then 14
-  else if level ≤ 4 then 258
+  if level ≤ 4 then 258
   else if level ≤ 7 then 65
   else 258
 

--- a/bench/graphs/canterbury_compress_heatmap.svg
+++ b/bench/graphs/canterbury_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p823434621b)">
+   <g clip-path="url(#pf69a2179c4)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJF0lEQVR4nO3YzaqdZx2H4axkbU3abQ2FxpLSIOhMoSOd2HnnPRCPwInH0DMoQuel0EHHThwWJwqiBAnEQhrzsbOz9/pwIHgE98PfLK7rCH4vD++77vVsDv/+4niDN8vli+kF67w+zWc7Xl1OT1hm88696Qlr/PCt6QXrbG5OL1jj+nTfs1M9s+OTf05PWOY0TwwAYJDAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCIbR9unkxvWOJqfzk9YZn37/50esIy54d70xOW2Lx6Nj1hmT+++sv0hCXu/+C96QnL7A+76QlLPN9dTE9YZnfcT09Y4lc/+mB6wjJusAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACC2PT+7O71hicP2MD1hmfMbt6cnrPP04fSCJY6vnk1PWObXD34zPWGJi93pntnLE322n5//cnrCMleb3fSEJY7/+HZ6wjJusAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACC2vXPrfHrDEpf7i+kJ62xOuItvvzO9YInNCZ/Z2W43PWGJUz6zt7en+Z49vno0PWGZ3eFqesISH7x9d3rCMqf7BQEAGCKwAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAILbZ//n3x+kR8D+Hw/QC+K+b/n++cXw/+D/iCwIAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAACx7W+/ezi9YYlnr/fTE5b506Pn0xOW+erTj6cnLPGTOw+mJyzz0ed/mJ6wxCc/e3d6wjJ/+/7V9IQl7mxvTU9Y5suv/zo9YYmLz343PWEZN1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQ2+wO3xynR6ywP+ymJyxzc3O6XXzr8mJ6whq3ttML1nn5ZHrBEvu7709PWOZwPExPWOJsc7rv2fXxNH/Tznan+Vw3brjBAgDICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgNj24vrZ9IYl9sfd9IRlfvzycnrCOs//Nb1giePV9fSEZTYf/mJ6whJX+9N9z15cP52esMR7t+9PT1jm7OXT6QlLHB//fXrCMm6wAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAIPYf212I7lRstEUAAAAASUVORK5CYII=" id="imageaa0de41442" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJF0lEQVR4nO3Yz4rdZx3H8ZzkjHbsWFKhNZi2FOxOwZXd6L77XkivoBuvwTsQwb0IXXTdjUvpRqEooRRaIcZkOjOZnD9dFLyC98PXHF6vK/j8ePj9zvs8m8N//3S8w8vl5nJ6wTrPT/PZjrc30xOW2bz25vSENX74o+kF62zuTi9Y48XpvmenembHx19OT1jmNE8MAGCQwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiG0fbR5Pb1jidn8zPWGZB/ffnZ6wzMXhzekJS2yun05PWOaz679PT1jiZz94Y3rCMvvDbnrCEs92V9MTltkd99MTlvj1jx9OT1jGDRYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEthdn96c3LHHYHqYnLHNx55XpCes8eTS9YInj9dPpCcu8/85vpicscbU73TP79kSf7b2LX05PWOZ2s5uesMTxX3+bnrCMGywAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCIbc/vXUxvWOJmfzU9YZ3NCXfxK69NL1hic8JndrbbTU9Y4pTP7NXtab5nX99+NT1hmd3hdnrCEg9fvT89YZnT/YIAAAwRWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABDb7D//3XF6BPzP4TC9AL531//Pl47vB/9HfEEAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgtv3o34+mNyzx9Pl+esIyf/3q2fSEZf7y4W+nJyzx0/N3pics86s//HF6whIf/Pwn0xOW+eI/19MTljjf3puesMyfP/nH9IQlrn7/8fSEZdxgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQGyzO3x6nB6xwv6wm56wzN3N6XbxvZur6Qlr3NtOL1jn28fTC5bY338wPWGZw/EwPWGJs83pvmcvjqf5m3a2O83nunPHDRYAQE5gAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEtte7y+kNS9zub6YnLPP61e30hHWefTO9YInj7YvpCcts3v7F9IQlTvkbcvniyfSEJd44f2t6wjJnl0+mJyxx/Pqf0xOWcYMFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAse8AZQWI8KWCDt0AAAAASUVORK5CYII=" id="imagefd2bb5829e" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="mb170d0d508" d="M 0 0 
+       <path id="mfcf808bf65" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mb170d0d508" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfcf808bf65" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#mb170d0d508" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfcf808bf65" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#mb170d0d508" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfcf808bf65" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mb170d0d508" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfcf808bf65" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#mb170d0d508" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfcf808bf65" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#mb170d0d508" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfcf808bf65" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#mb170d0d508" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfcf808bf65" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#mb170d0d508" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfcf808bf65" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#mb170d0d508" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfcf808bf65" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#mb170d0d508" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfcf808bf65" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#mb170d0d508" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfcf808bf65" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="m590a41a35e" d="M 0 0 
+       <path id="m35db743aac" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m590a41a35e" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m35db743aac" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m590a41a35e" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m35db743aac" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m590a41a35e" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m35db743aac" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m590a41a35e" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m35db743aac" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m590a41a35e" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m35db743aac" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m590a41a35e" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m35db743aac" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m590a41a35e" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m35db743aac" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m590a41a35e" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m35db743aac" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1328,7 +1328,7 @@ z
     </g>
    </g>
    <g id="text_21">
-    <!-- +33 -->
+    <!-- +35 -->
     <g transform="translate(147.693424 68.904519) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-33" d="M 2597 2516 
@@ -1366,7 +1366,7 @@ z
      </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_22">
@@ -1504,26 +1504,26 @@ z
     </g>
    </g>
    <g id="text_26">
-    <!-- +22 -->
+    <!-- +21 -->
     <g transform="translate(343.947416 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_27">
-    <!-- +46 -->
+    <!-- +45 -->
     <g transform="translate(383.198215 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_28">
-    <!-- -4 -->
+    <!-- -2 -->
     <g transform="translate(426.067685 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_29">
@@ -2178,18 +2178,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="image314f857a07" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
+iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="image7f38f44acb" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="m80aa4a1420" d="M 0 0 
+       <path id="m39bb2b0e9c" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m80aa4a1420" x="547.779688" y="276.293905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m39bb2b0e9c" x="547.779688" y="276.293905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
@@ -2212,7 +2212,7 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m80aa4a1420" x="547.779688" y="247.808905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m39bb2b0e9c" x="547.779688" y="247.808905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
@@ -2226,7 +2226,7 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m80aa4a1420" x="547.779688" y="219.323905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m39bb2b0e9c" x="547.779688" y="219.323905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
@@ -2240,7 +2240,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m80aa4a1420" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m39bb2b0e9c" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
@@ -2253,7 +2253,7 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m80aa4a1420" x="547.779688" y="162.353904" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m39bb2b0e9c" x="547.779688" y="162.353904" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_112">
@@ -2266,7 +2266,7 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m80aa4a1420" x="547.779688" y="133.868904" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m39bb2b0e9c" x="547.779688" y="133.868904" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
@@ -2279,7 +2279,7 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m80aa4a1420" x="547.779688" y="105.383904" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m39bb2b0e9c" x="547.779688" y="105.383904" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
@@ -2940,8 +2940,8 @@ z
    </g>
   </g>
   <g id="text_117">
-   <!-- 2026-07-09T17:31:54Z  ·  Linux chungus2 x86_64  ·  commit 324f086c  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(17.677578 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-10T04:34:01Z  ·  Linux chungus2 x86_64  ·  commit 74861182  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(16.380391 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -3007,17 +3007,17 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(290.576172 0)"/>
     <use xlink:href="#DejaVuSans-37" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(453.90625 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
     <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3057,109 +3057,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3262.744141 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3297.949219 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3361.572266 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3425.195312 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3488.818359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3543.798828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3575.585938 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3607.373047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3639.160156 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3670.947266 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3702.734375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3730.517578 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3792.041016 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3853.320312 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3916.699219 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3980.175781 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4019.039062 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4080.220703 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4139.400391 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4200.923828 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4242.037109 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4275.728516 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4303.511719 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4365.035156 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4426.314453 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4489.693359 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4553.316406 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4587.007812 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4646.1875 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4709.810547 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4741.597656 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4805.220703 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4868.84375 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4900.630859 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4964.253906 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5000.337891 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5039.201172 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5094.181641 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5157.804688 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5189.591797 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5221.378906 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5253.166016 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5284.953125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5316.740234 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5355.949219 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5419.328125 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5458.191406 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5519.373047 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5582.751953 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5646.228516 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5709.607422 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5773.083984 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5836.462891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5875.671875 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5907.458984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5991.248047 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6023.035156 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6120.447266 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6181.970703 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6245.447266 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6273.230469 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6334.509766 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6397.888672 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6429.675781 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6481.775391 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6545.154297 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6606.433594 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6669.910156 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6722.009766 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6785.388672 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6846.570312 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6885.779297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6919.470703 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6951.257812 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6992.371094 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7053.650391 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7092.859375 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7120.642578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7181.824219 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7213.611328 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7241.394531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7293.494141 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7325.28125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7388.757812 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7450.28125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7489.490234 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7551.013672 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7590.376953 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7687.789062 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7715.572266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7778.951172 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7806.734375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7858.833984 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7898.042969 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7925.826172 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3262.744141 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3326.367188 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3389.990234 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3453.613281 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3517.236328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3580.859375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3612.646484 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3644.433594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3676.220703 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3708.007812 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3739.794922 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3767.578125 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3829.101562 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3890.380859 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3953.759766 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4017.236328 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4056.099609 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4117.28125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4176.460938 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4237.984375 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4279.097656 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4312.789062 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4340.572266 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4402.095703 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4463.375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4526.753906 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4590.376953 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4624.068359 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4683.248047 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4746.871094 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4778.658203 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4842.28125 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4905.904297 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4937.691406 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(5001.314453 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5037.398438 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5076.261719 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5131.242188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5194.865234 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5226.652344 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5258.439453 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5290.226562 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5322.013672 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5353.800781 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5393.009766 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5456.388672 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5495.251953 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5556.433594 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5619.8125 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5683.289062 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5746.667969 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5810.144531 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5873.523438 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5912.732422 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5944.519531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6028.308594 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6060.095703 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6157.507812 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6219.03125 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6282.507812 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6310.291016 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6371.570312 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6434.949219 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6466.736328 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6518.835938 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6582.214844 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6643.494141 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6706.970703 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6759.070312 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6822.449219 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6883.630859 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6922.839844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6956.53125 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6988.318359 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7029.431641 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7090.710938 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7129.919922 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7157.703125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7218.884766 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7250.671875 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7278.455078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7330.554688 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7362.341797 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7425.818359 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7487.341797 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7526.550781 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7588.074219 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7627.4375 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7724.849609 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7752.632812 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7816.011719 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7843.794922 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7895.894531 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7935.103516 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7962.886719 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p823434621b">
+  <clipPath id="pf69a2179c4">
    <rect x="95.67625" y="49.4355" width="431.758783" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_compress_pareto.svg
+++ b/bench/graphs/canterbury_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 79.118387 412.80375 
 L 79.118387 48.323125 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m44cfe20ad5" d="M 0 0 
+       <path id="mc0692397a1" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m44cfe20ad5" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc0692397a1" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -161,11 +161,11 @@ z
      <g id="line2d_3">
       <path d="M 166.481434 412.80375 
 L 166.481434 48.323125 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m44cfe20ad5" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc0692397a1" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -216,11 +216,11 @@ z
      <g id="line2d_5">
       <path d="M 253.844481 412.80375 
 L 253.844481 48.323125 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m44cfe20ad5" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc0692397a1" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -237,11 +237,11 @@ L 253.844481 48.323125
      <g id="line2d_7">
       <path d="M 341.207528 412.80375 
 L 341.207528 48.323125 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m44cfe20ad5" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc0692397a1" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -279,11 +279,11 @@ z
      <g id="line2d_9">
       <path d="M 428.570575 412.80375 
 L 428.570575 48.323125 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m44cfe20ad5" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc0692397a1" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -332,11 +332,11 @@ z
      <g id="line2d_11">
       <path d="M 515.933622 412.80375 
 L 515.933622 48.323125 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m44cfe20ad5" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc0692397a1" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -353,11 +353,11 @@ L 515.933622 48.323125
      <g id="line2d_13">
       <path d="M 603.296669 412.80375 
 L 603.296669 48.323125 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m44cfe20ad5" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc0692397a1" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -854,16 +854,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 347.786382 
 L 637.2 347.786382 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="mf80b61b523" d="M 0 0 
+       <path id="m3be5b5c95a" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mf80b61b523" x="49.078125" y="347.786382" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3be5b5c95a" x="49.078125" y="347.786382" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -895,11 +895,11 @@ z
      <g id="line2d_17">
       <path d="M 49.078125 238.646289 
 L 637.2 238.646289 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mf80b61b523" x="49.078125" y="238.646289" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3be5b5c95a" x="49.078125" y="238.646289" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -915,11 +915,11 @@ L 637.2 238.646289
      <g id="line2d_19">
       <path d="M 49.078125 129.506196 
 L 637.2 129.506196 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#mf80b61b523" x="49.078125" y="129.506196" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3be5b5c95a" x="49.078125" y="129.506196" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -935,16 +935,16 @@ L 637.2 129.506196
      <g id="line2d_21">
       <path d="M 49.078125 404.853417 
 L 637.2 404.853417 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="m44e0f0e5c4" d="M 0 0 
+       <path id="md143ad22e1" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m44e0f0e5c4" x="49.078125" y="404.853417" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md143ad22e1" x="49.078125" y="404.853417" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -952,11 +952,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 391.217592 
 L 637.2 391.217592 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m44e0f0e5c4" x="49.078125" y="391.217592" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md143ad22e1" x="49.078125" y="391.217592" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -964,11 +964,11 @@ L 637.2 391.217592
      <g id="line2d_25">
       <path d="M 49.078125 380.640824 
 L 637.2 380.640824 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m44e0f0e5c4" x="49.078125" y="380.640824" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md143ad22e1" x="49.078125" y="380.640824" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -976,11 +976,11 @@ L 637.2 380.640824
      <g id="line2d_27">
       <path d="M 49.078125 371.998975 
 L 637.2 371.998975 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m44e0f0e5c4" x="49.078125" y="371.998975" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md143ad22e1" x="49.078125" y="371.998975" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -988,11 +988,11 @@ L 637.2 371.998975
      <g id="line2d_29">
       <path d="M 49.078125 364.692396 
 L 637.2 364.692396 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m44e0f0e5c4" x="49.078125" y="364.692396" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md143ad22e1" x="49.078125" y="364.692396" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1000,11 +1000,11 @@ L 637.2 364.692396
      <g id="line2d_31">
       <path d="M 49.078125 358.36315 
 L 637.2 358.36315 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m44e0f0e5c4" x="49.078125" y="358.36315" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md143ad22e1" x="49.078125" y="358.36315" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1012,11 +1012,11 @@ L 637.2 358.36315
      <g id="line2d_33">
       <path d="M 49.078125 352.780359 
 L 637.2 352.780359 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m44e0f0e5c4" x="49.078125" y="352.780359" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md143ad22e1" x="49.078125" y="352.780359" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1024,11 +1024,11 @@ L 637.2 352.780359
      <g id="line2d_35">
       <path d="M 49.078125 314.93194 
 L 637.2 314.93194 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m44e0f0e5c4" x="49.078125" y="314.93194" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md143ad22e1" x="49.078125" y="314.93194" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1036,11 +1036,11 @@ L 637.2 314.93194
      <g id="line2d_37">
       <path d="M 49.078125 295.713324 
 L 637.2 295.713324 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m44e0f0e5c4" x="49.078125" y="295.713324" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md143ad22e1" x="49.078125" y="295.713324" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1048,11 +1048,11 @@ L 637.2 295.713324
      <g id="line2d_39">
       <path d="M 49.078125 282.077499 
 L 637.2 282.077499 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m44e0f0e5c4" x="49.078125" y="282.077499" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md143ad22e1" x="49.078125" y="282.077499" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1060,11 +1060,11 @@ L 637.2 282.077499
      <g id="line2d_41">
       <path d="M 49.078125 271.500731 
 L 637.2 271.500731 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m44e0f0e5c4" x="49.078125" y="271.500731" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md143ad22e1" x="49.078125" y="271.500731" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1072,11 +1072,11 @@ L 637.2 271.500731
      <g id="line2d_43">
       <path d="M 49.078125 262.858882 
 L 637.2 262.858882 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m44e0f0e5c4" x="49.078125" y="262.858882" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md143ad22e1" x="49.078125" y="262.858882" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1084,11 +1084,11 @@ L 637.2 262.858882
      <g id="line2d_45">
       <path d="M 49.078125 255.552304 
 L 637.2 255.552304 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m44e0f0e5c4" x="49.078125" y="255.552304" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md143ad22e1" x="49.078125" y="255.552304" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1096,11 +1096,11 @@ L 637.2 255.552304
      <g id="line2d_47">
       <path d="M 49.078125 249.223057 
 L 637.2 249.223057 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m44e0f0e5c4" x="49.078125" y="249.223057" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md143ad22e1" x="49.078125" y="249.223057" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1108,11 +1108,11 @@ L 637.2 249.223057
      <g id="line2d_49">
       <path d="M 49.078125 243.640266 
 L 637.2 243.640266 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m44e0f0e5c4" x="49.078125" y="243.640266" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md143ad22e1" x="49.078125" y="243.640266" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1120,11 +1120,11 @@ L 637.2 243.640266
      <g id="line2d_51">
       <path d="M 49.078125 205.791848 
 L 637.2 205.791848 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m44e0f0e5c4" x="49.078125" y="205.791848" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md143ad22e1" x="49.078125" y="205.791848" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1132,11 +1132,11 @@ L 637.2 205.791848
      <g id="line2d_53">
       <path d="M 49.078125 186.573231 
 L 637.2 186.573231 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#m44e0f0e5c4" x="49.078125" y="186.573231" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md143ad22e1" x="49.078125" y="186.573231" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1144,11 +1144,11 @@ L 637.2 186.573231
      <g id="line2d_55">
       <path d="M 49.078125 172.937406 
 L 637.2 172.937406 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#m44e0f0e5c4" x="49.078125" y="172.937406" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md143ad22e1" x="49.078125" y="172.937406" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1156,11 +1156,11 @@ L 637.2 172.937406
      <g id="line2d_57">
       <path d="M 49.078125 162.360638 
 L 637.2 162.360638 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#m44e0f0e5c4" x="49.078125" y="162.360638" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md143ad22e1" x="49.078125" y="162.360638" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1168,11 +1168,11 @@ L 637.2 162.360638
      <g id="line2d_59">
       <path d="M 49.078125 153.71879 
 L 637.2 153.71879 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#m44e0f0e5c4" x="49.078125" y="153.71879" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md143ad22e1" x="49.078125" y="153.71879" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1180,11 +1180,11 @@ L 637.2 153.71879
      <g id="line2d_61">
       <path d="M 49.078125 146.412211 
 L 637.2 146.412211 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#m44e0f0e5c4" x="49.078125" y="146.412211" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md143ad22e1" x="49.078125" y="146.412211" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1192,11 +1192,11 @@ L 637.2 146.412211
      <g id="line2d_63">
       <path d="M 49.078125 140.082964 
 L 637.2 140.082964 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#m44e0f0e5c4" x="49.078125" y="140.082964" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md143ad22e1" x="49.078125" y="140.082964" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1204,11 +1204,11 @@ L 637.2 140.082964
      <g id="line2d_65">
       <path d="M 49.078125 134.500173 
 L 637.2 134.500173 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#m44e0f0e5c4" x="49.078125" y="134.500173" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md143ad22e1" x="49.078125" y="134.500173" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1216,11 +1216,11 @@ L 637.2 134.500173
      <g id="line2d_67">
       <path d="M 49.078125 96.651755 
 L 637.2 96.651755 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_68">
       <g>
-       <use xlink:href="#m44e0f0e5c4" x="49.078125" y="96.651755" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md143ad22e1" x="49.078125" y="96.651755" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1228,11 +1228,11 @@ L 637.2 96.651755
      <g id="line2d_69">
       <path d="M 49.078125 77.433138 
 L 637.2 77.433138 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_70">
       <g>
-       <use xlink:href="#m44e0f0e5c4" x="49.078125" y="77.433138" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md143ad22e1" x="49.078125" y="77.433138" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1240,11 +1240,11 @@ L 637.2 77.433138
      <g id="line2d_71">
       <path d="M 49.078125 63.797313 
 L 637.2 63.797313 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_72">
       <g>
-       <use xlink:href="#m44e0f0e5c4" x="49.078125" y="63.797313" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md143ad22e1" x="49.078125" y="63.797313" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1252,11 +1252,11 @@ L 637.2 63.797313
      <g id="line2d_73">
       <path d="M 49.078125 53.220545 
 L 637.2 53.220545 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_74">
       <g>
-       <use xlink:href="#m44e0f0e5c4" x="49.078125" y="53.220545" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md143ad22e1" x="49.078125" y="53.220545" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1378,7 +1378,7 @@ L 637.2 48.323125
    </g>
    <g id="text_13">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(294.783126 139.387822) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(294.783126 139.898227) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1410,7 +1410,7 @@ z
    </g>
    <g id="text_14">
     <!-- L10 -->
-    <g style="fill: #d62728" transform="translate(104.775489 294.492401) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(104.775489 295.355151) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1732,23 +1732,23 @@ z
    </g>
    <g id="line2d_75">
     <defs>
-     <path id="m2e38fef57b" d="M -2.5 2.5 
+     <path id="m4bd3f42fa6" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pa93c90c411)">
-     <use xlink:href="#m2e38fef57b" x="355.479835" y="95.382063" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2e38fef57b" x="308.273931" y="102.754513" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2e38fef57b" x="271.230161" y="116.528062" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2e38fef57b" x="217.83458" y="120.013651" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2e38fef57b" x="177.077692" y="138.43462" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2e38fef57b" x="162.880539" y="157.778627" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2e38fef57b" x="160.741445" y="165.196647" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2e38fef57b" x="153.966678" y="183.405761" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2e38fef57b" x="151.589614" y="194.488118" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pd4f8ac3ff4)">
+     <use xlink:href="#m4bd3f42fa6" x="355.479835" y="95.382063" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4bd3f42fa6" x="308.273931" y="102.754513" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4bd3f42fa6" x="271.230161" y="116.528062" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4bd3f42fa6" x="217.83458" y="120.013651" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4bd3f42fa6" x="177.077692" y="138.43462" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4bd3f42fa6" x="162.880539" y="157.778627" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4bd3f42fa6" x="160.741445" y="165.196647" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4bd3f42fa6" x="153.966678" y="183.405761" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4bd3f42fa6" x="151.589614" y="194.488118" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_76">
@@ -1801,7 +1801,7 @@ L 311.2243 102.325849
 L 310.240844 102.469168 
 L 309.257387 102.612055 
 L 308.273931 102.754513 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_77">
     <path d="M 308.273931 102.754513 
@@ -1853,7 +1853,7 @@ L 273.545396 115.775058
 L 272.773651 116.027391 
 L 272.001906 116.278388 
 L 271.230161 116.528062 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_78">
     <path d="M 271.230161 116.528062 
@@ -1905,7 +1905,7 @@ L 221.171803 119.803152
 L 220.059395 119.873422 
 L 218.946988 119.943588 
 L 217.83458 120.013651 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_79">
     <path d="M 217.83458 120.013651 
@@ -1957,7 +1957,7 @@ L 179.624997 137.470928
 L 178.775895 137.79434 
 L 177.926794 138.115561 
 L 177.077692 138.43462 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_80">
     <path d="M 177.077692 138.43462 
@@ -2009,7 +2009,7 @@ L 163.767861 156.775388
 L 163.472087 157.112166 
 L 163.176313 157.446568 
 L 162.880539 157.778627 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_81">
     <path d="M 162.880539 157.778627 
@@ -2061,7 +2061,7 @@ L 160.875139 164.765525
 L 160.830574 164.909668 
 L 160.78601 165.053375 
 L 160.741445 165.196647 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_82">
     <path d="M 160.741445 165.196647 
@@ -2113,7 +2113,7 @@ L 154.390101 182.45125
 L 154.24896 182.771561 
 L 154.107819 183.089721 
 L 153.966678 183.405761 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_83">
     <path d="M 153.966678 183.405761 
@@ -2165,26 +2165,26 @@ L 151.73818 193.866427
 L 151.688658 194.074564 
 L 151.639136 194.281792 
 L 151.589614 194.488118 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_84">
     <defs>
-     <path id="m98c195fde7" d="M 0 -2.5 
+     <path id="mbf51c307e4" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pa93c90c411)">
-     <use xlink:href="#m98c195fde7" x="531.649087" y="75.963093" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m98c195fde7" x="283.721324" y="99.020035" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m98c195fde7" x="218.882044" y="121.069315" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m98c195fde7" x="187.447228" y="127.10685" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m98c195fde7" x="176.342474" y="138.36311" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m98c195fde7" x="163.054314" y="161.312135" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m98c195fde7" x="162.210539" y="168.753955" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m98c195fde7" x="159.303811" y="175.753345" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m98c195fde7" x="157.793928" y="179.494802" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pd4f8ac3ff4)">
+     <use xlink:href="#mbf51c307e4" x="531.649087" y="75.963093" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbf51c307e4" x="283.721324" y="99.020035" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbf51c307e4" x="218.882044" y="121.069315" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbf51c307e4" x="187.447228" y="127.10685" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbf51c307e4" x="176.342474" y="138.36311" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbf51c307e4" x="163.054314" y="161.312135" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbf51c307e4" x="162.210539" y="168.753955" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbf51c307e4" x="159.303811" y="175.753345" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbf51c307e4" x="157.793928" y="179.494802" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_85">
@@ -2237,7 +2237,7 @@ L 299.21681 97.864971
 L 294.051648 98.253128 
 L 288.886486 98.638133 
 L 283.721324 99.020035 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_86">
     <path d="M 283.721324 99.020035 
@@ -2289,7 +2289,7 @@ L 222.934499 119.954333
 L 221.583681 120.328916 
 L 220.232863 120.700561 
 L 218.882044 121.069315 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_87">
     <path d="M 218.882044 121.069315 
@@ -2341,7 +2341,7 @@ L 189.411904 126.751217
 L 188.757012 126.870058 
 L 188.10212 126.988602 
 L 187.447228 127.10685 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_88">
     <path d="M 187.447228 127.10685 
@@ -2393,7 +2393,7 @@ L 177.036521 137.732718
 L 176.805172 137.943781 
 L 176.573823 138.153909 
 L 176.342474 138.36311 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_89">
     <path d="M 176.342474 138.36311 
@@ -2445,7 +2445,7 @@ L 163.884824 160.161325
 L 163.607987 160.548041 
 L 163.33115 160.931628 
 L 163.054314 161.312135 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_90">
     <path d="M 163.054314 161.312135 
@@ -2497,7 +2497,7 @@ L 162.263275 168.321549
 L 162.245696 168.466124 
 L 162.228118 168.610258 
 L 162.210539 168.753955 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_91">
     <path d="M 162.210539 168.753955 
@@ -2549,7 +2549,7 @@ L 159.485481 175.344896
 L 159.424925 175.481437 
 L 159.364368 175.617586 
 L 159.303811 175.753345 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_92">
     <path d="M 159.303811 175.753345 
@@ -2601,30 +2601,30 @@ L 157.888296 179.269417
 L 157.85684 179.344665 
 L 157.825384 179.419793 
 L 157.793928 179.494802 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_93">
     <defs>
-     <path id="me47f981e49" d="M -0 3.535534 
+     <path id="m12d2789ad8" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pa93c90c411)">
-     <use xlink:href="#me47f981e49" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me47f981e49" x="203.775848" y="81.750179" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me47f981e49" x="186.982691" y="88.344921" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me47f981e49" x="179.779306" y="91.045312" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me47f981e49" x="157.610419" y="99.395085" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me47f981e49" x="148.722526" y="107.864022" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me47f981e49" x="144.388162" y="121.237794" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me47f981e49" x="127.071247" y="144.560664" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me47f981e49" x="124.491988" y="152.083585" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me47f981e49" x="92.613662" y="207.637263" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me47f981e49" x="87.348715" y="225.457654" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me47f981e49" x="86.053433" y="242.017529" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pd4f8ac3ff4)">
+     <use xlink:href="#m12d2789ad8" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m12d2789ad8" x="203.775848" y="81.750179" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m12d2789ad8" x="186.982691" y="88.344921" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m12d2789ad8" x="179.779306" y="91.045312" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m12d2789ad8" x="157.610419" y="99.395085" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m12d2789ad8" x="148.722526" y="107.864022" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m12d2789ad8" x="144.388162" y="121.237794" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m12d2789ad8" x="127.071247" y="144.560664" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m12d2789ad8" x="124.491988" y="152.083585" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m12d2789ad8" x="92.613662" y="207.637263" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m12d2789ad8" x="87.348715" y="225.457654" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m12d2789ad8" x="86.053433" y="242.017529" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_94">
@@ -2677,7 +2677,7 @@ L 206.762331 80.855075
 L 205.766837 81.155325 
 L 204.771342 81.453685 
 L 203.775848 81.750179 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_95">
     <path d="M 203.775848 81.750179 
@@ -2729,7 +2729,7 @@ L 188.032264 87.958568
 L 187.682406 88.087703 
 L 187.332549 88.216487 
 L 186.982691 88.344921 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_96">
     <path d="M 186.982691 88.344921 
@@ -2781,7 +2781,7 @@ L 180.229518 90.88097
 L 180.079447 90.935814 
 L 179.929376 90.990595 
 L 179.779306 91.045312 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_97">
     <path d="M 179.779306 91.045312 
@@ -2833,7 +2833,7 @@ L 158.995974 98.914174
 L 158.534122 99.075021 
 L 158.07227 99.235323 
 L 157.610419 99.395085 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_98">
     <path d="M 157.610419 99.395085 
@@ -2885,7 +2885,7 @@ L 149.27802 107.37681
 L 149.092855 107.539771 
 L 148.907691 107.702174 
 L 148.722526 107.864022 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_99">
     <path d="M 148.722526 107.864022 
@@ -2937,7 +2937,7 @@ L 144.65906 120.50385
 L 144.568761 120.749763 
 L 144.478462 120.994407 
 L 144.388162 121.237794 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_100">
     <path d="M 144.388162 121.237794 
@@ -2989,7 +2989,7 @@ L 128.153555 143.395158
 L 127.792786 143.786853 
 L 127.432016 144.175338 
 L 127.071247 144.560664 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_101">
     <path d="M 127.071247 144.560664 
@@ -3041,7 +3041,7 @@ L 124.653192 151.646811
 L 124.599457 151.79285 
 L 124.545723 151.93844 
 L 124.491988 152.083585 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_102">
     <path d="M 124.491988 152.083585 
@@ -3093,7 +3093,7 @@ L 94.606058 205.546972
 L 93.941926 206.254028 
 L 93.277794 206.950691 
 L 92.613662 207.637263 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_103">
     <path d="M 92.613662 207.637263 
@@ -3145,7 +3145,7 @@ L 87.677774 224.520091
 L 87.568088 224.834677 
 L 87.458402 225.147189 
 L 87.348715 225.457654 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_104">
     <path d="M 87.348715 225.457654 
@@ -3197,23 +3197,23 @@ L 86.134388 241.135848
 L 86.107403 241.431568 
 L 86.080418 241.725454 
 L 86.053433 242.017529 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_105">
     <defs>
-     <path id="med6a60f151" d="M -0 2.5 
+     <path id="m3a6df921f4" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pa93c90c411)">
-     <use xlink:href="#med6a60f151" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pd4f8ac3ff4)">
+     <use xlink:href="#m3a6df921f4" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_106">
     <defs>
-     <path id="mb6e0298424" d="M -0.833333 2.5 
+     <path id="ma030b73396" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -3228,16 +3228,16 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pa93c90c411)">
-     <use xlink:href="#mb6e0298424" x="362.865999" y="115.428618" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb6e0298424" x="278.798176" y="122.858526" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb6e0298424" x="251.17632" y="128.261574" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb6e0298424" x="200.806828" y="131.522849" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb6e0298424" x="169.803221" y="147.931404" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb6e0298424" x="161.916638" y="160.718659" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb6e0298424" x="158.697104" y="167.705569" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb6e0298424" x="154.26679" y="181.026105" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb6e0298424" x="153.096464" y="191.924265" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pd4f8ac3ff4)">
+     <use xlink:href="#ma030b73396" x="362.865999" y="115.428618" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma030b73396" x="278.798176" y="122.858526" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma030b73396" x="251.17632" y="128.261574" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma030b73396" x="200.806828" y="131.522849" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma030b73396" x="169.803221" y="147.931404" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma030b73396" x="161.916638" y="160.718659" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma030b73396" x="158.697104" y="167.705569" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma030b73396" x="154.26679" y="181.026105" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma030b73396" x="153.096464" y="191.924265" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_107">
@@ -3290,7 +3290,7 @@ L 284.052415 122.426763
 L 282.301002 122.571121 
 L 280.549589 122.715042 
 L 278.798176 122.858526 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_108">
     <path d="M 278.798176 122.858526 
@@ -3342,7 +3342,7 @@ L 252.902686 127.94134
 L 252.327231 128.048325 
 L 251.751776 128.155069 
 L 251.17632 128.261574 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_109">
     <path d="M 251.17632 128.261574 
@@ -3394,7 +3394,7 @@ L 203.954921 131.325463
 L 202.905557 131.39135 
 L 201.856192 131.457145 
 L 200.806828 131.522849 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_110">
     <path d="M 200.806828 131.522849 
@@ -3446,7 +3446,7 @@ L 171.740947 147.056528
 L 171.095038 147.349951 
 L 170.44913 147.64157 
 L 169.803221 147.931404 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_111">
     <path d="M 169.803221 147.931404 
@@ -3498,7 +3498,7 @@ L 162.409549 160.012958
 L 162.245246 160.249361 
 L 162.080942 160.484591 
 L 161.916638 160.718659 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_112">
     <path d="M 161.916638 160.718659 
@@ -3550,7 +3550,7 @@ L 158.898325 167.297798
 L 158.831251 167.434112 
 L 158.764178 167.570034 
 L 158.697104 167.705569 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_113">
     <path d="M 158.697104 167.705569 
@@ -3602,7 +3602,7 @@ L 154.543684 180.294711
 L 154.451386 180.539765 
 L 154.359088 180.783558 
 L 154.26679 181.026105 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_114">
     <path d="M 154.26679 181.026105 
@@ -3654,11 +3654,11 @@ L 153.16961 191.311823
 L 153.145228 191.516851 
 L 153.120846 191.720996 
 L 153.096464 191.924265 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_115">
     <defs>
-     <path id="m9b4e721c73" d="M -1.25 2.5 
+     <path id="ma1efacaabd" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -3673,16 +3673,16 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pa93c90c411)">
-     <use xlink:href="#m9b4e721c73" x="301.619021" y="150.561849" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9b4e721c73" x="250.236474" y="156.671134" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9b4e721c73" x="225.418659" y="160.842551" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9b4e721c73" x="212.328936" y="161.382211" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9b4e721c73" x="209.030149" y="166.25091" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9b4e721c73" x="197.547749" y="171.432451" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9b4e721c73" x="194.819287" y="175.129495" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9b4e721c73" x="193.12279" y="181.606362" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9b4e721c73" x="192.79794" y="189.451167" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pd4f8ac3ff4)">
+     <use xlink:href="#ma1efacaabd" x="301.619021" y="150.561849" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma1efacaabd" x="250.236474" y="156.671134" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma1efacaabd" x="225.418659" y="160.842551" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma1efacaabd" x="212.328936" y="161.382211" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma1efacaabd" x="209.030149" y="166.25091" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma1efacaabd" x="197.547749" y="171.432451" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma1efacaabd" x="194.819287" y="175.129495" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma1efacaabd" x="193.12279" y="181.606362" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma1efacaabd" x="192.79794" y="189.451167" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_116">
@@ -3735,7 +3735,7 @@ L 253.447883 156.311526
 L 252.377414 156.431699 
 L 251.306944 156.551567 
 L 250.236474 156.671134 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_117">
     <path d="M 250.236474 156.671134 
@@ -3787,7 +3787,7 @@ L 226.969772 160.592321
 L 226.452735 160.675878 
 L 225.935697 160.759287 
 L 225.418659 160.842551 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_118">
     <path d="M 225.418659 160.842551 
@@ -3839,7 +3839,7 @@ L 213.147044 161.348661
 L 212.874341 161.359847 
 L 212.601639 161.37103 
 L 212.328936 161.382211 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_119">
     <path d="M 212.328936 161.382211 
@@ -3891,7 +3891,7 @@ L 209.236323 165.960837
 L 209.167599 166.057725 
 L 209.098874 166.154416 
 L 209.030149 166.25091 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_120">
     <path d="M 209.030149 166.25091 
@@ -3943,7 +3943,7 @@ L 198.265399 171.124681
 L 198.026182 171.227493 
 L 197.786966 171.330083 
 L 197.547749 171.432451 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_121">
     <path d="M 197.547749 171.432451 
@@ -3995,7 +3995,7 @@ L 194.989815 174.906688
 L 194.932972 174.981074 
 L 194.876129 175.055342 
 L 194.819287 175.129495 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_122">
     <path d="M 194.819287 175.129495 
@@ -4047,7 +4047,7 @@ L 193.228821 181.226479
 L 193.193478 181.353445 
 L 193.158134 181.480072 
 L 193.12279 181.606362 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_123">
     <path d="M 193.12279 181.606362 
@@ -4099,11 +4099,11 @@ L 192.818243 188.997124
 L 192.811475 189.148955 
 L 192.804707 189.300302 
 L 192.79794 189.451167 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_124">
     <defs>
-     <path id="mf88fb2684f" d="M 0 -2.5 
+     <path id="m8d60b354a1" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -4116,16 +4116,16 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#pa93c90c411)">
-     <use xlink:href="#mf88fb2684f" x="206.45578" y="118.584066" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mf88fb2684f" x="206.45578" y="118.258949" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mf88fb2684f" x="206.45578" y="118.759361" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mf88fb2684f" x="206.45578" y="118.234957" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mf88fb2684f" x="171.767499" y="134.097889" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mf88fb2684f" x="163.54283" y="144.663903" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mf88fb2684f" x="160.174881" y="151.505345" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mf88fb2684f" x="154.179217" y="169.303726" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mf88fb2684f" x="152.4406" y="178.584542" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#pd4f8ac3ff4)">
+     <use xlink:href="#m8d60b354a1" x="206.45578" y="118.584066" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m8d60b354a1" x="206.45578" y="118.258949" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m8d60b354a1" x="206.45578" y="118.759361" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m8d60b354a1" x="206.45578" y="118.234957" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m8d60b354a1" x="171.767499" y="134.097889" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m8d60b354a1" x="163.54283" y="144.663903" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m8d60b354a1" x="160.174881" y="151.505345" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m8d60b354a1" x="154.179217" y="169.303726" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m8d60b354a1" x="152.4406" y="178.584542" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_125">
@@ -4178,7 +4178,7 @@ L 206.45578 118.279335
 L 206.45578 118.27254 
 L 206.45578 118.265745 
 L 206.45578 118.258949 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_126">
     <path d="M 206.45578 118.258949 
@@ -4230,7 +4230,7 @@ L 206.45578 118.728239
 L 206.45578 118.738615 
 L 206.45578 118.748989 
 L 206.45578 118.759361 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_127">
     <path d="M 206.45578 118.759361 
@@ -4282,7 +4282,7 @@ L 206.45578 118.267903
 L 206.45578 118.256924 
 L 206.45578 118.245942 
 L 206.45578 118.234957 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_128">
     <path d="M 206.45578 118.234957 
@@ -4334,7 +4334,7 @@ L 173.935517 133.247721
 L 173.212844 133.532808 
 L 172.490172 133.816191 
 L 171.767499 134.097889 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_129">
     <path d="M 171.767499 134.097889 
@@ -4386,7 +4386,7 @@ L 164.056872 144.068227
 L 163.885524 144.267619 
 L 163.714177 144.466175 
 L 163.54283 144.663903 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_130">
     <path d="M 163.54283 144.663903 
@@ -4438,7 +4438,7 @@ L 160.385378 151.105499
 L 160.315212 151.239156 
 L 160.245047 151.372438 
 L 160.174881 151.505345 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_131">
     <path d="M 160.174881 151.505345 
@@ -4490,7 +4490,7 @@ L 154.553946 168.367127
 L 154.429036 168.681387 
 L 154.304126 168.993578 
 L 154.179217 169.303726 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_132">
     <path d="M 154.179217 169.303726 
@@ -4542,11 +4542,11 @@ L 152.549264 178.054798
 L 152.513043 178.232038 
 L 152.476822 178.408618 
 L 152.4406 178.584542 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_133">
     <defs>
-     <path id="m186a731b9e" d="M 0 -2.5 
+     <path id="m61177637be" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -4555,16 +4555,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pa93c90c411)">
-     <use xlink:href="#m186a731b9e" x="610.467188" y="172.829682" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m186a731b9e" x="592.067397" y="173.763838" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m186a731b9e" x="534.807821" y="180.385179" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m186a731b9e" x="327.802209" y="176.172104" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m186a731b9e" x="275.83761" y="186.734601" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m186a731b9e" x="258.25125" y="198.783148" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m186a731b9e" x="256.777056" y="203.737732" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m186a731b9e" x="248.769854" y="217.74136" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m186a731b9e" x="246.264594" y="227.740017" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pd4f8ac3ff4)">
+     <use xlink:href="#m61177637be" x="610.467188" y="172.829682" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m61177637be" x="592.067397" y="173.763838" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m61177637be" x="534.807821" y="180.385179" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m61177637be" x="327.802209" y="176.172104" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m61177637be" x="275.83761" y="186.734601" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m61177637be" x="258.25125" y="198.783148" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m61177637be" x="256.777056" y="203.737732" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m61177637be" x="248.769854" y="217.74136" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m61177637be" x="246.264594" y="227.740017" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_134">
@@ -4617,7 +4617,7 @@ L 593.217384 173.705989
 L 592.834055 173.72528 
 L 592.450726 173.744563 
 L 592.067397 173.763838 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_135">
     <path d="M 592.067397 173.763838 
@@ -4669,7 +4669,7 @@ L 538.386544 179.997367
 L 537.193636 180.126991 
 L 536.000728 180.25626 
 L 534.807821 180.385179 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_136">
     <path d="M 534.807821 180.385179 
@@ -4721,7 +4721,7 @@ L 340.74006 176.446681
 L 336.427443 176.355332 
 L 332.114826 176.263806 
 L 327.802209 176.172104 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_137">
     <path d="M 327.802209 176.172104 
@@ -4773,7 +4773,7 @@ L 279.085397 186.139102
 L 278.002801 186.338434 
 L 276.920205 186.536931 
 L 275.83761 186.734601 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_138">
     <path d="M 275.83761 186.734601 
@@ -4825,7 +4825,7 @@ L 259.350398 198.113494
 L 258.984015 198.337765 
 L 258.617633 198.560979 
 L 258.25125 198.783148 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_139">
     <path d="M 258.25125 198.783148 
@@ -4877,7 +4877,7 @@ L 256.869193 203.442789
 L 256.838481 203.541307 
 L 256.807768 203.639621 
 L 256.777056 203.737732 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_140">
     <path d="M 256.777056 203.737732 
@@ -4929,7 +4929,7 @@ L 249.270304 216.977455
 L 249.103487 217.23346 
 L 248.93667 217.48809 
 L 248.769854 217.74136 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_141">
     <path d="M 248.769854 217.74136 
@@ -4981,7 +4981,7 @@ L 246.421172 227.173237
 L 246.368979 227.362918 
 L 246.316786 227.551842 
 L 246.264594 227.740017 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="legend_1">
     <g id="patch_7">
@@ -4999,7 +4999,7 @@ z
     </g>
     <g id="line2d_142">
      <defs>
-      <path id="m368a0b380d" d="M 0 3.5 
+      <path id="m69164307c2" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -5012,7 +5012,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m368a0b380d" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m69164307c2" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -5071,7 +5071,7 @@ z
     </g>
     <g id="line2d_143">
      <g>
-      <use xlink:href="#m2e38fef57b" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m4bd3f42fa6" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -5085,7 +5085,7 @@ z
     </g>
     <g id="line2d_144">
      <g>
-      <use xlink:href="#m98c195fde7" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mbf51c307e4" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -5130,7 +5130,7 @@ z
     </g>
     <g id="line2d_145">
      <g>
-      <use xlink:href="#me47f981e49" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m12d2789ad8" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -5173,7 +5173,7 @@ z
     </g>
     <g id="line2d_146">
      <g>
-      <use xlink:href="#med6a60f151" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m3a6df921f4" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -5189,7 +5189,7 @@ z
     </g>
     <g id="line2d_147">
      <g>
-      <use xlink:href="#mb6e0298424" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#ma030b73396" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -5243,7 +5243,7 @@ z
     </g>
     <g id="line2d_148">
      <g>
-      <use xlink:href="#m9b4e721c73" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#ma1efacaabd" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -5308,7 +5308,7 @@ z
     </g>
     <g id="line2d_149">
      <g>
-      <use xlink:href="#mf88fb2684f" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#m8d60b354a1" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -5346,7 +5346,7 @@ z
     </g>
     <g id="line2d_150">
      <g>
-      <use xlink:href="#m186a731b9e" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m61177637be" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -5416,486 +5416,486 @@ z
     </g>
    </g>
    <g id="line2d_151">
-    <g clip-path="url(#pa93c90c411)">
-     <use xlink:href="#m368a0b380d" x="289.783126" y="144.387822" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m368a0b380d" x="223.847406" y="152.598403" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m368a0b380d" x="212.445767" y="156.86178" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m368a0b380d" x="181.367844" y="168.544499" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m368a0b380d" x="165.308999" y="177.922091" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m368a0b380d" x="160.074948" y="184.567562" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m368a0b380d" x="157.029538" y="187.747619" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m368a0b380d" x="149.72506" y="196.670382" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m368a0b380d" x="115.00257" y="273.714295" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m368a0b380d" x="99.775489" y="299.492401" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <g clip-path="url(#pd4f8ac3ff4)">
+     <use xlink:href="#m69164307c2" x="289.783126" y="144.898227" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m69164307c2" x="232.839775" y="149.541048" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m69164307c2" x="214.084819" y="154.335086" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m69164307c2" x="181.367844" y="168.499456" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m69164307c2" x="165.308999" y="177.801988" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m69164307c2" x="160.074948" y="184.44614" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m69164307c2" x="157.029538" y="187.485009" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m69164307c2" x="149.72506" y="196.499138" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m69164307c2" x="115.00257" y="274.312598" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m69164307c2" x="99.775489" y="300.355151" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
    <g id="line2d_152">
-    <path d="M 289.783126 144.387822 
-L 288.409466 144.574218 
-L 287.035805 144.759883 
-L 285.662144 144.944825 
-L 284.288483 145.129047 
-L 282.914822 145.312556 
-L 281.541161 145.495358 
-L 280.167501 145.677457 
-L 278.79384 145.858859 
-L 277.420179 146.03957 
-L 276.046518 146.219594 
-L 274.672857 146.398938 
-L 273.299196 146.577605 
-L 271.925536 146.755601 
-L 270.551875 146.932931 
-L 269.178214 147.1096 
-L 267.804553 147.285614 
-L 266.430892 147.460976 
-L 265.057231 147.635691 
-L 263.68357 147.809765 
-L 262.30991 147.983202 
-L 260.936249 148.156007 
-L 259.562588 148.328184 
-L 258.188927 148.499738 
-L 256.815266 148.670673 
-L 255.441605 148.840994 
-L 254.067945 149.010705 
-L 252.694284 149.179811 
-L 251.320623 149.348315 
-L 249.946962 149.516223 
-L 248.573301 149.683538 
-L 247.19964 149.850264 
-L 245.82598 150.016406 
-L 244.452319 150.181968 
-L 243.078658 150.346953 
-L 241.704997 150.511366 
-L 240.331336 150.675211 
-L 238.957675 150.838491 
-L 237.584015 151.001211 
-L 236.210354 151.163374 
-L 234.836693 151.324984 
-L 233.463032 151.486045 
-L 232.089371 151.64656 
-L 230.71571 151.806534 
-L 229.34205 151.96597 
-L 227.968389 152.124871 
-L 226.594728 152.283241 
-L 225.221067 152.441084 
-L 223.847406 152.598403 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 289.783126 144.898227 
+L 288.596807 144.999739 
+L 287.410487 145.101035 
+L 286.224167 145.202114 
+L 285.037847 145.302979 
+L 283.851527 145.403629 
+L 282.665207 145.504066 
+L 281.478888 145.60429 
+L 280.292568 145.704303 
+L 279.106248 145.804106 
+L 277.919928 145.903699 
+L 276.733608 146.003083 
+L 275.547289 146.102259 
+L 274.360969 146.201227 
+L 273.174649 146.29999 
+L 271.988329 146.398548 
+L 270.802009 146.4969 
+L 269.615689 146.59505 
+L 268.42937 146.692996 
+L 267.24305 146.79074 
+L 266.05673 146.888284 
+L 264.87041 146.985626 
+L 263.68409 147.08277 
+L 262.49777 147.179715 
+L 261.311451 147.276461 
+L 260.125131 147.373011 
+L 258.938811 147.469365 
+L 257.752491 147.565523 
+L 256.566171 147.661486 
+L 255.379852 147.757256 
+L 254.193532 147.852832 
+L 253.007212 147.948216 
+L 251.820892 148.043408 
+L 250.634572 148.13841 
+L 249.448252 148.233222 
+L 248.261933 148.327844 
+L 247.075613 148.422278 
+L 245.889293 148.516524 
+L 244.702973 148.610583 
+L 243.516653 148.704456 
+L 242.330333 148.798143 
+L 241.144014 148.891645 
+L 239.957694 148.984964 
+L 238.771374 149.078099 
+L 237.585054 149.171051 
+L 236.398734 149.263821 
+L 235.212415 149.356411 
+L 234.026095 149.448819 
+L 232.839775 149.541048 
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_153">
-    <path d="M 223.847406 152.598403 
-L 223.609872 152.691249 
-L 223.372338 152.783914 
-L 223.134804 152.876398 
-L 222.89727 152.968702 
-L 222.659735 153.060827 
-L 222.422201 153.152773 
-L 222.184667 153.244541 
-L 221.947133 153.336131 
-L 221.709599 153.427545 
-L 221.472065 153.518783 
-L 221.23453 153.609846 
-L 220.996996 153.700734 
-L 220.759462 153.791448 
-L 220.521928 153.881989 
-L 220.284394 153.972357 
-L 220.04686 154.062553 
-L 219.809325 154.152578 
-L 219.571791 154.242432 
-L 219.334257 154.332116 
-L 219.096723 154.421631 
-L 218.859189 154.510977 
-L 218.621655 154.600156 
-L 218.38412 154.689166 
-L 218.146586 154.77801 
-L 217.909052 154.866687 
-L 217.671518 154.955199 
-L 217.433984 155.043546 
-L 217.19645 155.131729 
-L 216.958916 155.219748 
-L 216.721381 155.307603 
-L 216.483847 155.395296 
-L 216.246313 155.482828 
-L 216.008779 155.570197 
-L 215.771245 155.657406 
-L 215.533711 155.744455 
-L 215.296176 155.831345 
-L 215.058642 155.918075 
-L 214.821108 156.004647 
-L 214.583574 156.091061 
-L 214.34604 156.177318 
-L 214.108506 156.263418 
-L 213.870971 156.349362 
-L 213.633437 156.435151 
-L 213.395903 156.520784 
-L 213.158369 156.606263 
-L 212.920835 156.691589 
-L 212.683301 156.776761 
-L 212.445767 156.86178 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 232.839775 149.541048 
+L 232.449047 149.646033 
+L 232.058318 149.750786 
+L 231.66759 149.855308 
+L 231.276862 149.9596 
+L 230.886134 150.063663 
+L 230.495405 150.167498 
+L 230.104677 150.271106 
+L 229.713949 150.374488 
+L 229.323221 150.477645 
+L 228.932492 150.580578 
+L 228.541764 150.683288 
+L 228.151036 150.785776 
+L 227.760308 150.888043 
+L 227.369579 150.990089 
+L 226.978851 151.091917 
+L 226.588123 151.193526 
+L 226.197395 151.294918 
+L 225.806666 151.396093 
+L 225.415938 151.497053 
+L 225.02521 151.597798 
+L 224.634482 151.69833 
+L 224.243753 151.798648 
+L 223.853025 151.898755 
+L 223.462297 151.998651 
+L 223.071569 152.098337 
+L 222.68084 152.197814 
+L 222.290112 152.297082 
+L 221.899384 152.396143 
+L 221.508656 152.494997 
+L 221.117927 152.593645 
+L 220.727199 152.692089 
+L 220.336471 152.790329 
+L 219.945743 152.888365 
+L 219.555014 152.986199 
+L 219.164286 153.083831 
+L 218.773558 153.181263 
+L 218.38283 153.278495 
+L 217.992101 153.375528 
+L 217.601373 153.472363 
+L 217.210645 153.569 
+L 216.819917 153.665441 
+L 216.429188 153.761685 
+L 216.03846 153.857735 
+L 215.647732 153.953591 
+L 215.257004 154.049253 
+L 214.866275 154.144722 
+L 214.475547 154.24 
+L 214.084819 154.335086 
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_154">
-    <path d="M 212.445767 156.86178 
-L 211.79831 157.136988 
-L 211.150853 157.410608 
-L 210.503396 157.682657 
-L 209.85594 157.953154 
-L 209.208483 158.222116 
-L 208.561026 158.48956 
-L 207.913569 158.755504 
-L 207.266113 159.019963 
-L 206.618656 159.282956 
-L 205.971199 159.544497 
-L 205.323743 159.804603 
-L 204.676286 160.06329 
-L 204.028829 160.320572 
-L 203.381372 160.576465 
-L 202.733916 160.830985 
-L 202.086459 161.084145 
-L 201.439002 161.335959 
-L 200.791546 161.586444 
-L 200.144089 161.835611 
-L 199.496632 162.083475 
-L 198.849175 162.330051 
-L 198.201719 162.575349 
-L 197.554262 162.819385 
-L 196.906805 163.062171 
-L 196.259348 163.30372 
-L 195.611892 163.544044 
-L 194.964435 163.783156 
-L 194.316978 164.021067 
-L 193.669522 164.257791 
-L 193.022065 164.493338 
-L 192.374608 164.72772 
-L 191.727151 164.960948 
-L 191.079695 165.193035 
-L 190.432238 165.423991 
-L 189.784781 165.653827 
-L 189.137324 165.882554 
-L 188.489868 166.110183 
-L 187.842411 166.336724 
-L 187.194954 166.562187 
-L 186.547498 166.786582 
-L 185.900041 167.009921 
-L 185.252584 167.232211 
-L 184.605127 167.453465 
-L 183.957671 167.67369 
-L 183.310214 167.892897 
-L 182.662757 168.111094 
-L 182.015301 168.328292 
-L 181.367844 168.544499 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 214.084819 154.335086 
+L 213.403215 154.677767 
+L 212.721611 155.017989 
+L 212.040008 155.355786 
+L 211.358404 155.691193 
+L 210.676801 156.024243 
+L 209.995197 156.354969 
+L 209.313593 156.683404 
+L 208.63199 157.009578 
+L 207.950386 157.333524 
+L 207.268782 157.65527 
+L 206.587179 157.974847 
+L 205.905575 158.292283 
+L 205.223971 158.607608 
+L 204.542368 158.920849 
+L 203.860764 159.232034 
+L 203.17916 159.541188 
+L 202.497557 159.84834 
+L 201.815953 160.153514 
+L 201.13435 160.456735 
+L 200.452746 160.75803 
+L 199.771142 161.057421 
+L 199.089539 161.354932 
+L 198.407935 161.650589 
+L 197.726331 161.944412 
+L 197.044728 162.236425 
+L 196.363124 162.52665 
+L 195.68152 162.815109 
+L 194.999917 163.101823 
+L 194.318313 163.386813 
+L 193.636709 163.6701 
+L 192.955106 163.951704 
+L 192.273502 164.231644 
+L 191.591898 164.509941 
+L 190.910295 164.786614 
+L 190.228691 165.06168 
+L 189.547088 165.33516 
+L 188.865484 165.607071 
+L 188.18388 165.877431 
+L 187.502277 166.146258 
+L 186.820673 166.413568 
+L 186.139069 166.67938 
+L 185.457466 166.943709 
+L 184.775862 167.206572 
+L 184.094258 167.467986 
+L 183.412655 167.727965 
+L 182.731051 167.986527 
+L 182.049447 168.243685 
+L 181.367844 168.499456 
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_155">
-    <path d="M 181.367844 168.544499 
-L 181.033285 168.760041 
-L 180.698725 168.974607 
-L 180.364166 169.188206 
-L 180.029607 169.400847 
-L 179.695047 169.612539 
-L 179.360488 169.823289 
-L 179.025929 170.033106 
-L 178.69137 170.241998 
-L 178.35681 170.449974 
-L 178.022251 170.657041 
-L 177.687692 170.863208 
-L 177.353133 171.068482 
-L 177.018573 171.27287 
-L 176.684014 171.476381 
-L 176.349455 171.679022 
-L 176.014895 171.880801 
-L 175.680336 172.081724 
-L 175.345777 172.281798 
-L 175.011218 172.481032 
-L 174.676658 172.679432 
-L 174.342099 172.877005 
-L 174.00754 173.073758 
-L 173.672981 173.269697 
-L 173.338421 173.46483 
-L 173.003862 173.659163 
-L 172.669303 173.852702 
-L 172.334743 174.045455 
-L 172.000184 174.237426 
-L 171.665625 174.428623 
-L 171.331066 174.619052 
-L 170.996506 174.80872 
-L 170.661947 174.997631 
-L 170.327388 175.185792 
-L 169.992829 175.373209 
-L 169.658269 175.559888 
-L 169.32371 175.745835 
-L 168.989151 175.931055 
-L 168.654591 176.115554 
-L 168.320032 176.299338 
-L 167.985473 176.482412 
-L 167.650914 176.664781 
-L 167.316354 176.846452 
-L 166.981795 177.027429 
-L 166.647236 177.207717 
-L 166.312676 177.387322 
-L 165.978117 177.56625 
-L 165.643558 177.744504 
-L 165.308999 177.922091 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 181.367844 168.499456 
+L 181.033285 168.713102 
+L 180.698725 168.92579 
+L 180.364166 169.137527 
+L 180.029607 169.348323 
+L 179.695047 169.558185 
+L 179.360488 169.767123 
+L 179.025929 169.975143 
+L 178.69137 170.182254 
+L 178.35681 170.388464 
+L 178.022251 170.593782 
+L 177.687692 170.798213 
+L 177.353133 171.001767 
+L 177.018573 171.20445 
+L 176.684014 171.40627 
+L 176.349455 171.607235 
+L 176.014895 171.807351 
+L 175.680336 172.006625 
+L 175.345777 172.205066 
+L 175.011218 172.402679 
+L 174.676658 172.599471 
+L 174.342099 172.79545 
+L 174.00754 172.990622 
+L 173.672981 173.184994 
+L 173.338421 173.378572 
+L 173.003862 173.571362 
+L 172.669303 173.763372 
+L 172.334743 173.954606 
+L 172.000184 174.145073 
+L 171.665625 174.334777 
+L 171.331066 174.523725 
+L 170.996506 174.711922 
+L 170.661947 174.899376 
+L 170.327388 175.08609 
+L 169.992829 175.272073 
+L 169.658269 175.457328 
+L 169.32371 175.641862 
+L 168.989151 175.825681 
+L 168.654591 176.008789 
+L 168.320032 176.191193 
+L 167.985473 176.372897 
+L 167.650914 176.553908 
+L 167.316354 176.73423 
+L 166.981795 176.913868 
+L 166.647236 177.092828 
+L 166.312676 177.271116 
+L 165.978117 177.448735 
+L 165.643558 177.625691 
+L 165.308999 177.801988 
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_156">
-    <path d="M 165.308999 177.922091 
-L 165.199956 178.070481 
-L 165.090913 178.218408 
-L 164.98187 178.365875 
-L 164.872828 178.512884 
-L 164.763785 178.659439 
-L 164.654742 178.805542 
-L 164.5457 178.951196 
-L 164.436657 179.096404 
-L 164.327614 179.241168 
-L 164.218571 179.385492 
-L 164.109529 179.529378 
-L 164.000486 179.672828 
-L 163.891443 179.815845 
-L 163.782401 179.958432 
-L 163.673358 180.100591 
-L 163.564315 180.242326 
-L 163.455272 180.383637 
-L 163.34623 180.524529 
-L 163.237187 180.665003 
-L 163.128144 180.805062 
-L 163.019101 180.944708 
-L 162.910059 181.083945 
-L 162.801016 181.222773 
-L 162.691973 181.361196 
-L 162.582931 181.499216 
-L 162.473888 181.636835 
-L 162.364845 181.774055 
-L 162.255802 181.91088 
-L 162.14676 182.047311 
-L 162.037717 182.18335 
-L 161.928674 182.319 
-L 161.819631 182.454263 
-L 161.710589 182.58914 
-L 161.601546 182.723636 
-L 161.492503 182.85775 
-L 161.383461 182.991486 
-L 161.274418 183.124846 
-L 161.165375 183.257832 
-L 161.056332 183.390446 
-L 160.94729 183.522689 
-L 160.838247 183.654565 
-L 160.729204 183.786075 
-L 160.620161 183.917221 
-L 160.511119 184.048005 
-L 160.402076 184.178429 
-L 160.293033 184.308496 
-L 160.183991 184.438206 
-L 160.074948 184.567562 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 165.308999 177.801988 
+L 165.199956 177.950347 
+L 165.090913 178.098242 
+L 164.98187 178.245678 
+L 164.872828 178.392656 
+L 164.763785 178.539181 
+L 164.654742 178.685253 
+L 164.5457 178.830877 
+L 164.436657 178.976054 
+L 164.327614 179.120789 
+L 164.218571 179.265083 
+L 164.109529 179.408939 
+L 164.000486 179.552359 
+L 163.891443 179.695347 
+L 163.782401 179.837905 
+L 163.673358 179.980035 
+L 163.564315 180.121741 
+L 163.455272 180.263024 
+L 163.34623 180.403887 
+L 163.237187 180.544333 
+L 163.128144 180.684364 
+L 163.019101 180.823982 
+L 162.910059 180.963191 
+L 162.801016 181.101991 
+L 162.691973 181.240387 
+L 162.582931 181.378379 
+L 162.473888 181.515971 
+L 162.364845 181.653165 
+L 162.255802 181.789963 
+L 162.14676 181.926367 
+L 162.037717 182.06238 
+L 161.928674 182.198003 
+L 161.819631 182.33324 
+L 161.710589 182.468091 
+L 161.601546 182.602561 
+L 161.492503 182.736649 
+L 161.383461 182.87036 
+L 161.274418 183.003694 
+L 161.165375 183.136655 
+L 161.056332 183.269243 
+L 160.94729 183.401462 
+L 160.838247 183.533313 
+L 160.729204 183.664798 
+L 160.620161 183.795919 
+L 160.511119 183.926679 
+L 160.402076 184.057079 
+L 160.293033 184.187121 
+L 160.183991 184.316807 
+L 160.074948 184.44614 
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_157">
-    <path d="M 160.074948 184.567562 
-L 160.011502 184.636037 
-L 159.948056 184.704413 
-L 159.88461 184.77269 
-L 159.821164 184.84087 
-L 159.757718 184.908951 
-L 159.694272 184.976935 
-L 159.630826 185.044821 
-L 159.56738 185.11261 
-L 159.503933 185.180302 
-L 159.440487 185.247898 
-L 159.377041 185.315398 
-L 159.313595 185.382801 
-L 159.250149 185.450109 
-L 159.186703 185.517321 
-L 159.123257 185.584439 
-L 159.059811 185.651461 
-L 158.996365 185.718389 
-L 158.932919 185.785222 
-L 158.869473 185.851961 
-L 158.806027 185.918607 
-L 158.742581 185.985158 
-L 158.679135 186.051617 
-L 158.615689 186.117982 
-L 158.552243 186.184255 
-L 158.488797 186.250435 
-L 158.425351 186.316523 
-L 158.361905 186.382519 
-L 158.298459 186.448423 
-L 158.235013 186.514235 
-L 158.171567 186.579957 
-L 158.108121 186.645587 
-L 158.044675 186.711126 
-L 157.981229 186.776576 
-L 157.917783 186.841934 
-L 157.854337 186.907203 
-L 157.790891 186.972382 
-L 157.727444 187.037472 
-L 157.663998 187.102472 
-L 157.600552 187.167383 
-L 157.537106 187.232206 
-L 157.47366 187.29694 
-L 157.410214 187.361585 
-L 157.346768 187.426143 
-L 157.283322 187.490613 
-L 157.219876 187.554995 
-L 157.15643 187.61929 
-L 157.092984 187.683498 
-L 157.029538 187.747619 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 160.074948 184.44614 
+L 160.011502 184.511478 
+L 159.948056 184.576726 
+L 159.88461 184.641885 
+L 159.821164 184.706954 
+L 159.757718 184.771934 
+L 159.694272 184.836825 
+L 159.630826 184.901627 
+L 159.56738 184.966341 
+L 159.503933 185.030967 
+L 159.440487 185.095504 
+L 159.377041 185.159954 
+L 159.313595 185.224317 
+L 159.250149 185.288592 
+L 159.186703 185.35278 
+L 159.123257 185.416881 
+L 159.059811 185.480896 
+L 158.996365 185.544824 
+L 158.932919 185.608666 
+L 158.869473 185.672422 
+L 158.806027 185.736093 
+L 158.742581 185.799678 
+L 158.679135 185.863178 
+L 158.615689 185.926593 
+L 158.552243 185.989924 
+L 158.488797 186.05317 
+L 158.425351 186.116331 
+L 158.361905 186.179409 
+L 158.298459 186.242403 
+L 158.235013 186.305313 
+L 158.171567 186.36814 
+L 158.108121 186.430883 
+L 158.044675 186.493544 
+L 157.981229 186.556122 
+L 157.917783 186.618617 
+L 157.854337 186.68103 
+L 157.790891 186.743361 
+L 157.727444 186.80561 
+L 157.663998 186.867778 
+L 157.600552 186.929864 
+L 157.537106 186.991869 
+L 157.47366 187.053793 
+L 157.410214 187.115636 
+L 157.346768 187.177398 
+L 157.283322 187.23908 
+L 157.219876 187.300682 
+L 157.15643 187.362204 
+L 157.092984 187.423646 
+L 157.029538 187.485009 
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_158">
-    <path d="M 157.029538 187.747619 
-L 156.877361 187.951718 
-L 156.725185 188.154942 
-L 156.573008 188.357299 
-L 156.420832 188.558795 
-L 156.268655 188.759439 
-L 156.116478 188.959236 
-L 155.964302 189.158195 
-L 155.812125 189.356322 
-L 155.659949 189.553625 
-L 155.507772 189.75011 
-L 155.355595 189.945783 
-L 155.203419 190.140652 
-L 155.051242 190.334724 
-L 154.899065 190.528003 
-L 154.746889 190.720498 
-L 154.594712 190.912215 
-L 154.442536 191.103159 
-L 154.290359 191.293336 
-L 154.138182 191.482754 
-L 153.986006 191.671418 
-L 153.833829 191.859334 
-L 153.681652 192.046508 
-L 153.529476 192.232946 
-L 153.377299 192.418653 
-L 153.225123 192.603635 
-L 153.072946 192.787899 
-L 152.920769 192.971448 
-L 152.768593 193.15429 
-L 152.616416 193.336429 
-L 152.46424 193.517871 
-L 152.312063 193.698621 
-L 152.159886 193.878685 
-L 152.00771 194.058066 
-L 151.855533 194.236772 
-L 151.703356 194.414806 
-L 151.55118 194.592175 
-L 151.399003 194.768881 
-L 151.246827 194.944932 
-L 151.09465 195.120331 
-L 150.942473 195.295084 
-L 150.790297 195.469194 
-L 150.63812 195.642667 
-L 150.485943 195.815508 
-L 150.333767 195.987721 
-L 150.18159 196.15931 
-L 150.029414 196.33028 
-L 149.877237 196.500636 
-L 149.72506 196.670382 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 157.029538 187.485009 
+L 156.877361 187.691398 
+L 156.725185 187.896893 
+L 156.573008 188.1015 
+L 156.420832 188.305228 
+L 156.268655 188.508084 
+L 156.116478 188.710076 
+L 155.964302 188.91121 
+L 155.812125 189.111495 
+L 155.659949 189.310937 
+L 155.507772 189.509543 
+L 155.355595 189.70732 
+L 155.203419 189.904276 
+L 155.051242 190.100416 
+L 154.899065 190.295749 
+L 154.746889 190.490279 
+L 154.594712 190.684015 
+L 154.442536 190.876962 
+L 154.290359 191.069126 
+L 154.138182 191.260515 
+L 153.986006 191.451134 
+L 153.833829 191.640989 
+L 153.681652 191.830087 
+L 153.529476 192.018434 
+L 153.377299 192.206035 
+L 153.225123 192.392897 
+L 153.072946 192.579025 
+L 152.920769 192.764424 
+L 152.768593 192.949102 
+L 152.616416 193.133062 
+L 152.46424 193.316312 
+L 152.312063 193.498856 
+L 152.159886 193.680699 
+L 152.00771 193.861847 
+L 151.855533 194.042306 
+L 151.703356 194.22208 
+L 151.55118 194.401175 
+L 151.399003 194.579596 
+L 151.246827 194.757348 
+L 151.09465 194.934436 
+L 150.942473 195.110864 
+L 150.790297 195.286639 
+L 150.63812 195.461763 
+L 150.485943 195.636244 
+L 150.333767 195.810084 
+L 150.18159 195.983289 
+L 150.029414 196.155863 
+L 149.877237 196.327811 
+L 149.72506 196.499138 
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_159">
-    <path d="M 149.72506 196.670382 
-L 149.001675 200.537761 
-L 148.27829 204.113258 
-L 147.554905 207.437856 
-L 146.831519 210.54447 
-L 146.108134 213.459935 
-L 145.384749 216.206416 
-L 144.661364 218.802434 
-L 143.937979 221.263622 
-L 143.214593 223.603297 
-L 142.491208 225.832894 
-L 141.767823 227.962308 
-L 141.044438 230.000157 
-L 140.321052 231.953991 
-L 139.597667 233.830464 
-L 138.874282 235.63547 
-L 138.150897 237.374253 
-L 137.427512 239.051501 
-L 136.704126 240.671422 
-L 135.980741 242.237804 
-L 135.257356 243.754074 
-L 134.533971 245.223339 
-L 133.810585 246.648426 
-L 133.0872 248.031915 
-L 132.363815 249.376164 
-L 131.64043 250.683339 
-L 130.917045 251.95543 
-L 130.193659 253.194271 
-L 129.470274 254.401557 
-L 128.746889 255.578853 
-L 128.023504 256.727616 
-L 127.300118 257.849195 
-L 126.576733 258.944846 
-L 125.853348 260.015742 
-L 125.129963 261.062977 
-L 124.406577 262.087573 
-L 123.683192 263.090489 
-L 122.959807 264.072624 
-L 122.236422 265.03482 
-L 121.513037 265.977872 
-L 120.789651 266.902526 
-L 120.066266 267.809487 
-L 119.342881 268.699418 
-L 118.619496 269.572949 
-L 117.89611 270.430671 
-L 117.172725 271.273148 
-L 116.44934 272.100912 
-L 115.725955 272.914468 
-L 115.00257 273.714295 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 149.72506 196.499138 
+L 149.001675 200.442141 
+L 148.27829 204.082177 
+L 147.554905 207.4625 
+L 146.831519 210.617715 
+L 146.108134 213.575941 
+L 145.384749 216.360337 
+L 144.661364 218.990202 
+L 143.937979 221.481791 
+L 143.214593 223.848922 
+L 142.491208 226.103438 
+L 141.767823 228.255571 
+L 141.044438 230.314216 
+L 140.321052 232.287158 
+L 139.597667 234.18125 
+L 138.874282 236.002552 
+L 138.150897 237.756453 
+L 137.427512 239.447763 
+L 136.704126 241.080796 
+L 135.980741 242.659436 
+L 135.257356 244.187188 
+L 134.533971 245.667233 
+L 133.810585 247.102458 
+L 133.0872 248.495499 
+L 132.363815 249.848766 
+L 131.64043 251.164466 
+L 130.917045 252.444629 
+L 130.193659 253.691124 
+L 129.470274 254.905677 
+L 128.746889 256.089885 
+L 128.023504 257.245226 
+L 127.300118 258.373074 
+L 126.576733 259.474709 
+L 125.853348 260.55132 
+L 125.129963 261.604019 
+L 124.406577 262.633845 
+L 123.683192 263.641772 
+L 122.959807 264.62871 
+L 122.236422 265.595518 
+L 121.513037 266.542998 
+L 120.789651 267.47191 
+L 120.066266 268.382966 
+L 119.342881 269.276841 
+L 118.619496 270.15417 
+L 117.89611 271.015554 
+L 117.172725 271.861564 
+L 116.44934 272.692738 
+L 115.725955 273.509588 
+L 115.00257 274.312598 
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_160">
-    <path d="M 115.00257 273.714295 
-L 114.685339 274.422561 
-L 114.368108 275.1204 
-L 114.050877 275.808113 
-L 113.733646 276.485991 
-L 113.416415 277.15431 
-L 113.099184 277.813337 
-L 112.781954 278.463327 
-L 112.464723 279.104524 
-L 112.147492 279.737163 
-L 111.830261 280.361468 
-L 111.51303 280.977658 
-L 111.195799 281.58594 
-L 110.878569 282.186514 
-L 110.561338 282.779574 
-L 110.244107 283.365305 
-L 109.926876 283.943886 
-L 109.609645 284.51549 
-L 109.292414 285.080282 
-L 108.975184 285.638424 
-L 108.657953 286.19007 
-L 108.340722 286.735369 
-L 108.023491 287.274467 
-L 107.70626 287.807501 
-L 107.389029 288.334608 
-L 107.071799 288.855918 
-L 106.754568 289.371556 
-L 106.437337 289.881646 
-L 106.120106 290.386304 
-L 105.802875 290.885646 
-L 105.485644 291.379782 
-L 105.168414 291.868819 
-L 104.851183 292.352863 
-L 104.533952 292.832013 
-L 104.216721 293.306368 
-L 103.89949 293.776023 
-L 103.582259 294.24107 
-L 103.265028 294.701599 
-L 102.947798 295.157696 
-L 102.630567 295.609446 
-L 102.313336 296.056931 
-L 101.996105 296.500231 
-L 101.678874 296.939423 
-L 101.361643 297.374583 
-L 101.044413 297.805784 
-L 100.727182 298.233098 
-L 100.409951 298.656594 
-L 100.09272 299.07634 
-L 99.775489 299.492401 
-" clip-path="url(#pa93c90c411)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 115.00257 274.312598 
+L 114.685339 275.030239 
+L 114.368108 275.737177 
+L 114.050877 276.433726 
+L 113.733646 277.120186 
+L 113.416415 277.796847 
+L 113.099184 278.463983 
+L 112.781954 279.12186 
+L 112.464723 279.770731 
+L 112.147492 280.410838 
+L 111.830261 281.042417 
+L 111.51303 281.66569 
+L 111.195799 282.280874 
+L 110.878569 282.888175 
+L 110.561338 283.487794 
+L 110.244107 284.079922 
+L 109.926876 284.664744 
+L 109.609645 285.242438 
+L 109.292414 285.813176 
+L 108.975184 286.377124 
+L 108.657953 286.93444 
+L 108.340722 287.48528 
+L 108.023491 288.029791 
+L 107.70626 288.568118 
+L 107.389029 289.1004 
+L 107.071799 289.626771 
+L 106.754568 290.147361 
+L 106.437337 290.662294 
+L 106.120106 291.171694 
+L 105.802875 291.675677 
+L 105.485644 292.174358 
+L 105.168414 292.667847 
+L 104.851183 293.156251 
+L 104.533952 293.639674 
+L 104.216721 294.118216 
+L 103.89949 294.591975 
+L 103.582259 295.061045 
+L 103.265028 295.525519 
+L 102.947798 295.985485 
+L 102.630567 296.441031 
+L 102.313336 296.89224 
+L 101.996105 297.339194 
+L 101.678874 297.781973 
+L 101.361643 298.220654 
+L 101.044413 298.655313 
+L 100.727182 299.086021 
+L 100.409951 299.512851 
+L 100.09272 299.935872 
+L 99.775489 300.355151 
+" clip-path="url(#pd4f8ac3ff4)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
   </g>
   <g id="text_25">
@@ -6254,8 +6254,8 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-07-09T17:31:54Z  ·  Linux chungus2 x86_64  ·  commit 324f086c  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(44.677578 465.66) scale(0.07 -0.07)">
+   <!-- 2026-07-10T04:34:01Z  ·  Linux chungus2 x86_64  ·  commit 74861182  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(43.380391 465.66) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -6265,36 +6265,6 @@ L 1172 0
 L 2766 4134 
 L 525 4134 
 L 525 4666 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-39" d="M 703 97 
-L 703 672 
-Q 941 559 1184 500 
-Q 1428 441 1663 441 
-Q 2288 441 2617 861 
-Q 2947 1281 2994 2138 
-Q 2813 1869 2534 1725 
-Q 2256 1581 1919 1581 
-Q 1219 1581 811 2004 
-Q 403 2428 403 3163 
-Q 403 3881 828 4315 
-Q 1253 4750 1959 4750 
-Q 2769 4750 3195 4129 
-Q 3622 3509 3622 2328 
-Q 3622 1225 3098 567 
-Q 2575 -91 1691 -91 
-Q 1453 -91 1209 -44 
-Q 966 3 703 97 
-z
-M 1959 2075 
-Q 2384 2075 2632 2365 
-Q 2881 2656 2881 3163 
-Q 2881 3666 2632 3958 
-Q 2384 4250 1959 4250 
-Q 1534 4250 1286 3958 
-Q 1038 3666 1038 3163 
-Q 1038 2656 1286 2365 
-Q 1534 2075 1959 2075 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-54" d="M -19 4666 
@@ -6319,31 +6289,6 @@ L 1409 3309
 L 1409 2516 
 L 750 2516 
 L 750 3309 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-b7" d="M 684 2619 
@@ -6440,17 +6385,17 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(290.576172 0)"/>
     <use xlink:href="#DejaVuSans-37" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(453.90625 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
     <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -6490,109 +6435,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3262.744141 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3297.949219 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3361.572266 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3425.195312 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3488.818359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3543.798828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3575.585938 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3607.373047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3639.160156 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3670.947266 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3702.734375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3730.517578 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3792.041016 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3853.320312 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3916.699219 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3980.175781 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4019.039062 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4080.220703 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4139.400391 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4200.923828 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4242.037109 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4275.728516 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4303.511719 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4365.035156 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4426.314453 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4489.693359 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4553.316406 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4587.007812 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4646.1875 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4709.810547 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4741.597656 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4805.220703 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4868.84375 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4900.630859 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4964.253906 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5000.337891 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5039.201172 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5094.181641 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5157.804688 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5189.591797 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5221.378906 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5253.166016 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5284.953125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5316.740234 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5355.949219 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5419.328125 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5458.191406 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5519.373047 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5582.751953 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5646.228516 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5709.607422 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5773.083984 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5836.462891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5875.671875 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5907.458984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5991.248047 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6023.035156 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6120.447266 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6181.970703 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6245.447266 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6273.230469 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6334.509766 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6397.888672 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6429.675781 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6481.775391 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6545.154297 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6606.433594 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6669.910156 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6722.009766 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6785.388672 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6846.570312 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6885.779297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6919.470703 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6951.257812 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6992.371094 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7053.650391 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7092.859375 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7120.642578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7181.824219 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7213.611328 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7241.394531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7293.494141 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7325.28125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7388.757812 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7450.28125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7489.490234 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7551.013672 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7590.376953 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7687.789062 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7715.572266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7778.951172 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7806.734375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7858.833984 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7898.042969 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7925.826172 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3262.744141 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3326.367188 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3389.990234 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3453.613281 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3517.236328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3580.859375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3612.646484 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3644.433594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3676.220703 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3708.007812 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3739.794922 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3767.578125 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3829.101562 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3890.380859 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3953.759766 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4017.236328 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4056.099609 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4117.28125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4176.460938 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4237.984375 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4279.097656 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4312.789062 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4340.572266 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4402.095703 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4463.375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4526.753906 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4590.376953 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4624.068359 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4683.248047 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4746.871094 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4778.658203 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4842.28125 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4905.904297 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4937.691406 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(5001.314453 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5037.398438 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5076.261719 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5131.242188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5194.865234 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5226.652344 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5258.439453 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5290.226562 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5322.013672 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5353.800781 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5393.009766 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5456.388672 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5495.251953 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5556.433594 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5619.8125 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5683.289062 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5746.667969 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5810.144531 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5873.523438 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5912.732422 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5944.519531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6028.308594 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6060.095703 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6157.507812 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6219.03125 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6282.507812 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6310.291016 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6371.570312 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6434.949219 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6466.736328 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6518.835938 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6582.214844 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6643.494141 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6706.970703 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6759.070312 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6822.449219 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6883.630859 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6922.839844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6956.53125 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6988.318359 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7029.431641 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7090.710938 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7129.919922 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7157.703125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7218.884766 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7250.671875 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7278.455078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7330.554688 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7362.341797 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7425.818359 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7487.341797 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7526.550781 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7588.074219 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7627.4375 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7724.849609 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7752.632812 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7816.011719 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7843.794922 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7895.894531 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7935.103516 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7962.886719 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pa93c90c411">
+  <clipPath id="pd4f8ac3ff4">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_ratio_heatmap.svg
+++ b/bench/graphs/canterbury_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#pce3af741db)">
+   <g clip-path="url(#p4f46414ad5)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAI/ElEQVR4nO3YwYqkVx2H4aqe7qZnxAFlEodZCu4kuMjG2bj2TnIFLsW91xG9AUFEdCOKGzfiTrILEmIyxnEmdNdUf+UlTIQT/lLv81zB71DU+V7OfvvXh6fduXn12fSCpU6fn9d5drvd7uOf/Gp6wlIf/fX19ITlfvSLH09PWG7/g/enJ6y1v5hesN7LT6YXrHfzeHrBUr/8zs+nJyx3hv8kAICvTgwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKTt746/Pk2PWO2026YnLLU/w2a9urienrDUYbudnrDc1d/+PD1hueP3n09PWOq4HaYnLPf6+HJ6wnJPzux6ePP4yfSE5c7vKwsA8D8QQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaZdXr7+Y3rDe3ZfTC9Y6bdML1nv4eHrBUtfTA74Gp5evpycsd/WfF9MTlrrajtMTlnt4jvfd7avpBUtdXZ7fjedlCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGn74/bb0/SI1U6nbXrCUtuZnWe32+2uLq6nJyx1fzpOT1juwasX0xPW++a70wuWerMdpics9/ntP6YnLPf07nJ6wlLbt55NT1jOyxAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkHb5l0//OL1huYvdfnrCUu88ejI9Ybn77Tg9YanrBzfTE5b74Pd/mJ6w3M9++L3pCUsdT9v0hOV++qe/T09Y7vmzb0xPWOqD955PT1jOyxAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDS9m/uf3OaHrHa4f52esJSD/c30xN4i8P+OD1huX/ffTY9Yblv3zydnrDUdtqmJyz3xd2n0xOWe3H3yfSEpb77+L3pCct5GQIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAEDaftt+d5oeAfwfOh6mF6x3eT29gLe4vf9yesJyNw8eTU/gLbwMAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIO1yd3+c3rDexZk13v7MzrPb7XZvbqcXrHVxOb1gucPFNj1huevpAaudzu83Om6H6QnL/fPwYnrCUu/cPJuesNwZfmUBAL46MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkPZfKmeKG6wY/4kAAAAASUVORK5CYII=" id="imagec337e14d61" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAI/ElEQVR4nO3YwYqkVx2H4aqe7qZnxAFlEodZCu4kuMjG2bj2TnIFLsW91xG9AUFEdCOKGzfiTrILEmIyxnEmdNdUf+UlTIQT/lLv81zB71DU+V7OfvvXh6fduXn12fSCpU6fn9d5drvd7uOf/Gp6wlIf/fX19ITlfvSLH09PWG7/g/enJ6y1v5hesN7LT6YXrHfzeHrBUr/8zs+nJyx3hv8kAICvTgwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKTt746/Pk2PWO2026YnLLU/w2a9urienrDUYbudnrDc1d/+PD1hueP3n09PWOq4HaYnLPf6+HJ6wnJPzux6ePP4yfSE5c7vKwsA8D8QQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaZdXr7+Y3rDe3ZfTC9Y6bdML1nv4eHrBUtfTA74Gp5evpycsd/WfF9MTlrrajtMTlnt4jvfd7avpBUtdXZ7fjedlCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGn74/bb0/SI1U6nbXrCUtuZnWe32+2uLq6nJyx1fzpOT1juwasX0xPW++a70wuWerMdpics9/ntP6YnLPf07nJ6wlLbt55NT1jOyxAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkHb5l0//OL1huYvdfnrCUu88ejI9Ybn77Tg9YanrBzfTE5b74Pd/mJ6w3M9++L3pCUsdT9v0hOV++qe/T09Y7vmzb0xPWOqD955PT1jOyxAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDS9m/uf3OaHrHa4f52esJSD/c30xN4i8P+OD1huX/ffTY9Yblv3zydnrDUdtqmJyz3xd2n0xOWe3H3yfSEpb77+L3pCct5GQIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAEDaftt+d5oeAfwfOh6mF6x3eT29gLe4vf9yesJyNw8eTU/gLbwMAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIO1yd3+c3rDexZk13v7MzrPb7XZvbqcXrHVxOb1gucPFNj1huevpAaudzu83Om6H6QnL/fPwYnrCUu/cPJuesNwZfmUBAL46MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkPZfKmeKG6wY/4kAAAAASUVORK5CYII=" id="image639cc7a85e" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m050ca7c316" d="M 0 0 
+       <path id="mfd636b5875" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m050ca7c316" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfd636b5875" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m050ca7c316" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfd636b5875" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m050ca7c316" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfd636b5875" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m050ca7c316" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfd636b5875" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m050ca7c316" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfd636b5875" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m050ca7c316" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfd636b5875" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m050ca7c316" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfd636b5875" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m050ca7c316" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfd636b5875" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m050ca7c316" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfd636b5875" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m050ca7c316" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfd636b5875" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m050ca7c316" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfd636b5875" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="me9a9fedfb0" d="M 0 0 
+       <path id="m44611011fe" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#me9a9fedfb0" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m44611011fe" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#me9a9fedfb0" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m44611011fe" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#me9a9fedfb0" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m44611011fe" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#me9a9fedfb0" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m44611011fe" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#me9a9fedfb0" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m44611011fe" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#me9a9fedfb0" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m44611011fe" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#me9a9fedfb0" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m44611011fe" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#me9a9fedfb0" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m44611011fe" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -2092,18 +2092,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="image8b65da8b18" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
+iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="image2ea34ea444" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="mb4983ae5c3" d="M 0 0 
+       <path id="m1d77b43dea" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mb4983ae5c3" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1d77b43dea" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
@@ -2129,7 +2129,7 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#mb4983ae5c3" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1d77b43dea" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
@@ -2146,7 +2146,7 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#mb4983ae5c3" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1d77b43dea" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
@@ -2163,7 +2163,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#mb4983ae5c3" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1d77b43dea" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
@@ -2180,7 +2180,7 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mb4983ae5c3" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1d77b43dea" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_112">
@@ -2196,7 +2196,7 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#mb4983ae5c3" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1d77b43dea" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
@@ -2212,7 +2212,7 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mb4983ae5c3" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1d77b43dea" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
@@ -2228,7 +2228,7 @@ z
     <g id="ytick_16">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#mb4983ae5c3" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1d77b43dea" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_115">
@@ -2244,7 +2244,7 @@ z
     <g id="ytick_17">
      <g id="line2d_28">
       <g>
-       <use xlink:href="#mb4983ae5c3" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1d77b43dea" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_116">
@@ -2882,8 +2882,8 @@ z
    </g>
   </g>
   <g id="text_119">
-   <!-- 2026-07-09T17:31:54Z  ·  Linux chungus2 x86_64  ·  commit 324f086c  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(17.677578 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-10T04:34:01Z  ·  Linux chungus2 x86_64  ·  commit 74861182  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(16.380391 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2949,17 +2949,17 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(290.576172 0)"/>
     <use xlink:href="#DejaVuSans-37" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(453.90625 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
     <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2999,109 +2999,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3262.744141 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3297.949219 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3361.572266 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3425.195312 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3488.818359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3543.798828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3575.585938 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3607.373047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3639.160156 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3670.947266 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3702.734375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3730.517578 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3792.041016 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3853.320312 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3916.699219 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3980.175781 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4019.039062 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4080.220703 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4139.400391 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4200.923828 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4242.037109 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4275.728516 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4303.511719 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4365.035156 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4426.314453 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4489.693359 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4553.316406 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4587.007812 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4646.1875 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4709.810547 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4741.597656 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4805.220703 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4868.84375 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4900.630859 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4964.253906 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5000.337891 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5039.201172 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5094.181641 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5157.804688 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5189.591797 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5221.378906 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5253.166016 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5284.953125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5316.740234 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5355.949219 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5419.328125 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5458.191406 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5519.373047 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5582.751953 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5646.228516 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5709.607422 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5773.083984 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5836.462891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5875.671875 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5907.458984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5991.248047 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6023.035156 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6120.447266 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6181.970703 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6245.447266 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6273.230469 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6334.509766 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6397.888672 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6429.675781 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6481.775391 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6545.154297 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6606.433594 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6669.910156 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6722.009766 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6785.388672 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6846.570312 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6885.779297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6919.470703 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6951.257812 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6992.371094 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7053.650391 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7092.859375 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7120.642578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7181.824219 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7213.611328 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7241.394531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7293.494141 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7325.28125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7388.757812 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7450.28125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7489.490234 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7551.013672 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7590.376953 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7687.789062 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7715.572266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7778.951172 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7806.734375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7858.833984 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7898.042969 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7925.826172 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3262.744141 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3326.367188 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3389.990234 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3453.613281 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3517.236328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3580.859375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3612.646484 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3644.433594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3676.220703 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3708.007812 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3739.794922 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3767.578125 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3829.101562 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3890.380859 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3953.759766 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4017.236328 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4056.099609 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4117.28125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4176.460938 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4237.984375 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4279.097656 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4312.789062 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4340.572266 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4402.095703 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4463.375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4526.753906 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4590.376953 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4624.068359 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4683.248047 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4746.871094 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4778.658203 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4842.28125 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4905.904297 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4937.691406 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(5001.314453 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5037.398438 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5076.261719 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5131.242188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5194.865234 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5226.652344 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5258.439453 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5290.226562 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5322.013672 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5353.800781 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5393.009766 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5456.388672 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5495.251953 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5556.433594 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5619.8125 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5683.289062 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5746.667969 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5810.144531 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5873.523438 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5912.732422 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5944.519531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6028.308594 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6060.095703 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6157.507812 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6219.03125 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6282.507812 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6310.291016 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6371.570312 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6434.949219 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6466.736328 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6518.835938 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6582.214844 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6643.494141 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6706.970703 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6759.070312 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6822.449219 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6883.630859 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6922.839844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6956.53125 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6988.318359 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7029.431641 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7090.710938 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7129.919922 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7157.703125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7218.884766 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7250.671875 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7278.455078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7330.554688 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7362.341797 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7425.818359 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7487.341797 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7526.550781 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7588.074219 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7627.4375 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7724.849609 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7752.632812 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7816.011719 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7843.794922 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7895.894531 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7935.103516 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7962.886719 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pce3af741db">
+  <clipPath id="p4f46414ad5">
    <rect x="95.67625" y="49.4355" width="416.571298" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_summary.svg
+++ b/bench/graphs/canterbury_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="573.044844pt" height="386.202469pt" viewBox="0 0 573.044844 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="575.639219pt" height="386.202469pt" viewBox="0 0 575.639219 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,232 +22,232 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 386.202469 
-L 573.044844 386.202469 
-L 573.044844 0 
+L 575.639219 386.202469 
+L 575.639219 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 188.647422 104.1264 
-L 293.272422 104.1264 
-L 293.272422 74.7432 
-L 188.647422 74.7432 
+    <path d="M 189.944609 104.1264 
+L 294.569609 104.1264 
+L 294.569609 74.7432 
+L 189.944609 74.7432 
 z
-" clip-path="url(#p74712be3cf)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pcc226b71c1)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 293.272422 104.1264 
-L 397.897422 104.1264 
-L 397.897422 74.7432 
-L 293.272422 74.7432 
+    <path d="M 294.569609 104.1264 
+L 399.194609 104.1264 
+L 399.194609 74.7432 
+L 294.569609 74.7432 
 z
-" clip-path="url(#p74712be3cf)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pcc226b71c1)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 397.897422 104.1264 
-L 502.522422 104.1264 
-L 502.522422 74.7432 
-L 397.897422 74.7432 
+    <path d="M 399.194609 104.1264 
+L 503.819609 104.1264 
+L 503.819609 74.7432 
+L 399.194609 74.7432 
 z
-" clip-path="url(#p74712be3cf)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pcc226b71c1)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 188.647422 133.5096 
-L 293.272422 133.5096 
-L 293.272422 104.1264 
-L 188.647422 104.1264 
+    <path d="M 189.944609 133.5096 
+L 294.569609 133.5096 
+L 294.569609 104.1264 
+L 189.944609 104.1264 
 z
-" clip-path="url(#p74712be3cf)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pcc226b71c1)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 293.272422 133.5096 
-L 397.897422 133.5096 
-L 397.897422 104.1264 
-L 293.272422 104.1264 
+    <path d="M 294.569609 133.5096 
+L 399.194609 133.5096 
+L 399.194609 104.1264 
+L 294.569609 104.1264 
 z
-" clip-path="url(#p74712be3cf)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pcc226b71c1)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 397.897422 133.5096 
-L 502.522422 133.5096 
-L 502.522422 104.1264 
-L 397.897422 104.1264 
+    <path d="M 399.194609 133.5096 
+L 503.819609 133.5096 
+L 503.819609 104.1264 
+L 399.194609 104.1264 
 z
-" clip-path="url(#p74712be3cf)" style="fill: #fdb768; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pcc226b71c1)" style="fill: #fdb768; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 188.647422 162.8928 
-L 293.272422 162.8928 
-L 293.272422 133.5096 
-L 188.647422 133.5096 
+    <path d="M 189.944609 162.8928 
+L 294.569609 162.8928 
+L 294.569609 133.5096 
+L 189.944609 133.5096 
 z
-" clip-path="url(#p74712be3cf)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pcc226b71c1)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 293.272422 162.8928 
-L 397.897422 162.8928 
-L 397.897422 133.5096 
-L 293.272422 133.5096 
+    <path d="M 294.569609 162.8928 
+L 399.194609 162.8928 
+L 399.194609 133.5096 
+L 294.569609 133.5096 
 z
-" clip-path="url(#p74712be3cf)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pcc226b71c1)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 397.897422 162.8928 
-L 502.522422 162.8928 
-L 502.522422 133.5096 
-L 397.897422 133.5096 
+    <path d="M 399.194609 162.8928 
+L 503.819609 162.8928 
+L 503.819609 133.5096 
+L 399.194609 133.5096 
 z
-" clip-path="url(#p74712be3cf)" style="fill: #bbe278; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pcc226b71c1)" style="fill: #bbe278; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 188.647422 192.276 
-L 293.272422 192.276 
-L 293.272422 162.8928 
-L 188.647422 162.8928 
+    <path d="M 189.944609 192.276 
+L 294.569609 192.276 
+L 294.569609 162.8928 
+L 189.944609 162.8928 
 z
-" clip-path="url(#p74712be3cf)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pcc226b71c1)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 293.272422 192.276 
-L 397.897422 192.276 
-L 397.897422 162.8928 
-L 293.272422 162.8928 
+    <path d="M 294.569609 192.276 
+L 399.194609 192.276 
+L 399.194609 162.8928 
+L 294.569609 162.8928 
 z
-" clip-path="url(#p74712be3cf)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pcc226b71c1)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 397.897422 192.276 
-L 502.522422 192.276 
-L 502.522422 162.8928 
-L 397.897422 162.8928 
+    <path d="M 399.194609 192.276 
+L 503.819609 192.276 
+L 503.819609 162.8928 
+L 399.194609 162.8928 
 z
-" clip-path="url(#p74712be3cf)" style="fill: #fdc776; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pcc226b71c1)" style="fill: #fdc776; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 188.647422 221.6592 
-L 293.272422 221.6592 
-L 293.272422 192.276 
-L 188.647422 192.276 
+    <path d="M 189.944609 221.6592 
+L 294.569609 221.6592 
+L 294.569609 192.276 
+L 189.944609 192.276 
 z
-" clip-path="url(#p74712be3cf)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pcc226b71c1)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 293.272422 221.6592 
-L 397.897422 221.6592 
-L 397.897422 192.276 
-L 293.272422 192.276 
+    <path d="M 294.569609 221.6592 
+L 399.194609 221.6592 
+L 399.194609 192.276 
+L 294.569609 192.276 
 z
-" clip-path="url(#p74712be3cf)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pcc226b71c1)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 397.897422 221.6592 
-L 502.522422 221.6592 
-L 502.522422 192.276 
-L 397.897422 192.276 
+    <path d="M 399.194609 221.6592 
+L 503.819609 221.6592 
+L 503.819609 192.276 
+L 399.194609 192.276 
 z
-" clip-path="url(#p74712be3cf)" style="fill: #addc6f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pcc226b71c1)" style="fill: #addc6f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 188.647422 251.0424 
-L 293.272422 251.0424 
-L 293.272422 221.6592 
-L 188.647422 221.6592 
+    <path d="M 189.944609 251.0424 
+L 294.569609 251.0424 
+L 294.569609 221.6592 
+L 189.944609 221.6592 
 z
-" clip-path="url(#p74712be3cf)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pcc226b71c1)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 293.272422 251.0424 
-L 397.897422 251.0424 
-L 397.897422 221.6592 
-L 293.272422 221.6592 
+    <path d="M 294.569609 251.0424 
+L 399.194609 251.0424 
+L 399.194609 221.6592 
+L 294.569609 221.6592 
 z
-" clip-path="url(#p74712be3cf)" style="fill: #fdbd6d; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pcc226b71c1)" style="fill: #fdbd6d; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 397.897422 251.0424 
-L 502.522422 251.0424 
-L 502.522422 221.6592 
-L 397.897422 221.6592 
+    <path d="M 399.194609 251.0424 
+L 503.819609 251.0424 
+L 503.819609 221.6592 
+L 399.194609 221.6592 
 z
-" clip-path="url(#p74712be3cf)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pcc226b71c1)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 188.647422 280.4256 
-L 293.272422 280.4256 
-L 293.272422 251.0424 
-L 188.647422 251.0424 
+    <path d="M 189.944609 280.4256 
+L 294.569609 280.4256 
+L 294.569609 251.0424 
+L 189.944609 251.0424 
 z
-" clip-path="url(#p74712be3cf)" style="fill: #f5fbb2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pcc226b71c1)" style="fill: #f5fbb2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 293.272422 280.4256 
-L 397.897422 280.4256 
-L 397.897422 251.0424 
-L 293.272422 251.0424 
+    <path d="M 294.569609 280.4256 
+L 399.194609 280.4256 
+L 399.194609 251.0424 
+L 294.569609 251.0424 
 z
-" clip-path="url(#p74712be3cf)" style="fill: #fca55d; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pcc226b71c1)" style="fill: #fca55d; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 397.897422 280.4256 
-L 502.522422 280.4256 
-L 502.522422 251.0424 
-L 397.897422 251.0424 
+    <path d="M 399.194609 280.4256 
+L 503.819609 280.4256 
+L 503.819609 251.0424 
+L 399.194609 251.0424 
 z
-" clip-path="url(#p74712be3cf)" style="fill: #fca85e; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pcc226b71c1)" style="fill: #fca55d; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 188.647422 309.8088 
-L 293.272422 309.8088 
-L 293.272422 280.4256 
-L 188.647422 280.4256 
+    <path d="M 189.944609 309.8088 
+L 294.569609 309.8088 
+L 294.569609 280.4256 
+L 189.944609 280.4256 
 z
-" clip-path="url(#p74712be3cf)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pcc226b71c1)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 293.272422 309.8088 
-L 397.897422 309.8088 
-L 397.897422 280.4256 
-L 293.272422 280.4256 
+    <path d="M 294.569609 309.8088 
+L 399.194609 309.8088 
+L 399.194609 280.4256 
+L 294.569609 280.4256 
 z
-" clip-path="url(#p74712be3cf)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pcc226b71c1)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 397.897422 309.8088 
-L 502.522422 309.8088 
-L 502.522422 280.4256 
-L 397.897422 280.4256 
+    <path d="M 399.194609 309.8088 
+L 503.819609 309.8088 
+L 503.819609 280.4256 
+L 399.194609 280.4256 
 z
-" clip-path="url(#p74712be3cf)" style="fill: #ee613e; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pcc226b71c1)" style="fill: #ee613e; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 188.647422 339.192 
-L 293.272422 339.192 
-L 293.272422 309.8088 
-L 188.647422 309.8088 
+    <path d="M 189.944609 339.192 
+L 294.569609 339.192 
+L 294.569609 309.8088 
+L 189.944609 309.8088 
 z
-" clip-path="url(#p74712be3cf)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pcc226b71c1)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 293.272422 339.192 
-L 397.897422 339.192 
-L 397.897422 309.8088 
-L 293.272422 309.8088 
+    <path d="M 294.569609 339.192 
+L 399.194609 339.192 
+L 399.194609 309.8088 
+L 294.569609 309.8088 
 z
-" clip-path="url(#p74712be3cf)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pcc226b71c1)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 397.897422 339.192 
-L 502.522422 339.192 
-L 502.522422 309.8088 
-L 397.897422 309.8088 
+    <path d="M 399.194609 339.192 
+L 503.819609 339.192 
+L 503.819609 309.8088 
+L 399.194609 309.8088 
 z
-" clip-path="url(#p74712be3cf)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pcc226b71c1)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(121.634688 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(122.931875 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(228.918906 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(230.216094 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(307.491016 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(308.788203 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(405.842734 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(407.139922 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(117.572422 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(118.869609 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.296 -->
-    <g transform="translate(229.508672 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(230.805859 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -946,7 +946,7 @@ z
    </g>
    <g id="text_7">
     <!-- 158 -->
-    <g transform="translate(337.949922 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(339.247109 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -1034,7 +1034,7 @@ z
    </g>
    <g id="text_8">
     <!-- 925 -->
-    <g transform="translate(442.574922 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(443.872109 91.6423) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-39"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
@@ -1042,7 +1042,7 @@ z
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(112.210547 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(113.507734 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1141,7 +1141,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.299 -->
-    <g transform="translate(229.508672 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(230.805859 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1151,7 +1151,7 @@ z
    </g>
    <g id="text_11">
     <!-- 73 -->
-    <g transform="translate(340.494922 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(341.792109 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -1202,7 +1202,7 @@ z
    </g>
    <g id="text_12">
     <!-- 283 -->
-    <g transform="translate(442.574922 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(443.872109 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(127.246094 0)"/>
@@ -1210,7 +1210,7 @@ z
    </g>
    <g id="text_13">
     <!-- zlib -->
-    <g transform="translate(129.473672 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(130.770859 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1234,7 +1234,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.299 -->
-    <g transform="translate(229.508672 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(230.805859 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1244,14 +1244,14 @@ z
    </g>
    <g id="text_15">
     <!-- 55 -->
-    <g transform="translate(340.494922 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(341.792109 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
     <!-- 692 -->
-    <g transform="translate(442.574922 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(443.872109 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-36"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
@@ -1259,7 +1259,7 @@ z
    </g>
    <g id="text_17">
     <!-- Go compress/flate -->
-    <g transform="translate(99.903672 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(101.200859 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -1430,7 +1430,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.299 -->
-    <g transform="translate(229.508672 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(230.805859 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1440,14 +1440,14 @@ z
    </g>
    <g id="text_19">
     <!-- 52 -->
-    <g transform="translate(340.494922 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(341.792109 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
     <!-- 323 -->
-    <g transform="translate(442.574922 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(443.872109 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(127.246094 0)"/>
@@ -1455,7 +1455,7 @@ z
    </g>
    <g id="text_21">
     <!-- miniz_oxide -->
-    <g transform="translate(112.779922 209.06385) scale(0.08 -0.08)">
+    <g transform="translate(114.077109 209.06385) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6e" d="M 3513 2113 
 L 3513 0 
@@ -1514,7 +1514,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.299 -->
-    <g transform="translate(229.508672 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(230.805859 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1524,14 +1524,14 @@ z
    </g>
    <g id="text_23">
     <!-- 51 -->
-    <g transform="translate(340.494922 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(341.792109 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_24">
     <!-- 729 -->
-    <g transform="translate(442.574922 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(443.872109 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-37"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(127.246094 0)"/>
@@ -1539,7 +1539,7 @@ z
    </g>
    <g id="text_25">
     <!-- JS fflate -->
-    <g transform="translate(120.936172 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(122.233359 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1599,7 +1599,7 @@ z
    </g>
    <g id="text_26">
     <!-- 0.307 -->
-    <g transform="translate(229.508672 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(230.805859 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1609,7 +1609,7 @@ z
    </g>
    <g id="text_27">
     <!-- 41 -->
-    <g transform="translate(340.494922 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(341.792109 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1637,14 +1637,14 @@ z
    </g>
    <g id="text_28">
     <!-- 80 -->
-    <g transform="translate(445.119922 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(446.417109 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-38"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_29">
     <!-- lean-zip (native) -->
-    <g transform="translate(99.281797 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(100.578984 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1753,7 +1753,7 @@ z
    </g>
    <g id="text_30">
     <!-- 0.299 -->
-    <g transform="translate(228.308047 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(229.605234 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1845,7 +1845,7 @@ z
    </g>
    <g id="text_31">
     <!-- 31 -->
-    <g transform="translate(340.018672 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(341.315859 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-33" d="M 2981 2516 
 Q 3453 2394 3698 2092 
@@ -1899,8 +1899,8 @@ z
     </g>
    </g>
    <g id="text_32">
-    <!-- 249 -->
-    <g transform="translate(441.860547 267.9415) scale(0.08 -0.08)">
+    <!-- 246 -->
+    <g transform="translate(443.157734 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-34" d="M 2356 3675 
 L 1038 1722 
@@ -1921,15 +1921,45 @@ L 288 1881
 L 2156 4666 
 z
 " transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-36" d="M 2316 2303 
+Q 2000 2303 1842 2098 
+Q 1684 1894 1684 1484 
+Q 1684 1075 1842 870 
+Q 2000 666 2316 666 
+Q 2634 666 2792 870 
+Q 2950 1075 2950 1484 
+Q 2950 1894 2792 2098 
+Q 2634 2303 2316 2303 
+z
+M 3803 4544 
+L 3803 3681 
+Q 3506 3822 3243 3889 
+Q 2981 3956 2731 3956 
+Q 2194 3956 1894 3657 
+Q 1594 3359 1544 2772 
+Q 1750 2925 1990 3001 
+Q 2231 3078 2516 3078 
+Q 3231 3078 3670 2659 
+Q 4109 2241 4109 1563 
+Q 4109 813 3618 361 
+Q 3128 -91 2303 -91 
+Q 1394 -91 895 523 
+Q 397 1138 397 2266 
+Q 397 3422 980 4083 
+Q 1563 4744 2578 4744 
+Q 2900 4744 3203 4694 
+Q 3506 4644 3803 4544 
+z
+" transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-Bold-32"/>
      <use xlink:href="#DejaVuSans-Bold-34" transform="translate(69.580078 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-39" transform="translate(139.160156 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-36" transform="translate(139.160156 0)"/>
     </g>
    </g>
    <g id="text_33">
     <!-- OCaml decompress -->
-    <g transform="translate(97.396797 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(98.693984 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -1994,7 +2024,7 @@ z
    </g>
    <g id="text_34">
     <!-- 0.321 -->
-    <g transform="translate(229.508672 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(230.805859 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -2004,14 +2034,14 @@ z
    </g>
    <g id="text_35">
     <!-- 23 -->
-    <g transform="translate(340.494922 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(341.792109 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_36">
     <!-- 117 -->
-    <g transform="translate(442.574922 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(443.872109 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
@@ -2019,7 +2049,7 @@ z
    </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(125.618047 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(126.915234 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -2030,7 +2060,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.279 -->
-    <g transform="translate(229.508672 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(230.805859 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -2040,13 +2070,13 @@ z
    </g>
    <g id="text_39">
     <!-- 0 -->
-    <g transform="translate(343.039922 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(344.337109 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(446.209922 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(447.507109 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2062,7 +2092,7 @@ z
   </g>
   <g id="text_41">
    <!-- canterbury — geomean over files, level 6 -->
-   <g transform="translate(136.031172 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(137.328359 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-62" d="M 2400 722 
 Q 2759 722 2948 984 
@@ -2201,36 +2231,6 @@ L 653 256
 L 653 1209 
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Bold-36" d="M 2316 2303 
-Q 2000 2303 1842 2098 
-Q 1684 1894 1684 1484 
-Q 1684 1075 1842 870 
-Q 2000 666 2316 666 
-Q 2634 666 2792 870 
-Q 2950 1075 2950 1484 
-Q 2950 1894 2792 2098 
-Q 2634 2303 2316 2303 
-z
-M 3803 4544 
-L 3803 3681 
-Q 3506 3822 3243 3889 
-Q 2981 3956 2731 3956 
-Q 2194 3956 1894 3657 
-Q 1594 3359 1544 2772 
-Q 1750 2925 1990 3001 
-Q 2231 3078 2516 3078 
-Q 3231 3078 3670 2659 
-Q 4109 2241 4109 1563 
-Q 4109 813 3618 361 
-Q 3128 -91 2303 -91 
-Q 1394 -91 895 523 
-Q 397 1138 397 2266 
-Q 397 3422 980 4083 
-Q 1563 4744 2578 4744 
-Q 2900 4744 3203 4694 
-Q 3506 4644 3803 4544 
-z
-" transform="scale(0.015625)"/>
     </defs>
     <use xlink:href="#DejaVuSans-Bold-63"/>
     <use xlink:href="#DejaVuSans-Bold-61" transform="translate(59.277344 0)"/>
@@ -2275,7 +2275,7 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-07-09T17:31:54Z  ·  Linux chungus2 x86_64  ·  commit 324f086c  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-07-10T04:34:01Z  ·  Linux chungus2 x86_64  ·  commit 74861182  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2413,17 +2413,17 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(290.576172 0)"/>
     <use xlink:href="#DejaVuSans-37" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(453.90625 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
     <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2463,110 +2463,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3262.744141 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3297.949219 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3361.572266 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3425.195312 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3488.818359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3543.798828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3575.585938 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3607.373047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3639.160156 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3670.947266 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3702.734375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3730.517578 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3792.041016 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3853.320312 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3916.699219 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3980.175781 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4019.039062 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4080.220703 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4139.400391 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4200.923828 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4242.037109 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4275.728516 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4303.511719 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4365.035156 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4426.314453 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4489.693359 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4553.316406 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4587.007812 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4646.1875 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4709.810547 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4741.597656 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4805.220703 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4868.84375 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4900.630859 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4964.253906 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5000.337891 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5039.201172 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5094.181641 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5157.804688 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5189.591797 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5221.378906 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5253.166016 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5284.953125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5316.740234 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5355.949219 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5419.328125 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5458.191406 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5519.373047 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5582.751953 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5646.228516 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5709.607422 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5773.083984 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5836.462891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5875.671875 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5907.458984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5991.248047 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6023.035156 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6120.447266 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6181.970703 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6245.447266 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6273.230469 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6334.509766 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6397.888672 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6429.675781 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6481.775391 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6545.154297 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6606.433594 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6669.910156 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6722.009766 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6785.388672 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6846.570312 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6885.779297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6919.470703 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6951.257812 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6992.371094 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7053.650391 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7092.859375 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7120.642578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7181.824219 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7213.611328 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7241.394531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7293.494141 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7325.28125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7388.757812 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7450.28125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7489.490234 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7551.013672 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7590.376953 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7687.789062 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7715.572266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7778.951172 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7806.734375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7858.833984 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7898.042969 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7925.826172 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3262.744141 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3326.367188 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3389.990234 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3453.613281 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3517.236328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3580.859375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3612.646484 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3644.433594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3676.220703 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3708.007812 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3739.794922 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3767.578125 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3829.101562 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3890.380859 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3953.759766 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4017.236328 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4056.099609 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4117.28125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4176.460938 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4237.984375 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4279.097656 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4312.789062 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4340.572266 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4402.095703 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4463.375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4526.753906 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4590.376953 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4624.068359 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4683.248047 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4746.871094 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4778.658203 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4842.28125 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4905.904297 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4937.691406 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(5001.314453 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5037.398438 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5076.261719 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5131.242188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5194.865234 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5226.652344 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5258.439453 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5290.226562 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5322.013672 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5353.800781 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5393.009766 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5456.388672 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5495.251953 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5556.433594 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5619.8125 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5683.289062 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5746.667969 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5810.144531 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5873.523438 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5912.732422 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5944.519531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6028.308594 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6060.095703 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6157.507812 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6219.03125 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6282.507812 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6310.291016 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6371.570312 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6434.949219 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6466.736328 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6518.835938 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6582.214844 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6643.494141 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6706.970703 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6759.070312 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6822.449219 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6883.630859 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6922.839844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6956.53125 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6988.318359 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7029.431641 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7090.710938 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7129.919922 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7157.703125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7218.884766 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7250.671875 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7278.455078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7330.554688 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7362.341797 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7425.818359 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7487.341797 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7526.550781 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7588.074219 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7627.4375 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7724.849609 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7752.632812 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7816.011719 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7843.794922 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7895.894531 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7935.103516 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7962.886719 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p74712be3cf">
-   <rect x="84.022422" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="pcc226b71c1">
+   <rect x="85.319609" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/graphs/silesia_compress_heatmap.svg
+++ b/bench/graphs/silesia_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.34175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#pbc55d5b544)">
+   <g clip-path="url(#p51298b2fab)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAqAAAAGaCAYAAADQNfGTAAAJ+0lEQVR4nO3YP25lZx3H4di+9ngcaTSZKNYMSgMNQhQoSFGUbWQdVLSsgQ3QUbIAijQUFEihSZmKSPmDFGVgBJPRxNjX11lE9H5+5uh5VvC9ev36fM45Ovz7j3dvbNn16+kFax0dTy9Y67CfXrDW1s9vfz29YK2Lx9ML1vrfq+kF/BgnZ9ML1tr63+fp+fSCpTb+9AMA4L4RoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApHaf7r+c3rDU2eluesJSV/vr6QlLPXv0k+kJS33x8qvpCUvtj26nJyz1i4dPpicstX9wPj1hqX+++np6wlKXDy+nJyx1dbafnrDU0Ruvpycs5QsoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQ2l1eXE5vWOrZmz+bnrDUt6+/nJ6w1NOrbb8jPXr7V9MTljo7OZ+esNTtYT89Yamtn9/mf9/xtn/f7vjd6QlLnV9dTU9YattPdwAA7h0BCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBAavfg5GJ6w1Ivrr6ZnrDU1s/v9q0n0xOW+uo/n05PWOrVzdX0hKXef+v96QlLXd/tpycs9cXLz6cnLPXLt389PWGpT7752/SEpd57Z9vn5wsoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQOro9q+/vZsesdThML2AH2Pr53fsHRDGbP3++f/5/22/n16w1MZPDwCA+0aAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQ2l1+8tn0hqVOzk6mJyz17WfPpycs9YffvDc9Yanf/33b5/fhu4+mJyz1p798Pj1hqd999PPpCUv9+R//nZ6w1E8fP5yesNSL72+mJyz1wbOL6QlL+QIKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkjm5uP76bHrHSyc319IS1Ts6mF6y1v5pesNbufHrBWie76QVr3R2mF6x1s/H7d7TxbzDH275/N0fbvn+n+/30hKU2fvsAALhvBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAAKnd8++/nt6w1NPTp9MTlnp5eDk9YalHtxt/R3qwm16w1s3V9IKlnu//NT1hqXcOF9MT1nrzyfSCpW4O19MTljr97sX0hLUuHk8vWGrjT3cAAO4bAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQOoHe0x9yWgI2DEAAAAASUVORK5CYII=" id="image12d7863257" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="483.84" height="295.2"/>
+iVBORw0KGgoAAAANSUhEUgAAAqAAAAGaCAYAAADQNfGTAAAJ+klEQVR4nO3YP25lZx3H4bF97fE40mgyAWsGpYEGIQoUpAhlG6yDipY1sAE6ShZAQUNBgRSalKmIlD9IUUJGYI0mN/a1zSKi9/MzR8+zgu/V69fnc87R3Td/vH+0ZddvphesdXQ8vWCtu8P0grW2fn6H6+kFa108m16w1nevpxfwfZycTS9Ya+t/n6fn0wuW2vjTDwCAh0aAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQ2n10+Gx6w1Jnp7vpCUvtD9fTE5Z6+fRH0xOW+vTq8+kJSx2ObqcnLPWzJ8+nJyx1eHw+PWGpf73+YnrCUpdPLqcnLLU/O0xPWOro0ZvpCUv5AgoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKR2lxeX0xuWevnWT6YnLPXVm8+mJyz1Yr/td6Sn7/xiesJSZyfn0xOWur07TE9Yauvnt/nfd7zt37c7fnd6wlLn+/30hKW2/XQHAODBEaAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKR2j08upjcs9Wr/5fSEpbZ+frdvP5+esNTn//loesJSr2/20xOWev/t96cnLHV9f5iesNSnV59MT1jq5+/8cnrCUh9++ffpCUu998Ntn58voAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAACpo9u//fZ+esRSd3fTC/g+tn5+x94BYczW75//n//fDofpBUtt/PQAAHhoBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAAKnd5YcfT29Y6uTsZHrCUl99/PX0hKX+8Jv3pics9ft/bPv8Pnj36fSEpf7010+mJyz1u1//dHrCUn/+53+nJyz142dPpics9erbm+kJS/3q5cX0hKV8AQUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFJHN7d/uZ8esdLJzfX0hLVOzqYXrHXYTy9Ya3c+vWCtk930grXu76YXrHWz8ft3tPFvMMfbvn83R9u+f6eHw/SEpTZ++wAAeGgEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAqd3X334xvWGpF6cvpicsdXV3NT1hqae3G39HerybXrDWzX56wVL/vn01PWGpH9yeT09Y663n0wuWur0/TE9Y6vRq2/fv0cWz6QVLbfzpDgDAQyNAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBI/Q+/aH3NAWD4pwAAAABJRU5ErkJggg==" id="imageff65a974f7" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="483.84" height="295.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m48204cc8a4" d="M 0 0 
+       <path id="meecd496522" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m48204cc8a4" x="115.814949" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#meecd496522" x="115.814949" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m48204cc8a4" x="156.092348" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#meecd496522" x="156.092348" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m48204cc8a4" x="196.369746" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#meecd496522" x="196.369746" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m48204cc8a4" x="236.647145" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#meecd496522" x="236.647145" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m48204cc8a4" x="276.924544" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#meecd496522" x="276.924544" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m48204cc8a4" x="317.201942" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#meecd496522" x="317.201942" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m48204cc8a4" x="357.479341" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#meecd496522" x="357.479341" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m48204cc8a4" x="397.756739" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#meecd496522" x="397.756739" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m48204cc8a4" x="438.034138" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#meecd496522" x="438.034138" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m48204cc8a4" x="478.311536" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#meecd496522" x="478.311536" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m48204cc8a4" x="518.588935" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#meecd496522" x="518.588935" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m48204cc8a4" x="558.866334" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#meecd496522" x="558.866334" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="mfd56e68120" d="M 0 0 
+       <path id="m52f7259f9a" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mfd56e68120" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m52f7259f9a" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mfd56e68120" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m52f7259f9a" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#mfd56e68120" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m52f7259f9a" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#mfd56e68120" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m52f7259f9a" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -836,7 +836,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#mfd56e68120" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m52f7259f9a" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -899,7 +899,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mfd56e68120" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m52f7259f9a" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -966,7 +966,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#mfd56e68120" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m52f7259f9a" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1047,7 +1047,7 @@ z
     <g id="ytick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#mfd56e68120" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m52f7259f9a" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -1281,8 +1281,16 @@ z
     </g>
    </g>
    <g id="text_24">
-    <!-- -20 -->
+    <!-- -21 -->
     <g transform="translate(231.338981 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_25">
+    <!-- +0 -->
+    <g transform="translate(272.133333 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -1306,14 +1314,6 @@ Q 1250 4750 2034 4750
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_25">
-    <!-- +0 -->
-    <g transform="translate(272.133333 69.553235) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
     </g>
@@ -1327,11 +1327,11 @@ z
     </g>
    </g>
    <g id="text_27">
-    <!-- +33 -->
+    <!-- +31 -->
     <g transform="translate(350.620317 69.553235) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_28">
@@ -1369,11 +1369,11 @@ z
     </g>
    </g>
    <g id="text_31">
-    <!-- -29 -->
+    <!-- -30 -->
     <g transform="translate(513.280771 69.553235) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_32">
@@ -2191,18 +2191,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB1ElEQVR4nO2b0a3DMAwD7cSzvM3fmI47gvpxCK6ENABhnkQ5aZH5P/7OAGpdFyEzBiQDnija2qSEghnZhIIZCa3NyWQkmZFOKJhRsDXsOopmJJwjaEPOmxHirE3MWjOqhSBr2EAGMyKtMVpc+ynYwe3viNQVbA0LrZDRFbxGbNbWyM3auG0RGbo1Qp0IZCSMiG2OgtNvbL+Oke6BvddIWaQ1qP3RjGSTLXypwdaIMP2ctWb0olAzKkr4LhLMCPvnOJiRbo6CrTWjF4WCGYHWJtU1TKgZvSZkfNAKZhRsDftFa96MkJCRrf29ausyWrOtWiMjmxDH6FAfDJzzIEKctQc60ToDEqJOBLbfZs04RxQjobWOSFXrjM0IdURqIaG1jkhVPmvGOUqOCPLJMdh+6kRk+zFGMtjKOdK13zbZ2EBGMxLOkSz90YygK9tozSbUa6Qu4RxtRifZ2np0jDY32YiOc44gIQo2aI1ZkB2Rb4SiIyJbtcr0Q0IPdCQyIpCQDnZHpC5uQ27uOtJFBBptH2zlHOnab+uaMSK29htXrW2NKK0hOtlrxLaPjIxys4a99x9dRKgTgUK69gsZ9RxVFWzNyIi6RZIZtbXfE+qI1BU8R5i1D2e5X2tFkZmlAAAAAElFTkSuQmCC" id="image2a02c79209" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-69.84" width="12.96" height="253.44"/>
+iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB1ElEQVR4nO2b0a3DMAwD7cSzvM3fmI47gvpxCK6ENABhnkQ5aZH5P/7OAGpdFyEzBiQDnija2qSEghnZhIIZCa3NyWQkmZFOKJhRsDXsOopmJJwjaEPOmxHirE3MWjOqhSBr2EAGMyKtMVpc+ynYwe3viNQVbA0LrZDRFbxGbNbWyM3auG0RGbo1Qp0IZCSMiG2OgtNvbL+Oke6BvddIWaQ1qP3RjGSTLXypwdaIMP2ctWb0olAzKkr4LhLMCPvnOJiRbo6CrTWjF4WCGYHWJtU1TKgZvSZkfNAKZhRsDftFa96MkJCRrf29ausyWrOtWiMjmxDH6FAfDJzzIEKctQc60ToDEqJOBLbfZs04RxQjobWOSFXrjM0IdURqIaG1jkhVPmvGOUqOCPLJMdh+6kRk+zFGMtjKOdK13zbZ2EBGMxLOkSz90YygK9tozSbUa6Qu4RxtRifZ2np0jDY32YiOc44gIQo2aI1ZkB2Rb4SiIyJbtcr0Q0IPdCQyIpCQDnZHpC5uQ27uOtJFBBptH2zlHOnab+uaMSK29htXrW2NKK0hOtlrxLaPjIxys4a99x9dRKgTgUK69gsZ9RxVFWzNyIi6RZIZtbXfE+qI1BU8R5i1D2e5X2tFkZmlAAAAAElFTkSuQmCC" id="image39c651d435" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-69.84" width="12.96" height="253.44"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_21">
       <defs>
-       <path id="m2abed29570" d="M 0 0 
+       <path id="m9d4d186866" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m2abed29570" x="601.779688" y="322.507463" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9d4d186866" x="601.779688" y="322.507463" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_117">
@@ -2225,7 +2225,7 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m2abed29570" x="601.779688" y="280.566603" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9d4d186866" x="601.779688" y="280.566603" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_118">
@@ -2239,7 +2239,7 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m2abed29570" x="601.779688" y="238.625742" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9d4d186866" x="601.779688" y="238.625742" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_119">
@@ -2253,7 +2253,7 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m2abed29570" x="601.779688" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9d4d186866" x="601.779688" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_120">
@@ -2266,7 +2266,7 @@ z
     <g id="ytick_13">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m2abed29570" x="601.779688" y="154.74402" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9d4d186866" x="601.779688" y="154.74402" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_121">
@@ -2279,7 +2279,7 @@ z
     <g id="ytick_14">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m2abed29570" x="601.779688" y="112.803159" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9d4d186866" x="601.779688" y="112.803159" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_122">
@@ -2292,7 +2292,7 @@ z
     <g id="ytick_15">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#m2abed29570" x="601.779688" y="70.862298" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9d4d186866" x="601.779688" y="70.862298" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_123">
@@ -2908,8 +2908,8 @@ z
    </g>
   </g>
   <g id="text_126">
-   <!-- 2026-07-09T17:31:54Z  ·  Linux chungus2 x86_64  ·  commit 324f086c  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(44.677578 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-10T04:34:01Z  ·  Linux chungus2 x86_64  ·  commit 74861182  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(43.380391 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2997,17 +2997,17 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(290.576172 0)"/>
     <use xlink:href="#DejaVuSans-37" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(453.90625 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
     <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3047,109 +3047,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3262.744141 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3297.949219 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3361.572266 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3425.195312 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3488.818359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3543.798828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3575.585938 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3607.373047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3639.160156 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3670.947266 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3702.734375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3730.517578 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3792.041016 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3853.320312 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3916.699219 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3980.175781 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4019.039062 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4080.220703 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4139.400391 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4200.923828 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4242.037109 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4275.728516 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4303.511719 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4365.035156 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4426.314453 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4489.693359 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4553.316406 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4587.007812 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4646.1875 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4709.810547 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4741.597656 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4805.220703 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4868.84375 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4900.630859 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4964.253906 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5000.337891 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5039.201172 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5094.181641 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5157.804688 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5189.591797 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5221.378906 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5253.166016 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5284.953125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5316.740234 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5355.949219 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5419.328125 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5458.191406 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5519.373047 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5582.751953 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5646.228516 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5709.607422 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5773.083984 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5836.462891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5875.671875 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5907.458984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5991.248047 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6023.035156 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6120.447266 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6181.970703 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6245.447266 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6273.230469 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6334.509766 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6397.888672 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6429.675781 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6481.775391 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6545.154297 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6606.433594 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6669.910156 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6722.009766 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6785.388672 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6846.570312 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6885.779297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6919.470703 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6951.257812 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6992.371094 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7053.650391 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7092.859375 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7120.642578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7181.824219 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7213.611328 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7241.394531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7293.494141 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7325.28125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7388.757812 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7450.28125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7489.490234 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7551.013672 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7590.376953 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7687.789062 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7715.572266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7778.951172 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7806.734375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7858.833984 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7898.042969 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7925.826172 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3262.744141 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3326.367188 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3389.990234 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3453.613281 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3517.236328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3580.859375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3612.646484 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3644.433594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3676.220703 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3708.007812 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3739.794922 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3767.578125 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3829.101562 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3890.380859 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3953.759766 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4017.236328 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4056.099609 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4117.28125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4176.460938 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4237.984375 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4279.097656 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4312.789062 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4340.572266 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4402.095703 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4463.375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4526.753906 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4590.376953 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4624.068359 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4683.248047 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4746.871094 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4778.658203 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4842.28125 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4905.904297 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4937.691406 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(5001.314453 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5037.398438 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5076.261719 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5131.242188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5194.865234 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5226.652344 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5258.439453 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5290.226562 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5322.013672 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5353.800781 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5393.009766 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5456.388672 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5495.251953 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5556.433594 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5619.8125 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5683.289062 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5746.667969 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5810.144531 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5873.523438 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5912.732422 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5944.519531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6028.308594 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6060.095703 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6157.507812 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6219.03125 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6282.507812 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6310.291016 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6371.570312 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6434.949219 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6466.736328 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6518.835938 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6582.214844 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6643.494141 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6706.970703 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6759.070312 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6822.449219 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6883.630859 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6922.839844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6956.53125 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6988.318359 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7029.431641 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7090.710938 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7129.919922 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7157.703125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7218.884766 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7250.671875 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7278.455078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7330.554688 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7362.341797 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7425.818359 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7487.341797 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7526.550781 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7588.074219 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7627.4375 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7724.849609 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7752.632812 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7816.011719 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7843.794922 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7895.894531 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7935.103516 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7962.886719 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pbc55d5b544">
+  <clipPath id="p51298b2fab">
    <rect x="95.67625" y="49.34175" width="483.328783" height="294.686261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_compress_pareto.svg
+++ b/bench/graphs/silesia_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 61.085542 412.80375 
 L 61.085542 48.323125 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m49613c94fa" d="M 0 0 
+       <path id="mdf7e46acdc" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m49613c94fa" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdf7e46acdc" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -130,11 +130,11 @@ z
      <g id="line2d_3">
       <path d="M 145.270284 412.80375 
 L 145.270284 48.323125 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m49613c94fa" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdf7e46acdc" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -177,11 +177,11 @@ z
      <g id="line2d_5">
       <path d="M 229.455026 412.80375 
 L 229.455026 48.323125 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m49613c94fa" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdf7e46acdc" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -219,11 +219,11 @@ z
      <g id="line2d_7">
       <path d="M 313.639768 412.80375 
 L 313.639768 48.323125 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m49613c94fa" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdf7e46acdc" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -272,11 +272,11 @@ z
      <g id="line2d_9">
       <path d="M 397.82451 412.80375 
 L 397.82451 48.323125 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m49613c94fa" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdf7e46acdc" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -334,11 +334,11 @@ z
      <g id="line2d_11">
       <path d="M 482.009253 412.80375 
 L 482.009253 48.323125 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m49613c94fa" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdf7e46acdc" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -355,11 +355,11 @@ L 482.009253 48.323125
      <g id="line2d_13">
       <path d="M 566.193995 412.80375 
 L 566.193995 48.323125 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m49613c94fa" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdf7e46acdc" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -856,16 +856,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 368.08164 
 L 637.2 368.08164 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="m13ec08a276" d="M 0 0 
+       <path id="m11a90cb14e" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m13ec08a276" x="49.078125" y="368.08164" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m11a90cb14e" x="49.078125" y="368.08164" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -897,11 +897,11 @@ z
      <g id="line2d_17">
       <path d="M 49.078125 243.439835 
 L 637.2 243.439835 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m13ec08a276" x="49.078125" y="243.439835" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m11a90cb14e" x="49.078125" y="243.439835" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -917,11 +917,11 @@ L 637.2 243.439835
      <g id="line2d_19">
       <path d="M 49.078125 118.798029 
 L 637.2 118.798029 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m13ec08a276" x="49.078125" y="118.798029" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m11a90cb14e" x="49.078125" y="118.798029" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -937,16 +937,16 @@ L 637.2 118.798029
      <g id="line2d_21">
       <path d="M 49.078125 405.602562 
 L 637.2 405.602562 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="mdaf5a0b89b" d="M 0 0 
+       <path id="mc3271002af" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#mdaf5a0b89b" x="49.078125" y="405.602562" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc3271002af" x="49.078125" y="405.602562" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -954,11 +954,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 395.733268 
 L 637.2 395.733268 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mdaf5a0b89b" x="49.078125" y="395.733268" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc3271002af" x="49.078125" y="395.733268" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -966,11 +966,11 @@ L 637.2 395.733268
      <g id="line2d_25">
       <path d="M 49.078125 387.3889 
 L 637.2 387.3889 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mdaf5a0b89b" x="49.078125" y="387.3889" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc3271002af" x="49.078125" y="387.3889" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -978,11 +978,11 @@ L 637.2 387.3889
      <g id="line2d_27">
       <path d="M 49.078125 380.160679 
 L 637.2 380.160679 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#mdaf5a0b89b" x="49.078125" y="380.160679" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc3271002af" x="49.078125" y="380.160679" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -990,11 +990,11 @@ L 637.2 380.160679
      <g id="line2d_29">
       <path d="M 49.078125 373.784936 
 L 637.2 373.784936 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#mdaf5a0b89b" x="49.078125" y="373.784936" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc3271002af" x="49.078125" y="373.784936" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1002,11 +1002,11 @@ L 637.2 373.784936
      <g id="line2d_31">
       <path d="M 49.078125 330.560718 
 L 637.2 330.560718 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#mdaf5a0b89b" x="49.078125" y="330.560718" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc3271002af" x="49.078125" y="330.560718" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1014,11 +1014,11 @@ L 637.2 330.560718
      <g id="line2d_33">
       <path d="M 49.078125 308.612385 
 L 637.2 308.612385 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#mdaf5a0b89b" x="49.078125" y="308.612385" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc3271002af" x="49.078125" y="308.612385" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1026,11 +1026,11 @@ L 637.2 308.612385
      <g id="line2d_35">
       <path d="M 49.078125 293.039796 
 L 637.2 293.039796 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#mdaf5a0b89b" x="49.078125" y="293.039796" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc3271002af" x="49.078125" y="293.039796" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1038,11 +1038,11 @@ L 637.2 293.039796
      <g id="line2d_37">
       <path d="M 49.078125 280.960757 
 L 637.2 280.960757 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#mdaf5a0b89b" x="49.078125" y="280.960757" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc3271002af" x="49.078125" y="280.960757" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1050,11 +1050,11 @@ L 637.2 280.960757
      <g id="line2d_39">
       <path d="M 49.078125 271.091463 
 L 637.2 271.091463 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#mdaf5a0b89b" x="49.078125" y="271.091463" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc3271002af" x="49.078125" y="271.091463" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1062,11 +1062,11 @@ L 637.2 271.091463
      <g id="line2d_41">
       <path d="M 49.078125 262.747094 
 L 637.2 262.747094 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#mdaf5a0b89b" x="49.078125" y="262.747094" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc3271002af" x="49.078125" y="262.747094" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1074,11 +1074,11 @@ L 637.2 262.747094
      <g id="line2d_43">
       <path d="M 49.078125 255.518874 
 L 637.2 255.518874 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#mdaf5a0b89b" x="49.078125" y="255.518874" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc3271002af" x="49.078125" y="255.518874" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1086,11 +1086,11 @@ L 637.2 255.518874
      <g id="line2d_45">
       <path d="M 49.078125 249.143131 
 L 637.2 249.143131 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#mdaf5a0b89b" x="49.078125" y="249.143131" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc3271002af" x="49.078125" y="249.143131" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1098,11 +1098,11 @@ L 637.2 249.143131
      <g id="line2d_47">
       <path d="M 49.078125 205.918912 
 L 637.2 205.918912 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#mdaf5a0b89b" x="49.078125" y="205.918912" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc3271002af" x="49.078125" y="205.918912" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1110,11 +1110,11 @@ L 637.2 205.918912
      <g id="line2d_49">
       <path d="M 49.078125 183.97058 
 L 637.2 183.97058 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#mdaf5a0b89b" x="49.078125" y="183.97058" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc3271002af" x="49.078125" y="183.97058" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1122,11 +1122,11 @@ L 637.2 183.97058
      <g id="line2d_51">
       <path d="M 49.078125 168.39799 
 L 637.2 168.39799 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#mdaf5a0b89b" x="49.078125" y="168.39799" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc3271002af" x="49.078125" y="168.39799" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1134,11 +1134,11 @@ L 637.2 168.39799
      <g id="line2d_53">
       <path d="M 49.078125 156.318951 
 L 637.2 156.318951 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#mdaf5a0b89b" x="49.078125" y="156.318951" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc3271002af" x="49.078125" y="156.318951" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1146,11 +1146,11 @@ L 637.2 156.318951
      <g id="line2d_55">
       <path d="M 49.078125 146.449658 
 L 637.2 146.449658 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#mdaf5a0b89b" x="49.078125" y="146.449658" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc3271002af" x="49.078125" y="146.449658" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1158,11 +1158,11 @@ L 637.2 146.449658
      <g id="line2d_57">
       <path d="M 49.078125 138.105289 
 L 637.2 138.105289 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#mdaf5a0b89b" x="49.078125" y="138.105289" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc3271002af" x="49.078125" y="138.105289" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1170,11 +1170,11 @@ L 637.2 138.105289
      <g id="line2d_59">
       <path d="M 49.078125 130.877068 
 L 637.2 130.877068 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#mdaf5a0b89b" x="49.078125" y="130.877068" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc3271002af" x="49.078125" y="130.877068" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1182,11 +1182,11 @@ L 637.2 130.877068
      <g id="line2d_61">
       <path d="M 49.078125 124.501326 
 L 637.2 124.501326 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#mdaf5a0b89b" x="49.078125" y="124.501326" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc3271002af" x="49.078125" y="124.501326" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1194,11 +1194,11 @@ L 637.2 124.501326
      <g id="line2d_63">
       <path d="M 49.078125 81.277107 
 L 637.2 81.277107 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#mdaf5a0b89b" x="49.078125" y="81.277107" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc3271002af" x="49.078125" y="81.277107" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1206,11 +1206,11 @@ L 637.2 81.277107
      <g id="line2d_65">
       <path d="M 49.078125 59.328775 
 L 637.2 59.328775 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#mdaf5a0b89b" x="49.078125" y="59.328775" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc3271002af" x="49.078125" y="59.328775" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1332,7 +1332,7 @@ L 637.2 48.323125
    </g>
    <g id="text_13">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(324.643112 112.176023) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(324.643112 111.988668) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1364,7 +1364,7 @@ z
    </g>
    <g id="text_14">
     <!-- L10 -->
-    <g style="fill: #d62728" transform="translate(102.814287 308.360586) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(102.814287 309.288725) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1686,23 +1686,23 @@ z
    </g>
    <g id="line2d_67">
     <defs>
-     <path id="m709da15e7e" d="M -2.5 2.5 
+     <path id="m3c0c7774e4" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p49dad874ee)">
-     <use xlink:href="#m709da15e7e" x="377.110281" y="104.685421" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m709da15e7e" x="323.801439" y="110.409833" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m709da15e7e" x="272.665744" y="126.308323" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m709da15e7e" x="235.168828" y="128.026741" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m709da15e7e" x="186.228265" y="149.377587" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m709da15e7e" x="158.303164" y="171.457731" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m709da15e7e" x="149.489547" y="182.192614" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m709da15e7e" x="140.563162" y="202.482797" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m709da15e7e" x="138.984853" y="209.328911" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p8096bb383d)">
+     <use xlink:href="#m3c0c7774e4" x="377.110281" y="104.685421" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3c0c7774e4" x="323.801439" y="110.409833" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3c0c7774e4" x="272.665744" y="126.308323" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3c0c7774e4" x="235.168828" y="128.026741" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3c0c7774e4" x="186.228265" y="149.377587" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3c0c7774e4" x="158.303164" y="171.457731" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3c0c7774e4" x="149.489547" y="182.192614" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3c0c7774e4" x="140.563162" y="202.482797" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3c0c7774e4" x="138.984853" y="209.328911" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_68">
@@ -1755,7 +1755,7 @@ L 327.133241 110.069256
 L 326.02264 110.18302 
 L 324.91204 110.296545 
 L 323.801439 110.409833 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_69">
     <path d="M 323.801439 110.409833 
@@ -1807,7 +1807,7 @@ L 275.861725 125.44037
 L 274.796398 125.731236 
 L 273.731071 126.020548 
 L 272.665744 126.308323 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_70">
     <path d="M 272.665744 126.308323 
@@ -1859,7 +1859,7 @@ L 237.512385 127.920923
 L 236.7312 127.956219 
 L 235.950014 127.991491 
 L 235.168828 128.026741 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_71">
     <path d="M 235.168828 128.026741 
@@ -1911,7 +1911,7 @@ L 189.28705 148.263499
 L 188.267455 148.637415 
 L 187.24786 149.008766 
 L 186.228265 149.377587 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_72">
     <path d="M 186.228265 149.377587 
@@ -1963,7 +1963,7 @@ L 160.048483 170.312481
 L 159.46671 170.696929 
 L 158.884937 171.078667 
 L 158.303164 171.457731 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_73">
     <path d="M 158.303164 171.457731 
@@ -2015,7 +2015,7 @@ L 150.040398 181.580576
 L 149.856781 181.785359 
 L 149.673164 181.989369 
 L 149.489547 182.192614 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_74">
     <path d="M 149.489547 182.192614 
@@ -2067,7 +2067,7 @@ L 141.121061 201.414753
 L 140.935095 201.773114 
 L 140.749129 202.129119 
 L 140.563162 202.482797 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_75">
     <path d="M 140.563162 202.482797 
@@ -2119,26 +2119,26 @@ L 139.083497 208.925481
 L 139.050616 209.060292 
 L 139.017734 209.194768 
 L 138.984853 209.328911 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_76">
     <defs>
-     <path id="m8323a7be1f" d="M 0 -2.5 
+     <path id="m7aec2d94f9" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p49dad874ee)">
-     <use xlink:href="#m8323a7be1f" x="610.467187" y="71.939349" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8323a7be1f" x="319.880958" y="101.884157" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8323a7be1f" x="210.281253" y="129.778154" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8323a7be1f" x="196.287076" y="133.586625" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8323a7be1f" x="176.054419" y="147.38645" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8323a7be1f" x="152.161413" y="174.753272" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8323a7be1f" x="146.720208" y="186.587648" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8323a7be1f" x="143.994022" y="196.356323" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8323a7be1f" x="142.666037" y="200.180971" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p8096bb383d)">
+     <use xlink:href="#m7aec2d94f9" x="610.467187" y="71.939349" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7aec2d94f9" x="319.880958" y="101.884157" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7aec2d94f9" x="210.281253" y="129.778154" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7aec2d94f9" x="196.287076" y="133.586625" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7aec2d94f9" x="176.054419" y="147.38645" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7aec2d94f9" x="152.161413" y="174.753272" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7aec2d94f9" x="146.720208" y="186.587648" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7aec2d94f9" x="143.994022" y="196.356323" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7aec2d94f9" x="142.666037" y="200.180971" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_77">
@@ -2191,7 +2191,7 @@ L 338.042598 100.427247
 L 331.988718 100.917253 
 L 325.934838 101.402864 
 L 319.880958 101.884157 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_78">
     <path d="M 319.880958 101.884157 
@@ -2243,7 +2243,7 @@ L 217.131235 128.398367
 L 214.847908 128.862215 
 L 212.564581 129.322122 
 L 210.281253 129.778154 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_79">
     <path d="M 210.281253 129.778154 
@@ -2295,7 +2295,7 @@ L 197.161712 133.356286
 L 196.870166 133.433175 
 L 196.578621 133.509954 
 L 196.287076 133.586625 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_80">
     <path d="M 196.287076 133.586625 
@@ -2347,7 +2347,7 @@ L 177.31896 146.619719
 L 176.897447 146.876504 
 L 176.475933 147.132078 
 L 176.054419 147.38645 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_81">
     <path d="M 176.054419 147.38645 
@@ -2399,7 +2399,7 @@ L 153.654726 173.393769
 L 153.156955 173.850741 
 L 152.659184 174.303887 
 L 152.161413 174.753272 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_82">
     <path d="M 152.161413 174.753272 
@@ -2451,7 +2451,7 @@ L 147.060283 185.919158
 L 146.946925 186.142906 
 L 146.833566 186.365734 
 L 146.720208 186.587648 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_83">
     <path d="M 146.720208 186.587648 
@@ -2503,7 +2503,7 @@ L 144.164409 195.794799
 L 144.107613 195.982622 
 L 144.050817 196.169795 
 L 143.994022 196.356323 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_84">
     <path d="M 143.994022 196.356323 
@@ -2555,30 +2555,30 @@ L 142.749036 199.949687
 L 142.72137 200.026891 
 L 142.693704 200.103986 
 L 142.666037 200.180971 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_85">
     <defs>
-     <path id="m0ead7fa3ab" d="M -0 3.535534 
+     <path id="m0fca5ea94d" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p49dad874ee)">
-     <use xlink:href="#m0ead7fa3ab" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0ead7fa3ab" x="242.839153" y="80.778898" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0ead7fa3ab" x="218.251194" y="86.377096" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0ead7fa3ab" x="197.814984" y="90.309617" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0ead7fa3ab" x="166.378359" y="99.066934" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0ead7fa3ab" x="145.830392" y="110.431955" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0ead7fa3ab" x="134.598477" y="126.026287" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0ead7fa3ab" x="124.077268" y="149.033155" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0ead7fa3ab" x="122.462976" y="157.476606" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0ead7fa3ab" x="81.012077" y="220.06889" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0ead7fa3ab" x="77.44276" y="239.652656" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0ead7fa3ab" x="76.953425" y="252.706566" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p8096bb383d)">
+     <use xlink:href="#m0fca5ea94d" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0fca5ea94d" x="242.839153" y="80.778898" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0fca5ea94d" x="218.251194" y="86.377096" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0fca5ea94d" x="197.814984" y="90.309617" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0fca5ea94d" x="166.378359" y="99.066934" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0fca5ea94d" x="145.830392" y="110.431955" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0fca5ea94d" x="134.598477" y="126.026287" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0fca5ea94d" x="124.077268" y="149.033155" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0fca5ea94d" x="122.462976" y="157.476606" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0fca5ea94d" x="81.012077" y="220.06889" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0fca5ea94d" x="77.44276" y="239.652656" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0fca5ea94d" x="76.953425" y="252.706566" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_86">
@@ -2631,7 +2631,7 @@ L 245.91379 79.91142
 L 244.888911 80.202126 
 L 243.864032 80.49128 
 L 242.839153 80.778898 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_87">
     <path d="M 242.839153 80.778898 
@@ -2683,7 +2683,7 @@ L 219.787941 86.043669
 L 219.275692 86.155039 
 L 218.763443 86.266182 
 L 218.251194 86.377096 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_88">
     <path d="M 218.251194 86.377096 
@@ -2735,7 +2735,7 @@ L 199.092247 90.072029
 L 198.666492 90.151341 
 L 198.240738 90.230537 
 L 197.814984 90.309617 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_89">
     <path d="M 197.814984 90.309617 
@@ -2787,7 +2787,7 @@ L 168.343148 98.559208
 L 167.688219 98.72898 
 L 167.033289 98.898221 
 L 166.378359 99.066934 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_90">
     <path d="M 166.378359 99.066934 
@@ -2839,7 +2839,7 @@ L 147.11464 109.78743
 L 146.686557 110.003126 
 L 146.258475 110.217965 
 L 145.830392 110.431955 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_91">
     <path d="M 145.830392 110.431955 
@@ -2891,7 +2891,7 @@ L 135.300472 125.172774
 L 135.066474 125.458776 
 L 134.832476 125.743276 
 L 134.598477 126.026287 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_92">
     <path d="M 134.598477 126.026287 
@@ -2943,7 +2943,7 @@ L 124.734843 147.848882
 L 124.515652 148.246526 
 L 124.29646 148.641269 
 L 124.077268 149.033155 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_93">
     <path d="M 124.077268 149.033155 
@@ -2995,7 +2995,7 @@ L 122.56387 156.985769
 L 122.530239 157.149876 
 L 122.496607 157.313488 
 L 122.462976 157.476606 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_94">
     <path d="M 122.462976 157.476606 
@@ -3047,7 +3047,7 @@ L 83.602758 217.699074
 L 82.739198 218.500595 
 L 81.875637 219.290422 
 L 81.012077 220.06889 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_95">
     <path d="M 81.012077 220.06889 
@@ -3099,7 +3099,7 @@ L 77.665842 238.615761
 L 77.591481 238.963605 
 L 77.517121 239.309227 
 L 77.44276 239.652656 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_96">
     <path d="M 77.44276 239.652656 
@@ -3151,23 +3151,23 @@ L 76.984008 251.97672
 L 76.973814 252.221097 
 L 76.96362 252.464376 
 L 76.953425 252.706566 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_97">
     <defs>
-     <path id="m42903246a3" d="M -0 2.5 
+     <path id="m970474939d" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p49dad874ee)">
-     <use xlink:href="#m42903246a3" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p8096bb383d)">
+     <use xlink:href="#m970474939d" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_98">
     <defs>
-     <path id="mca89382c6b" d="M -0.833333 2.5 
+     <path id="m804318e276" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -3182,16 +3182,16 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p49dad874ee)">
-     <use xlink:href="#mca89382c6b" x="432.495268" y="96.067622" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mca89382c6b" x="300.62247" y="112.493412" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mca89382c6b" x="266.967623" y="120.8136" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mca89382c6b" x="226.040946" y="122.099593" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mca89382c6b" x="180.985721" y="141.85872" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mca89382c6b" x="164.441833" y="156.106179" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mca89382c6b" x="157.761315" y="165.23787" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mca89382c6b" x="151.269082" y="178.700983" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mca89382c6b" x="150.327087" y="185.23695" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p8096bb383d)">
+     <use xlink:href="#m804318e276" x="432.495268" y="96.067622" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m804318e276" x="300.62247" y="112.493412" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m804318e276" x="266.967623" y="120.8136" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m804318e276" x="226.040946" y="122.099593" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m804318e276" x="180.985721" y="141.85872" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m804318e276" x="164.441833" y="156.106179" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m804318e276" x="157.761315" y="165.23787" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m804318e276" x="151.269082" y="178.700983" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m804318e276" x="150.327087" y="185.23695" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_99">
@@ -3244,7 +3244,7 @@ L 308.86452 111.600609
 L 306.11717 111.899849 
 L 303.36982 112.197444 
 L 300.62247 112.493412 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_100">
     <path d="M 300.62247 112.493412 
@@ -3296,7 +3296,7 @@ L 269.071051 120.329422
 L 268.369908 120.491297 
 L 267.668766 120.652688 
 L 266.967623 120.8136 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_101">
     <path d="M 266.967623 120.8136 
@@ -3348,7 +3348,7 @@ L 228.598863 122.020108
 L 227.746224 122.046616 
 L 226.893585 122.073111 
 L 226.040946 122.099593 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_102">
     <path d="M 226.040946 122.099593 
@@ -3400,7 +3400,7 @@ L 183.801673 140.814056
 L 182.863022 141.164522 
 L 181.924372 141.512734 
 L 180.985721 141.85872 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_103">
     <path d="M 180.985721 141.85872 
@@ -3452,7 +3452,7 @@ L 165.475826 155.317544
 L 165.131161 155.581701 
 L 164.786497 155.844575 
 L 164.441833 156.106179 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_104">
     <path d="M 164.441833 156.106179 
@@ -3504,7 +3504,7 @@ L 158.178848 164.710119
 L 158.03967 164.886608 
 L 157.900493 165.062524 
 L 157.761315 165.23787 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_105">
     <path d="M 157.761315 165.23787 
@@ -3556,7 +3556,7 @@ L 151.674847 177.950842
 L 151.539592 178.202046 
 L 151.404337 178.452089 
 L 151.269082 178.700983 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_106">
     <path d="M 151.269082 178.700983 
@@ -3608,11 +3608,11 @@ L 150.385962 184.850776
 L 150.366337 184.979807 
 L 150.346712 185.108531 
 L 150.327087 185.23695 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_107">
     <defs>
-     <path id="m45cfdb7b80" d="M -1.25 2.5 
+     <path id="m51ef127478" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -3627,16 +3627,16 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p49dad874ee)">
-     <use xlink:href="#m45cfdb7b80" x="345.030867" y="136.859359" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m45cfdb7b80" x="273.364924" y="143.571257" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m45cfdb7b80" x="240.719951" y="149.310846" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m45cfdb7b80" x="221.353978" y="154.160538" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m45cfdb7b80" x="207.129625" y="156.092215" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m45cfdb7b80" x="181.064802" y="166.758473" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m45cfdb7b80" x="179.282169" y="170.289343" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m45cfdb7b80" x="177.719335" y="175.489948" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m45cfdb7b80" x="177.643939" y="181.552088" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p8096bb383d)">
+     <use xlink:href="#m51ef127478" x="345.030867" y="136.859359" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m51ef127478" x="273.364924" y="143.571257" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m51ef127478" x="240.719951" y="149.310846" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m51ef127478" x="221.353978" y="154.160538" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m51ef127478" x="207.129625" y="156.092215" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m51ef127478" x="181.064802" y="166.758473" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m51ef127478" x="179.282169" y="170.289343" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m51ef127478" x="177.719335" y="175.489948" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m51ef127478" x="177.643939" y="181.552088" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_108">
@@ -3689,7 +3689,7 @@ L 277.844045 143.175283
 L 276.351005 143.307597 
 L 274.857964 143.439587 
 L 273.364924 143.571257 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_109">
     <path d="M 273.364924 143.571257 
@@ -3741,7 +3741,7 @@ L 242.760262 148.96941
 L 242.080158 149.083462 
 L 241.400055 149.197273 
 L 240.719951 149.310846 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_110">
     <path d="M 240.719951 149.310846 
@@ -3793,7 +3793,7 @@ L 222.564351 153.869835
 L 222.160893 153.966909 
 L 221.757435 154.06381 
 L 221.353978 154.160538 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_111">
     <path d="M 221.353978 154.160538 
@@ -3845,7 +3845,7 @@ L 208.018647 155.973483
 L 207.722306 156.013089 
 L 207.425965 156.052666 
 L 207.129625 156.092215 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_112">
     <path d="M 207.129625 156.092215 
@@ -3897,7 +3897,7 @@ L 182.693853 166.149994
 L 182.150836 166.353581 
 L 181.607819 166.556405 
 L 181.064802 166.758473 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_113">
     <path d="M 181.064802 166.758473 
@@ -3949,7 +3949,7 @@ L 179.393584 170.075284
 L 179.356445 170.146731 
 L 179.319307 170.218084 
 L 179.282169 170.289343 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_114">
     <path d="M 179.282169 170.289343 
@@ -4001,7 +4001,7 @@ L 177.817012 175.179146
 L 177.784453 175.282945 
 L 177.751894 175.386546 
 L 177.719335 175.489948 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_115">
     <path d="M 177.719335 175.489948 
@@ -4053,11 +4053,11 @@ L 177.648651 181.192458
 L 177.64708 181.3126 
 L 177.645509 181.432477 
 L 177.643939 181.552088 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_116">
     <defs>
-     <path id="mec2cc8893d" d="M 0 -2.5 
+     <path id="m5f33a78c59" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -4070,16 +4070,16 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p49dad874ee)">
-     <use xlink:href="#mec2cc8893d" x="226.871027" y="113.224491" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mec2cc8893d" x="226.871027" y="113.066324" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mec2cc8893d" x="226.871027" y="113.178221" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mec2cc8893d" x="226.871027" y="113.089884" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mec2cc8893d" x="177.768423" y="132.327899" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mec2cc8893d" x="160.37503" y="145.652356" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mec2cc8893d" x="153.995779" y="152.678629" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mec2cc8893d" x="147.106887" y="168.143801" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mec2cc8893d" x="145.871703" y="175.118358" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p8096bb383d)">
+     <use xlink:href="#m5f33a78c59" x="226.871027" y="113.224491" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m5f33a78c59" x="226.871027" y="113.066324" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m5f33a78c59" x="226.871027" y="113.178221" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m5f33a78c59" x="226.871027" y="113.089884" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m5f33a78c59" x="177.768423" y="132.327899" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m5f33a78c59" x="160.37503" y="145.652356" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m5f33a78c59" x="153.995779" y="152.678629" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m5f33a78c59" x="147.106887" y="168.143801" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m5f33a78c59" x="145.871703" y="175.118358" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_117">
@@ -4132,7 +4132,7 @@ L 226.871027 113.076223
 L 226.871027 113.072924 
 L 226.871027 113.069624 
 L 226.871027 113.066324 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_118">
     <path d="M 226.871027 113.066324 
@@ -4184,7 +4184,7 @@ L 226.871027 113.171234
 L 226.871027 113.173563 
 L 226.871027 113.175892 
 L 226.871027 113.178221 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_119">
     <path d="M 226.871027 113.178221 
@@ -4236,7 +4236,7 @@ L 226.871027 113.09541
 L 226.871027 113.093568 
 L 226.871027 113.091726 
 L 226.871027 113.089884 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_120">
     <path d="M 226.871027 113.089884 
@@ -4288,7 +4288,7 @@ L 180.837336 131.306392
 L 179.814365 131.649041 
 L 178.791394 131.989534 
 L 177.768423 132.327899 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_121">
     <path d="M 177.768423 132.327899 
@@ -4340,7 +4340,7 @@ L 161.462117 144.909076
 L 161.099755 145.157972 
 L 160.737393 145.405728 
 L 160.37503 145.652356 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_122">
     <path d="M 160.37503 145.652356 
@@ -4392,7 +4392,7 @@ L 154.394483 152.265218
 L 154.261581 152.403373 
 L 154.12868 152.541176 
 L 153.995779 152.678629 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_123">
     <path d="M 153.995779 152.678629 
@@ -4444,7 +4444,7 @@ L 147.537442 167.296442
 L 147.393924 167.580372 
 L 147.250405 167.862819 
 L 147.106887 168.143801 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_124">
     <path d="M 147.106887 168.143801 
@@ -4496,11 +4496,11 @@ L 145.948902 174.70781
 L 145.923169 174.845005 
 L 145.897436 174.981854 
 L 145.871703 175.118358 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_125">
     <defs>
-     <path id="mae17d241f7" d="M 0 -2.5 
+     <path id="m22f29a78ca" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -4509,16 +4509,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p49dad874ee)">
-     <use xlink:href="#mae17d241f7" x="585.66883" y="173.051371" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mae17d241f7" x="527.144592" y="175.326465" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mae17d241f7" x="457.339427" y="183.688849" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mae17d241f7" x="292.124837" y="178.486631" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mae17d241f7" x="243.129344" y="190.369032" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mae17d241f7" x="213.541392" y="204.43395" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mae17d241f7" x="204.551957" y="212.140784" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mae17d241f7" x="195.860087" y="228.582256" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mae17d241f7" x="194.019853" y="234.294862" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p8096bb383d)">
+     <use xlink:href="#m22f29a78ca" x="585.66883" y="173.051371" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m22f29a78ca" x="527.144592" y="175.326465" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m22f29a78ca" x="457.339427" y="183.688849" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m22f29a78ca" x="292.124837" y="178.486631" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m22f29a78ca" x="243.129344" y="190.369032" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m22f29a78ca" x="213.541392" y="204.43395" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m22f29a78ca" x="204.551957" y="212.140784" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m22f29a78ca" x="195.860087" y="228.582256" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m22f29a78ca" x="194.019853" y="234.294862" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_126">
@@ -4571,7 +4571,7 @@ L 530.802357 175.187039
 L 529.583102 175.233554 
 L 528.363847 175.28003 
 L 527.144592 175.326465 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_127">
     <path d="M 527.144592 175.326465 
@@ -4623,7 +4623,7 @@ L 461.70225 183.20239
 L 460.247976 183.36503 
 L 458.793701 183.527182 
 L 457.339427 183.688849 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_128">
     <path d="M 457.339427 183.688849 
@@ -4675,7 +4675,7 @@ L 302.450749 178.826834
 L 299.008779 178.713671 
 L 295.566808 178.60027 
 L 292.124837 178.486631 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_129">
     <path d="M 292.124837 178.486631 
@@ -4727,7 +4727,7 @@ L 246.191563 189.6981
 L 245.170823 189.922669 
 L 244.150084 190.146311 
 L 243.129344 190.369032 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_130">
     <path d="M 243.129344 190.369032 
@@ -4779,7 +4779,7 @@ L 215.390639 203.654226
 L 214.774224 203.915384 
 L 214.157808 204.175288 
 L 213.541392 204.43395 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_131">
     <path d="M 213.541392 204.43395 
@@ -4831,7 +4831,7 @@ L 205.113797 211.689953
 L 204.926517 211.840648 
 L 204.739237 211.990924 
 L 204.551957 212.140784 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_132">
     <path d="M 204.551957 212.140784 
@@ -4883,7 +4883,7 @@ L 196.403329 227.688717
 L 196.222248 227.988205 
 L 196.041168 228.286045 
 L 195.860087 228.582256 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_133">
     <path d="M 195.860087 228.582256 
@@ -4935,7 +4935,7 @@ L 194.134867 233.954953
 L 194.096529 234.068494 
 L 194.058191 234.181796 
 L 194.019853 234.294862 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="legend_1">
     <g id="patch_7">
@@ -4953,7 +4953,7 @@ z
     </g>
     <g id="line2d_134">
      <defs>
-      <path id="m34154200ec" d="M 0 3.5 
+      <path id="mb38f89f762" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -4966,7 +4966,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m34154200ec" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#mb38f89f762" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -5025,7 +5025,7 @@ z
     </g>
     <g id="line2d_135">
      <g>
-      <use xlink:href="#m709da15e7e" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m3c0c7774e4" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -5039,7 +5039,7 @@ z
     </g>
     <g id="line2d_136">
      <g>
-      <use xlink:href="#m8323a7be1f" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m7aec2d94f9" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -5084,7 +5084,7 @@ z
     </g>
     <g id="line2d_137">
      <g>
-      <use xlink:href="#m0ead7fa3ab" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m0fca5ea94d" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -5127,7 +5127,7 @@ z
     </g>
     <g id="line2d_138">
      <g>
-      <use xlink:href="#m42903246a3" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m970474939d" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -5143,7 +5143,7 @@ z
     </g>
     <g id="line2d_139">
      <g>
-      <use xlink:href="#mca89382c6b" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m804318e276" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -5197,7 +5197,7 @@ z
     </g>
     <g id="line2d_140">
      <g>
-      <use xlink:href="#m45cfdb7b80" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m51ef127478" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -5262,7 +5262,7 @@ z
     </g>
     <g id="line2d_141">
      <g>
-      <use xlink:href="#mec2cc8893d" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#m5f33a78c59" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -5300,7 +5300,7 @@ z
     </g>
     <g id="line2d_142">
      <g>
-      <use xlink:href="#mae17d241f7" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m22f29a78ca" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -5370,486 +5370,486 @@ z
     </g>
    </g>
    <g id="line2d_143">
-    <g clip-path="url(#p49dad874ee)">
-     <use xlink:href="#m34154200ec" x="319.643112" y="117.176023" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m34154200ec" x="269.129958" y="129.719036" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m34154200ec" x="247.452898" y="135.539692" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m34154200ec" x="192.820547" y="151.842181" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m34154200ec" x="180.389901" y="163.51492" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m34154200ec" x="155.351585" y="172.655677" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m34154200ec" x="149.634124" y="177.205842" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m34154200ec" x="139.514773" y="190.541672" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m34154200ec" x="119.666036" y="285.81942" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m34154200ec" x="97.814287" y="313.360586" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <g clip-path="url(#p8096bb383d)">
+     <use xlink:href="#mb38f89f762" x="319.643112" y="116.988668" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mb38f89f762" x="263.489417" y="123.91363" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mb38f89f762" x="236.23654" y="131.649268" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mb38f89f762" x="192.820547" y="151.602511" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mb38f89f762" x="180.389901" y="163.269829" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mb38f89f762" x="155.351585" y="172.905838" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mb38f89f762" x="149.634124" y="177.912892" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mb38f89f762" x="139.514773" y="191.247614" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mb38f89f762" x="119.666036" y="285.929951" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mb38f89f762" x="97.814287" y="314.288725" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
    <g id="line2d_144">
-    <path d="M 319.643112 117.176023 
-L 318.590755 117.469295 
-L 317.538397 117.760987 
-L 316.48604 118.051115 
-L 315.433682 118.339697 
-L 314.381325 118.626749 
-L 313.328968 118.912286 
-L 312.27661 119.196325 
-L 311.224253 119.478882 
-L 310.171896 119.759971 
-L 309.119538 120.039608 
-L 308.067181 120.317808 
-L 307.014823 120.594585 
-L 305.962466 120.869955 
-L 304.910109 121.143931 
-L 303.857751 121.416527 
-L 302.805394 121.687757 
-L 301.753037 121.957635 
-L 300.700679 122.226174 
-L 299.648322 122.493387 
-L 298.595965 122.759288 
-L 297.543607 123.023889 
-L 296.49125 123.287203 
-L 295.438892 123.549243 
-L 294.386535 123.81002 
-L 293.334178 124.069546 
-L 292.28182 124.327835 
-L 291.229463 124.584896 
-L 290.177106 124.840743 
-L 289.124748 125.095386 
-L 288.072391 125.348837 
-L 287.020033 125.601107 
-L 285.967676 125.852207 
-L 284.915319 126.102147 
-L 283.862961 126.350938 
-L 282.810604 126.598591 
-L 281.758247 126.845117 
-L 280.705889 127.090524 
-L 279.653532 127.334825 
-L 278.601175 127.578027 
-L 277.548817 127.820142 
-L 276.49646 128.061179 
-L 275.444102 128.301147 
-L 274.391745 128.540056 
-L 273.339388 128.777915 
-L 272.28703 129.014733 
-L 271.234673 129.250521 
-L 270.182316 129.485285 
-L 269.129958 129.719036 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 319.643112 116.988668 
+L 318.473243 117.142354 
+L 317.303375 117.295605 
+L 316.133506 117.448424 
+L 314.963637 117.600812 
+L 313.793769 117.752773 
+L 312.6239 117.904308 
+L 311.454031 118.05542 
+L 310.284163 118.206111 
+L 309.114294 118.356384 
+L 307.944425 118.506241 
+L 306.774557 118.655685 
+L 305.604688 118.804717 
+L 304.43482 118.953339 
+L 303.264951 119.101555 
+L 302.095082 119.249366 
+L 300.925214 119.396775 
+L 299.755345 119.543783 
+L 298.585476 119.690393 
+L 297.415608 119.836607 
+L 296.245739 119.982427 
+L 295.07587 120.127856 
+L 293.906002 120.272895 
+L 292.736133 120.417546 
+L 291.566264 120.561811 
+L 290.396396 120.705694 
+L 289.226527 120.849194 
+L 288.056658 120.992316 
+L 286.88679 121.13506 
+L 285.716921 121.277428 
+L 284.547053 121.419423 
+L 283.377184 121.561047 
+L 282.207315 121.702301 
+L 281.037447 121.843187 
+L 279.867578 121.983708 
+L 278.697709 122.123865 
+L 277.527841 122.26366 
+L 276.357972 122.403094 
+L 275.188103 122.542171 
+L 274.018235 122.680891 
+L 272.848366 122.819257 
+L 271.678497 122.957269 
+L 270.508629 123.094931 
+L 269.33876 123.232244 
+L 268.168891 123.369209 
+L 266.999023 123.505828 
+L 265.829154 123.642104 
+L 264.659286 123.778037 
+L 263.489417 123.91363 
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_145">
-    <path d="M 269.129958 129.719036 
-L 268.678353 129.846908 
-L 268.226747 129.974479 
-L 267.775142 130.10175 
-L 267.323537 130.228722 
-L 266.871931 130.355398 
-L 266.420326 130.481777 
-L 265.96872 130.607862 
-L 265.517115 130.733655 
-L 265.065509 130.859155 
-L 264.613904 130.984365 
-L 264.162299 131.109287 
-L 263.710693 131.23392 
-L 263.259088 131.358268 
-L 262.807482 131.48233 
-L 262.355877 131.606109 
-L 261.904271 131.729605 
-L 261.452666 131.85282 
-L 261.001061 131.975756 
-L 260.549455 132.098413 
-L 260.09785 132.220792 
-L 259.646244 132.342896 
-L 259.194639 132.464724 
-L 258.743034 132.586279 
-L 258.291428 132.707562 
-L 257.839823 132.828574 
-L 257.388217 132.949315 
-L 256.936612 133.069788 
-L 256.485006 133.189994 
-L 256.033401 133.309933 
-L 255.581796 133.429607 
-L 255.13019 133.549017 
-L 254.678585 133.668164 
-L 254.226979 133.787049 
-L 253.775374 133.905674 
-L 253.323769 134.02404 
-L 252.872163 134.142147 
-L 252.420558 134.259997 
-L 251.968952 134.377591 
-L 251.517347 134.49493 
-L 251.065741 134.612016 
-L 250.614136 134.728848 
-L 250.162531 134.845429 
-L 249.710925 134.96176 
-L 249.25932 135.077841 
-L 248.807714 135.193674 
-L 248.356109 135.309259 
-L 247.904503 135.424598 
-L 247.452898 135.539692 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 263.489417 123.91363 
+L 262.921649 124.086596 
+L 262.35388 124.259012 
+L 261.786112 124.43088 
+L 261.218344 124.602204 
+L 260.650576 124.772988 
+L 260.082807 124.943234 
+L 259.515039 125.112947 
+L 258.947271 125.282129 
+L 258.379503 125.450784 
+L 257.811734 125.618916 
+L 257.243966 125.786526 
+L 256.676198 125.95362 
+L 256.108429 126.120199 
+L 255.540661 126.286267 
+L 254.972893 126.451827 
+L 254.405125 126.616883 
+L 253.837356 126.781436 
+L 253.269588 126.945491 
+L 252.70182 127.10905 
+L 252.134052 127.272117 
+L 251.566283 127.434693 
+L 250.998515 127.596783 
+L 250.430747 127.758389 
+L 249.862979 127.919514 
+L 249.29521 128.080161 
+L 248.727442 128.240333 
+L 248.159674 128.400032 
+L 247.591906 128.559261 
+L 247.024137 128.718023 
+L 246.456369 128.876321 
+L 245.888601 129.034157 
+L 245.320832 129.191535 
+L 244.753064 129.348456 
+L 244.185296 129.504923 
+L 243.617528 129.66094 
+L 243.049759 129.816508 
+L 242.481991 129.971631 
+L 241.914223 130.12631 
+L 241.346455 130.280548 
+L 240.778686 130.434349 
+L 240.210918 130.587713 
+L 239.64315 130.740644 
+L 239.075382 130.893145 
+L 238.507613 131.045217 
+L 237.939845 131.196863 
+L 237.372077 131.348085 
+L 236.804309 131.498886 
+L 236.23654 131.649268 
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_146">
-    <path d="M 247.452898 135.539692 
-L 246.314724 135.934572 
-L 245.17655 136.326592 
-L 244.038376 136.715794 
-L 242.900202 137.102217 
-L 241.762028 137.485901 
-L 240.623854 137.866885 
-L 239.48568 138.245206 
-L 238.347506 138.620901 
-L 237.209332 138.994007 
-L 236.071158 139.364559 
-L 234.932984 139.732591 
-L 233.79481 140.098138 
-L 232.656636 140.461233 
-L 231.518462 140.821909 
-L 230.380288 141.180197 
-L 229.242114 141.53613 
-L 228.10394 141.889737 
-L 226.965766 142.24105 
-L 225.827592 142.590097 
-L 224.689418 142.936908 
-L 223.551244 143.281511 
-L 222.41307 143.623934 
-L 221.274896 143.964205 
-L 220.136722 144.30235 
-L 218.998548 144.638396 
-L 217.860374 144.972369 
-L 216.7222 145.304294 
-L 215.584026 145.634195 
-L 214.445852 145.962099 
-L 213.307678 146.288028 
-L 212.169505 146.612006 
-L 211.031331 146.934057 
-L 209.893157 147.254203 
-L 208.754983 147.572467 
-L 207.616809 147.888871 
-L 206.478635 148.203436 
-L 205.340461 148.516183 
-L 204.202287 148.827134 
-L 203.064113 149.136309 
-L 201.925939 149.443728 
-L 200.787765 149.749411 
-L 199.649591 150.053377 
-L 198.511417 150.355647 
-L 197.373243 150.656237 
-L 196.235069 150.955168 
-L 195.096895 151.252457 
-L 193.958721 151.548122 
-L 192.820547 151.842181 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 236.23654 131.649268 
+L 235.33204 132.149604 
+L 234.427541 132.645358 
+L 233.523041 133.136613 
+L 232.618541 133.623449 
+L 231.714041 134.105946 
+L 230.809541 134.584181 
+L 229.905041 135.058227 
+L 229.000541 135.528158 
+L 228.096041 135.994044 
+L 227.191542 136.455955 
+L 226.287042 136.913958 
+L 225.382542 137.368117 
+L 224.478042 137.818499 
+L 223.573542 138.265164 
+L 222.669042 138.708173 
+L 221.764542 139.147586 
+L 220.860043 139.583461 
+L 219.955543 140.015854 
+L 219.051043 140.444821 
+L 218.146543 140.870415 
+L 217.242043 141.292689 
+L 216.337543 141.711694 
+L 215.433043 142.127481 
+L 214.528544 142.540099 
+L 213.624044 142.949595 
+L 212.719544 143.356016 
+L 211.815044 143.759409 
+L 210.910544 144.159818 
+L 210.006044 144.557287 
+L 209.101544 144.951858 
+L 208.197044 145.343575 
+L 207.292545 145.732477 
+L 206.388045 146.118605 
+L 205.483545 146.501998 
+L 204.579045 146.882694 
+L 203.674545 147.260732 
+L 202.770045 147.636149 
+L 201.865545 148.008979 
+L 200.961046 148.379259 
+L 200.056546 148.747024 
+L 199.152046 149.112307 
+L 198.247546 149.475141 
+L 197.343046 149.83556 
+L 196.438546 150.193594 
+L 195.534046 150.549276 
+L 194.629546 150.902637 
+L 193.725047 151.253705 
+L 192.820547 151.602511 
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_147">
-    <path d="M 192.820547 151.842181 
-L 192.561575 152.112895 
-L 192.302603 152.382263 
-L 192.043631 152.650296 
-L 191.78466 152.917009 
-L 191.525688 153.182414 
-L 191.266716 153.446524 
-L 191.007744 153.709352 
-L 190.748773 153.97091 
-L 190.489801 154.23121 
-L 190.230829 154.490265 
-L 189.971857 154.748085 
-L 189.712885 155.004684 
-L 189.453914 155.260072 
-L 189.194942 155.51426 
-L 188.93597 155.767261 
-L 188.676998 156.019084 
-L 188.418027 156.269742 
-L 188.159055 156.519244 
-L 187.900083 156.767601 
-L 187.641111 157.014824 
-L 187.382139 157.260924 
-L 187.123168 157.505909 
-L 186.864196 157.749791 
-L 186.605224 157.992578 
-L 186.346252 158.234282 
-L 186.087281 158.474911 
-L 185.828309 158.714476 
-L 185.569337 158.952984 
-L 185.310365 159.190447 
-L 185.051393 159.426872 
-L 184.792422 159.662269 
-L 184.53345 159.896647 
-L 184.274478 160.130015 
-L 184.015506 160.362381 
-L 183.756535 160.593753 
-L 183.497563 160.824141 
-L 183.238591 161.053552 
-L 182.979619 161.281996 
-L 182.720647 161.509479 
-L 182.461676 161.73601 
-L 182.202704 161.961597 
-L 181.943732 162.186248 
-L 181.68476 162.409971 
-L 181.425789 162.632772 
-L 181.166817 162.854661 
-L 180.907845 163.075643 
-L 180.648873 163.295728 
-L 180.389901 163.51492 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 192.820547 151.602511 
+L 192.561575 151.873086 
+L 192.302603 152.142316 
+L 192.043631 152.410212 
+L 191.78466 152.67679 
+L 191.525688 152.942061 
+L 191.266716 153.206038 
+L 191.007744 153.468735 
+L 190.748773 153.730163 
+L 190.489801 153.990334 
+L 190.230829 154.249261 
+L 189.971857 154.506955 
+L 189.712885 154.763428 
+L 189.453914 155.018692 
+L 189.194942 155.272757 
+L 188.93597 155.525636 
+L 188.676998 155.777339 
+L 188.418027 156.027877 
+L 188.159055 156.277261 
+L 187.900083 156.525501 
+L 187.641111 156.772607 
+L 187.382139 157.018591 
+L 187.123168 157.263462 
+L 186.864196 157.507231 
+L 186.605224 157.749907 
+L 186.346252 157.991499 
+L 186.087281 158.232018 
+L 185.828309 158.471473 
+L 185.569337 158.709874 
+L 185.310365 158.947229 
+L 185.051393 159.183548 
+L 184.792422 159.41884 
+L 184.53345 159.653113 
+L 184.274478 159.886377 
+L 184.015506 160.11864 
+L 183.756535 160.349911 
+L 183.497563 160.580197 
+L 183.238591 160.809509 
+L 182.979619 161.037853 
+L 182.720647 161.265237 
+L 182.461676 161.491671 
+L 182.202704 161.717161 
+L 181.943732 161.941716 
+L 181.68476 162.165344 
+L 181.425789 162.388051 
+L 181.166817 162.609846 
+L 180.907845 162.830735 
+L 180.648873 163.050727 
+L 180.389901 163.269829 
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_148">
-    <path d="M 180.389901 163.51492 
-L 179.86827 163.721979 
-L 179.346638 163.928249 
-L 178.825007 164.133736 
-L 178.303375 164.338446 
-L 177.781744 164.542385 
-L 177.260112 164.745558 
-L 176.73848 164.947971 
-L 176.216849 165.14963 
-L 175.695217 165.350541 
-L 175.173586 165.550709 
-L 174.651954 165.75014 
-L 174.130322 165.948838 
-L 173.608691 166.14681 
-L 173.087059 166.34406 
-L 172.565428 166.540594 
-L 172.043796 166.736418 
-L 171.522165 166.931535 
-L 171.000533 167.125951 
-L 170.478901 167.319672 
-L 169.95727 167.512702 
-L 169.435638 167.705046 
-L 168.914007 167.896709 
-L 168.392375 168.087696 
-L 167.870743 168.278012 
-L 167.349112 168.46766 
-L 166.82748 168.656647 
-L 166.305849 168.844976 
-L 165.784217 169.032652 
-L 165.262586 169.219679 
-L 164.740954 169.406063 
-L 164.219322 169.591807 
-L 163.697691 169.776916 
-L 163.176059 169.961394 
-L 162.654428 170.145246 
-L 162.132796 170.328475 
-L 161.611164 170.511086 
-L 161.089533 170.693083 
-L 160.567901 170.87447 
-L 160.04627 171.055252 
-L 159.524638 171.235431 
-L 159.003007 171.415013 
-L 158.481375 171.594001 
-L 157.959743 171.7724 
-L 157.438112 171.950212 
-L 156.91648 172.127442 
-L 156.394849 172.304094 
-L 155.873217 172.480171 
-L 155.351585 172.655677 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 180.389901 163.269829 
+L 179.86827 163.489111 
+L 179.346638 163.707509 
+L 178.825007 163.925029 
+L 178.303375 164.141679 
+L 177.781744 164.357465 
+L 177.260112 164.572394 
+L 176.73848 164.786473 
+L 176.216849 164.999709 
+L 175.695217 165.212109 
+L 175.173586 165.423678 
+L 174.651954 165.634423 
+L 174.130322 165.844351 
+L 173.608691 166.053468 
+L 173.087059 166.26178 
+L 172.565428 166.469294 
+L 172.043796 166.676016 
+L 171.522165 166.88195 
+L 171.000533 167.087105 
+L 170.478901 167.291485 
+L 169.95727 167.495096 
+L 169.435638 167.697944 
+L 168.914007 167.900034 
+L 168.392375 168.101373 
+L 167.870743 168.301966 
+L 167.349112 168.501819 
+L 166.82748 168.700936 
+L 166.305849 168.899323 
+L 165.784217 169.096986 
+L 165.262586 169.29393 
+L 164.740954 169.49016 
+L 164.219322 169.685682 
+L 163.697691 169.880499 
+L 163.176059 170.074618 
+L 162.654428 170.268043 
+L 162.132796 170.46078 
+L 161.611164 170.652832 
+L 161.089533 170.844206 
+L 160.567901 171.034906 
+L 160.04627 171.224936 
+L 159.524638 171.414301 
+L 159.003007 171.603006 
+L 158.481375 171.791056 
+L 157.959743 171.978454 
+L 157.438112 172.165207 
+L 156.91648 172.351317 
+L 156.394849 172.536789 
+L 155.873217 172.721628 
+L 155.351585 172.905838 
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_149">
-    <path d="M 155.351585 172.655677 
-L 155.232472 172.75448 
-L 155.113358 172.853103 
-L 154.994244 172.951547 
-L 154.87513 173.049812 
-L 154.756017 173.147899 
-L 154.636903 173.245808 
-L 154.517789 173.343541 
-L 154.398675 173.441097 
-L 154.279561 173.538478 
-L 154.160448 173.635685 
-L 154.041334 173.732717 
-L 153.92222 173.829575 
-L 153.803106 173.92626 
-L 153.683992 174.022773 
-L 153.564879 174.119114 
-L 153.445765 174.215284 
-L 153.326651 174.311284 
-L 153.207537 174.407113 
-L 153.088424 174.502774 
-L 152.96931 174.598265 
-L 152.850196 174.693588 
-L 152.731082 174.788744 
-L 152.611968 174.883733 
-L 152.492855 174.978555 
-L 152.373741 175.073212 
-L 152.254627 175.167703 
-L 152.135513 175.262029 
-L 152.016399 175.356192 
-L 151.897286 175.450191 
-L 151.778172 175.544027 
-L 151.659058 175.637701 
-L 151.539944 175.731213 
-L 151.420831 175.824563 
-L 151.301717 175.917753 
-L 151.182603 176.010783 
-L 151.063489 176.103653 
-L 150.944375 176.196364 
-L 150.825262 176.288917 
-L 150.706148 176.381311 
-L 150.587034 176.473549 
-L 150.46792 176.565629 
-L 150.348806 176.657553 
-L 150.229693 176.749321 
-L 150.110579 176.840933 
-L 149.991465 176.932391 
-L 149.872351 177.023695 
-L 149.753238 177.114845 
-L 149.634124 177.205842 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 155.351585 172.905838 
+L 155.232472 173.015018 
+L 155.113358 173.123978 
+L 154.994244 173.23272 
+L 154.87513 173.341243 
+L 154.756017 173.44955 
+L 154.636903 173.55764 
+L 154.517789 173.665514 
+L 154.398675 173.773174 
+L 154.279561 173.880621 
+L 154.160448 173.987854 
+L 154.041334 174.094876 
+L 153.92222 174.201686 
+L 153.803106 174.308286 
+L 153.683992 174.414677 
+L 153.564879 174.520859 
+L 153.445765 174.626833 
+L 153.326651 174.7326 
+L 153.207537 174.83816 
+L 153.088424 174.943515 
+L 152.96931 175.048666 
+L 152.850196 175.153613 
+L 152.731082 175.258356 
+L 152.611968 175.362898 
+L 152.492855 175.467237 
+L 152.373741 175.571376 
+L 152.254627 175.675316 
+L 152.135513 175.779055 
+L 152.016399 175.882597 
+L 151.897286 175.985941 
+L 151.778172 176.089088 
+L 151.659058 176.192038 
+L 151.539944 176.294794 
+L 151.420831 176.397354 
+L 151.301717 176.499721 
+L 151.182603 176.601894 
+L 151.063489 176.703875 
+L 150.944375 176.805664 
+L 150.825262 176.907263 
+L 150.706148 177.00867 
+L 150.587034 177.109889 
+L 150.46792 177.210918 
+L 150.348806 177.311759 
+L 150.229693 177.412412 
+L 150.110579 177.512879 
+L 149.991465 177.61316 
+L 149.872351 177.713255 
+L 149.753238 177.813165 
+L 149.634124 177.912892 
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_150">
-    <path d="M 149.634124 177.205842 
-L 149.423304 177.519974 
-L 149.212484 177.832294 
-L 149.001664 178.142822 
-L 148.790845 178.451579 
-L 148.580025 178.758584 
-L 148.369205 179.063859 
-L 148.158385 179.367421 
-L 147.947565 179.669291 
-L 147.736745 179.969486 
-L 147.525926 180.268026 
-L 147.315106 180.564929 
-L 147.104286 180.860211 
-L 146.893466 181.153892 
-L 146.682646 181.445988 
-L 146.471827 181.736517 
-L 146.261007 182.025494 
-L 146.050187 182.312937 
-L 145.839367 182.598862 
-L 145.628547 182.883284 
-L 145.417728 183.16622 
-L 145.206908 183.447684 
-L 144.996088 183.727692 
-L 144.785268 184.00626 
-L 144.574448 184.283401 
-L 144.363629 184.559131 
-L 144.152809 184.833463 
-L 143.941989 185.106412 
-L 143.731169 185.377992 
-L 143.520349 185.648216 
-L 143.30953 185.917097 
-L 143.09871 186.18465 
-L 142.88789 186.450886 
-L 142.67707 186.71582 
-L 142.46625 186.979463 
-L 142.25543 187.241829 
-L 142.044611 187.502929 
-L 141.833791 187.762775 
-L 141.622971 188.02138 
-L 141.412151 188.278756 
-L 141.201331 188.534914 
-L 140.990512 188.789865 
-L 140.779692 189.043621 
-L 140.568872 189.296193 
-L 140.358052 189.547592 
-L 140.147232 189.797829 
-L 139.936413 190.046914 
-L 139.725593 190.294858 
-L 139.514773 190.541672 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 149.634124 177.912892 
+L 149.423304 178.226995 
+L 149.212484 178.539285 
+L 149.001664 178.849785 
+L 148.790845 179.158513 
+L 148.580025 179.465491 
+L 148.369205 179.770738 
+L 148.158385 180.074273 
+L 147.947565 180.376115 
+L 147.736745 180.676284 
+L 147.525926 180.974797 
+L 147.315106 181.271673 
+L 147.104286 181.56693 
+L 146.893466 181.860585 
+L 146.682646 182.152656 
+L 146.471827 182.443159 
+L 146.261007 182.732112 
+L 146.050187 183.01953 
+L 145.839367 183.305431 
+L 145.628547 183.589829 
+L 145.417728 183.872741 
+L 145.206908 184.154181 
+L 144.996088 184.434167 
+L 144.785268 184.712711 
+L 144.574448 184.989829 
+L 144.363629 185.265536 
+L 144.152809 185.539846 
+L 143.941989 185.812773 
+L 143.731169 186.084331 
+L 143.520349 186.354533 
+L 143.30953 186.623393 
+L 143.09871 186.890924 
+L 142.88789 187.15714 
+L 142.67707 187.422053 
+L 142.46625 187.685675 
+L 142.25543 187.94802 
+L 142.044611 188.2091 
+L 141.833791 188.468926 
+L 141.622971 188.727511 
+L 141.412151 188.984867 
+L 141.201331 189.241005 
+L 140.990512 189.495937 
+L 140.779692 189.749674 
+L 140.568872 190.002227 
+L 140.358052 190.253607 
+L 140.147232 190.503826 
+L 139.936413 190.752892 
+L 139.725593 191.000819 
+L 139.514773 191.247614 
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_151">
-    <path d="M 139.514773 190.541672 
-L 139.101258 195.714424 
-L 138.687742 200.435699 
-L 138.274227 204.778021 
-L 137.860712 208.797728 
-L 137.447196 212.539461 
-L 137.033681 216.03919 
-L 136.620165 219.326328 
-L 136.20665 222.42523 
-L 135.793135 225.35629 
-L 135.379619 228.136762 
-L 134.966104 230.781363 
-L 134.552589 233.302758 
-L 134.139073 235.711916 
-L 133.725558 238.018406 
-L 133.312043 240.230622 
-L 132.898527 242.355968 
-L 132.485012 244.40101 
-L 132.071496 246.371596 
-L 131.657981 248.272957 
-L 131.244466 250.109794 
-L 130.83095 251.886341 
-L 130.417435 253.606431 
-L 130.00392 255.273542 
-L 129.590404 256.890841 
-L 129.176889 258.461217 
-L 128.763374 259.987318 
-L 128.349858 261.471571 
-L 127.936343 262.91621 
-L 127.522827 264.323295 
-L 127.109312 265.694729 
-L 126.695797 267.032274 
-L 126.282281 268.337565 
-L 125.868766 269.61212 
-L 125.455251 270.857355 
-L 125.041735 272.074586 
-L 124.62822 273.265048 
-L 124.214705 274.42989 
-L 123.801189 275.570194 
-L 123.387674 276.686972 
-L 122.974158 277.781174 
-L 122.560643 278.853696 
-L 122.147128 279.90538 
-L 121.733612 280.93702 
-L 121.320097 281.949366 
-L 120.906582 282.943126 
-L 120.493066 283.918971 
-L 120.079551 284.877535 
-L 119.666036 285.81942 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 139.514773 191.247614 
+L 139.101258 196.355149 
+L 138.687742 201.022041 
+L 138.274227 205.318321 
+L 137.860712 209.298546 
+L 137.447196 213.006047 
+L 137.033681 216.475813 
+L 136.620165 219.736505 
+L 136.20665 222.811892 
+L 135.793135 225.721909 
+L 135.379619 228.483437 
+L 134.966104 231.110895 
+L 134.552589 233.616703 
+L 134.139073 236.011627 
+L 133.725558 238.305067 
+L 133.312043 240.505275 
+L 132.898527 242.619536 
+L 132.485012 244.654312 
+L 132.071496 246.615365 
+L 131.657981 248.50785 
+L 131.244466 250.336401 
+L 130.83095 252.105196 
+L 130.417435 253.818019 
+L 130.00392 255.478302 
+L 129.590404 257.089174 
+L 129.176889 258.653491 
+L 128.763374 260.173868 
+L 128.349858 261.652706 
+L 127.936343 263.092215 
+L 127.522827 264.494433 
+L 127.109312 265.861244 
+L 126.695797 267.19439 
+L 126.282281 268.495492 
+L 125.868766 269.766052 
+L 125.455251 271.007473 
+L 125.041735 272.221061 
+L 124.62822 273.408037 
+L 124.214705 274.569542 
+L 123.801189 275.706648 
+L 123.387674 276.820357 
+L 122.974158 277.911614 
+L 122.560643 278.981306 
+L 122.147128 280.030268 
+L 121.733612 281.05929 
+L 121.320097 282.069114 
+L 120.906582 283.060444 
+L 120.493066 284.033946 
+L 120.079551 284.990249 
+L 119.666036 285.929951 
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_152">
-    <path d="M 119.666036 285.81942 
-L 119.210791 286.56229 
-L 118.755546 287.295104 
-L 118.300301 288.018129 
-L 117.845056 288.731624 
-L 117.389812 289.435837 
-L 116.934567 290.131006 
-L 116.479322 290.817361 
-L 116.024077 291.495122 
-L 115.568833 292.164501 
-L 115.113588 292.825704 
-L 114.658343 293.478928 
-L 114.203098 294.124364 
-L 113.747854 294.762194 
-L 113.292609 295.392595 
-L 112.837364 296.01574 
-L 112.382119 296.631793 
-L 111.926875 297.240913 
-L 111.47163 297.843256 
-L 111.016385 298.43897 
-L 110.56114 299.028199 
-L 110.105895 299.611083 
-L 109.650651 300.187757 
-L 109.195406 300.758353 
-L 108.740161 301.322997 
-L 108.284916 301.881812 
-L 107.829672 302.434917 
-L 107.374427 302.982427 
-L 106.919182 303.524455 
-L 106.463937 304.06111 
-L 106.008693 304.592496 
-L 105.553448 305.118716 
-L 105.098203 305.63987 
-L 104.642958 306.156055 
-L 104.187713 306.667363 
-L 103.732469 307.173888 
-L 103.277224 307.675716 
-L 102.821979 308.172935 
-L 102.366734 308.665628 
-L 101.91149 309.153877 
-L 101.456245 309.637762 
-L 101.001 310.117359 
-L 100.545755 310.592745 
-L 100.090511 311.063992 
-L 99.635266 311.531172 
-L 99.180021 311.994354 
-L 98.724776 312.453607 
-L 98.269531 312.908996 
-L 97.814287 313.360586 
-" clip-path="url(#p49dad874ee)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 119.666036 285.929951 
+L 119.210791 286.700971 
+L 118.755546 287.461164 
+L 118.300301 288.210828 
+L 117.845056 288.950252 
+L 117.389812 289.679711 
+L 116.934567 290.399471 
+L 116.479322 291.109786 
+L 116.024077 291.810901 
+L 115.568833 292.503051 
+L 115.113588 293.186462 
+L 114.658343 293.861353 
+L 114.203098 294.527933 
+L 113.747854 295.186404 
+L 113.292609 295.836962 
+L 112.837364 296.479794 
+L 112.382119 297.115081 
+L 111.926875 297.742999 
+L 111.47163 298.363717 
+L 111.016385 298.977398 
+L 110.56114 299.584199 
+L 110.105895 300.184274 
+L 109.650651 300.777769 
+L 109.195406 301.364827 
+L 108.740161 301.945588 
+L 108.284916 302.520183 
+L 107.829672 303.088743 
+L 107.374427 303.651394 
+L 106.919182 304.208256 
+L 106.463937 304.759448 
+L 106.008693 305.305084 
+L 105.553448 305.845275 
+L 105.098203 306.380128 
+L 104.642958 306.909748 
+L 104.187713 307.434237 
+L 103.732469 307.953693 
+L 103.277224 308.468211 
+L 102.821979 308.977884 
+L 102.366734 309.482804 
+L 101.91149 309.983057 
+L 101.456245 310.478729 
+L 101.001 310.969904 
+L 100.545755 311.456662 
+L 100.090511 311.939082 
+L 99.635266 312.417241 
+L 99.180021 312.891212 
+L 98.724776 313.36107 
+L 98.269531 313.826885 
+L 97.814287 314.288725 
+" clip-path="url(#p8096bb383d)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
   </g>
   <g id="text_25">
@@ -6166,8 +6166,8 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-07-09T17:31:54Z  ·  Linux chungus2 x86_64  ·  commit 324f086c  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(44.677578 465.66) scale(0.07 -0.07)">
+   <!-- 2026-07-10T04:34:01Z  ·  Linux chungus2 x86_64  ·  commit 74861182  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(43.380391 465.66) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -6177,36 +6177,6 @@ L 1172 0
 L 2766 4134 
 L 525 4134 
 L 525 4666 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-39" d="M 703 97 
-L 703 672 
-Q 941 559 1184 500 
-Q 1428 441 1663 441 
-Q 2288 441 2617 861 
-Q 2947 1281 2994 2138 
-Q 2813 1869 2534 1725 
-Q 2256 1581 1919 1581 
-Q 1219 1581 811 2004 
-Q 403 2428 403 3163 
-Q 403 3881 828 4315 
-Q 1253 4750 1959 4750 
-Q 2769 4750 3195 4129 
-Q 3622 3509 3622 2328 
-Q 3622 1225 3098 567 
-Q 2575 -91 1691 -91 
-Q 1453 -91 1209 -44 
-Q 966 3 703 97 
-z
-M 1959 2075 
-Q 2384 2075 2632 2365 
-Q 2881 2656 2881 3163 
-Q 2881 3666 2632 3958 
-Q 2384 4250 1959 4250 
-Q 1534 4250 1286 3958 
-Q 1038 3666 1038 3163 
-Q 1038 2656 1286 2365 
-Q 1534 2075 1959 2075 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-54" d="M -19 4666 
@@ -6231,31 +6201,6 @@ L 1409 3309
 L 1409 2516 
 L 750 2516 
 L 750 3309 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-b7" d="M 684 2619 
@@ -6352,17 +6297,17 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(290.576172 0)"/>
     <use xlink:href="#DejaVuSans-37" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(453.90625 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
     <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -6402,109 +6347,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3262.744141 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3297.949219 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3361.572266 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3425.195312 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3488.818359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3543.798828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3575.585938 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3607.373047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3639.160156 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3670.947266 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3702.734375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3730.517578 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3792.041016 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3853.320312 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3916.699219 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3980.175781 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4019.039062 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4080.220703 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4139.400391 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4200.923828 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4242.037109 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4275.728516 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4303.511719 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4365.035156 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4426.314453 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4489.693359 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4553.316406 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4587.007812 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4646.1875 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4709.810547 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4741.597656 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4805.220703 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4868.84375 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4900.630859 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4964.253906 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5000.337891 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5039.201172 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5094.181641 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5157.804688 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5189.591797 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5221.378906 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5253.166016 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5284.953125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5316.740234 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5355.949219 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5419.328125 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5458.191406 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5519.373047 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5582.751953 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5646.228516 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5709.607422 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5773.083984 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5836.462891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5875.671875 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5907.458984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5991.248047 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6023.035156 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6120.447266 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6181.970703 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6245.447266 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6273.230469 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6334.509766 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6397.888672 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6429.675781 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6481.775391 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6545.154297 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6606.433594 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6669.910156 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6722.009766 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6785.388672 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6846.570312 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6885.779297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6919.470703 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6951.257812 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6992.371094 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7053.650391 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7092.859375 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7120.642578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7181.824219 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7213.611328 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7241.394531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7293.494141 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7325.28125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7388.757812 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7450.28125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7489.490234 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7551.013672 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7590.376953 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7687.789062 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7715.572266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7778.951172 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7806.734375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7858.833984 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7898.042969 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7925.826172 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3262.744141 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3326.367188 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3389.990234 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3453.613281 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3517.236328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3580.859375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3612.646484 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3644.433594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3676.220703 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3708.007812 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3739.794922 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3767.578125 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3829.101562 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3890.380859 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3953.759766 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4017.236328 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4056.099609 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4117.28125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4176.460938 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4237.984375 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4279.097656 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4312.789062 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4340.572266 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4402.095703 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4463.375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4526.753906 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4590.376953 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4624.068359 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4683.248047 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4746.871094 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4778.658203 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4842.28125 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4905.904297 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4937.691406 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(5001.314453 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5037.398438 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5076.261719 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5131.242188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5194.865234 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5226.652344 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5258.439453 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5290.226562 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5322.013672 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5353.800781 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5393.009766 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5456.388672 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5495.251953 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5556.433594 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5619.8125 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5683.289062 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5746.667969 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5810.144531 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5873.523438 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5912.732422 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5944.519531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6028.308594 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6060.095703 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6157.507812 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6219.03125 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6282.507812 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6310.291016 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6371.570312 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6434.949219 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6466.736328 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6518.835938 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6582.214844 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6643.494141 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6706.970703 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6759.070312 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6822.449219 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6883.630859 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6922.839844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6956.53125 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6988.318359 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7029.431641 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7090.710938 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7129.919922 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7157.703125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7218.884766 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7250.671875 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7278.455078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7330.554688 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7362.341797 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7425.818359 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7487.341797 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7526.550781 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7588.074219 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7627.4375 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7724.849609 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7752.632812 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7816.011719 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7843.794922 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7895.894531 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7935.103516 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7962.886719 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p49dad874ee">
+  <clipPath id="p8096bb383d">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_decode_density.svg
+++ b/bench/graphs/silesia_decode_density.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 82.373685 412.80375 
 L 82.373685 47.3475 
-" clip-path="url(#p828f705f24)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p76f41c36bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m8a7c3a19a5" d="M 0 0 
+       <path id="mea72bcbcdc" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m8a7c3a19a5" x="82.373685" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mea72bcbcdc" x="82.373685" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -111,11 +111,11 @@ z
      <g id="line2d_3">
       <path d="M 165.44644 412.80375 
 L 165.44644 47.3475 
-" clip-path="url(#p828f705f24)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p76f41c36bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m8a7c3a19a5" x="165.44644" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mea72bcbcdc" x="165.44644" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -157,11 +157,11 @@ z
      <g id="line2d_5">
       <path d="M 248.519195 412.80375 
 L 248.519195 47.3475 
-" clip-path="url(#p828f705f24)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p76f41c36bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m8a7c3a19a5" x="248.519195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mea72bcbcdc" x="248.519195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -211,11 +211,11 @@ z
      <g id="line2d_7">
       <path d="M 331.59195 412.80375 
 L 331.59195 47.3475 
-" clip-path="url(#p828f705f24)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p76f41c36bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m8a7c3a19a5" x="331.59195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mea72bcbcdc" x="331.59195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -252,11 +252,11 @@ z
      <g id="line2d_9">
       <path d="M 414.664704 412.80375 
 L 414.664704 47.3475 
-" clip-path="url(#p828f705f24)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p76f41c36bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m8a7c3a19a5" x="414.664704" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mea72bcbcdc" x="414.664704" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -299,11 +299,11 @@ z
      <g id="line2d_11">
       <path d="M 497.737459 412.80375 
 L 497.737459 47.3475 
-" clip-path="url(#p828f705f24)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p76f41c36bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m8a7c3a19a5" x="497.737459" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mea72bcbcdc" x="497.737459" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -351,11 +351,11 @@ z
      <g id="line2d_13">
       <path d="M 580.810214 412.80375 
 L 580.810214 47.3475 
-" clip-path="url(#p828f705f24)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p76f41c36bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m8a7c3a19a5" x="580.810214" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mea72bcbcdc" x="580.810214" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -897,16 +897,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 391.33747 
 L 637.2 391.33747 
-" clip-path="url(#p828f705f24)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p76f41c36bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="m409263b295" d="M 0 0 
+       <path id="mc92d7f50a3" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m409263b295" x="49.078125" y="391.33747" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc92d7f50a3" x="49.078125" y="391.33747" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -922,11 +922,11 @@ L -3.5 0
      <g id="line2d_17">
       <path d="M 49.078125 263.934445 
 L 637.2 263.934445 
-" clip-path="url(#p828f705f24)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p76f41c36bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m409263b295" x="49.078125" y="263.934445" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc92d7f50a3" x="49.078125" y="263.934445" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -942,11 +942,11 @@ L 637.2 263.934445
      <g id="line2d_19">
       <path d="M 49.078125 136.53142 
 L 637.2 136.53142 
-" clip-path="url(#p828f705f24)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p76f41c36bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m409263b295" x="49.078125" y="136.53142" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc92d7f50a3" x="49.078125" y="136.53142" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -962,16 +962,16 @@ L 637.2 136.53142
      <g id="line2d_21">
       <path d="M 49.078125 411.072449 
 L 637.2 411.072449 
-" clip-path="url(#p828f705f24)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p76f41c36bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="mc6b54a5c44" d="M 0 0 
+       <path id="m40f8968b2a" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#mc6b54a5c44" x="49.078125" y="411.072449" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m40f8968b2a" x="49.078125" y="411.072449" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -979,11 +979,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 403.684099 
 L 637.2 403.684099 
-" clip-path="url(#p828f705f24)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p76f41c36bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mc6b54a5c44" x="49.078125" y="403.684099" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m40f8968b2a" x="49.078125" y="403.684099" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -991,11 +991,11 @@ L 637.2 403.684099
      <g id="line2d_25">
       <path d="M 49.078125 397.167113 
 L 637.2 397.167113 
-" clip-path="url(#p828f705f24)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p76f41c36bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mc6b54a5c44" x="49.078125" y="397.167113" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m40f8968b2a" x="49.078125" y="397.167113" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1003,11 +1003,11 @@ L 637.2 397.167113
      <g id="line2d_27">
       <path d="M 49.078125 352.985338 
 L 637.2 352.985338 
-" clip-path="url(#p828f705f24)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p76f41c36bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#mc6b54a5c44" x="49.078125" y="352.985338" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m40f8968b2a" x="49.078125" y="352.985338" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1015,11 +1015,11 @@ L 637.2 352.985338
      <g id="line2d_29">
       <path d="M 49.078125 330.550779 
 L 637.2 330.550779 
-" clip-path="url(#p828f705f24)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p76f41c36bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#mc6b54a5c44" x="49.078125" y="330.550779" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m40f8968b2a" x="49.078125" y="330.550779" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1027,11 +1027,11 @@ L 637.2 330.550779
      <g id="line2d_31">
       <path d="M 49.078125 314.633206 
 L 637.2 314.633206 
-" clip-path="url(#p828f705f24)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p76f41c36bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#mc6b54a5c44" x="49.078125" y="314.633206" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m40f8968b2a" x="49.078125" y="314.633206" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1039,11 +1039,11 @@ L 637.2 314.633206
      <g id="line2d_33">
       <path d="M 49.078125 302.286577 
 L 637.2 302.286577 
-" clip-path="url(#p828f705f24)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p76f41c36bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#mc6b54a5c44" x="49.078125" y="302.286577" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m40f8968b2a" x="49.078125" y="302.286577" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1051,11 +1051,11 @@ L 637.2 302.286577
      <g id="line2d_35">
       <path d="M 49.078125 292.198647 
 L 637.2 292.198647 
-" clip-path="url(#p828f705f24)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p76f41c36bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#mc6b54a5c44" x="49.078125" y="292.198647" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m40f8968b2a" x="49.078125" y="292.198647" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1063,11 +1063,11 @@ L 637.2 292.198647
      <g id="line2d_37">
       <path d="M 49.078125 283.669424 
 L 637.2 283.669424 
-" clip-path="url(#p828f705f24)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p76f41c36bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#mc6b54a5c44" x="49.078125" y="283.669424" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m40f8968b2a" x="49.078125" y="283.669424" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1075,11 +1075,11 @@ L 637.2 283.669424
      <g id="line2d_39">
       <path d="M 49.078125 276.281074 
 L 637.2 276.281074 
-" clip-path="url(#p828f705f24)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p76f41c36bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#mc6b54a5c44" x="49.078125" y="276.281074" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m40f8968b2a" x="49.078125" y="276.281074" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1087,11 +1087,11 @@ L 637.2 276.281074
      <g id="line2d_41">
       <path d="M 49.078125 269.764088 
 L 637.2 269.764088 
-" clip-path="url(#p828f705f24)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p76f41c36bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#mc6b54a5c44" x="49.078125" y="269.764088" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m40f8968b2a" x="49.078125" y="269.764088" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1099,11 +1099,11 @@ L 637.2 269.764088
      <g id="line2d_43">
       <path d="M 49.078125 225.582313 
 L 637.2 225.582313 
-" clip-path="url(#p828f705f24)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p76f41c36bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#mc6b54a5c44" x="49.078125" y="225.582313" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m40f8968b2a" x="49.078125" y="225.582313" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1111,11 +1111,11 @@ L 637.2 225.582313
      <g id="line2d_45">
       <path d="M 49.078125 203.147754 
 L 637.2 203.147754 
-" clip-path="url(#p828f705f24)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p76f41c36bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#mc6b54a5c44" x="49.078125" y="203.147754" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m40f8968b2a" x="49.078125" y="203.147754" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1123,11 +1123,11 @@ L 637.2 203.147754
      <g id="line2d_47">
       <path d="M 49.078125 187.230181 
 L 637.2 187.230181 
-" clip-path="url(#p828f705f24)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p76f41c36bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#mc6b54a5c44" x="49.078125" y="187.230181" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m40f8968b2a" x="49.078125" y="187.230181" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1135,11 +1135,11 @@ L 637.2 187.230181
      <g id="line2d_49">
       <path d="M 49.078125 174.883552 
 L 637.2 174.883552 
-" clip-path="url(#p828f705f24)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p76f41c36bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#mc6b54a5c44" x="49.078125" y="174.883552" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m40f8968b2a" x="49.078125" y="174.883552" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1147,11 +1147,11 @@ L 637.2 174.883552
      <g id="line2d_51">
       <path d="M 49.078125 164.795622 
 L 637.2 164.795622 
-" clip-path="url(#p828f705f24)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p76f41c36bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#mc6b54a5c44" x="49.078125" y="164.795622" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m40f8968b2a" x="49.078125" y="164.795622" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1159,11 +1159,11 @@ L 637.2 164.795622
      <g id="line2d_53">
       <path d="M 49.078125 156.266399 
 L 637.2 156.266399 
-" clip-path="url(#p828f705f24)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p76f41c36bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#mc6b54a5c44" x="49.078125" y="156.266399" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m40f8968b2a" x="49.078125" y="156.266399" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1171,11 +1171,11 @@ L 637.2 156.266399
      <g id="line2d_55">
       <path d="M 49.078125 148.878049 
 L 637.2 148.878049 
-" clip-path="url(#p828f705f24)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p76f41c36bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#mc6b54a5c44" x="49.078125" y="148.878049" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m40f8968b2a" x="49.078125" y="148.878049" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1183,11 +1183,11 @@ L 637.2 148.878049
      <g id="line2d_57">
       <path d="M 49.078125 142.361063 
 L 637.2 142.361063 
-" clip-path="url(#p828f705f24)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p76f41c36bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#mc6b54a5c44" x="49.078125" y="142.361063" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m40f8968b2a" x="49.078125" y="142.361063" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1195,11 +1195,11 @@ L 637.2 142.361063
      <g id="line2d_59">
       <path d="M 49.078125 98.179288 
 L 637.2 98.179288 
-" clip-path="url(#p828f705f24)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p76f41c36bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#mc6b54a5c44" x="49.078125" y="98.179288" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m40f8968b2a" x="49.078125" y="98.179288" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1207,11 +1207,11 @@ L 637.2 98.179288
      <g id="line2d_61">
       <path d="M 49.078125 75.744729 
 L 637.2 75.744729 
-" clip-path="url(#p828f705f24)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p76f41c36bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#mc6b54a5c44" x="49.078125" y="75.744729" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m40f8968b2a" x="49.078125" y="75.744729" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1219,11 +1219,11 @@ L 637.2 75.744729
      <g id="line2d_63">
       <path d="M 49.078125 59.827156 
 L 637.2 59.827156 
-" clip-path="url(#p828f705f24)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p76f41c36bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#mc6b54a5c44" x="49.078125" y="59.827156" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m40f8968b2a" x="49.078125" y="59.827156" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1231,11 +1231,11 @@ L 637.2 59.827156
      <g id="line2d_65">
       <path d="M 49.078125 47.480527 
 L 637.2 47.480527 
-" clip-path="url(#p828f705f24)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p76f41c36bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#mc6b54a5c44" x="49.078125" y="47.480527" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m40f8968b2a" x="49.078125" y="47.480527" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1398,7 +1398,7 @@ z
    <g id="line2d_67">
     <path d="M 49.078125 63.959148 
 L 637.2 63.959148 
-" clip-path="url(#p828f705f24)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
+" clip-path="url(#p76f41c36bf)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
    </g>
    <g id="patch_3">
     <path d="M 49.078125 412.80375 
@@ -1762,78 +1762,78 @@ z
    </g>
    <g id="line2d_68">
     <defs>
-     <path id="m27d7d46dae" d="M -2.5 2.5 
+     <path id="maf006d073b" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p828f705f24)">
-     <use xlink:href="#m27d7d46dae" x="75.810937" y="263.190298" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m27d7d46dae" x="105.634056" y="267.887378" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m27d7d46dae" x="204.490635" y="300.240046" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m27d7d46dae" x="234.479899" y="306.367428" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m27d7d46dae" x="242.537956" y="316.909198" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m27d7d46dae" x="300.771958" y="297.352079" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m27d7d46dae" x="303.26414" y="310.698625" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m27d7d46dae" x="304.261013" y="317.548512" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m27d7d46dae" x="313.897453" y="317.953886" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m27d7d46dae" x="414.166268" y="334.149272" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m27d7d46dae" x="587.289889" y="327.780982" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m27d7d46dae" x="610.467187" y="318.981257" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p76f41c36bf)">
+     <use xlink:href="#maf006d073b" x="75.810937" y="263.190298" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#maf006d073b" x="105.634056" y="267.887378" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#maf006d073b" x="204.490635" y="300.240046" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#maf006d073b" x="234.479899" y="306.367428" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#maf006d073b" x="242.537956" y="316.909198" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#maf006d073b" x="300.771958" y="297.352079" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#maf006d073b" x="303.26414" y="310.698625" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#maf006d073b" x="304.261013" y="317.548512" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#maf006d073b" x="313.897453" y="317.953886" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#maf006d073b" x="414.166268" y="334.149272" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#maf006d073b" x="587.289889" y="327.780982" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#maf006d073b" x="610.467187" y="318.981257" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_69">
     <defs>
-     <path id="m64205cd5eb" d="M 0 -2.5 
+     <path id="m15a7cd7662" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p828f705f24)">
-     <use xlink:href="#m64205cd5eb" x="75.810937" y="260.629553" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m64205cd5eb" x="105.634056" y="253.888028" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m64205cd5eb" x="204.490635" y="301.454063" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m64205cd5eb" x="234.479899" y="296.198152" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m64205cd5eb" x="242.537956" y="306.497434" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m64205cd5eb" x="300.771958" y="285.157082" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m64205cd5eb" x="303.26414" y="299.127298" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m64205cd5eb" x="304.261013" y="312.289143" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m64205cd5eb" x="313.897453" y="305.55147" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m64205cd5eb" x="414.166268" y="323.799851" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m64205cd5eb" x="587.289889" y="327.192921" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m64205cd5eb" x="610.467187" y="316.49707" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p76f41c36bf)">
+     <use xlink:href="#m15a7cd7662" x="75.810937" y="260.629553" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m15a7cd7662" x="105.634056" y="253.888028" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m15a7cd7662" x="204.490635" y="301.454063" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m15a7cd7662" x="234.479899" y="296.198152" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m15a7cd7662" x="242.537956" y="306.497434" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m15a7cd7662" x="300.771958" y="285.157082" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m15a7cd7662" x="303.26414" y="299.127298" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m15a7cd7662" x="304.261013" y="312.289143" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m15a7cd7662" x="313.897453" y="305.55147" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m15a7cd7662" x="414.166268" y="323.799851" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m15a7cd7662" x="587.289889" y="327.192921" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m15a7cd7662" x="610.467187" y="316.49707" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_70">
     <defs>
-     <path id="m450b86a470" d="M -0 3.535534 
+     <path id="m638393f682" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p828f705f24)">
-     <use xlink:href="#m450b86a470" x="75.810937" y="229.675972" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m450b86a470" x="105.634056" y="230.807252" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m450b86a470" x="204.490635" y="262.817606" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m450b86a470" x="234.479899" y="260.308889" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m450b86a470" x="242.537956" y="274.651617" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m450b86a470" x="300.771958" y="258.820574" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m450b86a470" x="303.26414" y="270.569757" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m450b86a470" x="304.261013" y="279.042037" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m450b86a470" x="313.897453" y="275.908162" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m450b86a470" x="414.166268" y="294.938772" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m450b86a470" x="587.289889" y="301.872049" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m450b86a470" x="610.467187" y="298.545064" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p76f41c36bf)">
+     <use xlink:href="#m638393f682" x="75.810937" y="229.675972" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m638393f682" x="105.634056" y="230.807252" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m638393f682" x="204.490635" y="262.817606" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m638393f682" x="234.479899" y="260.308889" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m638393f682" x="242.537956" y="274.651617" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m638393f682" x="300.771958" y="258.820574" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m638393f682" x="303.26414" y="270.569757" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m638393f682" x="304.261013" y="279.042037" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m638393f682" x="313.897453" y="275.908162" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m638393f682" x="414.166268" y="294.938772" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m638393f682" x="587.289889" y="301.872049" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m638393f682" x="610.467187" y="298.545064" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_71">
     <defs>
-     <path id="m6a23b2edcd" d="M -0.833333 2.5 
+     <path id="mee19a58dec" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -1848,24 +1848,24 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p828f705f24)">
-     <use xlink:href="#m6a23b2edcd" x="75.810937" y="286.028664" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a23b2edcd" x="105.634056" y="293.887771" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a23b2edcd" x="204.490635" y="326.335201" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a23b2edcd" x="234.479899" y="337.903307" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a23b2edcd" x="242.537956" y="341.092058" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a23b2edcd" x="300.771958" y="336.485034" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a23b2edcd" x="303.26414" y="344.754119" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a23b2edcd" x="304.261013" y="344.606502" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a23b2edcd" x="313.897453" y="351.527394" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a23b2edcd" x="414.166268" y="363.295034" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a23b2edcd" x="587.289889" y="368.159128" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a23b2edcd" x="610.467187" y="356.976913" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p76f41c36bf)">
+     <use xlink:href="#mee19a58dec" x="75.810937" y="286.028664" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mee19a58dec" x="105.634056" y="293.887771" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mee19a58dec" x="204.490635" y="326.335201" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mee19a58dec" x="234.479899" y="337.903307" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mee19a58dec" x="242.537956" y="341.092058" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mee19a58dec" x="300.771958" y="336.485034" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mee19a58dec" x="303.26414" y="344.754119" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mee19a58dec" x="304.261013" y="344.606502" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mee19a58dec" x="313.897453" y="351.527394" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mee19a58dec" x="414.166268" y="363.295034" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mee19a58dec" x="587.289889" y="368.159128" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mee19a58dec" x="610.467187" y="356.976913" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_72">
     <defs>
-     <path id="ma39df6705a" d="M -1.25 2.5 
+     <path id="mf2f7dd9570" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -1880,24 +1880,24 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p828f705f24)">
-     <use xlink:href="#ma39df6705a" x="75.810937" y="327.723121" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma39df6705a" x="105.634056" y="342.646685" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma39df6705a" x="204.490635" y="362.850184" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma39df6705a" x="234.479899" y="371.338643" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma39df6705a" x="242.537956" y="367.245927" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma39df6705a" x="300.771958" y="360.026985" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma39df6705a" x="303.26414" y="374.683393" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma39df6705a" x="304.261013" y="357.457726" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma39df6705a" x="313.897453" y="374.58929" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma39df6705a" x="414.166268" y="385.027438" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma39df6705a" x="587.289889" y="394.333029" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma39df6705a" x="610.467187" y="391.249012" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p76f41c36bf)">
+     <use xlink:href="#mf2f7dd9570" x="75.810937" y="327.723121" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf2f7dd9570" x="105.634056" y="342.646685" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf2f7dd9570" x="204.490635" y="362.850184" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf2f7dd9570" x="234.479899" y="371.338643" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf2f7dd9570" x="242.537956" y="367.245927" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf2f7dd9570" x="300.771958" y="360.026985" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf2f7dd9570" x="303.26414" y="374.683393" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf2f7dd9570" x="304.261013" y="357.457726" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf2f7dd9570" x="313.897453" y="374.58929" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf2f7dd9570" x="414.166268" y="385.027438" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf2f7dd9570" x="587.289889" y="394.333029" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf2f7dd9570" x="610.467187" y="391.249012" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_73">
     <defs>
-     <path id="m0b1c8772e1" d="M 0 -2.5 
+     <path id="mb83ba1d500" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -1910,24 +1910,24 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p828f705f24)">
-     <use xlink:href="#m0b1c8772e1" x="75.810937" y="273.778134" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m0b1c8772e1" x="105.634056" y="286.227815" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m0b1c8772e1" x="204.490635" y="319.608779" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m0b1c8772e1" x="234.479899" y="321.188418" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m0b1c8772e1" x="242.537956" y="325.921453" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m0b1c8772e1" x="300.771958" y="333.05015" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m0b1c8772e1" x="303.26414" y="336.951003" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m0b1c8772e1" x="304.261013" y="345.759761" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m0b1c8772e1" x="313.897453" y="336.754653" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m0b1c8772e1" x="414.166268" y="357.454726" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m0b1c8772e1" x="587.289889" y="366.280671" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m0b1c8772e1" x="610.467187" y="360.878702" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p76f41c36bf)">
+     <use xlink:href="#mb83ba1d500" x="75.810937" y="273.778134" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mb83ba1d500" x="105.634056" y="286.227815" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mb83ba1d500" x="204.490635" y="319.608779" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mb83ba1d500" x="234.479899" y="321.188418" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mb83ba1d500" x="242.537956" y="325.921453" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mb83ba1d500" x="300.771958" y="333.05015" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mb83ba1d500" x="303.26414" y="336.951003" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mb83ba1d500" x="304.261013" y="345.759761" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mb83ba1d500" x="313.897453" y="336.754653" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mb83ba1d500" x="414.166268" y="357.454726" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mb83ba1d500" x="587.289889" y="366.280671" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mb83ba1d500" x="610.467187" y="360.878702" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_74">
     <defs>
-     <path id="m359336e8e1" d="M 0 -2.5 
+     <path id="m83f7e7f81f" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -1936,19 +1936,19 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p828f705f24)">
-     <use xlink:href="#m359336e8e1" x="75.810937" y="347.176172" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m359336e8e1" x="105.634056" y="348.704001" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m359336e8e1" x="204.490635" y="367.31757" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m359336e8e1" x="234.479899" y="373.033423" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m359336e8e1" x="242.537956" y="380.00037" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m359336e8e1" x="300.771958" y="370.53122" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m359336e8e1" x="303.26414" y="375.375651" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m359336e8e1" x="304.261013" y="383.030012" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m359336e8e1" x="313.897453" y="385.215351" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m359336e8e1" x="414.166268" y="391.648192" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m359336e8e1" x="587.289889" y="396.192102" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m359336e8e1" x="610.467187" y="383.710333" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p76f41c36bf)">
+     <use xlink:href="#m83f7e7f81f" x="75.810937" y="347.176172" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m83f7e7f81f" x="105.634056" y="348.704001" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m83f7e7f81f" x="204.490635" y="367.31757" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m83f7e7f81f" x="234.479899" y="373.033423" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m83f7e7f81f" x="242.537956" y="380.00037" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m83f7e7f81f" x="300.771958" y="370.53122" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m83f7e7f81f" x="303.26414" y="375.375651" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m83f7e7f81f" x="304.261013" y="383.030012" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m83f7e7f81f" x="313.897453" y="385.215351" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m83f7e7f81f" x="414.166268" y="391.648192" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m83f7e7f81f" x="587.289889" y="396.192102" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m83f7e7f81f" x="610.467187" y="383.710333" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="legend_1">
@@ -1967,7 +1967,7 @@ z
     </g>
     <g id="line2d_75">
      <defs>
-      <path id="m9e13b04e6c" d="M 0 3.5 
+      <path id="mc626f2ea6b" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -1980,7 +1980,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m9e13b04e6c" x="434.04625" y="211.758125" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#mc626f2ea6b" x="434.04625" y="211.758125" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_15">
@@ -2039,7 +2039,7 @@ z
     </g>
     <g id="line2d_76">
      <g>
-      <use xlink:href="#m27d7d46dae" x="434.04625" y="223.500625" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#maf006d073b" x="434.04625" y="223.500625" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_16">
@@ -2053,7 +2053,7 @@ z
     </g>
     <g id="line2d_77">
      <g>
-      <use xlink:href="#m64205cd5eb" x="434.04625" y="235.243125" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m15a7cd7662" x="434.04625" y="235.243125" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -2098,7 +2098,7 @@ z
     </g>
     <g id="line2d_78">
      <g>
-      <use xlink:href="#m450b86a470" x="434.04625" y="247.208125" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m638393f682" x="434.04625" y="247.208125" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -2118,7 +2118,7 @@ z
     </g>
     <g id="line2d_79">
      <g>
-      <use xlink:href="#m6a23b2edcd" x="537.72375" y="211.758125" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mee19a58dec" x="537.72375" y="211.758125" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -2145,7 +2145,7 @@ z
     </g>
     <g id="line2d_80">
      <g>
-      <use xlink:href="#ma39df6705a" x="537.72375" y="223.500625" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mf2f7dd9570" x="537.72375" y="223.500625" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -2210,7 +2210,7 @@ z
     </g>
     <g id="line2d_81">
      <g>
-      <use xlink:href="#m0b1c8772e1" x="537.72375" y="235.243125" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#mb83ba1d500" x="537.72375" y="235.243125" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_21">
@@ -2248,7 +2248,7 @@ z
     </g>
     <g id="line2d_82">
      <g>
-      <use xlink:href="#m359336e8e1" x="537.72375" y="246.985625" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m83f7e7f81f" x="537.72375" y="246.985625" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -2318,19 +2318,19 @@ z
     </g>
    </g>
    <g id="line2d_83">
-    <g clip-path="url(#p828f705f24)">
-     <use xlink:href="#m9e13b04e6c" x="75.810937" y="272.143954" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m9e13b04e6c" x="105.634056" y="288.399073" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m9e13b04e6c" x="204.490635" y="322.103822" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m9e13b04e6c" x="234.479899" y="324.29343" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m9e13b04e6c" x="242.537956" y="324.418753" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m9e13b04e6c" x="300.771958" y="312.453798" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m9e13b04e6c" x="303.26414" y="333.249253" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m9e13b04e6c" x="304.261013" y="351.748791" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m9e13b04e6c" x="313.897453" y="337.048403" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m9e13b04e6c" x="414.166268" y="356.441315" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m9e13b04e6c" x="587.289889" y="359.296601" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m9e13b04e6c" x="610.467187" y="343.193293" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <g clip-path="url(#p76f41c36bf)">
+     <use xlink:href="#mc626f2ea6b" x="75.810937" y="272.143954" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mc626f2ea6b" x="105.634056" y="288.399073" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mc626f2ea6b" x="204.490635" y="322.103822" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mc626f2ea6b" x="234.479899" y="324.29343" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mc626f2ea6b" x="242.537956" y="324.418753" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mc626f2ea6b" x="300.771958" y="312.453798" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mc626f2ea6b" x="303.26414" y="333.249253" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mc626f2ea6b" x="304.261013" y="351.748791" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mc626f2ea6b" x="313.897453" y="337.048403" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mc626f2ea6b" x="414.166268" y="356.441315" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mc626f2ea6b" x="587.289889" y="359.296601" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mc626f2ea6b" x="610.467187" y="343.193293" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
   </g>
@@ -3154,7 +3154,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p828f705f24">
+  <clipPath id="p76f41c36bf">
    <rect x="49.078125" y="47.3475" width="588.121875" height="365.45625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_decode_ranking.svg
+++ b/bench/graphs/silesia_decode_ranking.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 292.269187 308.04375 
 L 292.269187 56.7075 
-" clip-path="url(#p398923bc0b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p10a2de1d56)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m613f197692" d="M 0 0 
+       <path id="m499239ac6a" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m613f197692" x="292.269187" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m499239ac6a" x="292.269187" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -136,11 +136,11 @@ z
      <g id="line2d_3">
       <path d="M 449.991563 308.04375 
 L 449.991563 56.7075 
-" clip-path="url(#p398923bc0b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p10a2de1d56)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m613f197692" x="449.991563" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m499239ac6a" x="449.991563" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -177,16 +177,16 @@ z
      <g id="line2d_5">
       <path d="M 182.025977 308.04375 
 L 182.025977 56.7075 
-" clip-path="url(#p398923bc0b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p10a2de1d56)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <defs>
-       <path id="m63c3cce68d" d="M 0 0 
+       <path id="mab4d4c535f" d="M 0 0 
 L 0 2 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m63c3cce68d" x="182.025977" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mab4d4c535f" x="182.025977" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -194,11 +194,11 @@ L 0 2
      <g id="line2d_7">
       <path d="M 209.799509 308.04375 
 L 209.799509 56.7075 
-" clip-path="url(#p398923bc0b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p10a2de1d56)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m63c3cce68d" x="209.799509" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mab4d4c535f" x="209.799509" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -206,11 +206,11 @@ L 209.799509 56.7075
      <g id="line2d_9">
       <path d="M 229.505143 308.04375 
 L 229.505143 56.7075 
-" clip-path="url(#p398923bc0b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p10a2de1d56)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m63c3cce68d" x="229.505143" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mab4d4c535f" x="229.505143" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -218,11 +218,11 @@ L 229.505143 56.7075
      <g id="line2d_11">
       <path d="M 244.790021 308.04375 
 L 244.790021 56.7075 
-" clip-path="url(#p398923bc0b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p10a2de1d56)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m63c3cce68d" x="244.790021" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mab4d4c535f" x="244.790021" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -230,11 +230,11 @@ L 244.790021 56.7075
      <g id="line2d_13">
       <path d="M 257.278675 308.04375 
 L 257.278675 56.7075 
-" clip-path="url(#p398923bc0b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p10a2de1d56)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m63c3cce68d" x="257.278675" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mab4d4c535f" x="257.278675" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -242,11 +242,11 @@ L 257.278675 56.7075
      <g id="line2d_15">
       <path d="M 267.837682 308.04375 
 L 267.837682 56.7075 
-" clip-path="url(#p398923bc0b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p10a2de1d56)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m63c3cce68d" x="267.837682" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mab4d4c535f" x="267.837682" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -254,11 +254,11 @@ L 267.837682 56.7075
      <g id="line2d_17">
       <path d="M 276.984309 308.04375 
 L 276.984309 56.7075 
-" clip-path="url(#p398923bc0b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p10a2de1d56)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m63c3cce68d" x="276.984309" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mab4d4c535f" x="276.984309" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -266,11 +266,11 @@ L 276.984309 56.7075
      <g id="line2d_19">
       <path d="M 285.052207 308.04375 
 L 285.052207 56.7075 
-" clip-path="url(#p398923bc0b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p10a2de1d56)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m63c3cce68d" x="285.052207" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mab4d4c535f" x="285.052207" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -278,11 +278,11 @@ L 285.052207 56.7075
      <g id="line2d_21">
       <path d="M 339.748353 308.04375 
 L 339.748353 56.7075 
-" clip-path="url(#p398923bc0b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p10a2de1d56)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m63c3cce68d" x="339.748353" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mab4d4c535f" x="339.748353" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -290,11 +290,11 @@ L 339.748353 56.7075
      <g id="line2d_23">
       <path d="M 367.521885 308.04375 
 L 367.521885 56.7075 
-" clip-path="url(#p398923bc0b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p10a2de1d56)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m63c3cce68d" x="367.521885" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mab4d4c535f" x="367.521885" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -302,11 +302,11 @@ L 367.521885 56.7075
      <g id="line2d_25">
       <path d="M 387.227519 308.04375 
 L 387.227519 56.7075 
-" clip-path="url(#p398923bc0b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p10a2de1d56)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m63c3cce68d" x="387.227519" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mab4d4c535f" x="387.227519" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -314,11 +314,11 @@ L 387.227519 56.7075
      <g id="line2d_27">
       <path d="M 402.512397 308.04375 
 L 402.512397 56.7075 
-" clip-path="url(#p398923bc0b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p10a2de1d56)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m63c3cce68d" x="402.512397" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mab4d4c535f" x="402.512397" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -326,11 +326,11 @@ L 402.512397 56.7075
      <g id="line2d_29">
       <path d="M 415.001051 308.04375 
 L 415.001051 56.7075 
-" clip-path="url(#p398923bc0b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p10a2de1d56)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m63c3cce68d" x="415.001051" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mab4d4c535f" x="415.001051" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -338,11 +338,11 @@ L 415.001051 56.7075
      <g id="line2d_31">
       <path d="M 425.560057 308.04375 
 L 425.560057 56.7075 
-" clip-path="url(#p398923bc0b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p10a2de1d56)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m63c3cce68d" x="425.560057" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mab4d4c535f" x="425.560057" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -350,11 +350,11 @@ L 425.560057 56.7075
      <g id="line2d_33">
       <path d="M 434.706685 308.04375 
 L 434.706685 56.7075 
-" clip-path="url(#p398923bc0b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p10a2de1d56)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m63c3cce68d" x="434.706685" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mab4d4c535f" x="434.706685" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -362,11 +362,11 @@ L 434.706685 56.7075
      <g id="line2d_35">
       <path d="M 442.774583 308.04375 
 L 442.774583 56.7075 
-" clip-path="url(#p398923bc0b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p10a2de1d56)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m63c3cce68d" x="442.774583" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mab4d4c535f" x="442.774583" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -374,11 +374,11 @@ L 442.774583 56.7075
      <g id="line2d_37">
       <path d="M 497.470729 308.04375 
 L 497.470729 56.7075 
-" clip-path="url(#p398923bc0b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p10a2de1d56)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m63c3cce68d" x="497.470729" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mab4d4c535f" x="497.470729" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -386,11 +386,11 @@ L 497.470729 56.7075
      <g id="line2d_39">
       <path d="M 525.24426 308.04375 
 L 525.24426 56.7075 
-" clip-path="url(#p398923bc0b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p10a2de1d56)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m63c3cce68d" x="525.24426" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mab4d4c535f" x="525.24426" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -398,11 +398,11 @@ L 525.24426 56.7075
      <g id="line2d_41">
       <path d="M 544.949895 308.04375 
 L 544.949895 56.7075 
-" clip-path="url(#p398923bc0b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p10a2de1d56)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m63c3cce68d" x="544.949895" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mab4d4c535f" x="544.949895" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -410,11 +410,11 @@ L 544.949895 56.7075
      <g id="line2d_43">
       <path d="M 560.234772 308.04375 
 L 560.234772 56.7075 
-" clip-path="url(#p398923bc0b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p10a2de1d56)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m63c3cce68d" x="560.234772" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mab4d4c535f" x="560.234772" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1016,12 +1016,12 @@ z
     <g id="ytick_1">
      <g id="line2d_45">
       <defs>
-       <path id="m45d753604a" d="M 0 0 
+       <path id="m5cc0a6afe4" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m45d753604a" x="139.360469" y="296.619375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5cc0a6afe4" x="139.360469" y="296.619375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -1093,7 +1093,7 @@ z
     <g id="ytick_2">
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m45d753604a" x="139.360469" y="263.978304" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5cc0a6afe4" x="139.360469" y="263.978304" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -1160,7 +1160,7 @@ z
     <g id="ytick_3">
      <g id="line2d_47">
       <g>
-       <use xlink:href="#m45d753604a" x="139.360469" y="231.337232" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5cc0a6afe4" x="139.360469" y="231.337232" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -1216,7 +1216,7 @@ z
     <g id="ytick_4">
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m45d753604a" x="139.360469" y="198.696161" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5cc0a6afe4" x="139.360469" y="198.696161" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -1263,7 +1263,7 @@ z
     <g id="ytick_5">
      <g id="line2d_49">
       <g>
-       <use xlink:href="#m45d753604a" x="139.360469" y="166.055089" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5cc0a6afe4" x="139.360469" y="166.055089" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -1376,7 +1376,7 @@ z
     <g id="ytick_6">
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m45d753604a" x="139.360469" y="133.414018" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5cc0a6afe4" x="139.360469" y="133.414018" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -1392,7 +1392,7 @@ z
     <g id="ytick_7">
      <g id="line2d_51">
       <g>
-       <use xlink:href="#m45d753604a" x="139.360469" y="100.772946" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5cc0a6afe4" x="139.360469" y="100.772946" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -1439,7 +1439,7 @@ z
     <g id="ytick_8">
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m45d753604a" x="139.360469" y="68.131875" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5cc0a6afe4" x="139.360469" y="68.131875" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -1462,47 +1462,47 @@ z
    <g id="LineCollection_1">
     <path d="M 139.360469 296.619375 
 L 154.645346 296.619375 
-" clip-path="url(#p398923bc0b)" style="fill: none; stroke: #17becf; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p10a2de1d56)" style="fill: none; stroke: #17becf; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_2">
     <path d="M 139.360469 263.978304 
 L 161.142927 263.978304 
-" clip-path="url(#p398923bc0b)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p10a2de1d56)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_3">
     <path d="M 139.360469 231.337232 
 L 200.65327 231.337232 
-" clip-path="url(#p398923bc0b)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p10a2de1d56)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_4">
     <path d="M 139.360469 198.696161 
 L 208.426981 198.696161 
-" clip-path="url(#p398923bc0b)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p10a2de1d56)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_5">
     <path d="M 139.360469 166.055089 
 L 212.673671 166.055089 
-" clip-path="url(#p398923bc0b)" style="fill: none; stroke: #d62728; stroke-opacity: 0.9; stroke-width: 2.4"/>
+" clip-path="url(#p10a2de1d56)" style="fill: none; stroke: #d62728; stroke-opacity: 0.9; stroke-width: 2.4"/>
    </g>
    <g id="LineCollection_6">
     <path d="M 139.360469 133.414018 
 L 239.878265 133.414018 
-" clip-path="url(#p398923bc0b)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p10a2de1d56)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_7">
     <path d="M 139.360469 100.772946 
 L 248.943982 100.772946 
-" clip-path="url(#p398923bc0b)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p10a2de1d56)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_8">
     <path d="M 139.360469 68.131875 
 L 284.774562 68.131875 
-" clip-path="url(#p398923bc0b)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p10a2de1d56)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="line2d_53">
     <path d="M 542.152339 308.04375 
 L 542.152339 56.7075 
-" clip-path="url(#p398923bc0b)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
+" clip-path="url(#p10a2de1d56)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
    </g>
    <g id="patch_3">
     <path d="M 139.360469 308.04375 
@@ -1888,7 +1888,7 @@ z
    </g>
    <g id="line2d_54">
     <defs>
-     <path id="m97922aba73" d="M 0 3 
+     <path id="m6203d8fc74" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1900,13 +1900,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #17becf"/>
     </defs>
-    <g clip-path="url(#p398923bc0b)">
-     <use xlink:href="#m97922aba73" x="154.645346" y="296.619375" style="fill: #17becf; stroke: #17becf"/>
+    <g clip-path="url(#p10a2de1d56)">
+     <use xlink:href="#m6203d8fc74" x="154.645346" y="296.619375" style="fill: #17becf; stroke: #17becf"/>
     </g>
    </g>
    <g id="line2d_55">
     <defs>
-     <path id="m7dbf2a5378" d="M 0 3 
+     <path id="m3746c87554" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1918,13 +1918,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #e377c2"/>
     </defs>
-    <g clip-path="url(#p398923bc0b)">
-     <use xlink:href="#m7dbf2a5378" x="161.142927" y="263.978304" style="fill: #e377c2; stroke: #e377c2"/>
+    <g clip-path="url(#p10a2de1d56)">
+     <use xlink:href="#m3746c87554" x="161.142927" y="263.978304" style="fill: #e377c2; stroke: #e377c2"/>
     </g>
    </g>
    <g id="line2d_56">
     <defs>
-     <path id="m75a88064a1" d="M 0 3 
+     <path id="m63af459d2d" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1936,13 +1936,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #8c564b"/>
     </defs>
-    <g clip-path="url(#p398923bc0b)">
-     <use xlink:href="#m75a88064a1" x="200.65327" y="231.337232" style="fill: #8c564b; stroke: #8c564b"/>
+    <g clip-path="url(#p10a2de1d56)">
+     <use xlink:href="#m63af459d2d" x="200.65327" y="231.337232" style="fill: #8c564b; stroke: #8c564b"/>
     </g>
    </g>
    <g id="line2d_57">
     <defs>
-     <path id="ma72a4a66a3" d="M 0 3 
+     <path id="mcfae11000e" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1954,13 +1954,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #bcbd22"/>
     </defs>
-    <g clip-path="url(#p398923bc0b)">
-     <use xlink:href="#ma72a4a66a3" x="208.426981" y="198.696161" style="fill: #bcbd22; stroke: #bcbd22"/>
+    <g clip-path="url(#p10a2de1d56)">
+     <use xlink:href="#mcfae11000e" x="208.426981" y="198.696161" style="fill: #bcbd22; stroke: #bcbd22"/>
     </g>
    </g>
    <g id="line2d_58">
     <defs>
-     <path id="ma7e1dec914" d="M 0 5 
+     <path id="m8e06d0ee63" d="M 0 5 
 C 1.326016 5 2.597899 4.473168 3.535534 3.535534 
 C 4.473168 2.597899 5 1.326016 5 0 
 C 5 -1.326016 4.473168 -2.597899 3.535534 -3.535534 
@@ -1972,13 +1972,13 @@ C -2.597899 4.473168 -1.326016 5 0 5
 z
 " style="stroke: #d62728"/>
     </defs>
-    <g clip-path="url(#p398923bc0b)">
-     <use xlink:href="#ma7e1dec914" x="212.673671" y="166.055089" style="fill: #d62728; stroke: #d62728"/>
+    <g clip-path="url(#p10a2de1d56)">
+     <use xlink:href="#m8e06d0ee63" x="212.673671" y="166.055089" style="fill: #d62728; stroke: #d62728"/>
     </g>
    </g>
    <g id="line2d_59">
     <defs>
-     <path id="mfdad4e2ec3" d="M 0 3 
+     <path id="mc19eda87af" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1990,13 +1990,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #1f77b4"/>
     </defs>
-    <g clip-path="url(#p398923bc0b)">
-     <use xlink:href="#mfdad4e2ec3" x="239.878265" y="133.414018" style="fill: #1f77b4; stroke: #1f77b4"/>
+    <g clip-path="url(#p10a2de1d56)">
+     <use xlink:href="#mc19eda87af" x="239.878265" y="133.414018" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_60">
     <defs>
-     <path id="m2c644d6cb3" d="M 0 3 
+     <path id="md6697833a6" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -2008,13 +2008,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #2ca02c"/>
     </defs>
-    <g clip-path="url(#p398923bc0b)">
-     <use xlink:href="#m2c644d6cb3" x="248.943982" y="100.772946" style="fill: #2ca02c; stroke: #2ca02c"/>
+    <g clip-path="url(#p10a2de1d56)">
+     <use xlink:href="#md6697833a6" x="248.943982" y="100.772946" style="fill: #2ca02c; stroke: #2ca02c"/>
     </g>
    </g>
    <g id="line2d_61">
     <defs>
-     <path id="m605554a70c" d="M 0 3 
+     <path id="m42e0e70f77" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -2026,8 +2026,8 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #9467bd"/>
     </defs>
-    <g clip-path="url(#p398923bc0b)">
-     <use xlink:href="#m605554a70c" x="284.774562" y="68.131875" style="fill: #9467bd; stroke: #9467bd"/>
+    <g clip-path="url(#p10a2de1d56)">
+     <use xlink:href="#m42e0e70f77" x="284.774562" y="68.131875" style="fill: #9467bd; stroke: #9467bd"/>
     </g>
    </g>
   </g>
@@ -2967,7 +2967,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p398923bc0b">
+  <clipPath id="p10a2de1d56">
    <rect x="139.360469" y="56.7075" width="425.839531" height="251.33625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_ratio_heatmap.svg
+++ b/bench/graphs/silesia_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.34175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#pab5eac449f)">
+   <g clip-path="url(#p33c433af07)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAosAAAGaCAYAAABniAm0AAAJ80lEQVR4nO3YO44dZhnH4TOe8UUe22NbECICAuGIghAoUSioUiEoWAMroKGiQuyAig3QoYjSTUqkcCdURISLuMgaYnzBcuzxzBxW8CtQ9OlFR8+zgr80Z97zO9/e+b0fbTc76OTHd6cnLHHxzdenJyyz99Inpycssf3t76YnLLH3pdemJyyxffp4esIyx999a3rCEi/94BvTE5bYu/2J6QlrnDydXrDM+c93895fmB4AAMD/L7EIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEDa+8/JW9vpESsc/vt4esISH9y4Oj1hmQ9Pn0xPWOLTj06mJyzx6OMvT09Y4nx7Pj1hmVsHt6cnrHH/L9MLlnh8azf/Xtf//IfpCctsP/+V6QlLeFkEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACAdHN6/N71hjas3pxcssd2eTE9Y5lNv/3J6whpvfn16wRJHH/xzesIa56fTC9Y53NH7cfna9IIlbvxrN7+fH3zmzvSEZW797d3pCUt4WQQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAADS3ouzu9vpESvsH/9pesIS965fmp6wzJMXD6cnLHHnrw+nJyxx+sWvTk9Y4unp4+kJyxzt35yesMT2/V9MT1ji2eden56wxJV335mesMzzL78xPWEJL4sAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA2vvp+9/ZTo9Y4faVw+kJS7z38P70hGW+/cNfT09Y4jff/+b0hCWOLh9NT1jiez/71fSEZb72ypXpCUt8684b0xOWePvv70xPWOLaxd38HG42m81P/vhgesISXhYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAtPfi7O52esQKD54fT09Y4vDgxvSEZd57+PvpCUu8evO16QlLbLfn0xOWuHa6u7+h/3G+m3fxlcNXpycs8ezs6fSEJXb1dmw2m83+hYPpCUvs7lUEAOAjE4sAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAOtjfO5jesMTH9m9PT1hj/9L0gmWOLh9NT1ji8ODG9IQlzran0xOWOL+4u7+hX95enZ7A/2BXv59Pts+mJyzz+Pnx9IQldvcqAgDwkYlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAADSwWZ7Pr1hiUfbJ9MTljg4uzQ9YZnPXv/C9IQlzran0xOW+PB0N//Hrm2uTE9Y5tmF3bz3+9MDFrm4v5v3fv/CwfSEZQ73rk5PWMLLIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJD+C2EVlmm8G2EiAAAAAElFTkSuQmCC" id="imageb5b3f040bd" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="468.72" height="295.2"/>
+iVBORw0KGgoAAAANSUhEUgAAAosAAAGaCAYAAABniAm0AAAJ80lEQVR4nO3YO44dZhnH4TOe8UUe22NbECICAuGIghAoUSioUiEoWAMroKGiQuyAig3QoYjSTUqkcCdURISLuMgaYnzBcuzxzBxW8CtQ9OlFR8+zgr80Z97zO9/e+b0fbTc76OTHd6cnLHHxzdenJyyz99Inpycssf3t76YnLLH3pdemJyyxffp4esIyx999a3rCEi/94BvTE5bYu/2J6QlrnDydXrDM+c93895fmB4AAMD/L7EIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEDa+8/JW9vpESsc/vt4esISH9y4Oj1hmQ9Pn0xPWOLTj06mJyzx6OMvT09Y4nx7Pj1hmVsHt6cnrHH/L9MLlnh8azf/Xtf//IfpCctsP/+V6QlLeFkEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACAdHN6/N71hjas3pxcssd2eTE9Y5lNv/3J6whpvfn16wRJHH/xzesIa56fTC9Y53NH7cfna9IIlbvxrN7+fH3zmzvSEZW797d3pCUt4WQQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAADS3ouzu9vpESvsH/9pesIS965fmp6wzJMXD6cnLHHnrw+nJyxx+sWvTk9Y4unp4+kJyxzt35yesMT2/V9MT1ji2eden56wxJV335mesMzzL78xPWEJL4sAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA2vvp+9/ZTo9Y4faVw+kJS7z38P70hGW+/cNfT09Y4jff/+b0hCWOLh9NT1jiez/71fSEZb72ypXpCUt8684b0xOWePvv70xPWOLaxd38HG42m81P/vhgesISXhYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAtPfi7O52esQKD54fT09Y4vDgxvSEZd57+PvpCUu8evO16QlLbLfn0xOWuHa6u7+h/3G+m3fxlcNXpycs8ezs6fSEJXb1dmw2m83+hYPpCUvs7lUEAOAjE4sAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAOtjfO5jesMTH9m9PT1hj/9L0gmWOLh9NT1ji8ODG9IQlzran0xOWOL+4u7+hX95enZ7A/2BXv59Pts+mJyzz+Pnx9IQldvcqAgDwkYlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAADSwWZ7Pr1hiUfbJ9MTljg4uzQ9YZnPXv/C9IQlzran0xOW+PB0N//Hrm2uTE9Y5tmF3bz3+9MDFrm4v5v3fv/CwfSEZQ73rk5PWMLLIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJD+C2EVlmm8G2EiAAAAAElFTkSuQmCC" id="image18542146fa" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="468.72" height="295.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="me2d8feb9da" d="M 0 0 
+       <path id="mc5527ba30d" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#me2d8feb9da" x="115.182137" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc5527ba30d" x="115.182137" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#me2d8feb9da" x="154.193912" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc5527ba30d" x="154.193912" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#me2d8feb9da" x="193.205687" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc5527ba30d" x="193.205687" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#me2d8feb9da" x="232.217462" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc5527ba30d" x="232.217462" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#me2d8feb9da" x="271.229237" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc5527ba30d" x="271.229237" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#me2d8feb9da" x="310.241012" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc5527ba30d" x="310.241012" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#me2d8feb9da" x="349.252787" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc5527ba30d" x="349.252787" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#me2d8feb9da" x="388.264562" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc5527ba30d" x="388.264562" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#me2d8feb9da" x="427.276336" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc5527ba30d" x="427.276336" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#me2d8feb9da" x="466.288111" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc5527ba30d" x="466.288111" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#me2d8feb9da" x="505.299886" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc5527ba30d" x="505.299886" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#me2d8feb9da" x="544.311661" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc5527ba30d" x="544.311661" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="mca8875d409" d="M 0 0 
+       <path id="m1d30c384f1" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mca8875d409" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1d30c384f1" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mca8875d409" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1d30c384f1" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#mca8875d409" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1d30c384f1" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#mca8875d409" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1d30c384f1" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -836,7 +836,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#mca8875d409" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1d30c384f1" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -899,7 +899,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mca8875d409" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1d30c384f1" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -966,7 +966,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#mca8875d409" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1d30c384f1" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1047,7 +1047,7 @@ z
     <g id="ytick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#mca8875d409" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1d30c384f1" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -2060,18 +2060,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABEAAAFUCAYAAADCj9eRAAAB2ElEQVR4nO2aQY7EIAwEIeFP+6X9/33C3MPcKKSS1TygZRftNlLS2//fbJtn9KvvajAi17ZCM7Uzeg+TEyJhsh4TE8D25ZhYRMJkPSYmmZ0zIhfQEMPkJq74JpgQlUBMABkIrOV2KLMRItXMhrQjqcQUSszsbGuomFSbHULEAlblE0klor1zMaG0XwnDBDAsBVY0O4CIBizlE4ntEbCijK3mE8vKUPkEEIF8YslYje2RZFP5BJkdCxOonf1i6jEhRICOyjEBzFaPiWd2iChoYbKKhMkqgmSsh4kkHkU+6UyeACJEJaLZ6QQTzy7WtGPyicX2Kp/c+yKaATTliSWoTXsnPllEEtTLGX37f+7WRpuPQ4RhomlntCdMTohATIDbKceEaGfOD1BJZueIiImJZQBNTCxgw2Q91N7Zf7RBsxMmR0TqMdmvxPRmI0TmDJNVJExWkTBZRcJkFSnFZH6Q5aVhQrQzkYUOVEIxIXxSjAnRDjQ7mndsZud9VEwsPtFcsWjvaNZofHKoEpFPELCPJmORdqblMWxiYjEbw+QJk/dR+SQD+BbROFbEJAP4Q4RgQpiNCupKIhAT4gewakws7YTJIREoY4FPeNWYaNoJk18iQNqXY1LKJ1/07Ct/l+QCQgAAAABJRU5ErkJggg==" id="image2386148777" transform="scale(1 -1) translate(0 -244.8)" x="573.84" y="-74.16" width="12.24" height="244.8"/>
+iVBORw0KGgoAAAANSUhEUgAAABEAAAFUCAYAAADCj9eRAAAB2ElEQVR4nO2aQY7EIAwEIeFP+6X9/33C3MPcKKSS1TygZRftNlLS2//fbJtn9KvvajAi17ZCM7Uzeg+TEyJhsh4TE8D25ZhYRMJkPSYmmZ0zIhfQEMPkJq74JpgQlUBMABkIrOV2KLMRItXMhrQjqcQUSszsbGuomFSbHULEAlblE0klor1zMaG0XwnDBDAsBVY0O4CIBizlE4ntEbCijK3mE8vKUPkEEIF8YslYje2RZFP5BJkdCxOonf1i6jEhRICOyjEBzFaPiWd2iChoYbKKhMkqgmSsh4kkHkU+6UyeACJEJaLZ6QQTzy7WtGPyicX2Kp/c+yKaATTliSWoTXsnPllEEtTLGX37f+7WRpuPQ4RhomlntCdMTohATIDbKceEaGfOD1BJZueIiImJZQBNTCxgw2Q91N7Zf7RBsxMmR0TqMdmvxPRmI0TmDJNVJExWkTBZRcJkFSnFZH6Q5aVhQrQzkYUOVEIxIXxSjAnRDjQ7mndsZud9VEwsPtFcsWjvaNZofHKoEpFPELCPJmORdqblMWxiYjEbw+QJk/dR+SQD+BbROFbEJAP4Q4RgQpiNCupKIhAT4gewakws7YTJIREoY4FPeNWYaNoJk18iQNqXY1LKJ1/07Ct/l+QCQgAAAABJRU5ErkJggg==" id="image3c4c21d16b" transform="scale(1 -1) translate(0 -244.8)" x="573.84" y="-74.16" width="12.24" height="244.8"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_21">
       <defs>
-       <path id="maeaf339fe3" d="M 0 0 
+       <path id="m95c038ae2a" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#maeaf339fe3" x="585.876562" y="282.022672" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m95c038ae2a" x="585.876562" y="282.022672" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_117">
@@ -2097,7 +2097,7 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#maeaf339fe3" x="585.876562" y="239.353777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m95c038ae2a" x="585.876562" y="239.353777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_118">
@@ -2114,7 +2114,7 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#maeaf339fe3" x="585.876562" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m95c038ae2a" x="585.876562" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_119">
@@ -2130,7 +2130,7 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#maeaf339fe3" x="585.876562" y="154.015985" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m95c038ae2a" x="585.876562" y="154.015985" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_120">
@@ -2146,7 +2146,7 @@ z
     <g id="ytick_13">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#maeaf339fe3" x="585.876562" y="111.347089" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m95c038ae2a" x="585.876562" y="111.347089" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_121">
@@ -2739,8 +2739,8 @@ z
    </g>
   </g>
   <g id="text_124">
-   <!-- 2026-07-09T17:31:54Z  ·  Linux chungus2 x86_64  ·  commit 324f086c  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(44.677578 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-10T04:34:01Z  ·  Linux chungus2 x86_64  ·  commit 74861182  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(43.380391 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2867,17 +2867,17 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(290.576172 0)"/>
     <use xlink:href="#DejaVuSans-37" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(453.90625 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
     <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2917,109 +2917,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3262.744141 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3297.949219 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3361.572266 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3425.195312 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3488.818359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3543.798828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3575.585938 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3607.373047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3639.160156 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3670.947266 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3702.734375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3730.517578 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3792.041016 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3853.320312 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3916.699219 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3980.175781 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4019.039062 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4080.220703 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4139.400391 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4200.923828 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4242.037109 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4275.728516 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4303.511719 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4365.035156 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4426.314453 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4489.693359 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4553.316406 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4587.007812 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4646.1875 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4709.810547 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4741.597656 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4805.220703 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4868.84375 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4900.630859 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4964.253906 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5000.337891 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5039.201172 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5094.181641 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5157.804688 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5189.591797 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5221.378906 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5253.166016 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5284.953125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5316.740234 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5355.949219 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5419.328125 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5458.191406 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5519.373047 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5582.751953 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5646.228516 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5709.607422 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5773.083984 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5836.462891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5875.671875 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5907.458984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5991.248047 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6023.035156 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6120.447266 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6181.970703 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6245.447266 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6273.230469 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6334.509766 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6397.888672 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6429.675781 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6481.775391 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6545.154297 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6606.433594 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6669.910156 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6722.009766 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6785.388672 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6846.570312 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6885.779297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6919.470703 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6951.257812 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6992.371094 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7053.650391 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7092.859375 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7120.642578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7181.824219 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7213.611328 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7241.394531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7293.494141 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7325.28125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7388.757812 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7450.28125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7489.490234 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7551.013672 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7590.376953 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7687.789062 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7715.572266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7778.951172 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7806.734375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7858.833984 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7898.042969 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7925.826172 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3262.744141 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3326.367188 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3389.990234 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3453.613281 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3517.236328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3580.859375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3612.646484 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3644.433594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3676.220703 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3708.007812 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3739.794922 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3767.578125 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3829.101562 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3890.380859 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3953.759766 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4017.236328 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4056.099609 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4117.28125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4176.460938 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4237.984375 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4279.097656 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4312.789062 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4340.572266 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4402.095703 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4463.375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4526.753906 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4590.376953 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4624.068359 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4683.248047 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4746.871094 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4778.658203 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4842.28125 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4905.904297 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4937.691406 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(5001.314453 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5037.398438 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5076.261719 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5131.242188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5194.865234 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5226.652344 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5258.439453 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5290.226562 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5322.013672 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5353.800781 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5393.009766 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5456.388672 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5495.251953 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5556.433594 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5619.8125 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5683.289062 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5746.667969 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5810.144531 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5873.523438 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5912.732422 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5944.519531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6028.308594 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6060.095703 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6157.507812 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6219.03125 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6282.507812 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6310.291016 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6371.570312 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6434.949219 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6466.736328 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6518.835938 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6582.214844 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6643.494141 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6706.970703 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6759.070312 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6822.449219 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6883.630859 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6922.839844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6956.53125 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6988.318359 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7029.431641 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7090.710938 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7129.919922 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7157.703125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7218.884766 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7250.671875 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7278.455078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7330.554688 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7362.341797 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7425.818359 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7487.341797 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7526.550781 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7588.074219 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7627.4375 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7724.849609 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7752.632812 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7816.011719 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7843.794922 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7895.894531 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7935.103516 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7962.886719 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pab5eac449f">
+  <clipPath id="p33c433af07">
    <rect x="95.67625" y="49.34175" width="468.141298" height="294.686261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_summary.svg
+++ b/bench/graphs/silesia_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="573.044844pt" height="386.202469pt" viewBox="0 0 573.044844 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="575.639219pt" height="386.202469pt" viewBox="0 0 575.639219 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,232 +22,232 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 386.202469 
-L 573.044844 386.202469 
-L 573.044844 0 
+L 575.639219 386.202469 
+L 575.639219 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 188.647422 104.1264 
-L 293.272422 104.1264 
-L 293.272422 74.7432 
-L 188.647422 74.7432 
+    <path d="M 189.944609 104.1264 
+L 294.569609 104.1264 
+L 294.569609 74.7432 
+L 189.944609 74.7432 
 z
-" clip-path="url(#pc5033f41c3)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p86aac820ff)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 293.272422 104.1264 
-L 397.897422 104.1264 
-L 397.897422 74.7432 
-L 293.272422 74.7432 
+    <path d="M 294.569609 104.1264 
+L 399.194609 104.1264 
+L 399.194609 74.7432 
+L 294.569609 74.7432 
 z
-" clip-path="url(#pc5033f41c3)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p86aac820ff)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 397.897422 104.1264 
-L 502.522422 104.1264 
-L 502.522422 74.7432 
-L 397.897422 74.7432 
+    <path d="M 399.194609 104.1264 
+L 503.819609 104.1264 
+L 503.819609 74.7432 
+L 399.194609 74.7432 
 z
-" clip-path="url(#pc5033f41c3)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p86aac820ff)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 188.647422 133.5096 
-L 293.272422 133.5096 
-L 293.272422 104.1264 
-L 188.647422 104.1264 
+    <path d="M 189.944609 133.5096 
+L 294.569609 133.5096 
+L 294.569609 104.1264 
+L 189.944609 104.1264 
 z
-" clip-path="url(#pc5033f41c3)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p86aac820ff)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 293.272422 133.5096 
-L 397.897422 133.5096 
-L 397.897422 104.1264 
-L 293.272422 104.1264 
+    <path d="M 294.569609 133.5096 
+L 399.194609 133.5096 
+L 399.194609 104.1264 
+L 294.569609 104.1264 
 z
-" clip-path="url(#pc5033f41c3)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p86aac820ff)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 397.897422 133.5096 
-L 502.522422 133.5096 
-L 502.522422 104.1264 
-L 397.897422 104.1264 
+    <path d="M 399.194609 133.5096 
+L 503.819609 133.5096 
+L 503.819609 104.1264 
+L 399.194609 104.1264 
 z
-" clip-path="url(#pc5033f41c3)" style="fill: #fece7c; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p86aac820ff)" style="fill: #fece7c; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 188.647422 162.8928 
-L 293.272422 162.8928 
-L 293.272422 133.5096 
-L 188.647422 133.5096 
+    <path d="M 189.944609 162.8928 
+L 294.569609 162.8928 
+L 294.569609 133.5096 
+L 189.944609 133.5096 
 z
-" clip-path="url(#pc5033f41c3)" style="fill: #fee08b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p86aac820ff)" style="fill: #fee08b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 293.272422 162.8928 
-L 397.897422 162.8928 
-L 397.897422 133.5096 
-L 293.272422 133.5096 
+    <path d="M 294.569609 162.8928 
+L 399.194609 162.8928 
+L 399.194609 133.5096 
+L 294.569609 133.5096 
 z
-" clip-path="url(#pc5033f41c3)" style="fill: #feefa3; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p86aac820ff)" style="fill: #feefa3; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 397.897422 162.8928 
-L 502.522422 162.8928 
-L 502.522422 133.5096 
-L 397.897422 133.5096 
+    <path d="M 399.194609 162.8928 
+L 503.819609 162.8928 
+L 503.819609 133.5096 
+L 399.194609 133.5096 
 z
-" clip-path="url(#pc5033f41c3)" style="fill: #fdbf6f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p86aac820ff)" style="fill: #fdbf6f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 188.647422 192.276 
-L 293.272422 192.276 
-L 293.272422 162.8928 
-L 188.647422 162.8928 
+    <path d="M 189.944609 192.276 
+L 294.569609 192.276 
+L 294.569609 162.8928 
+L 189.944609 162.8928 
 z
-" clip-path="url(#pc5033f41c3)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p86aac820ff)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 293.272422 192.276 
-L 397.897422 192.276 
-L 397.897422 162.8928 
-L 293.272422 162.8928 
+    <path d="M 294.569609 192.276 
+L 399.194609 192.276 
+L 399.194609 162.8928 
+L 294.569609 162.8928 
 z
-" clip-path="url(#pc5033f41c3)" style="fill: #fede89; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p86aac820ff)" style="fill: #fede89; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 397.897422 192.276 
-L 502.522422 192.276 
-L 502.522422 162.8928 
-L 397.897422 162.8928 
+    <path d="M 399.194609 192.276 
+L 503.819609 192.276 
+L 503.819609 162.8928 
+L 399.194609 162.8928 
 z
-" clip-path="url(#pc5033f41c3)" style="fill: #f7814c; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p86aac820ff)" style="fill: #f7814c; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 188.647422 221.6592 
-L 293.272422 221.6592 
-L 293.272422 192.276 
-L 188.647422 192.276 
+    <path d="M 189.944609 221.6592 
+L 294.569609 221.6592 
+L 294.569609 192.276 
+L 189.944609 192.276 
 z
-" clip-path="url(#pc5033f41c3)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p86aac820ff)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 293.272422 221.6592 
-L 397.897422 221.6592 
-L 397.897422 192.276 
-L 293.272422 192.276 
+    <path d="M 294.569609 221.6592 
+L 399.194609 221.6592 
+L 399.194609 192.276 
+L 294.569609 192.276 
 z
-" clip-path="url(#pc5033f41c3)" style="fill: #fed27f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p86aac820ff)" style="fill: #fed27f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 397.897422 221.6592 
-L 502.522422 221.6592 
-L 502.522422 192.276 
-L 397.897422 192.276 
+    <path d="M 399.194609 221.6592 
+L 503.819609 221.6592 
+L 503.819609 192.276 
+L 399.194609 192.276 
 z
-" clip-path="url(#pc5033f41c3)" style="fill: #fffcba; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p86aac820ff)" style="fill: #fffcba; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 188.647422 251.0424 
-L 293.272422 251.0424 
-L 293.272422 221.6592 
-L 188.647422 221.6592 
+    <path d="M 189.944609 251.0424 
+L 294.569609 251.0424 
+L 294.569609 221.6592 
+L 189.944609 221.6592 
 z
-" clip-path="url(#pc5033f41c3)" style="fill: #feefa3; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p86aac820ff)" style="fill: #feefa3; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 293.272422 251.0424 
-L 397.897422 251.0424 
-L 397.897422 221.6592 
-L 293.272422 221.6592 
+    <path d="M 294.569609 251.0424 
+L 399.194609 251.0424 
+L 399.194609 221.6592 
+L 294.569609 221.6592 
 z
-" clip-path="url(#pc5033f41c3)" style="fill: #fed07e; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p86aac820ff)" style="fill: #fed07e; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 397.897422 251.0424 
-L 502.522422 251.0424 
-L 502.522422 221.6592 
-L 397.897422 221.6592 
+    <path d="M 399.194609 251.0424 
+L 503.819609 251.0424 
+L 503.819609 221.6592 
+L 399.194609 221.6592 
 z
-" clip-path="url(#pc5033f41c3)" style="fill: #fec877; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p86aac820ff)" style="fill: #fdc776; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 188.647422 280.4256 
-L 293.272422 280.4256 
-L 293.272422 251.0424 
-L 188.647422 251.0424 
+    <path d="M 189.944609 280.4256 
+L 294.569609 280.4256 
+L 294.569609 251.0424 
+L 189.944609 251.0424 
 z
-" clip-path="url(#pc5033f41c3)" style="fill: #fff3ac; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p86aac820ff)" style="fill: #fff3ac; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 293.272422 280.4256 
-L 397.897422 280.4256 
-L 397.897422 251.0424 
-L 293.272422 251.0424 
+    <path d="M 294.569609 280.4256 
+L 399.194609 280.4256 
+L 399.194609 251.0424 
+L 294.569609 251.0424 
 z
-" clip-path="url(#pc5033f41c3)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p86aac820ff)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 397.897422 280.4256 
-L 502.522422 280.4256 
-L 502.522422 251.0424 
-L 397.897422 251.0424 
+    <path d="M 399.194609 280.4256 
+L 503.819609 280.4256 
+L 503.819609 251.0424 
+L 399.194609 251.0424 
 z
-" clip-path="url(#pc5033f41c3)" style="fill: #e8f59f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p86aac820ff)" style="fill: #e8f59f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 188.647422 309.8088 
-L 293.272422 309.8088 
-L 293.272422 280.4256 
-L 188.647422 280.4256 
+    <path d="M 189.944609 309.8088 
+L 294.569609 309.8088 
+L 294.569609 280.4256 
+L 189.944609 280.4256 
 z
-" clip-path="url(#pc5033f41c3)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p86aac820ff)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 293.272422 309.8088 
-L 397.897422 309.8088 
-L 397.897422 280.4256 
-L 293.272422 280.4256 
+    <path d="M 294.569609 309.8088 
+L 399.194609 309.8088 
+L 399.194609 280.4256 
+L 294.569609 280.4256 
 z
-" clip-path="url(#pc5033f41c3)" style="fill: #fa9b58; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p86aac820ff)" style="fill: #fa9b58; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 397.897422 309.8088 
-L 502.522422 309.8088 
-L 502.522422 280.4256 
-L 397.897422 280.4256 
+    <path d="M 399.194609 309.8088 
+L 503.819609 309.8088 
+L 503.819609 280.4256 
+L 399.194609 280.4256 
 z
-" clip-path="url(#pc5033f41c3)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p86aac820ff)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 188.647422 339.192 
-L 293.272422 339.192 
-L 293.272422 309.8088 
-L 188.647422 309.8088 
+    <path d="M 189.944609 339.192 
+L 294.569609 339.192 
+L 294.569609 309.8088 
+L 189.944609 309.8088 
 z
-" clip-path="url(#pc5033f41c3)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p86aac820ff)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 293.272422 339.192 
-L 397.897422 339.192 
-L 397.897422 309.8088 
-L 293.272422 309.8088 
+    <path d="M 294.569609 339.192 
+L 399.194609 339.192 
+L 399.194609 309.8088 
+L 294.569609 309.8088 
 z
-" clip-path="url(#pc5033f41c3)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p86aac820ff)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 397.897422 339.192 
-L 502.522422 339.192 
-L 502.522422 309.8088 
-L 397.897422 309.8088 
+    <path d="M 399.194609 339.192 
+L 503.819609 339.192 
+L 503.819609 309.8088 
+L 399.194609 309.8088 
 z
-" clip-path="url(#pc5033f41c3)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p86aac820ff)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(121.634688 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(122.931875 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(228.918906 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(230.216094 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(307.491016 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(308.788203 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(405.842734 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(407.139922 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(117.572422 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(118.869609 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.320 -->
-    <g transform="translate(229.508672 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(230.805859 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -918,7 +918,7 @@ z
    </g>
    <g id="text_7">
     <!-- 117 -->
-    <g transform="translate(337.949922 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(339.247109 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -952,7 +952,7 @@ z
    </g>
    <g id="text_8">
     <!-- 852 -->
-    <g transform="translate(442.574922 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(443.872109 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -1026,7 +1026,7 @@ z
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(112.210547 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(113.507734 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1125,7 +1125,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.324 -->
-    <g transform="translate(229.508672 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(230.805859 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1156,7 +1156,7 @@ z
    </g>
    <g id="text_11">
     <!-- 61 -->
-    <g transform="translate(340.494922 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(341.792109 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -1195,7 +1195,7 @@ z
    </g>
    <g id="text_12">
     <!-- 312 -->
-    <g transform="translate(442.574922 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(443.872109 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
@@ -1203,7 +1203,7 @@ z
    </g>
    <g id="text_13">
     <!-- Go compress/flate -->
-    <g transform="translate(99.903672 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(101.200859 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -1374,7 +1374,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.325 -->
-    <g transform="translate(229.508672 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(230.805859 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1384,14 +1384,14 @@ z
    </g>
    <g id="text_15">
     <!-- 50 -->
-    <g transform="translate(340.494922 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(341.792109 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
     <!-- 275 -->
-    <g transform="translate(442.574922 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(443.872109 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
@@ -1399,7 +1399,7 @@ z
    </g>
    <g id="text_17">
     <!-- JS fflate -->
-    <g transform="translate(120.936172 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(122.233359 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1459,7 +1459,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.329 -->
-    <g transform="translate(229.508672 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(230.805859 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-39" d="M 703 97 
 L 703 672 
@@ -1501,14 +1501,14 @@ z
    </g>
    <g id="text_19">
     <!-- 41 -->
-    <g transform="translate(340.494922 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(341.792109 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
     <!-- 160 -->
-    <g transform="translate(442.574922 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(443.872109 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -1516,7 +1516,7 @@ z
    </g>
    <g id="text_21">
     <!-- zlib -->
-    <g transform="translate(129.473672 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(130.770859 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1540,7 +1540,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.323 -->
-    <g transform="translate(229.508672 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(230.805859 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1550,14 +1550,14 @@ z
    </g>
    <g id="text_23">
     <!-- 38 -->
-    <g transform="translate(340.494922 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(341.792109 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_24">
     <!-- 448 -->
-    <g transform="translate(442.574922 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(443.872109 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(127.246094 0)"/>
@@ -1565,7 +1565,7 @@ z
    </g>
    <g id="text_25">
     <!-- lean-zip (native) -->
-    <g transform="translate(99.281797 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(100.578984 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1674,7 +1674,7 @@ z
    </g>
    <g id="text_26">
     <!-- 0.322 -->
-    <g transform="translate(228.308047 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(229.605234 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1768,7 +1768,7 @@ z
    </g>
    <g id="text_27">
     <!-- 37 -->
-    <g transform="translate(340.018672 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(341.315859 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-37" d="M 428 4666 
 L 3944 4666 
@@ -1786,8 +1786,8 @@ z
     </g>
    </g>
    <g id="text_28">
-    <!-- 295 -->
-    <g transform="translate(441.860547 238.5583) scale(0.08 -0.08)">
+    <!-- 293 -->
+    <g transform="translate(443.157734 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-39" d="M 641 103 
 L 641 966 
@@ -1819,40 +1819,15 @@ Q 1491 2759 1650 2554
 Q 1809 2350 2125 2350 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-35" d="M 678 4666 
-L 3669 4666 
-L 3669 3781 
-L 1638 3781 
-L 1638 3059 
-Q 1775 3097 1914 3117 
-Q 2053 3138 2203 3138 
-Q 3056 3138 3531 2711 
-Q 4006 2284 4006 1522 
-Q 4006 766 3489 337 
-Q 2972 -91 2053 -91 
-Q 1656 -91 1267 -14 
-Q 878 63 494 219 
-L 494 1166 
-Q 875 947 1217 837 
-Q 1559 728 1863 728 
-Q 2300 728 2551 942 
-Q 2803 1156 2803 1522 
-Q 2803 1891 2551 2103 
-Q 2300 2316 1863 2316 
-Q 1603 2316 1309 2248 
-Q 1016 2181 678 2041 
-L 678 4666 
-z
-" transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-Bold-32"/>
      <use xlink:href="#DejaVuSans-Bold-39" transform="translate(69.580078 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-35" transform="translate(139.160156 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-33" transform="translate(139.160156 0)"/>
     </g>
    </g>
    <g id="text_29">
     <!-- miniz_oxide -->
-    <g transform="translate(112.779922 267.83025) scale(0.08 -0.08)">
+    <g transform="translate(114.077109 267.83025) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6e" d="M 3513 2113 
 L 3513 0 
@@ -1911,7 +1886,7 @@ z
    </g>
    <g id="text_30">
     <!-- 0.322 -->
-    <g transform="translate(229.508672 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(230.805859 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1921,14 +1896,14 @@ z
    </g>
    <g id="text_31">
     <!-- 36 -->
-    <g transform="translate(340.494922 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(341.792109 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_32">
     <!-- 527 -->
-    <g transform="translate(442.574922 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(443.872109 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
@@ -1936,7 +1911,7 @@ z
    </g>
    <g id="text_33">
     <!-- OCaml decompress -->
-    <g transform="translate(97.396797 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(98.693984 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -2001,7 +1976,7 @@ z
    </g>
    <g id="text_34">
     <!-- 0.336 -->
-    <g transform="translate(229.508672 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(230.805859 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -2011,21 +1986,21 @@ z
    </g>
    <g id="text_35">
     <!-- 21 -->
-    <g transform="translate(340.494922 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(341.792109 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_36">
     <!-- 69 -->
-    <g transform="translate(445.119922 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(446.417109 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-36"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(125.618047 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(126.915234 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -2036,7 +2011,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.303 -->
-    <g transform="translate(229.508672 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(230.805859 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -2046,13 +2021,13 @@ z
    </g>
    <g id="text_39">
     <!-- 1 -->
-    <g transform="translate(343.039922 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(344.337109 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(446.209922 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(447.507109 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2068,7 +2043,7 @@ z
   </g>
   <g id="text_41">
    <!-- silesia — geomean over files, level 6 -->
-   <g transform="translate(153.124141 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(154.421328 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-2014" d="M 344 2156 
 L 6056 2156 
@@ -2212,7 +2187,7 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-07-09T17:31:54Z  ·  Linux chungus2 x86_64  ·  commit 324f086c  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-07-10T04:34:01Z  ·  Linux chungus2 x86_64  ·  commit 74861182  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2350,17 +2325,17 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(290.576172 0)"/>
     <use xlink:href="#DejaVuSans-37" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(453.90625 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
     <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2400,110 +2375,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3262.744141 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3297.949219 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3361.572266 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3425.195312 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3488.818359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3543.798828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3575.585938 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3607.373047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3639.160156 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3670.947266 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3702.734375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3730.517578 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3792.041016 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3853.320312 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3916.699219 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3980.175781 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4019.039062 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4080.220703 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4139.400391 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4200.923828 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4242.037109 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4275.728516 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4303.511719 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4365.035156 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4426.314453 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4489.693359 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4553.316406 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4587.007812 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4646.1875 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4709.810547 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4741.597656 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4805.220703 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4868.84375 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4900.630859 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4964.253906 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5000.337891 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5039.201172 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5094.181641 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5157.804688 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5189.591797 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5221.378906 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5253.166016 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5284.953125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5316.740234 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5355.949219 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5419.328125 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5458.191406 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5519.373047 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5582.751953 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5646.228516 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5709.607422 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5773.083984 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5836.462891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5875.671875 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5907.458984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5991.248047 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6023.035156 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6120.447266 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6181.970703 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6245.447266 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6273.230469 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6334.509766 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6397.888672 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6429.675781 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6481.775391 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6545.154297 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6606.433594 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6669.910156 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6722.009766 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6785.388672 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6846.570312 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6885.779297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6919.470703 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6951.257812 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6992.371094 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7053.650391 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7092.859375 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7120.642578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7181.824219 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7213.611328 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7241.394531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7293.494141 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7325.28125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7388.757812 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7450.28125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7489.490234 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7551.013672 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7590.376953 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7687.789062 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7715.572266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7778.951172 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7806.734375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7858.833984 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7898.042969 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7925.826172 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3262.744141 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3326.367188 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3389.990234 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3453.613281 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3517.236328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3580.859375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3612.646484 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3644.433594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3676.220703 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3708.007812 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3739.794922 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3767.578125 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3829.101562 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3890.380859 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3953.759766 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4017.236328 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4056.099609 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4117.28125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4176.460938 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4237.984375 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4279.097656 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4312.789062 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4340.572266 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4402.095703 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4463.375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4526.753906 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4590.376953 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4624.068359 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4683.248047 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4746.871094 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4778.658203 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4842.28125 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4905.904297 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4937.691406 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(5001.314453 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5037.398438 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5076.261719 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5131.242188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5194.865234 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5226.652344 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5258.439453 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5290.226562 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5322.013672 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5353.800781 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5393.009766 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5456.388672 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5495.251953 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5556.433594 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5619.8125 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5683.289062 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5746.667969 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5810.144531 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5873.523438 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5912.732422 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5944.519531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6028.308594 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6060.095703 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6157.507812 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6219.03125 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6282.507812 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6310.291016 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6371.570312 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6434.949219 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6466.736328 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6518.835938 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6582.214844 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6643.494141 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6706.970703 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6759.070312 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6822.449219 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6883.630859 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6922.839844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6956.53125 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6988.318359 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7029.431641 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7090.710938 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7129.919922 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7157.703125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7218.884766 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7250.671875 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7278.455078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7330.554688 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7362.341797 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7425.818359 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7487.341797 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7526.550781 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7588.074219 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7627.4375 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7724.849609 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7752.632812 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7816.011719 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7843.794922 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7895.894531 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7935.103516 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7962.886719 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pc5033f41c3">
-   <rect x="84.022422" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="p86aac820ff">
+   <rect x="85.319609" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/results/latest.json
+++ b/bench/results/latest.json
@@ -1,8 +1,8 @@
 {
  "meta": {
-  "date": "2026-07-09T17:31:54Z",
+  "date": "2026-07-10T04:34:01Z",
   "machine": "Linux chungus2 x86_64",
-  "git_commit": "324f086c",
+  "git_commit": "74861182",
   "toolchain": "leanprover/lean4:v4.30.0-rc2",
   "note": "compress_mbps/decompress_mbps are a median-of-5 snapshot on the machine above; ratio is deterministic"
  },
@@ -14,28 +14,28 @@
    "level": 1,
    "out_size": 60455,
    "ratio": 0.3975,
-   "compress_mbps": 82.64,
-   "decompress_mbps": 215.57
+   "compress_mbps": 82.12,
+   "decompress_mbps": 212.8
   },
   {
    "compressor": "native",
    "pattern": "canterbury/alice29.txt",
    "size": 152089,
    "level": 2,
-   "out_size": 56316,
-   "ratio": 0.3703,
-   "compress_mbps": 61.84,
-   "decompress_mbps": 246.97
+   "out_size": 57095,
+   "ratio": 0.3754,
+   "compress_mbps": 69.88,
+   "decompress_mbps": 244.12
   },
   {
    "compressor": "native",
    "pattern": "canterbury/alice29.txt",
    "size": 152089,
    "level": 3,
-   "out_size": 55646,
-   "ratio": 0.3659,
-   "compress_mbps": 53.84,
-   "decompress_mbps": 268.91
+   "out_size": 56050,
+   "ratio": 0.3685,
+   "compress_mbps": 60.89,
+   "decompress_mbps": 266.95
   },
   {
    "compressor": "native",
@@ -44,8 +44,8 @@
    "level": 4,
    "out_size": 54357,
    "ratio": 0.3574,
-   "compress_mbps": 38.5,
-   "decompress_mbps": 273.01
+   "compress_mbps": 38.39,
+   "decompress_mbps": 269.42
   },
   {
    "compressor": "native",
@@ -54,8 +54,8 @@
    "level": 5,
    "out_size": 54078,
    "ratio": 0.3556,
-   "compress_mbps": 30.84,
-   "decompress_mbps": 273.3
+   "compress_mbps": 30.81,
+   "decompress_mbps": 271.02
   },
   {
    "compressor": "native",
@@ -64,8 +64,8 @@
    "level": 6,
    "out_size": 54593,
    "ratio": 0.359,
-   "compress_mbps": 31.88,
-   "decompress_mbps": 280.09
+   "compress_mbps": 31.86,
+   "decompress_mbps": 277.68
   },
   {
    "compressor": "native",
@@ -74,8 +74,8 @@
    "level": 7,
    "out_size": 54469,
    "ratio": 0.3581,
-   "compress_mbps": 28.61,
-   "decompress_mbps": 280.24
+   "compress_mbps": 28.73,
+   "decompress_mbps": 278.18
   },
   {
    "compressor": "native",
@@ -84,8 +84,8 @@
    "level": 8,
    "out_size": 54216,
    "ratio": 0.3565,
-   "compress_mbps": 22.79,
-   "decompress_mbps": 280.41
+   "compress_mbps": 22.86,
+   "decompress_mbps": 277.58
   },
   {
    "compressor": "native",
@@ -94,8 +94,8 @@
    "level": 9,
    "out_size": 52732,
    "ratio": 0.3467,
-   "compress_mbps": 4.3,
-   "decompress_mbps": 281.43
+   "compress_mbps": 4.22,
+   "decompress_mbps": 278.99
   },
   {
    "compressor": "native",
@@ -104,7 +104,7 @@
    "level": 10,
    "out_size": 52078,
    "ratio": 0.3424,
-   "compress_mbps": 2.42,
+   "compress_mbps": 2.39,
    "decompress_mbps": null
   },
   {
@@ -114,28 +114,28 @@
    "level": 1,
    "out_size": 53135,
    "ratio": 0.4245,
-   "compress_mbps": 75.19,
-   "decompress_mbps": 208.45
+   "compress_mbps": 75.0,
+   "decompress_mbps": 207.4
   },
   {
    "compressor": "native",
    "pattern": "canterbury/asyoulik.txt",
    "size": 125179,
    "level": 2,
-   "out_size": 50187,
-   "ratio": 0.4009,
-   "compress_mbps": 57.65,
-   "decompress_mbps": 226.82
+   "out_size": 50676,
+   "ratio": 0.4048,
+   "compress_mbps": 64.49,
+   "decompress_mbps": 226.36
   },
   {
    "compressor": "native",
    "pattern": "canterbury/asyoulik.txt",
    "size": 125179,
    "level": 3,
-   "out_size": 49810,
-   "ratio": 0.3979,
-   "compress_mbps": 51.31,
-   "decompress_mbps": 248.39
+   "out_size": 50023,
+   "ratio": 0.3996,
+   "compress_mbps": 56.78,
+   "decompress_mbps": 247.17
   },
   {
    "compressor": "native",
@@ -144,8 +144,8 @@
    "level": 4,
    "out_size": 48687,
    "ratio": 0.3889,
-   "compress_mbps": 36.08,
-   "decompress_mbps": 250.72
+   "compress_mbps": 36.46,
+   "decompress_mbps": 250.07
   },
   {
    "compressor": "native",
@@ -154,8 +154,8 @@
    "level": 5,
    "out_size": 48586,
    "ratio": 0.3881,
-   "compress_mbps": 30.88,
-   "decompress_mbps": 251.53
+   "compress_mbps": 31.26,
+   "decompress_mbps": 249.28
   },
   {
    "compressor": "native",
@@ -164,8 +164,8 @@
    "level": 6,
    "out_size": 49005,
    "ratio": 0.3915,
-   "compress_mbps": 30.31,
-   "decompress_mbps": 255.89
+   "compress_mbps": 30.72,
+   "decompress_mbps": 254.01
   },
   {
    "compressor": "native",
@@ -174,8 +174,8 @@
    "level": 7,
    "out_size": 48910,
    "ratio": 0.3907,
-   "compress_mbps": 27.56,
-   "decompress_mbps": 256.45
+   "compress_mbps": 27.93,
+   "decompress_mbps": 254.52
   },
   {
    "compressor": "native",
@@ -184,8 +184,8 @@
    "level": 8,
    "out_size": 48839,
    "ratio": 0.3902,
-   "compress_mbps": 24.83,
-   "decompress_mbps": 256.58
+   "compress_mbps": 24.92,
+   "decompress_mbps": 254.49
   },
   {
    "compressor": "native",
@@ -194,8 +194,8 @@
    "level": 9,
    "out_size": 47433,
    "ratio": 0.3789,
-   "compress_mbps": 4.68,
-   "decompress_mbps": 256.75
+   "compress_mbps": 4.6,
+   "decompress_mbps": 255.62
   },
   {
    "compressor": "native",
@@ -204,7 +204,7 @@
    "level": 10,
    "out_size": 46866,
    "ratio": 0.3744,
-   "compress_mbps": 2.84,
+   "compress_mbps": 2.78,
    "decompress_mbps": null
   },
   {
@@ -214,28 +214,28 @@
    "level": 1,
    "out_size": 8476,
    "ratio": 0.3445,
-   "compress_mbps": 69.76,
-   "decompress_mbps": 275.19
+   "compress_mbps": 70.49,
+   "decompress_mbps": 272.74
   },
   {
    "compressor": "native",
    "pattern": "canterbury/cp.html",
    "size": 24603,
    "level": 2,
-   "out_size": 8271,
-   "ratio": 0.3362,
-   "compress_mbps": 61.83,
-   "decompress_mbps": 284.53
+   "out_size": 8249,
+   "ratio": 0.3353,
+   "compress_mbps": 65.22,
+   "decompress_mbps": 280.72
   },
   {
    "compressor": "native",
    "pattern": "canterbury/cp.html",
    "size": 24603,
    "level": 3,
-   "out_size": 8159,
-   "ratio": 0.3316,
-   "compress_mbps": 59.7,
-   "decompress_mbps": 285.91
+   "out_size": 8112,
+   "ratio": 0.3297,
+   "compress_mbps": 60.84,
+   "decompress_mbps": 283.8
   },
   {
    "compressor": "native",
@@ -244,8 +244,8 @@
    "level": 4,
    "out_size": 7948,
    "ratio": 0.3231,
-   "compress_mbps": 49.31,
-   "decompress_mbps": 295.89
+   "compress_mbps": 49.68,
+   "decompress_mbps": 291.88
   },
   {
    "compressor": "native",
@@ -254,8 +254,8 @@
    "level": 5,
    "out_size": 7899,
    "ratio": 0.3211,
-   "compress_mbps": 41.89,
-   "decompress_mbps": 302.73
+   "compress_mbps": 42.44,
+   "decompress_mbps": 298.34
   },
   {
    "compressor": "native",
@@ -264,8 +264,8 @@
    "level": 6,
    "out_size": 7962,
    "ratio": 0.3236,
-   "compress_mbps": 37.27,
-   "decompress_mbps": 301.65
+   "compress_mbps": 37.26,
+   "decompress_mbps": 298.67
   },
   {
    "compressor": "native",
@@ -274,8 +274,8 @@
    "level": 7,
    "out_size": 7950,
    "ratio": 0.3231,
-   "compress_mbps": 35.36,
-   "decompress_mbps": 307.03
+   "compress_mbps": 35.63,
+   "decompress_mbps": 303.1
   },
   {
    "compressor": "native",
@@ -284,8 +284,8 @@
    "level": 8,
    "out_size": 7934,
    "ratio": 0.3225,
-   "compress_mbps": 32.21,
-   "decompress_mbps": 306.43
+   "compress_mbps": 32.43,
+   "decompress_mbps": 303.93
   },
   {
    "compressor": "native",
@@ -294,8 +294,8 @@
    "level": 9,
    "out_size": 7803,
    "ratio": 0.3172,
-   "compress_mbps": 5.03,
-   "decompress_mbps": 306.41
+   "compress_mbps": 4.92,
+   "decompress_mbps": 303.63
   },
   {
    "compressor": "native",
@@ -304,7 +304,7 @@
    "level": 10,
    "out_size": 7737,
    "ratio": 0.3145,
-   "compress_mbps": 2.99,
+   "compress_mbps": 2.91,
    "decompress_mbps": null
   },
   {
@@ -314,28 +314,28 @@
    "level": 1,
    "out_size": 3509,
    "ratio": 0.3147,
-   "compress_mbps": 52.89,
-   "decompress_mbps": 185.68
+   "compress_mbps": 52.76,
+   "decompress_mbps": 182.44
   },
   {
    "compressor": "native",
    "pattern": "canterbury/fields.c",
    "size": 11150,
    "level": 2,
-   "out_size": 3269,
-   "ratio": 0.2932,
-   "compress_mbps": 48.72,
-   "decompress_mbps": 188.3
+   "out_size": 3317,
+   "ratio": 0.2975,
+   "compress_mbps": 50.11,
+   "decompress_mbps": 184.4
   },
   {
    "compressor": "native",
    "pattern": "canterbury/fields.c",
    "size": 11150,
    "level": 3,
-   "out_size": 3209,
-   "ratio": 0.2878,
-   "compress_mbps": 47.49,
-   "decompress_mbps": 191.69
+   "out_size": 3227,
+   "ratio": 0.2894,
+   "compress_mbps": 47.82,
+   "decompress_mbps": 188.08
   },
   {
    "compressor": "native",
@@ -344,8 +344,8 @@
    "level": 4,
    "out_size": 3128,
    "ratio": 0.2805,
-   "compress_mbps": 40.66,
-   "decompress_mbps": 196.88
+   "compress_mbps": 40.48,
+   "decompress_mbps": 192.9
   },
   {
    "compressor": "native",
@@ -354,8 +354,8 @@
    "level": 5,
    "out_size": 3112,
    "ratio": 0.2791,
-   "compress_mbps": 36.44,
-   "decompress_mbps": 197.69
+   "compress_mbps": 36.07,
+   "decompress_mbps": 192.84
   },
   {
    "compressor": "native",
@@ -364,8 +364,8 @@
    "level": 6,
    "out_size": 3136,
    "ratio": 0.2813,
-   "compress_mbps": 33.94,
-   "decompress_mbps": 198.09
+   "compress_mbps": 33.88,
+   "decompress_mbps": 193.41
   },
   {
    "compressor": "native",
@@ -374,8 +374,8 @@
    "level": 7,
    "out_size": 3122,
    "ratio": 0.28,
-   "compress_mbps": 32.53,
-   "decompress_mbps": 198.84
+   "compress_mbps": 32.62,
+   "decompress_mbps": 193.85
   },
   {
    "compressor": "native",
@@ -384,8 +384,8 @@
    "level": 8,
    "out_size": 3117,
    "ratio": 0.2796,
-   "compress_mbps": 30.45,
-   "decompress_mbps": 197.17
+   "compress_mbps": 30.54,
+   "decompress_mbps": 194.06
   },
   {
    "compressor": "native",
@@ -394,8 +394,8 @@
    "level": 9,
    "out_size": 3056,
    "ratio": 0.2741,
-   "compress_mbps": 5.49,
-   "decompress_mbps": 197.42
+   "compress_mbps": 5.38,
+   "decompress_mbps": 194.39
   },
   {
    "compressor": "native",
@@ -404,7 +404,7 @@
    "level": 10,
    "out_size": 3031,
    "ratio": 0.2718,
-   "compress_mbps": 3.1,
+   "compress_mbps": 3.04,
    "decompress_mbps": null
   },
   {
@@ -414,28 +414,28 @@
    "level": 1,
    "out_size": 1283,
    "ratio": 0.3448,
-   "compress_mbps": 25.95,
-   "decompress_mbps": 84.68
+   "compress_mbps": 25.73,
+   "decompress_mbps": 83.09
   },
   {
    "compressor": "native",
    "pattern": "canterbury/grammar.lsp",
    "size": 3721,
    "level": 2,
-   "out_size": 1225,
-   "ratio": 0.3292,
-   "compress_mbps": 25.41,
-   "decompress_mbps": 85.61
+   "out_size": 1234,
+   "ratio": 0.3316,
+   "compress_mbps": 25.45,
+   "decompress_mbps": 84.08
   },
   {
    "compressor": "native",
    "pattern": "canterbury/grammar.lsp",
    "size": 3721,
    "level": 3,
-   "out_size": 1222,
-   "ratio": 0.3284,
-   "compress_mbps": 25.06,
-   "decompress_mbps": 85.95
+   "out_size": 1223,
+   "ratio": 0.3287,
+   "compress_mbps": 25.0,
+   "decompress_mbps": 84.03
   },
   {
    "compressor": "native",
@@ -444,8 +444,8 @@
    "level": 4,
    "out_size": 1213,
    "ratio": 0.326,
-   "compress_mbps": 22.01,
-   "decompress_mbps": 86.55
+   "compress_mbps": 21.95,
+   "decompress_mbps": 84.04
   },
   {
    "compressor": "native",
@@ -454,8 +454,8 @@
    "level": 5,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 21.43,
-   "decompress_mbps": 87.0
+   "compress_mbps": 21.34,
+   "decompress_mbps": 84.49
   },
   {
    "compressor": "native",
@@ -464,8 +464,8 @@
    "level": 6,
    "out_size": 1220,
    "ratio": 0.3279,
-   "compress_mbps": 19.63,
-   "decompress_mbps": 86.83
+   "compress_mbps": 19.67,
+   "decompress_mbps": 84.79
   },
   {
    "compressor": "native",
@@ -474,8 +474,8 @@
    "level": 7,
    "out_size": 1219,
    "ratio": 0.3276,
-   "compress_mbps": 19.45,
-   "decompress_mbps": 86.91
+   "compress_mbps": 19.5,
+   "decompress_mbps": 85.01
   },
   {
    "compressor": "native",
@@ -485,7 +485,7 @@
    "out_size": 1219,
    "ratio": 0.3276,
    "compress_mbps": 19.29,
-   "decompress_mbps": 86.67
+   "decompress_mbps": 84.69
   },
   {
    "compressor": "native",
@@ -494,8 +494,8 @@
    "level": 9,
    "out_size": 1205,
    "ratio": 0.3238,
-   "compress_mbps": 4.95,
-   "decompress_mbps": 86.12
+   "compress_mbps": 4.9,
+   "decompress_mbps": 84.79
   },
   {
    "compressor": "native",
@@ -504,7 +504,7 @@
    "level": 10,
    "out_size": 1191,
    "ratio": 0.3201,
-   "compress_mbps": 3.0,
+   "compress_mbps": 2.93,
    "decompress_mbps": null
   },
   {
@@ -514,28 +514,28 @@
    "level": 1,
    "out_size": 251793,
    "ratio": 0.2445,
-   "compress_mbps": 170.66,
-   "decompress_mbps": 401.3
+   "compress_mbps": 171.2,
+   "decompress_mbps": 397.44
   },
   {
    "compressor": "native",
    "pattern": "canterbury/kennedy.xls",
    "size": 1029744,
    "level": 2,
-   "out_size": 242565,
-   "ratio": 0.2356,
-   "compress_mbps": 140.65,
-   "decompress_mbps": 430.39
+   "out_size": 244112,
+   "ratio": 0.2371,
+   "compress_mbps": 140.43,
+   "decompress_mbps": 424.71
   },
   {
    "compressor": "native",
    "pattern": "canterbury/kennedy.xls",
    "size": 1029744,
    "level": 3,
-   "out_size": 242532,
-   "ratio": 0.2355,
-   "compress_mbps": 114.28,
-   "decompress_mbps": 457.5
+   "out_size": 242564,
+   "ratio": 0.2356,
+   "compress_mbps": 117.67,
+   "decompress_mbps": 451.43
   },
   {
    "compressor": "native",
@@ -544,8 +544,8 @@
    "level": 4,
    "out_size": 239953,
    "ratio": 0.233,
-   "compress_mbps": 100.69,
-   "decompress_mbps": 486.6
+   "compress_mbps": 100.77,
+   "decompress_mbps": 481.64
   },
   {
    "compressor": "native",
@@ -554,8 +554,8 @@
    "level": 5,
    "out_size": 218565,
    "ratio": 0.2123,
-   "compress_mbps": 54.34,
-   "decompress_mbps": 468.69
+   "compress_mbps": 54.6,
+   "decompress_mbps": 465.84
   },
   {
    "compressor": "native",
@@ -564,8 +564,8 @@
    "level": 6,
    "out_size": 202437,
    "ratio": 0.1966,
-   "compress_mbps": 39.8,
-   "decompress_mbps": 485.51
+   "compress_mbps": 40.16,
+   "decompress_mbps": 483.11
   },
   {
    "compressor": "native",
@@ -574,8 +574,8 @@
    "level": 7,
    "out_size": 201821,
    "ratio": 0.196,
-   "compress_mbps": 36.84,
-   "decompress_mbps": 488.48
+   "compress_mbps": 37.24,
+   "decompress_mbps": 486.53
   },
   {
    "compressor": "native",
@@ -584,8 +584,8 @@
    "level": 8,
    "out_size": 200869,
    "ratio": 0.1951,
-   "compress_mbps": 21.57,
-   "decompress_mbps": 498.72
+   "compress_mbps": 21.67,
+   "decompress_mbps": 494.81
   },
   {
    "compressor": "native",
@@ -594,8 +594,8 @@
    "level": 9,
    "out_size": 182511,
    "ratio": 0.1772,
-   "compress_mbps": 3.5,
-   "decompress_mbps": 500.1
+   "compress_mbps": 3.46,
+   "decompress_mbps": 495.44
   },
   {
    "compressor": "native",
@@ -604,7 +604,7 @@
    "level": 10,
    "out_size": 178069,
    "ratio": 0.1729,
-   "compress_mbps": 1.49,
+   "compress_mbps": 1.48,
    "decompress_mbps": null
   },
   {
@@ -614,28 +614,28 @@
    "level": 1,
    "out_size": 160674,
    "ratio": 0.3765,
-   "compress_mbps": 90.62,
-   "decompress_mbps": 222.37
+   "compress_mbps": 90.65,
+   "decompress_mbps": 222.68
   },
   {
    "compressor": "native",
    "pattern": "canterbury/lcet10.txt",
    "size": 426754,
    "level": 2,
-   "out_size": 149787,
-   "ratio": 0.351,
-   "compress_mbps": 67.6,
-   "decompress_mbps": 241.62
+   "out_size": 151578,
+   "ratio": 0.3552,
+   "compress_mbps": 75.98,
+   "decompress_mbps": 241.52
   },
   {
    "compressor": "native",
    "pattern": "canterbury/lcet10.txt",
    "size": 426754,
    "level": 3,
-   "out_size": 148055,
-   "ratio": 0.3469,
-   "compress_mbps": 58.43,
-   "decompress_mbps": 269.75
+   "out_size": 148848,
+   "ratio": 0.3488,
+   "compress_mbps": 64.81,
+   "decompress_mbps": 269.98
   },
   {
    "compressor": "native",
@@ -644,8 +644,8 @@
    "level": 4,
    "out_size": 144750,
    "ratio": 0.3392,
-   "compress_mbps": 42.3,
-   "decompress_mbps": 272.7
+   "compress_mbps": 42.07,
+   "decompress_mbps": 272.44
   },
   {
    "compressor": "native",
@@ -654,8 +654,8 @@
    "level": 5,
    "out_size": 144408,
    "ratio": 0.3384,
-   "compress_mbps": 33.9,
-   "decompress_mbps": 273.59
+   "compress_mbps": 33.94,
+   "decompress_mbps": 273.9
   },
   {
    "compressor": "native",
@@ -664,8 +664,8 @@
    "level": 6,
    "out_size": 144872,
    "ratio": 0.3395,
-   "compress_mbps": 31.97,
-   "decompress_mbps": 279.6
+   "compress_mbps": 31.83,
+   "decompress_mbps": 279.21
   },
   {
    "compressor": "native",
@@ -674,8 +674,8 @@
    "level": 7,
    "out_size": 144583,
    "ratio": 0.3388,
-   "compress_mbps": 29.16,
-   "decompress_mbps": 280.16
+   "compress_mbps": 29.04,
+   "decompress_mbps": 280.05
   },
   {
    "compressor": "native",
@@ -684,8 +684,8 @@
    "level": 8,
    "out_size": 144045,
    "ratio": 0.3375,
-   "compress_mbps": 23.95,
-   "decompress_mbps": 280.66
+   "compress_mbps": 23.98,
+   "decompress_mbps": 280.4
   },
   {
    "compressor": "native",
@@ -694,8 +694,8 @@
    "level": 9,
    "out_size": 140323,
    "ratio": 0.3288,
-   "compress_mbps": 4.25,
-   "decompress_mbps": 280.11
+   "compress_mbps": 4.22,
+   "decompress_mbps": 279.95
   },
   {
    "compressor": "native",
@@ -704,7 +704,7 @@
    "level": 10,
    "out_size": 138833,
    "ratio": 0.3253,
-   "compress_mbps": 2.55,
+   "compress_mbps": 2.51,
    "decompress_mbps": null
   },
   {
@@ -714,28 +714,28 @@
    "level": 1,
    "out_size": 212588,
    "ratio": 0.4412,
-   "compress_mbps": 77.47,
-   "decompress_mbps": 192.5
+   "compress_mbps": 68.15,
+   "decompress_mbps": 147.97
   },
   {
    "compressor": "native",
    "pattern": "canterbury/plrabn12.txt",
    "size": 481861,
    "level": 2,
-   "out_size": 199981,
-   "ratio": 0.415,
-   "compress_mbps": 56.65,
-   "decompress_mbps": 215.02
+   "out_size": 202277,
+   "ratio": 0.4198,
+   "compress_mbps": 64.37,
+   "decompress_mbps": 215.93
   },
   {
    "compressor": "native",
    "pattern": "canterbury/plrabn12.txt",
    "size": 481861,
    "level": 3,
-   "out_size": 198551,
-   "ratio": 0.4121,
-   "compress_mbps": 49.21,
-   "decompress_mbps": 237.97
+   "out_size": 199922,
+   "ratio": 0.4149,
+   "compress_mbps": 55.79,
+   "decompress_mbps": 238.33
   },
   {
    "compressor": "native",
@@ -744,8 +744,8 @@
    "level": 4,
    "out_size": 193783,
    "ratio": 0.4022,
-   "compress_mbps": 32.85,
-   "decompress_mbps": 241.58
+   "compress_mbps": 32.73,
+   "decompress_mbps": 240.97
   },
   {
    "compressor": "native",
@@ -754,8 +754,8 @@
    "level": 5,
    "out_size": 193223,
    "ratio": 0.401,
-   "compress_mbps": 27.32,
-   "decompress_mbps": 237.52
+   "compress_mbps": 27.16,
+   "decompress_mbps": 237.23
   },
   {
    "compressor": "native",
@@ -764,8 +764,8 @@
    "level": 6,
    "out_size": 195643,
    "ratio": 0.406,
-   "compress_mbps": 28.15,
-   "decompress_mbps": 242.16
+   "compress_mbps": 28.0,
+   "decompress_mbps": 242.09
   },
   {
    "compressor": "native",
@@ -774,8 +774,8 @@
    "level": 7,
    "out_size": 195104,
    "ratio": 0.4049,
-   "compress_mbps": 25.2,
-   "decompress_mbps": 242.18
+   "compress_mbps": 25.13,
+   "decompress_mbps": 241.67
   },
   {
    "compressor": "native",
@@ -784,8 +784,8 @@
    "level": 8,
    "out_size": 194355,
    "ratio": 0.4033,
-   "compress_mbps": 20.44,
-   "decompress_mbps": 241.39
+   "compress_mbps": 20.43,
+   "decompress_mbps": 242.03
   },
   {
    "compressor": "native",
@@ -795,7 +795,7 @@
    "out_size": 189368,
    "ratio": 0.393,
    "compress_mbps": 4.05,
-   "decompress_mbps": 242.31
+   "decompress_mbps": 240.99
   },
   {
    "compressor": "native",
@@ -804,7 +804,7 @@
    "level": 10,
    "out_size": 186146,
    "ratio": 0.3863,
-   "compress_mbps": 2.47,
+   "compress_mbps": 2.44,
    "decompress_mbps": null
   },
   {
@@ -814,28 +814,28 @@
    "level": 1,
    "out_size": 60161,
    "ratio": 0.1172,
-   "compress_mbps": 249.72,
-   "decompress_mbps": 590.55
+   "compress_mbps": 250.95,
+   "decompress_mbps": 586.54
   },
   {
    "compressor": "native",
    "pattern": "canterbury/ptt5",
    "size": 513216,
    "level": 2,
-   "out_size": 58873,
-   "ratio": 0.1147,
-   "compress_mbps": 202.94,
-   "decompress_mbps": 618.29
+   "out_size": 58606,
+   "ratio": 0.1142,
+   "compress_mbps": 226.14,
+   "decompress_mbps": 613.27
   },
   {
    "compressor": "native",
    "pattern": "canterbury/ptt5",
    "size": 513216,
    "level": 3,
-   "out_size": 58327,
-   "ratio": 0.1137,
-   "compress_mbps": 180.16,
-   "decompress_mbps": 648.7
+   "out_size": 57685,
+   "ratio": 0.1124,
+   "compress_mbps": 188.89,
+   "decompress_mbps": 642.86
   },
   {
    "compressor": "native",
@@ -844,8 +844,8 @@
    "level": 4,
    "out_size": 55586,
    "ratio": 0.1083,
-   "compress_mbps": 121.32,
-   "decompress_mbps": 666.08
+   "compress_mbps": 122.7,
+   "decompress_mbps": 663.35
   },
   {
    "compressor": "native",
@@ -854,8 +854,8 @@
    "level": 5,
    "out_size": 55097,
    "ratio": 0.1074,
-   "compress_mbps": 89.47,
-   "decompress_mbps": 693.44
+   "compress_mbps": 90.37,
+   "decompress_mbps": 687.12
   },
   {
    "compressor": "native",
@@ -864,8 +864,8 @@
    "level": 6,
    "out_size": 55674,
    "ratio": 0.1085,
-   "compress_mbps": 74.13,
-   "decompress_mbps": 711.47
+   "compress_mbps": 75.12,
+   "decompress_mbps": 706.72
   },
   {
    "compressor": "native",
@@ -874,8 +874,8 @@
    "level": 7,
    "out_size": 55495,
    "ratio": 0.1081,
-   "compress_mbps": 66.31,
-   "decompress_mbps": 727.38
+   "compress_mbps": 67.31,
+   "decompress_mbps": 721.81
   },
   {
    "compressor": "native",
@@ -884,8 +884,8 @@
    "level": 8,
    "out_size": 53384,
    "ratio": 0.104,
-   "compress_mbps": 42.25,
-   "decompress_mbps": 749.07
+   "compress_mbps": 42.87,
+   "decompress_mbps": 747.9
   },
   {
    "compressor": "native",
@@ -894,8 +894,8 @@
    "level": 9,
    "out_size": 52603,
    "ratio": 0.1025,
-   "compress_mbps": 5.87,
-   "decompress_mbps": 769.0
+   "compress_mbps": 5.9,
+   "decompress_mbps": 757.1
   },
   {
    "compressor": "native",
@@ -904,7 +904,7 @@
    "level": 10,
    "out_size": 52236,
    "ratio": 0.1018,
-   "compress_mbps": 3.87,
+   "compress_mbps": 3.8,
    "decompress_mbps": null
   },
   {
@@ -914,28 +914,28 @@
    "level": 1,
    "out_size": 14249,
    "ratio": 0.3726,
-   "compress_mbps": 63.9,
-   "decompress_mbps": 240.81
+   "compress_mbps": 64.22,
+   "decompress_mbps": 237.66
   },
   {
    "compressor": "native",
    "pattern": "canterbury/sum",
    "size": 38240,
    "level": 2,
-   "out_size": 13825,
-   "ratio": 0.3615,
-   "compress_mbps": 57.93,
-   "decompress_mbps": 251.05
+   "out_size": 13835,
+   "ratio": 0.3618,
+   "compress_mbps": 59.62,
+   "decompress_mbps": 248.32
   },
   {
    "compressor": "native",
    "pattern": "canterbury/sum",
    "size": 38240,
    "level": 3,
-   "out_size": 13751,
-   "ratio": 0.3596,
-   "compress_mbps": 55.68,
-   "decompress_mbps": 253.35
+   "out_size": 13760,
+   "ratio": 0.3598,
+   "compress_mbps": 57.12,
+   "decompress_mbps": 247.31
   },
   {
    "compressor": "native",
@@ -944,8 +944,8 @@
    "level": 4,
    "out_size": 13290,
    "ratio": 0.3475,
-   "compress_mbps": 46.38,
-   "decompress_mbps": 260.76
+   "compress_mbps": 46.32,
+   "decompress_mbps": 257.22
   },
   {
    "compressor": "native",
@@ -954,8 +954,8 @@
    "level": 5,
    "out_size": 13244,
    "ratio": 0.3463,
-   "compress_mbps": 39.51,
-   "decompress_mbps": 269.99
+   "compress_mbps": 39.84,
+   "decompress_mbps": 266.18
   },
   {
    "compressor": "native",
@@ -964,8 +964,8 @@
    "level": 6,
    "out_size": 12675,
    "ratio": 0.3315,
-   "compress_mbps": 21.15,
-   "decompress_mbps": 272.21
+   "compress_mbps": 21.21,
+   "decompress_mbps": 266.6
   },
   {
    "compressor": "native",
@@ -974,8 +974,8 @@
    "level": 7,
    "out_size": 12653,
    "ratio": 0.3309,
-   "compress_mbps": 20.42,
-   "decompress_mbps": 276.27
+   "compress_mbps": 20.57,
+   "decompress_mbps": 270.21
   },
   {
    "compressor": "native",
@@ -985,7 +985,7 @@
    "out_size": 12632,
    "ratio": 0.3303,
    "compress_mbps": 17.03,
-   "decompress_mbps": 276.97
+   "decompress_mbps": 271.66
   },
   {
    "compressor": "native",
@@ -994,8 +994,8 @@
    "level": 9,
    "out_size": 12427,
    "ratio": 0.325,
-   "compress_mbps": 5.47,
-   "decompress_mbps": 278.65
+   "compress_mbps": 5.4,
+   "decompress_mbps": 271.76
   },
   {
    "compressor": "native",
@@ -1004,7 +1004,7 @@
    "level": 10,
    "out_size": 12273,
    "ratio": 0.3209,
-   "compress_mbps": 3.16,
+   "compress_mbps": 3.11,
    "decompress_mbps": null
   },
   {
@@ -1014,28 +1014,28 @@
    "level": 1,
    "out_size": 1800,
    "ratio": 0.4258,
-   "compress_mbps": 27.81,
-   "decompress_mbps": 93.67
+   "compress_mbps": 27.97,
+   "decompress_mbps": 90.23
   },
   {
    "compressor": "native",
    "pattern": "canterbury/xargs.1",
    "size": 4227,
    "level": 2,
-   "out_size": 1750,
-   "ratio": 0.414,
-   "compress_mbps": 27.23,
-   "decompress_mbps": 93.92
+   "out_size": 1756,
+   "ratio": 0.4154,
+   "compress_mbps": 27.56,
+   "decompress_mbps": 90.57
   },
   {
    "compressor": "native",
    "pattern": "canterbury/xargs.1",
    "size": 4227,
    "level": 3,
-   "out_size": 1742,
-   "ratio": 0.4121,
-   "compress_mbps": 27.04,
-   "decompress_mbps": 93.49
+   "out_size": 1741,
+   "ratio": 0.4119,
+   "compress_mbps": 27.24,
+   "decompress_mbps": 90.23
   },
   {
    "compressor": "native",
@@ -1044,8 +1044,8 @@
    "level": 4,
    "out_size": 1726,
    "ratio": 0.4083,
-   "compress_mbps": 24.09,
-   "decompress_mbps": 94.82
+   "compress_mbps": 24.11,
+   "decompress_mbps": 91.56
   },
   {
    "compressor": "native",
@@ -1054,8 +1054,8 @@
    "level": 5,
    "out_size": 1722,
    "ratio": 0.4074,
-   "compress_mbps": 23.8,
-   "decompress_mbps": 95.41
+   "compress_mbps": 23.79,
+   "decompress_mbps": 92.13
   },
   {
    "compressor": "native",
@@ -1065,7 +1065,7 @@
    "out_size": 1735,
    "ratio": 0.4105,
    "compress_mbps": 20.94,
-   "decompress_mbps": 95.1
+   "decompress_mbps": 91.93
   },
   {
    "compressor": "native",
@@ -1074,8 +1074,8 @@
    "level": 7,
    "out_size": 1734,
    "ratio": 0.4102,
-   "compress_mbps": 20.86,
-   "decompress_mbps": 95.13
+   "compress_mbps": 20.95,
+   "decompress_mbps": 91.88
   },
   {
    "compressor": "native",
@@ -1084,8 +1084,8 @@
    "level": 8,
    "out_size": 1734,
    "ratio": 0.4102,
-   "compress_mbps": 20.91,
-   "decompress_mbps": 95.13
+   "compress_mbps": 20.98,
+   "decompress_mbps": 91.66
   },
   {
    "compressor": "native",
@@ -1094,8 +1094,8 @@
    "level": 9,
    "out_size": 1708,
    "ratio": 0.4041,
-   "compress_mbps": 5.49,
-   "decompress_mbps": 95.23
+   "compress_mbps": 5.36,
+   "decompress_mbps": 91.09
   },
   {
    "compressor": "native",
@@ -1104,7 +1104,7 @@
    "level": 10,
    "out_size": 1693,
    "ratio": 0.4005,
-   "compress_mbps": 3.36,
+   "compress_mbps": 3.27,
    "decompress_mbps": null
   },
   {
@@ -4414,28 +4414,28 @@
    "level": 1,
    "out_size": 4259644,
    "ratio": 0.4179,
-   "compress_mbps": 80.38,
-   "decompress_mbps": 195.94
+   "compress_mbps": 80.67,
+   "decompress_mbps": 194.18
   },
   {
    "compressor": "native",
    "pattern": "silesia/dickens",
    "size": 10192446,
    "level": 2,
-   "out_size": 3977395,
-   "ratio": 0.3902,
-   "compress_mbps": 58.6,
-   "decompress_mbps": 214.72
+   "out_size": 4029026,
+   "ratio": 0.3953,
+   "compress_mbps": 67.33,
+   "decompress_mbps": 214.49
   },
   {
    "compressor": "native",
    "pattern": "silesia/dickens",
    "size": 10192446,
    "level": 3,
-   "out_size": 3945296,
-   "ratio": 0.3871,
-   "compress_mbps": 50.94,
-   "decompress_mbps": 236.13
+   "out_size": 3970599,
+   "ratio": 0.3896,
+   "compress_mbps": 57.88,
+   "decompress_mbps": 236.42
   },
   {
    "compressor": "native",
@@ -4444,8 +4444,8 @@
    "level": 4,
    "out_size": 3851998,
    "ratio": 0.3779,
-   "compress_mbps": 35.02,
-   "decompress_mbps": 239.43
+   "compress_mbps": 35.12,
+   "decompress_mbps": 236.86
   },
   {
    "compressor": "native",
@@ -4454,8 +4454,8 @@
    "level": 5,
    "out_size": 3840481,
    "ratio": 0.3768,
-   "compress_mbps": 29.43,
-   "decompress_mbps": 238.07
+   "compress_mbps": 29.5,
+   "decompress_mbps": 234.82
   },
   {
    "compressor": "native",
@@ -4464,8 +4464,8 @@
    "level": 6,
    "out_size": 3878125,
    "ratio": 0.3805,
-   "compress_mbps": 29.47,
-   "decompress_mbps": 241.16
+   "compress_mbps": 29.33,
+   "decompress_mbps": 242.91
   },
   {
    "compressor": "native",
@@ -4474,8 +4474,8 @@
    "level": 7,
    "out_size": 3868436,
    "ratio": 0.3795,
-   "compress_mbps": 26.31,
-   "decompress_mbps": 242.1
+   "compress_mbps": 26.41,
+   "decompress_mbps": 243.57
   },
   {
    "compressor": "native",
@@ -4484,8 +4484,8 @@
    "level": 8,
    "out_size": 3854820,
    "ratio": 0.3782,
-   "compress_mbps": 21.33,
-   "decompress_mbps": 242.75
+   "compress_mbps": 21.37,
+   "decompress_mbps": 243.37
   },
   {
    "compressor": "native",
@@ -4494,8 +4494,8 @@
    "level": 9,
    "out_size": 3766619,
    "ratio": 0.3696,
-   "compress_mbps": 4.17,
-   "decompress_mbps": 253.02
+   "compress_mbps": 4.15,
+   "decompress_mbps": 254.27
   },
   {
    "compressor": "native",
@@ -4504,7 +4504,7 @@
    "level": 10,
    "out_size": 3711208,
    "ratio": 0.3641,
-   "compress_mbps": 2.47,
+   "compress_mbps": 2.49,
    "decompress_mbps": null
   },
   {
@@ -4514,28 +4514,28 @@
    "level": 1,
    "out_size": 21267086,
    "ratio": 0.4152,
-   "compress_mbps": 95.36,
-   "decompress_mbps": 213.1
+   "compress_mbps": 96.23,
+   "decompress_mbps": 213.74
   },
   {
    "compressor": "native",
    "pattern": "silesia/mozilla",
    "size": 51220480,
    "level": 2,
-   "out_size": 20802983,
-   "ratio": 0.4061,
-   "compress_mbps": 79.75,
-   "decompress_mbps": 229.45
+   "out_size": 20833417,
+   "ratio": 0.4067,
+   "compress_mbps": 87.55,
+   "decompress_mbps": 229.42
   },
   {
    "compressor": "native",
    "pattern": "silesia/mozilla",
    "size": 51220480,
    "level": 3,
-   "out_size": 20665485,
-   "ratio": 0.4035,
-   "compress_mbps": 73.9,
-   "decompress_mbps": 233.44
+   "out_size": 20636431,
+   "ratio": 0.4029,
+   "compress_mbps": 76.96,
+   "decompress_mbps": 233.18
   },
   {
    "compressor": "native",
@@ -4544,8 +4544,8 @@
    "level": 4,
    "out_size": 20356893,
    "ratio": 0.3974,
-   "compress_mbps": 56.11,
-   "decompress_mbps": 244.52
+   "compress_mbps": 55.88,
+   "decompress_mbps": 244.65
   },
   {
    "compressor": "native",
@@ -4554,8 +4554,8 @@
    "level": 5,
    "out_size": 20209289,
    "ratio": 0.3946,
-   "compress_mbps": 41.97,
-   "decompress_mbps": 254.77
+   "compress_mbps": 42.17,
+   "decompress_mbps": 254.57
   },
   {
    "compressor": "native",
@@ -4564,8 +4564,8 @@
    "level": 6,
    "out_size": 18875267,
    "ratio": 0.3685,
-   "compress_mbps": 30.31,
-   "decompress_mbps": 253.15
+   "compress_mbps": 30.29,
+   "decompress_mbps": 251.77
   },
   {
    "compressor": "native",
@@ -4574,8 +4574,8 @@
    "level": 7,
    "out_size": 18835212,
    "ratio": 0.3677,
-   "compress_mbps": 28.3,
-   "decompress_mbps": 258.91
+   "compress_mbps": 28.1,
+   "decompress_mbps": 258.81
   },
   {
    "compressor": "native",
@@ -4584,8 +4584,8 @@
    "level": 8,
    "out_size": 18777212,
    "ratio": 0.3666,
-   "compress_mbps": 19.49,
-   "decompress_mbps": 259.84
+   "compress_mbps": 19.6,
+   "decompress_mbps": 258.68
   },
   {
    "compressor": "native",
@@ -4594,8 +4594,8 @@
    "level": 9,
    "out_size": 18688252,
    "ratio": 0.3649,
-   "compress_mbps": 4.41,
-   "decompress_mbps": 257.94
+   "compress_mbps": 4.43,
+   "decompress_mbps": 258.51
   },
   {
    "compressor": "native",
@@ -4604,7 +4604,7 @@
    "level": 10,
    "out_size": 18541040,
    "ratio": 0.362,
-   "compress_mbps": 2.36,
+   "compress_mbps": 2.35,
    "decompress_mbps": null
   },
   {
@@ -4614,28 +4614,28 @@
    "level": 1,
    "out_size": 3864163,
    "ratio": 0.3876,
-   "compress_mbps": 99.83,
-   "decompress_mbps": 243.62
+   "compress_mbps": 100.24,
+   "decompress_mbps": 253.95
   },
   {
    "compressor": "native",
    "pattern": "silesia/mr",
    "size": 9970564,
    "level": 2,
-   "out_size": 3734957,
-   "ratio": 0.3746,
-   "compress_mbps": 76.98,
-   "decompress_mbps": 250.94
+   "out_size": 3772158,
+   "ratio": 0.3783,
+   "compress_mbps": 87.26,
+   "decompress_mbps": 250.81
   },
   {
    "compressor": "native",
    "pattern": "silesia/mr",
    "size": 9970564,
    "level": 3,
-   "out_size": 3708443,
-   "ratio": 0.3719,
-   "compress_mbps": 64.27,
-   "decompress_mbps": 261.64
+   "out_size": 3733442,
+   "ratio": 0.3744,
+   "compress_mbps": 75.81,
+   "decompress_mbps": 261.32
   },
   {
    "compressor": "native",
@@ -4644,8 +4644,8 @@
    "level": 4,
    "out_size": 3683603,
    "ratio": 0.3694,
-   "compress_mbps": 42.69,
-   "decompress_mbps": 249.68
+   "compress_mbps": 42.29,
+   "decompress_mbps": 248.19
   },
   {
    "compressor": "native",
@@ -4654,8 +4654,8 @@
    "level": 5,
    "out_size": 3677014,
    "ratio": 0.3688,
-   "compress_mbps": 33.91,
-   "decompress_mbps": 231.34
+   "compress_mbps": 33.66,
+   "decompress_mbps": 232.82
   },
   {
    "compressor": "native",
@@ -4664,8 +4664,8 @@
    "level": 6,
    "out_size": 3646607,
    "ratio": 0.3657,
-   "compress_mbps": 32.38,
-   "decompress_mbps": 249.6
+   "compress_mbps": 32.24,
+   "decompress_mbps": 244.85
   },
   {
    "compressor": "native",
@@ -4674,8 +4674,8 @@
    "level": 7,
    "out_size": 3642579,
    "ratio": 0.3653,
-   "compress_mbps": 29.38,
-   "decompress_mbps": 249.37
+   "compress_mbps": 29.4,
+   "decompress_mbps": 248.42
   },
   {
    "compressor": "native",
@@ -4684,8 +4684,8 @@
    "level": 8,
    "out_size": 3634763,
    "ratio": 0.3645,
-   "compress_mbps": 22.56,
-   "decompress_mbps": 255.16
+   "compress_mbps": 22.42,
+   "decompress_mbps": 254.02
   },
   {
    "compressor": "native",
@@ -4694,8 +4694,8 @@
    "level": 9,
    "out_size": 3581643,
    "ratio": 0.3592,
-   "compress_mbps": 4.83,
-   "decompress_mbps": 266.58
+   "compress_mbps": 4.81,
+   "decompress_mbps": 266.31
   },
   {
    "compressor": "native",
@@ -4704,7 +4704,7 @@
    "level": 10,
    "out_size": 3513006,
    "ratio": 0.3523,
-   "compress_mbps": 3.0,
+   "compress_mbps": 2.94,
    "decompress_mbps": null
   },
   {
@@ -4714,28 +4714,28 @@
    "level": 1,
    "out_size": 3785443,
    "ratio": 0.1128,
-   "compress_mbps": 299.73,
-   "decompress_mbps": 674.78
+   "compress_mbps": 299.99,
+   "decompress_mbps": 671.11
   },
   {
    "compressor": "native",
    "pattern": "silesia/nci",
    "size": 33553445,
    "level": 2,
-   "out_size": 3761560,
-   "ratio": 0.1121,
-   "compress_mbps": 223.67,
-   "decompress_mbps": 749.0
+   "out_size": 3601032,
+   "ratio": 0.1073,
+   "compress_mbps": 255.54,
+   "decompress_mbps": 749.92
   },
   {
    "compressor": "native",
    "pattern": "silesia/nci",
    "size": 33553445,
    "level": 3,
-   "out_size": 3606997,
-   "ratio": 0.1075,
-   "compress_mbps": 194.16,
-   "decompress_mbps": 833.32
+   "out_size": 3447001,
+   "ratio": 0.1027,
+   "compress_mbps": 198.49,
+   "decompress_mbps": 831.93
   },
   {
    "compressor": "native",
@@ -4744,8 +4744,8 @@
    "level": 4,
    "out_size": 3201209,
    "ratio": 0.0954,
-   "compress_mbps": 138.79,
-   "decompress_mbps": 847.75
+   "compress_mbps": 139.08,
+   "decompress_mbps": 846.03
   },
   {
    "compressor": "native",
@@ -4754,8 +4754,8 @@
    "level": 5,
    "out_size": 3091564,
    "ratio": 0.0921,
-   "compress_mbps": 94.45,
-   "decompress_mbps": 909.95
+   "compress_mbps": 95.09,
+   "decompress_mbps": 924.02
   },
   {
    "compressor": "native",
@@ -4764,8 +4764,8 @@
    "level": 6,
    "out_size": 3205217,
    "ratio": 0.0955,
-   "compress_mbps": 91.23,
-   "decompress_mbps": 968.43
+   "compress_mbps": 90.29,
+   "decompress_mbps": 894.97
   },
   {
    "compressor": "native",
@@ -4774,8 +4774,8 @@
    "level": 7,
    "out_size": 3146242,
    "ratio": 0.0938,
-   "compress_mbps": 80.58,
-   "decompress_mbps": 973.29
+   "compress_mbps": 68.48,
+   "decompress_mbps": 808.54
   },
   {
    "compressor": "native",
@@ -4784,8 +4784,8 @@
    "level": 8,
    "out_size": 3078031,
    "ratio": 0.0917,
-   "compress_mbps": 50.69,
-   "decompress_mbps": 993.93
+   "compress_mbps": 42.43,
+   "decompress_mbps": 851.66
   },
   {
    "compressor": "native",
@@ -4795,7 +4795,7 @@
    "out_size": 3031645,
    "ratio": 0.0904,
    "compress_mbps": 3.56,
-   "decompress_mbps": 1012.4
+   "decompress_mbps": 1014.5
   },
   {
    "compressor": "native",
@@ -4804,7 +4804,7 @@
    "level": 10,
    "out_size": 2902212,
    "ratio": 0.0865,
-   "compress_mbps": 2.04,
+   "compress_mbps": 1.84,
    "decompress_mbps": null
   },
   {
@@ -4814,28 +4814,28 @@
    "level": 1,
    "out_size": 3357083,
    "ratio": 0.5457,
-   "compress_mbps": 66.52,
-   "decompress_mbps": 146.59
+   "compress_mbps": 66.91,
+   "decompress_mbps": 146.64
   },
   {
    "compressor": "native",
    "pattern": "silesia/ooffice",
    "size": 6152192,
    "level": 2,
-   "out_size": 3285077,
-   "ratio": 0.534,
-   "compress_mbps": 55.71,
-   "decompress_mbps": 149.65
+   "out_size": 3292412,
+   "ratio": 0.5352,
+   "compress_mbps": 59.18,
+   "decompress_mbps": 148.72
   },
   {
    "compressor": "native",
    "pattern": "silesia/ooffice",
    "size": 6152192,
    "level": 3,
-   "out_size": 3272746,
-   "ratio": 0.532,
-   "compress_mbps": 53.25,
-   "decompress_mbps": 155.03
+   "out_size": 3273720,
+   "ratio": 0.5321,
+   "compress_mbps": 55.52,
+   "decompress_mbps": 153.8
   },
   {
    "compressor": "native",
@@ -4844,8 +4844,8 @@
    "level": 4,
    "out_size": 3228052,
    "ratio": 0.5247,
-   "compress_mbps": 41.78,
-   "decompress_mbps": 166.0
+   "compress_mbps": 42.15,
+   "decompress_mbps": 164.73
   },
   {
    "compressor": "native",
@@ -4854,8 +4854,8 @@
    "level": 5,
    "out_size": 3223415,
    "ratio": 0.5239,
-   "compress_mbps": 37.9,
-   "decompress_mbps": 171.73
+   "compress_mbps": 37.79,
+   "decompress_mbps": 169.58
   },
   {
    "compressor": "native",
@@ -4864,8 +4864,8 @@
    "level": 6,
    "out_size": 3087517,
    "ratio": 0.5019,
-   "compress_mbps": 26.5,
-   "decompress_mbps": 173.41
+   "compress_mbps": 26.4,
+   "decompress_mbps": 170.25
   },
   {
    "compressor": "native",
@@ -4874,8 +4874,8 @@
    "level": 7,
    "out_size": 3082738,
    "ratio": 0.5011,
-   "compress_mbps": 25.11,
-   "decompress_mbps": 173.76
+   "compress_mbps": 25.04,
+   "decompress_mbps": 171.13
   },
   {
    "compressor": "native",
@@ -4884,8 +4884,8 @@
    "level": 8,
    "out_size": 3078530,
    "ratio": 0.5004,
-   "compress_mbps": 22.5,
-   "decompress_mbps": 175.21
+   "compress_mbps": 22.45,
+   "decompress_mbps": 171.25
   },
   {
    "compressor": "native",
@@ -4894,8 +4894,8 @@
    "level": 9,
    "out_size": 3049028,
    "ratio": 0.4956,
-   "compress_mbps": 5.14,
-   "decompress_mbps": 175.71
+   "compress_mbps": 5.11,
+   "decompress_mbps": 177.18
   },
   {
    "compressor": "native",
@@ -4904,7 +4904,7 @@
    "level": 10,
    "out_size": 3022127,
    "ratio": 0.4912,
-   "compress_mbps": 3.25,
+   "compress_mbps": 3.24,
    "decompress_mbps": null
   },
   {
@@ -4914,28 +4914,28 @@
    "level": 1,
    "out_size": 3838828,
    "ratio": 0.3806,
-   "compress_mbps": 108.54,
-   "decompress_mbps": 253.08
+   "compress_mbps": 112.67,
+   "decompress_mbps": 266.18
   },
   {
    "compressor": "native",
    "pattern": "silesia/osdb",
    "size": 10085684,
    "level": 2,
-   "out_size": 3792520,
-   "ratio": 0.376,
-   "compress_mbps": 88.49,
-   "decompress_mbps": 259.86
+   "out_size": 3790968,
+   "ratio": 0.3759,
+   "compress_mbps": 98.28,
+   "decompress_mbps": 274.57
   },
   {
    "compressor": "native",
    "pattern": "silesia/osdb",
    "size": 10085684,
    "level": 3,
-   "out_size": 3783171,
-   "ratio": 0.3751,
-   "compress_mbps": 84.2,
-   "decompress_mbps": 264.1
+   "out_size": 3760350,
+   "ratio": 0.3728,
+   "compress_mbps": 85.54,
+   "decompress_mbps": 280.64
   },
   {
    "compressor": "native",
@@ -4944,8 +4944,8 @@
    "level": 4,
    "out_size": 3648458,
    "ratio": 0.3617,
-   "compress_mbps": 70.85,
-   "decompress_mbps": 279.08
+   "compress_mbps": 72.55,
+   "decompress_mbps": 294.59
   },
   {
    "compressor": "native",
@@ -4954,8 +4954,8 @@
    "level": 5,
    "out_size": 3648472,
    "ratio": 0.3617,
-   "compress_mbps": 65.46,
-   "decompress_mbps": 281.31
+   "compress_mbps": 65.62,
+   "decompress_mbps": 296.69
   },
   {
    "compressor": "native",
@@ -4964,8 +4964,8 @@
    "level": 6,
    "out_size": 3661305,
    "ratio": 0.363,
-   "compress_mbps": 44.76,
-   "decompress_mbps": 287.85
+   "compress_mbps": 44.44,
+   "decompress_mbps": 288.61
   },
   {
    "compressor": "native",
@@ -4974,8 +4974,8 @@
    "level": 7,
    "out_size": 3659614,
    "ratio": 0.3629,
-   "compress_mbps": 42.57,
-   "decompress_mbps": 296.96
+   "compress_mbps": 43.0,
+   "decompress_mbps": 291.69
   },
   {
    "compressor": "native",
@@ -4984,8 +4984,8 @@
    "level": 8,
    "out_size": 3659136,
    "ratio": 0.3628,
-   "compress_mbps": 42.64,
-   "decompress_mbps": 296.49
+   "compress_mbps": 42.81,
+   "decompress_mbps": 291.78
   },
   {
    "compressor": "native",
@@ -4994,8 +4994,8 @@
    "level": 9,
    "out_size": 3648156,
    "ratio": 0.3617,
-   "compress_mbps": 6.09,
-   "decompress_mbps": 308.44
+   "compress_mbps": 6.06,
+   "decompress_mbps": 306.37
   },
   {
    "compressor": "native",
@@ -5004,7 +5004,7 @@
    "level": 10,
    "out_size": 3647385,
    "ratio": 0.3616,
-   "compress_mbps": 3.5,
+   "compress_mbps": 3.46,
    "decompress_mbps": null
   },
   {
@@ -5014,28 +5014,28 @@
    "level": 1,
    "out_size": 2254442,
    "ratio": 0.3402,
-   "compress_mbps": 104.1,
-   "decompress_mbps": 249.35
+   "compress_mbps": 103.56,
+   "decompress_mbps": 245.07
   },
   {
    "compressor": "native",
    "pattern": "silesia/reymont",
    "size": 6627202,
    "level": 2,
-   "out_size": 2044843,
-   "ratio": 0.3086,
-   "compress_mbps": 73.01,
-   "decompress_mbps": 265.96
+   "out_size": 2090589,
+   "ratio": 0.3155,
+   "compress_mbps": 86.13,
+   "decompress_mbps": 264.95
   },
   {
    "compressor": "native",
    "pattern": "silesia/reymont",
    "size": 6627202,
    "level": 3,
-   "out_size": 1992105,
-   "ratio": 0.3006,
-   "compress_mbps": 57.34,
-   "decompress_mbps": 290.92
+   "out_size": 2018042,
+   "ratio": 0.3045,
+   "compress_mbps": 69.65,
+   "decompress_mbps": 303.94
   },
   {
    "compressor": "native",
@@ -5044,8 +5044,8 @@
    "level": 4,
    "out_size": 1890729,
    "ratio": 0.2853,
-   "compress_mbps": 35.18,
-   "decompress_mbps": 296.72
+   "compress_mbps": 35.85,
+   "decompress_mbps": 294.65
   },
   {
    "compressor": "native",
@@ -5054,8 +5054,8 @@
    "level": 5,
    "out_size": 1858234,
    "ratio": 0.2804,
-   "compress_mbps": 22.48,
-   "decompress_mbps": 294.55
+   "compress_mbps": 22.8,
+   "decompress_mbps": 303.39
   },
   {
    "compressor": "native",
@@ -5064,8 +5064,8 @@
    "level": 6,
    "out_size": 1869426,
    "ratio": 0.2821,
-   "compress_mbps": 30.46,
-   "decompress_mbps": 309.76
+   "compress_mbps": 29.93,
+   "decompress_mbps": 300.87
   },
   {
    "compressor": "native",
@@ -5074,8 +5074,8 @@
    "level": 7,
    "out_size": 1860657,
    "ratio": 0.2808,
-   "compress_mbps": 25.58,
-   "decompress_mbps": 329.07
+   "compress_mbps": 25.48,
+   "decompress_mbps": 301.91
   },
   {
    "compressor": "native",
@@ -5084,8 +5084,8 @@
    "level": 8,
    "out_size": 1826296,
    "ratio": 0.2756,
-   "compress_mbps": 14.07,
-   "decompress_mbps": 314.24
+   "compress_mbps": 14.04,
+   "decompress_mbps": 305.81
   },
   {
    "compressor": "native",
@@ -5094,8 +5094,8 @@
    "level": 9,
    "out_size": 1773469,
    "ratio": 0.2676,
-   "compress_mbps": 2.94,
-   "decompress_mbps": 325.21
+   "compress_mbps": 2.93,
+   "decompress_mbps": 318.97
   },
   {
    "compressor": "native",
@@ -5114,28 +5114,28 @@
    "level": 1,
    "out_size": 6406301,
    "ratio": 0.2965,
-   "compress_mbps": 134.32,
-   "decompress_mbps": 341.7
+   "compress_mbps": 133.2,
+   "decompress_mbps": 337.21
   },
   {
    "compressor": "native",
    "pattern": "silesia/samba",
    "size": 21606400,
    "level": 2,
-   "out_size": 6102377,
-   "ratio": 0.2824,
-   "compress_mbps": 108.16,
-   "decompress_mbps": 361.23
+   "out_size": 6136026,
+   "ratio": 0.284,
+   "compress_mbps": 118.77,
+   "decompress_mbps": 356.86
   },
   {
    "compressor": "native",
    "pattern": "silesia/samba",
    "size": 21606400,
    "level": 3,
-   "out_size": 6022184,
-   "ratio": 0.2787,
-   "compress_mbps": 96.55,
-   "decompress_mbps": 374.52
+   "out_size": 6008304,
+   "ratio": 0.2781,
+   "compress_mbps": 99.56,
+   "decompress_mbps": 375.25
   },
   {
    "compressor": "native",
@@ -5144,8 +5144,8 @@
    "level": 4,
    "out_size": 5880892,
    "ratio": 0.2722,
-   "compress_mbps": 70.35,
-   "decompress_mbps": 393.36
+   "compress_mbps": 70.65,
+   "decompress_mbps": 393.03
   },
   {
    "compressor": "native",
@@ -5154,8 +5154,8 @@
    "level": 5,
    "out_size": 5834363,
    "ratio": 0.27,
-   "compress_mbps": 54.21,
-   "decompress_mbps": 400.98
+   "compress_mbps": 54.54,
+   "decompress_mbps": 400.38
   },
   {
    "compressor": "native",
@@ -5164,8 +5164,8 @@
    "level": 6,
    "out_size": 5418390,
    "ratio": 0.2508,
-   "compress_mbps": 44.09,
-   "decompress_mbps": 406.9
+   "compress_mbps": 43.96,
+   "decompress_mbps": 407.59
   },
   {
    "compressor": "native",
@@ -5174,8 +5174,8 @@
    "level": 7,
    "out_size": 5406915,
    "ratio": 0.2502,
-   "compress_mbps": 40.66,
-   "decompress_mbps": 400.39
+   "compress_mbps": 40.28,
+   "decompress_mbps": 405.55
   },
   {
    "compressor": "native",
@@ -5184,8 +5184,8 @@
    "level": 8,
    "out_size": 5387415,
    "ratio": 0.2493,
-   "compress_mbps": 31.85,
-   "decompress_mbps": 409.45
+   "compress_mbps": 32.14,
+   "decompress_mbps": 408.6
   },
   {
    "compressor": "native",
@@ -5194,8 +5194,8 @@
    "level": 9,
    "out_size": 5236015,
    "ratio": 0.2423,
-   "compress_mbps": 4.82,
-   "decompress_mbps": 409.96
+   "compress_mbps": 4.84,
+   "decompress_mbps": 410.17
   },
   {
    "compressor": "native",
@@ -5214,28 +5214,28 @@
    "level": 1,
    "out_size": 5612204,
    "ratio": 0.7739,
-   "compress_mbps": 55.98,
-   "decompress_mbps": 148.32
+   "compress_mbps": 56.53,
+   "decompress_mbps": 147.25
   },
   {
    "compressor": "native",
    "pattern": "silesia/sao",
    "size": 7251944,
    "level": 2,
-   "out_size": 5533875,
-   "ratio": 0.7631,
-   "compress_mbps": 46.15,
-   "decompress_mbps": 154.62
+   "out_size": 5553137,
+   "ratio": 0.7657,
+   "compress_mbps": 50.73,
+   "decompress_mbps": 154.57
   },
   {
    "compressor": "native",
    "pattern": "silesia/sao",
    "size": 7251944,
    "level": 3,
-   "out_size": 5522436,
-   "ratio": 0.7615,
-   "compress_mbps": 42.79,
-   "decompress_mbps": 158.1
+   "out_size": 5533873,
+   "ratio": 0.7631,
+   "compress_mbps": 46.44,
+   "decompress_mbps": 158.08
   },
   {
    "compressor": "native",
@@ -5244,8 +5244,8 @@
    "level": 4,
    "out_size": 5494383,
    "ratio": 0.7576,
-   "compress_mbps": 35.03,
-   "decompress_mbps": 164.88
+   "compress_mbps": 35.18,
+   "decompress_mbps": 164.63
   },
   {
    "compressor": "native",
@@ -5254,8 +5254,8 @@
    "level": 5,
    "out_size": 5489807,
    "ratio": 0.757,
-   "compress_mbps": 32.95,
-   "decompress_mbps": 162.23
+   "compress_mbps": 33.11,
+   "decompress_mbps": 160.63
   },
   {
    "compressor": "native",
@@ -5264,8 +5264,8 @@
    "level": 6,
    "out_size": 5346796,
    "ratio": 0.7373,
-   "compress_mbps": 22.94,
-   "decompress_mbps": 164.43
+   "compress_mbps": 22.95,
+   "decompress_mbps": 163.86
   },
   {
    "compressor": "native",
@@ -5274,8 +5274,8 @@
    "level": 7,
    "out_size": 5336745,
    "ratio": 0.7359,
-   "compress_mbps": 21.87,
-   "decompress_mbps": 164.79
+   "compress_mbps": 22.04,
+   "decompress_mbps": 164.5
   },
   {
    "compressor": "native",
@@ -5284,8 +5284,8 @@
    "level": 8,
    "out_size": 5330972,
    "ratio": 0.7351,
-   "compress_mbps": 20.73,
-   "decompress_mbps": 163.54
+   "compress_mbps": 20.88,
+   "decompress_mbps": 164.8
   },
   {
    "compressor": "native",
@@ -5294,8 +5294,8 @@
    "level": 9,
    "out_size": 5284606,
    "ratio": 0.7287,
-   "compress_mbps": 5.29,
-   "decompress_mbps": 162.88
+   "compress_mbps": 5.27,
+   "decompress_mbps": 162.84
   },
   {
    "compressor": "native",
@@ -5304,7 +5304,7 @@
    "level": 10,
    "out_size": 5262387,
    "ratio": 0.7257,
-   "compress_mbps": 3.74,
+   "compress_mbps": 3.62,
    "decompress_mbps": null
   },
   {
@@ -5314,28 +5314,28 @@
    "level": 1,
    "out_size": 13727247,
    "ratio": 0.3311,
-   "compress_mbps": 100.98,
-   "decompress_mbps": 251.17
+   "compress_mbps": 99.21,
+   "decompress_mbps": 251.86
   },
   {
    "compressor": "native",
    "pattern": "silesia/webster",
    "size": 41458703,
    "level": 2,
-   "out_size": 12940398,
-   "ratio": 0.3121,
-   "compress_mbps": 79.33,
-   "decompress_mbps": 272.8
+   "out_size": 12920739,
+   "ratio": 0.3117,
+   "compress_mbps": 87.25,
+   "decompress_mbps": 273.84
   },
   {
    "compressor": "native",
    "pattern": "silesia/webster",
    "size": 41458703,
    "level": 3,
-   "out_size": 12703756,
-   "ratio": 0.3064,
-   "compress_mbps": 70.88,
-   "decompress_mbps": 294.47
+   "out_size": 12582079,
+   "ratio": 0.3035,
+   "compress_mbps": 75.5,
+   "decompress_mbps": 293.56
   },
   {
    "compressor": "native",
@@ -5344,8 +5344,8 @@
    "level": 4,
    "out_size": 12177338,
    "ratio": 0.2937,
-   "compress_mbps": 50.5,
-   "decompress_mbps": 298.6
+   "compress_mbps": 50.53,
+   "decompress_mbps": 298.82
   },
   {
    "compressor": "native",
@@ -5354,8 +5354,8 @@
    "level": 5,
    "out_size": 12051075,
    "ratio": 0.2907,
-   "compress_mbps": 38.04,
-   "decompress_mbps": 303.95
+   "compress_mbps": 38.69,
+   "decompress_mbps": 302.14
   },
   {
    "compressor": "native",
@@ -5364,8 +5364,8 @@
    "level": 6,
    "out_size": 12220199,
    "ratio": 0.2948,
-   "compress_mbps": 38.94,
-   "decompress_mbps": 311.71
+   "compress_mbps": 38.82,
+   "decompress_mbps": 310.54
   },
   {
    "compressor": "native",
@@ -5374,8 +5374,8 @@
    "level": 7,
    "out_size": 12178598,
    "ratio": 0.2938,
-   "compress_mbps": 34.99,
-   "decompress_mbps": 313.5
+   "compress_mbps": 35.37,
+   "decompress_mbps": 311.3
   },
   {
    "compressor": "native",
@@ -5384,8 +5384,8 @@
    "level": 8,
    "out_size": 12096772,
    "ratio": 0.2918,
-   "compress_mbps": 26.56,
-   "decompress_mbps": 298.97
+   "compress_mbps": 26.58,
+   "decompress_mbps": 312.67
   },
   {
    "compressor": "native",
@@ -5394,8 +5394,8 @@
    "level": 9,
    "out_size": 11806641,
    "ratio": 0.2848,
-   "compress_mbps": 3.89,
-   "decompress_mbps": 313.82
+   "compress_mbps": 3.91,
+   "decompress_mbps": 312.81
   },
   {
    "compressor": "native",
@@ -5404,7 +5404,7 @@
    "level": 10,
    "out_size": 11636945,
    "ratio": 0.2807,
-   "compress_mbps": 2.04,
+   "compress_mbps": 2.05,
    "decompress_mbps": null
   },
   {
@@ -5414,28 +5414,28 @@
    "level": 1,
    "out_size": 6438176,
    "ratio": 0.7597,
-   "compress_mbps": 49.5,
-   "decompress_mbps": 144.36
+   "compress_mbps": 50.04,
+   "decompress_mbps": 143.72
   },
   {
    "compressor": "native",
    "pattern": "silesia/x-ray",
    "size": 8474240,
    "level": 2,
-   "out_size": 6392101,
+   "out_size": 6392132,
    "ratio": 0.7543,
-   "compress_mbps": 47.82,
-   "decompress_mbps": 146.2
+   "compress_mbps": 48.28,
+   "decompress_mbps": 144.04
   },
   {
    "compressor": "native",
    "pattern": "silesia/x-ray",
    "size": 8474240,
    "level": 3,
-   "out_size": 6392124,
+   "out_size": 6392125,
    "ratio": 0.7543,
-   "compress_mbps": 47.92,
-   "decompress_mbps": 144.34
+   "compress_mbps": 48.23,
+   "decompress_mbps": 148.54
   },
   {
    "compressor": "native",
@@ -5444,8 +5444,8 @@
    "level": 4,
    "out_size": 6360604,
    "ratio": 0.7506,
-   "compress_mbps": 42.99,
-   "decompress_mbps": 133.73
+   "compress_mbps": 42.3,
+   "decompress_mbps": 133.39
   },
   {
    "compressor": "native",
@@ -5454,8 +5454,8 @@
    "level": 5,
    "out_size": 6360567,
    "ratio": 0.7506,
-   "compress_mbps": 43.27,
-   "decompress_mbps": 136.04
+   "compress_mbps": 42.81,
+   "decompress_mbps": 135.56
   },
   {
    "compressor": "native",
@@ -5464,8 +5464,8 @@
    "level": 6,
    "out_size": 6036758,
    "ratio": 0.7124,
-   "compress_mbps": 24.74,
-   "decompress_mbps": 137.48
+   "compress_mbps": 24.49,
+   "decompress_mbps": 136.33
   },
   {
    "compressor": "native",
@@ -5474,8 +5474,8 @@
    "level": 7,
    "out_size": 6036620,
    "ratio": 0.7123,
-   "compress_mbps": 24.81,
-   "decompress_mbps": 136.27
+   "compress_mbps": 24.69,
+   "decompress_mbps": 136.41
   },
   {
    "compressor": "native",
@@ -5484,8 +5484,8 @@
    "level": 8,
    "out_size": 6036614,
    "ratio": 0.7123,
-   "compress_mbps": 24.66,
-   "decompress_mbps": 137.46
+   "compress_mbps": 24.69,
+   "decompress_mbps": 136.45
   },
   {
    "compressor": "native",
@@ -5494,8 +5494,8 @@
    "level": 9,
    "out_size": 5952975,
    "ratio": 0.7025,
-   "compress_mbps": 6.29,
-   "decompress_mbps": 139.68
+   "compress_mbps": 6.26,
+   "decompress_mbps": 139.5
   },
   {
    "compressor": "native",
@@ -5504,7 +5504,7 @@
    "level": 10,
    "out_size": 5849157,
    "ratio": 0.6902,
-   "compress_mbps": 4.62,
+   "compress_mbps": 4.48,
    "decompress_mbps": null
   },
   {
@@ -5514,28 +5514,28 @@
    "level": 1,
    "out_size": 858525,
    "ratio": 0.1606,
-   "compress_mbps": 221.13,
-   "decompress_mbps": 507.04
+   "compress_mbps": 219.22,
+   "decompress_mbps": 405.05
   },
   {
    "compressor": "native",
    "pattern": "silesia/xml",
    "size": 5345280,
    "level": 2,
-   "out_size": 846807,
-   "ratio": 0.1584,
-   "compress_mbps": 161.98,
-   "decompress_mbps": 568.6
+   "out_size": 798553,
+   "ratio": 0.1494,
+   "compress_mbps": 192.51,
+   "decompress_mbps": 519.18
   },
   {
    "compressor": "native",
    "pattern": "silesia/xml",
    "size": 5345280,
    "level": 3,
-   "out_size": 806798,
-   "ratio": 0.1509,
-   "compress_mbps": 144.24,
-   "decompress_mbps": 630.14
+   "out_size": 762011,
+   "ratio": 0.1426,
+   "compress_mbps": 155.13,
+   "decompress_mbps": 630.98
   },
   {
    "compressor": "native",
@@ -5544,8 +5544,8 @@
    "level": 4,
    "out_size": 717301,
    "ratio": 0.1342,
-   "compress_mbps": 101.54,
-   "decompress_mbps": 623.92
+   "compress_mbps": 103.32,
+   "decompress_mbps": 616.67
   },
   {
    "compressor": "native",
@@ -5554,8 +5554,8 @@
    "level": 5,
    "out_size": 701552,
    "ratio": 0.1312,
-   "compress_mbps": 76.35,
-   "decompress_mbps": 606.55
+   "compress_mbps": 77.66,
+   "decompress_mbps": 674.39
   },
   {
    "compressor": "native",
@@ -5564,8 +5564,8 @@
    "level": 6,
    "out_size": 689796,
    "ratio": 0.129,
-   "compress_mbps": 70.28,
-   "decompress_mbps": 655.56
+   "compress_mbps": 70.91,
+   "decompress_mbps": 725.41
   },
   {
    "compressor": "native",
@@ -5574,8 +5574,8 @@
    "level": 7,
    "out_size": 680793,
    "ratio": 0.1274,
-   "compress_mbps": 63.99,
-   "decompress_mbps": 740.67
+   "compress_mbps": 64.05,
+   "decompress_mbps": 737.15
   },
   {
    "compressor": "native",
@@ -5584,8 +5584,8 @@
    "level": 8,
    "out_size": 662896,
    "ratio": 0.124,
-   "compress_mbps": 44.62,
-   "decompress_mbps": 751.59
+   "compress_mbps": 44.72,
+   "decompress_mbps": 747.8
   },
   {
    "compressor": "native",
@@ -5594,8 +5594,8 @@
    "level": 9,
    "out_size": 659422,
    "ratio": 0.1234,
-   "compress_mbps": 4.58,
-   "decompress_mbps": 658.58
+   "compress_mbps": 4.55,
+   "decompress_mbps": 636.24
   },
   {
    "compressor": "native",
@@ -5604,7 +5604,7 @@
    "level": 10,
    "out_size": 643101,
    "ratio": 0.1203,
-   "compress_mbps": 3.07,
+   "compress_mbps": 3.03,
    "decompress_mbps": null
   },
   {


### PR DESCRIPTION
This PR re-grid the greedy-tier L2/L3 knobs after #2827 (merged greedy loop) and #2829 (packed emit tables) shifted the tier's cost balance. The `l1-sweep2` grid (chain × insertCap × niceLen through the exact production fast-tier dispatch, all 12 Silesia files, pinned interleaved timing; certification rows byte-exact against production at L1/L2/L3) showed both production mid rows sitting ~10% below the greedy-band mixing frontier, with the libdeflate `niceLen` 10/14 cutoffs (#2744) as the culprit — they cost ~0.5pp weighted ratio for speed better bought by shallowing the chain. L2 becomes (chain 8, insertCap 8, cutoff off): equal weighted ratio (0.34543 vs 0.34545) at **+12.0% speed**. L3 becomes (chain 16, insertCap 32, cutoff off): **better ratio** (0.34028 vs 0.34171) at **+5.3% speed**. Both are strict dominations of the rows they replace, the ladder stays ratio- and speed-monotone, and L1/L4+ are byte-identical. Worst per-file regressions: reymont +2.2% (L2) / +1.3% (L3), against xml −5.7% / nci −4.3% wins. The same sweep's round 1 settled the L1 endpoint question: no weaker-matcher corner comes within 40% of the extrapolated L1–L2 line (the head-probe-only corner reaches 111 MB/s where the line demands ~340), so L1's knobs are confirmed and its movement comes from the output-neutral structural PRs. All knobs are emission-re-verified heuristics; no proof changes; 24/24 out-bytes verified against the sweep's measured rows; `lake exe test` green.

🤖 Prepared with Claude Code