### PR TITLE
perf: fuse token-frequency counting into the L1-L3 matcher pass

### DIFF
--- a/Zip.lean
+++ b/Zip.lean
@@ -43,6 +43,8 @@ import Zip.Native.BitWriter
 import Zip.Native.Deflate
 import Zip.Native.DeflateDynamic
 import Zip.Native.DeflateFreqs
+import Zip.Native.DeflateFreqsFused
+import Zip.Spec.DeflateFreqsFusedCorrect
 import Zip.Native.DeflateParse
 import Zip.Spec.LZ77NativeCorrect
 import Zip.Spec.LZ77OptimalCorrect

--- a/Zip/Native/DeflateDynamic.lean
+++ b/Zip/Native/DeflateDynamic.lean
@@ -1,5 +1,7 @@
 import Zip.Native.Deflate
 import Zip.Native.DeflateFreqs
+import Zip.Native.DeflateFreqsFused
+import Zip.Spec.DeflateFreqsFusedCorrect
 import Zip.Native.DeflateParse
 import Zip.Spec.DeflateEncodeDynamic
 import Zip.Spec.DeflateStoredCorrect
@@ -1614,6 +1616,30 @@ def deflateRawBaseP (data : ByteArray) (ptokens : Array UInt32) : ByteArray :=
   else deflateDynamicBlockCorePWith data ptokens lens.1 lens.2 plan hcl
     (dynamicCodeLengths_length f.1 f.2).1 (dynamicCodeLengths_length f.1 f.2).2
 
+/-- `deflateRawBaseP` with the whole-stream frequencies supplied as a parameter
+    instead of recomputed via `tokenFreqsP ptokens` — the emit twin of
+    `deflateRawBasePPrepF`. Used by `deflateRawBaseF` to consume the frequencies
+    the fused matcher already produced. At `f = tokenFreqsP ptokens` this is
+    definitionally `deflateRawBaseP` (`deflateRawBasePF_tokenFreqsP`). -/
+def deflateRawBasePF (data : ByteArray) (ptokens : Array UInt32)
+    (f : Array Nat × Array Nat) : ByteArray :=
+  let lens := dynamicCodeLengths f.1 f.2
+  let plan := dynHeaderCodes lens.1 lens.2
+  have hcl : plan.clCodes.size ≥ 19 :=
+    Nat.le_of_eq (dynHeaderCodes_clCodes_size lens.1 lens.2).symm
+  let fixedBytes := fixedBlockBytes f.1 f.2
+  let dynBytes := dynBlockBytesWith f.1 f.2 lens.1 lens.2 plan hcl
+  let storedBytes := storedBlockBytes data
+  if storedBytes < (if fixedBytes < dynBytes then fixedBytes else dynBytes) then deflateStoredPure data
+  else if fixedBytes < dynBytes then deflateFixedBlockP data ptokens
+  else deflateDynamicBlockCorePWith data ptokens lens.1 lens.2 plan hcl
+    (dynamicCodeLengths_length f.1 f.2).1 (dynamicCodeLengths_length f.1 f.2).2
+
+/-- `deflateRawBasePF` at the whole-stream frequencies is `deflateRawBaseP`. -/
+theorem deflateRawBasePF_tokenFreqsP (data : ByteArray) (ptokens : Array UInt32) :
+    deflateRawBasePF data ptokens (tokenFreqsP ptokens) = deflateRawBaseP data ptokens :=
+  rfl
+
 /-- The base candidate *sized and prepared* from one shared token pass: the
     winner's flushed byte size (the same stored / fixed / dynamic comparison
     `deflateRawBaseP` makes internally) **paired with** a thunk that emits it. The
@@ -1685,6 +1711,30 @@ def deflateRawBase (data : ByteArray) (level : UInt8) : ByteArray :=
 
 theorem deflateRawBaseP_def (data : ByteArray) (level : UInt8) :
     deflateRawBaseP data (lzMatchP data level) = deflateRawBase data level := rfl
+
+/-- The greedy-tier (levels 1–3) base candidate computed from **one fused pass**:
+    the fused matcher (`lz77ChainIterPMergedF`) produces the packed tokens and
+    their `tokenFreqsP` histograms together, and the base sizing/emit consumes
+    those frequencies directly (`deflateRawBasePF`) instead of re-walking the
+    token array with a second `tokenFreqsP`. Byte-identical to `deflateRawBase`
+    on the greedy tier (`deflateRawBaseF_eq`). -/
+def deflateRawBaseF (data : ByteArray) (level : UInt8) : ByteArray :=
+  let (ptokens, litF, distF) :=
+    lz77ChainIterPMergedF data (chainDepth level) 32768 (insertCap level) (niceLen level)
+  deflateRawBasePF data ptokens (litF.val, distF.val)
+
+/-- On the greedy tier (`level ≤ 3`, i.e. `¬ 4 ≤ level`) the fused base candidate
+    is byte-identical to `deflateRawBase`: the fused matcher returns exactly the
+    plain matcher's tokens and `tokenFreqsP` (`lz77ChainIterPMergedF_eq`), and at
+    those frequencies `deflateRawBasePF` is `deflateRawBaseP`. -/
+theorem deflateRawBaseF_eq (data : ByteArray) (level : UInt8) (h : ¬ (4 ≤ level)) :
+    deflateRawBaseF data level = deflateRawBase data level := by
+  have hlz : lzMatchP data level =
+      lz77ChainIterPMerged data (chainDepth level) 32768 (insertCap level) (niceLen level) := by
+    unfold lzMatchP; rw [if_neg h]
+  unfold deflateRawBaseF deflateRawBase
+  rw [hlz, lz77ChainIterPMergedF_eq]
+  exact deflateRawBasePF_tokenFreqsP data _
 
 theorem deflateDynamicBlocksSharedAt_def (data : ByteArray)
     (choose : Array LZ77Token → List Nat) (level : UInt8) :
@@ -2073,6 +2123,13 @@ def deflateRaw (data : ByteArray) (level : UInt8 := 6) : ByteArray :=
           let basePrep := deflateRawBasePPrepF data ptokens obsFreqs.2
           if basePrep.1 < obsFreqs.1.1 then basePrep else obsFreqs.1
       withObs.2 ()
-  else deflateRawBase data level
+  else if 4 ≤ level then deflateRawBase data level
+  else
+    -- Greedy tier (levels 1–3): fuse the whole-stream `tokenFreqsP` walk into the
+    -- matcher pass. `deflateRawBaseF` produces the tokens and their frequencies in
+    -- one pass and sizes/emits the base candidate from them, byte-identical to
+    -- `deflateRawBase data level` (`deflateRawBaseF_eq`) — it removes the separate
+    -- re-read of the (possibly cache-spilling) token array (#freq-fusion).
+    deflateRawBaseF data level
 
 end Zip.Native.Deflate

--- a/Zip/Native/DeflateFreqsFused.lean
+++ b/Zip/Native/DeflateFreqsFused.lean
@@ -1,0 +1,108 @@
+import Zip.Native.DeflateFreqs
+
+/-!
+# Fused greedy matcher: tokens and frequencies in one pass
+
+`tokenFreqsP` is a full second walk over the packed token array (8.5% of L1
+time on dickens; ~2.4% of total compress on the large Silesia binaries whose
+token array spills L3 cache). The greedy merged matcher already touches every
+token as it pushes it, so counting frequencies at each `acc.push` site removes
+the re-read.
+
+`lz77GreedyMergedLoopF` is the fused twin of `lz77GreedyMergedLoop`
+(`Zip.Native.Deflate`): byte-for-byte the same control flow and token
+accumulator, but it additionally threads the two histogram arrays, bumping at
+each push site with the *same* helpers `tokenFreqsP` uses
+(`bumpLitFreqP`/`bumpRefLitFreqP`/`bumpRefDistFreqP`). The histograms are seeded
+exactly like `tokenFreqsP` (286 lit/len with EOB pre-counted, 30 distance), so
+the running frequencies are `tokenFreqsP` of the running token accumulator at
+every step — the invariant proved in `Zip/Spec/DeflateFreqsFusedCorrect.lean`.
+
+As with `tokenFreqsP`/`emitTokensP`, the per-token frequency work lives inside
+the opaque `bump*FreqP` helpers, so the well-founded-recursion body never forces
+a `findTableCode` reduction (the landmine documented in `DeflateFreqs.lean`).
+-/
+
+namespace Zip.Native.Deflate
+
+/-- Lit/len histogram seeded with the EOB pre-count, exactly `tokenFreqsP`'s
+    initial `litLenFreqs` (`(replicate 286 0).set! 256 1`). -/
+def initLitFreqF : {a : Array Nat // a.size = 286} :=
+  ⟨(Array.replicate 286 0).set! 256 1, by rw [Array.size_set!, Array.size_replicate]⟩
+
+/-- Distance histogram seeded to all-zero, exactly `tokenFreqsP`'s initial
+    `distFreqs` (`replicate 30 0`). -/
+def initDistFreqF : {a : Array Nat // a.size = 30} :=
+  ⟨Array.replicate 30 0, by rw [Array.size_replicate]⟩
+
+/-- Fused twin of `trailingP`: pushes each remaining byte as a literal token and
+    bumps the lit/len histogram at the same site (`bumpLitFreqP`). -/
+def trailingPF (data : ByteArray) (pos : Nat) (acc : Array UInt32)
+    (litF : {a : Array Nat // a.size = 286}) (distF : {a : Array Nat // a.size = 30}) :
+    Array UInt32 × {a : Array Nat // a.size = 286} × {a : Array Nat // a.size = 30} :=
+  if h : pos < data.size then
+    let w := packTok (.literal data[pos])
+    trailingPF data (pos + 1) (acc.push w) (bumpLitFreqP litF w) distF
+  else (acc, litF, distF)
+termination_by data.size - pos
+
+/-- Fused twin of `lz77GreedyMergedLoop` (`Zip.Native.Deflate`): identical
+    control flow and token accumulator, additionally threading the two
+    histograms. Every `acc.push (packTok t)` site is paired with the histogram
+    bump `tokenFreqsP` performs on that packed word — literals through
+    `bumpLitFreqP`, references through `bumpRefLitFreqP` + `bumpRefDistFreqP`.
+    Proven equal to `(lz77GreedyMergedLoop ..., tokenFreqsP-of-tokens)` in
+    `Zip/Spec/DeflateFreqsFusedCorrect.lean`. -/
+def lz77GreedyMergedLoopF (data : ByteArray)
+    (windowSize hashSize prevSize maxChain insertCap niceLen : Nat)
+    (c : Array Nat) (pos : Nat) (acc : Array UInt32)
+    (litF : {a : Array Nat // a.size = 286}) (distF : {a : Array Nat // a.size = 30}) :
+    Array UInt32 × {a : Array Nat // a.size = 286} × {a : Array Nat // a.size = 30} :=
+  if hlt : pos + 2 < data.size then
+    let h := lz77Greedy.hash3 data pos hashSize hlt
+    let head := headProbeGuarded c (prevSize + h)
+    let c := guardedSet c (prevSize + h) pos
+    let c := guardedSet c (pos &&& 0x7FFF) head
+    let maxLen := min 258 (data.size - pos)
+    have hmaxLenP : pos + maxLen ≤ data.size := by omega
+    let r := chainWalkGuardedPackedU data c windowSize pos maxLen niceLen hmaxLenP head maxChain 0 0
+    let matchLen := r % 512
+    let matchPos := r / 512
+    if hge : matchLen ≥ 3 then
+      if hle : pos + matchLen ≤ data.size then
+        have : data.size - (pos + matchLen) < data.size - pos := by omega
+        let c := updateHashesMergedGuarded data hashSize prevSize c pos 1 matchLen insertCap
+        let w := packTok (.reference matchLen (pos - matchPos))
+        lz77GreedyMergedLoopF data windowSize hashSize prevSize maxChain insertCap niceLen c (pos + matchLen)
+          (acc.push w) (bumpRefLitFreqP litF w) (bumpRefDistFreqP distF w)
+      else
+        let w := packTok (.literal (data[pos]'(by omega)))
+        lz77GreedyMergedLoopF data windowSize hashSize prevSize maxChain insertCap niceLen c (pos + 1)
+          (acc.push w) (bumpLitFreqP litF w) distF
+    else
+      let w := packTok (.literal (data[pos]'(by omega)))
+      lz77GreedyMergedLoopF data windowSize hashSize prevSize maxChain insertCap niceLen c (pos + 1)
+        (acc.push w) (bumpLitFreqP litF w) distF
+  else
+    trailingPF data pos acc litF distF
+termination_by data.size - pos
+decreasing_by all_goals omega
+
+/-- Fused entry mirroring `lz77ChainIterPMerged` (`Zip.Native.Deflate`): builds
+    the combined `prevSize + hashSize` array and runs `lz77GreedyMergedLoopF`,
+    returning the packed token stream and its `tokenFreqsP` histograms in one
+    pass. Proven equal to `(lz77ChainIterPMerged ..., tokenFreqsP-of-tokens)` in
+    `Zip/Spec/DeflateFreqsFusedCorrect.lean`. -/
+def lz77ChainIterPMergedF (data : ByteArray) (maxChain : Nat) (windowSize : Nat := 32768)
+    (insertCap : Nat := 1000000000) (niceLen : Nat := 258) :
+    Array UInt32 × {a : Array Nat // a.size = 286} × {a : Array Nat // a.size = 30} :=
+  if data.size < 3 then
+    trailingPF data 0 #[] initLitFreqF initDistFreqF
+  else
+    let hashSize := 65536
+    let prevSize := min chainWinSize data.size
+    lz77GreedyMergedLoopF data windowSize hashSize prevSize maxChain insertCap niceLen
+      (.replicate (prevSize + hashSize) data.size) 0
+      (Array.emptyWithCapacity data.size) initLitFreqF initDistFreqF
+
+end Zip.Native.Deflate

--- a/Zip/Spec/DeflateFreqsFusedCorrect.lean
+++ b/Zip/Spec/DeflateFreqsFusedCorrect.lean
@@ -1,0 +1,233 @@
+import Zip.Native.DeflateFreqsFused
+import Zip.Spec.DeflateFreqsAdditive
+
+/-!
+# Correctness of the fused greedy matcher
+
+`lz77GreedyMergedLoopF` (`Zip.Native.DeflateFreqsFused`) threads the two
+frequency histograms alongside the token accumulator, bumping at each push site.
+This file proves it computes exactly the plain matcher's tokens *and* their
+`tokenFreqsP` histogram in one pass:
+
+    lz77ChainIterPMergedF data mc ws ic nl
+      = (lz77ChainIterPMerged data mc ws ic nl,
+         tokenFreqsP (lz77ChainIterPMerged data mc ws ic nl))            (`lz77ChainIterPMergedF_eq`)
+
+The loop invariant is `(litF, distF) = tokenFreqsP acc`: seeded like
+`tokenFreqsP` (EOB pre-counted), each bump keeps the running histogram equal to
+`tokenFreqsP` of the running token accumulator. The per-step correspondence
+(`bump* = tokenFreqsP (acc.push w)`) is proved element-wise from
+`tokenFreqsP_lit`/`tokenFreqsP_dist` and the single-element additivity of
+`litDeltaP`/`distDeltaP` (`Zip/Spec/DeflateFreqsAdditive.lean`). Because the
+fused loop and `lz77GreedyMergedLoop` run the *same* merged-array chain state,
+their control flow aligns definitionally, so the loop induction only has to
+discharge the freq hypotheses at each recursion.
+-/
+
+namespace Zip.Native.Deflate
+
+/-- A packed literal token has the tag bit clear. -/
+theorem packTok_literal_tag (b : UInt8) :
+    packTok (.literal b) &&& ((1 : UInt32) <<< 31) = 0 := by
+  simp only [packTok]; bv_decide
+
+/-- A packed reference token has the tag bit set. -/
+theorem packTok_reference_tag (len dist : Nat) :
+    ¬ (packTok (.reference len dist) &&& ((1 : UInt32) <<< 31) = 0) := by
+  simp only [packTok]
+  generalize len.toUInt32 = l
+  generalize dist.toUInt32 = d
+  bv_decide
+
+/-- `acc.push w` as an append, so the `litDeltaP`/`distDeltaP` append lemmas apply. -/
+theorem push_eq_append (acc : Array UInt32) (w : UInt32) : acc.push w = acc ++ #[w] := by
+  apply Array.ext'
+  simp [Array.toList_push]
+
+/-- One trailing element adds exactly its lit/len bump to the running count. -/
+theorem litDeltaP_push (acc : Array UInt32) (w : UInt32) (k : Nat) :
+    litDeltaP (acc.push w) 0 k = litDeltaP acc 0 k + (if litBumpIdxP w = k then 1 else 0) := by
+  rw [push_eq_append, litDeltaP_append acc #[w] 0 k (Nat.zero_le _)]
+  congr 1
+  rw [litDeltaP_succ #[w] 0 k (by simp), litDeltaP_of_ge #[w] 1 k (by simp), Nat.add_zero]
+  simp
+
+/-- One trailing element adds exactly its distance bump to the running count. -/
+theorem distDeltaP_push (acc : Array UInt32) (w : UInt32) (k : Nat) :
+    distDeltaP (acc.push w) 0 k =
+      distDeltaP acc 0 k +
+        (if w &&& ((1 : UInt32) <<< 31) = 0 then 0
+         else if codeIdx (distCodeWord ((w &&& 0xFFFF).toNat)) = k then 1 else 0) := by
+  rw [push_eq_append, distDeltaP_append acc #[w] 0 k (Nat.zero_le _)]
+  congr 1
+  rw [distDeltaP_succ #[w] 0 k (by simp), distDeltaP_of_ge #[w] 1 k (by simp), Nat.add_zero]
+  simp
+
+/-- **Push-literal correspondence (lit/len).** For a literal word, bumping the
+    running lit/len histogram equals `tokenFreqsP` of the extended stream. -/
+theorem bumpLitFreqP_push (acc : Array UInt32) (w : UInt32)
+    (litF : {a : Array Nat // a.size = 286})
+    (hc : w &&& ((1 : UInt32) <<< 31) = 0) (hlit : litF.val = (tokenFreqsP acc).1) :
+    (bumpLitFreqP litF w).val = (tokenFreqsP (acc.push w)).1 := by
+  have hidx : w.toUInt8.toNat < litF.val.size := by
+    have := UInt8.toNat_lt w.toUInt8; rw [litF.property]; omega
+  have hbump : litBumpIdxP w = w.toUInt8.toNat := by unfold litBumpIdxP; rw [if_pos hc]
+  apply Array.ext
+  · simp only [bumpLitFreqP, Array.size_set!]; rw [litF.property, (tokenFreqsP_size (acc.push w)).1]
+  · intro k hk _
+    simp only [bumpLitFreqP, Array.size_set!, litF.property] at hk
+    rw [← getElem!_pos _ k (by simp only [bumpLitFreqP, Array.size_set!, litF.property]; exact hk),
+      ← getElem!_pos _ k (by rw [(tokenFreqsP_size (acc.push w)).1]; exact hk)]
+    rw [tokenFreqsP_lit (acc.push w) k, litDeltaP_push, ← Nat.add_assoc, ← tokenFreqsP_lit acc k,
+      hbump, ← hlit]
+    simp only [bumpLitFreqP]
+    by_cases hk2 : k = w.toUInt8.toNat
+    · subst hk2
+      rw [Array.getElem!_set!_self _ _ _ hidx, ← getElem!_pos litF.val _ hidx, if_pos rfl]
+    · rw [Array.getElem!_set!_ne _ _ _ _ (Ne.symm hk2), if_neg (fun h => hk2 h.symm), Nat.add_zero]
+
+/-- For a literal word, the distance histogram is unchanged. -/
+theorem distFreq_push_lit (acc : Array UInt32) (w : UInt32)
+    (distF : {a : Array Nat // a.size = 30})
+    (hc : w &&& ((1 : UInt32) <<< 31) = 0) (hdist : distF.val = (tokenFreqsP acc).2) :
+    distF.val = (tokenFreqsP (acc.push w)).2 := by
+  rw [hdist]
+  apply Array.ext
+  · rw [(tokenFreqsP_size acc).2, (tokenFreqsP_size (acc.push w)).2]
+  · intro k hk _
+    rw [(tokenFreqsP_size acc).2] at hk
+    rw [← getElem!_pos _ k (by rw [(tokenFreqsP_size acc).2]; exact hk),
+      ← getElem!_pos _ k (by rw [(tokenFreqsP_size (acc.push w)).2]; exact hk)]
+    rw [tokenFreqsP_dist (acc.push w) k, distDeltaP_push, if_pos hc, Nat.add_zero,
+      ← tokenFreqsP_dist acc k]
+
+/-- **Push-reference correspondence (lit/len).** -/
+theorem bumpRefLitFreqP_push (acc : Array UInt32) (w : UInt32)
+    (litF : {a : Array Nat // a.size = 286})
+    (hc : ¬ (w &&& ((1 : UInt32) <<< 31) = 0)) (hlit : litF.val = (tokenFreqsP acc).1) :
+    (bumpRefLitFreqP litF w).val = (tokenFreqsP (acc.push w)).1 := by
+  obtain ⟨⟨li, le, lv⟩, hli⟩ := Option.isSome_iff_exists.mp
+    (findLengthCode_isSome (((w >>> 16) &&& 0x7FFF).toNat))
+  have hbnd := nativeFindLengthCode_idx_bound _ _ _ _ hli
+  have hcodeeq : codeIdx (lenCodeWord (((w >>> 16) &&& 0x7FFF).toNat)) = li :=
+    codeIdx_lenCodeWord _ _ _ _ hli
+  have hidx : codeIdx (lenCodeWord (((w >>> 16) &&& 0x7FFF).toNat)) + 257 < litF.val.size := by
+    rw [litF.property, hcodeeq]; omega
+  have hbump : litBumpIdxP w = codeIdx (lenCodeWord (((w >>> 16) &&& 0x7FFF).toNat)) + 257 := by
+    unfold litBumpIdxP; rw [if_neg hc]
+  apply Array.ext
+  · simp only [bumpRefLitFreqP, Array.size_set!]; rw [litF.property, (tokenFreqsP_size (acc.push w)).1]
+  · intro k hk _
+    simp only [bumpRefLitFreqP, Array.size_set!, litF.property] at hk
+    rw [← getElem!_pos _ k (by simp only [bumpRefLitFreqP, Array.size_set!, litF.property]; exact hk),
+      ← getElem!_pos _ k (by rw [(tokenFreqsP_size (acc.push w)).1]; exact hk)]
+    rw [tokenFreqsP_lit (acc.push w) k, litDeltaP_push, ← Nat.add_assoc, ← tokenFreqsP_lit acc k,
+      hbump, ← hlit]
+    simp only [bumpRefLitFreqP]
+    by_cases hk2 : k = codeIdx (lenCodeWord (((w >>> 16) &&& 0x7FFF).toNat)) + 257
+    · subst hk2
+      rw [Array.getElem!_set!_self _ _ _ hidx, ← getElem!_pos litF.val _ hidx, if_pos rfl]
+    · rw [Array.getElem!_set!_ne _ _ _ _ (Ne.symm hk2), if_neg (fun h => hk2 h.symm), Nat.add_zero]
+
+/-- **Push-reference correspondence (distance).** -/
+theorem bumpRefDistFreqP_push (acc : Array UInt32) (w : UInt32)
+    (distF : {a : Array Nat // a.size = 30})
+    (hc : ¬ (w &&& ((1 : UInt32) <<< 31) = 0)) (hdist : distF.val = (tokenFreqsP acc).2) :
+    (bumpRefDistFreqP distF w).val = (tokenFreqsP (acc.push w)).2 := by
+  obtain ⟨⟨di, de, dv⟩, hdi⟩ := Option.isSome_iff_exists.mp
+    (findDistCode_isSome ((w &&& 0xFFFF).toNat))
+  have hbnd := nativeFindDistCode_idx_bound _ _ _ _ hdi
+  have hcodeeq : codeIdx (distCodeWord ((w &&& 0xFFFF).toNat)) = di :=
+    codeIdx_distCodeWord _ _ _ _ hdi
+  have hidx : codeIdx (distCodeWord ((w &&& 0xFFFF).toNat)) < distF.val.size := by
+    rw [distF.property, hcodeeq]; omega
+  apply Array.ext
+  · simp only [bumpRefDistFreqP, Array.size_set!]; rw [distF.property, (tokenFreqsP_size (acc.push w)).2]
+  · intro k hk _
+    simp only [bumpRefDistFreqP, Array.size_set!, distF.property] at hk
+    rw [← getElem!_pos _ k (by simp only [bumpRefDistFreqP, Array.size_set!, distF.property]; exact hk),
+      ← getElem!_pos _ k (by rw [(tokenFreqsP_size (acc.push w)).2]; exact hk)]
+    rw [tokenFreqsP_dist (acc.push w) k, distDeltaP_push, if_neg hc, ← tokenFreqsP_dist acc k, ← hdist]
+    simp only [bumpRefDistFreqP]
+    by_cases hk2 : k = codeIdx (distCodeWord ((w &&& 0xFFFF).toNat))
+    · subst hk2
+      rw [Array.getElem!_set!_self _ _ _ hidx, ← getElem!_pos distF.val _ hidx, if_pos rfl]
+    · rw [Array.getElem!_set!_ne _ _ _ _ (Ne.symm hk2), if_neg (fun h => hk2 h.symm), Nat.add_zero]
+
+/-- `tokenFreqsP` of the empty stream is the seed histogram (lit/len). -/
+theorem tokenFreqsP_nil_fst : initLitFreqF.val = (tokenFreqsP (#[] : Array UInt32)).1 := by
+  unfold tokenFreqsP tokenFreqsP.go
+  rw [dif_neg (by decide)]
+  simp only [initLitFreqF]
+
+/-- `tokenFreqsP` of the empty stream is the seed histogram (distance). -/
+theorem tokenFreqsP_nil_snd : initDistFreqF.val = (tokenFreqsP (#[] : Array UInt32)).2 := by
+  unfold tokenFreqsP tokenFreqsP.go
+  rw [dif_neg (by decide)]
+  simp only [initDistFreqF]
+
+/-- The fused trailing loop computes the plain trailing tokens and their
+    `tokenFreqsP`, given the freq invariant at entry. -/
+theorem trailingPF_spec (data : ByteArray) (pos : Nat) (acc : Array UInt32)
+    (litF : {a : Array Nat // a.size = 286}) (distF : {a : Array Nat // a.size = 30})
+    (hlit : litF.val = (tokenFreqsP acc).1) (hdist : distF.val = (tokenFreqsP acc).2) :
+    trailingPF data pos acc litF distF =
+      (trailingP data pos acc,
+       ⟨(tokenFreqsP (trailingP data pos acc)).1, (tokenFreqsP_size _).1⟩,
+       ⟨(tokenFreqsP (trailingP data pos acc)).2, (tokenFreqsP_size _).2⟩) := by
+  induction hn : data.size - pos using Nat.strongRecOn generalizing pos acc litF distF with
+  | _ n ih =>
+    unfold trailingPF trailingP
+    by_cases h : pos < data.size
+    · simp only [h, ↓reduceDIte]
+      have hc : packTok (.literal data[pos]) &&& ((1 : UInt32) <<< 31) = 0 :=
+        packTok_literal_tag _
+      exact ih (data.size - (pos + 1)) (by omega) (pos + 1) _ _ _
+        (bumpLitFreqP_push acc _ _ hc hlit) (distFreq_push_lit acc _ _ hc hdist) rfl
+    · simp only [h, ↓reduceDIte]
+      exact Prod.ext rfl (Prod.ext (Subtype.ext hlit) (Subtype.ext hdist))
+
+/-- The fused greedy loop computes the plain greedy loop's tokens and their
+    `tokenFreqsP`, maintaining the invariant `(litF, distF) = tokenFreqsP acc`. -/
+theorem lz77GreedyMergedLoopF_spec (data : ByteArray)
+    (windowSize hashSize prevSize maxChain insertCap niceLen : Nat)
+    (c : Array Nat) (pos : Nat) (acc : Array UInt32)
+    (litF : {a : Array Nat // a.size = 286}) (distF : {a : Array Nat // a.size = 30})
+    (hlit : litF.val = (tokenFreqsP acc).1) (hdist : distF.val = (tokenFreqsP acc).2) :
+    lz77GreedyMergedLoopF data windowSize hashSize prevSize maxChain insertCap niceLen c pos acc litF distF =
+      (lz77GreedyMergedLoop data windowSize hashSize prevSize maxChain insertCap niceLen c pos acc,
+       ⟨(tokenFreqsP (lz77GreedyMergedLoop data windowSize hashSize prevSize maxChain insertCap niceLen c pos acc)).1, (tokenFreqsP_size _).1⟩,
+       ⟨(tokenFreqsP (lz77GreedyMergedLoop data windowSize hashSize prevSize maxChain insertCap niceLen c pos acc)).2, (tokenFreqsP_size _).2⟩) := by
+  induction hn : data.size - pos using Nat.strongRecOn generalizing pos acc litF distF c with
+  | _ n ih =>
+    unfold lz77GreedyMergedLoopF lz77GreedyMergedLoop
+    by_cases hlt : pos + 2 < data.size
+    · simp only [hlt, ↓reduceDIte]
+      split
+      · split
+        · exact ih _ (by omega) _ _ _ _ _
+            (bumpRefLitFreqP_push acc _ _ (packTok_reference_tag _ _) hlit)
+            (bumpRefDistFreqP_push acc _ _ (packTok_reference_tag _ _) hdist) rfl
+        · exact ih _ (by omega) _ _ _ _ _
+            (bumpLitFreqP_push acc _ _ (packTok_literal_tag _) hlit)
+            (distFreq_push_lit acc _ _ (packTok_literal_tag _) hdist) rfl
+      · exact ih _ (by omega) _ _ _ _ _
+          (bumpLitFreqP_push acc _ _ (packTok_literal_tag _) hlit)
+          (distFreq_push_lit acc _ _ (packTok_literal_tag _) hdist) rfl
+    · simp only [hlt, ↓reduceDIte]
+      exact trailingPF_spec data pos acc litF distF hlit hdist
+
+/-- **The fused greedy entry computes the merged matcher's tokens and their
+    frequencies in one pass.** -/
+theorem lz77ChainIterPMergedF_eq (data : ByteArray) (maxChain windowSize insertCap niceLen : Nat) :
+    lz77ChainIterPMergedF data maxChain windowSize insertCap niceLen =
+      (lz77ChainIterPMerged data maxChain windowSize insertCap niceLen,
+       ⟨(tokenFreqsP (lz77ChainIterPMerged data maxChain windowSize insertCap niceLen)).1, (tokenFreqsP_size _).1⟩,
+       ⟨(tokenFreqsP (lz77ChainIterPMerged data maxChain windowSize insertCap niceLen)).2, (tokenFreqsP_size _).2⟩) := by
+  unfold lz77ChainIterPMergedF lz77ChainIterPMerged
+  split
+  · exact trailingPF_spec data 0 #[] initLitFreqF initDistFreqF tokenFreqsP_nil_fst tokenFreqsP_nil_snd
+  · exact lz77GreedyMergedLoopF_spec data windowSize 65536 (min chainWinSize data.size) maxChain
+      insertCap niceLen _ 0 _ initLitFreqF initDistFreqF tokenFreqsP_nil_fst tokenFreqsP_nil_snd
+
+end Zip.Native.Deflate

--- a/Zip/Spec/DeflateRoundtrip.lean
+++ b/Zip/Spec/DeflateRoundtrip.lean
@@ -201,7 +201,13 @@ theorem inflate_deflateRaw (data : ByteArray) (level : UInt8)
                 (inflate_deflateDynamicBlocksOptimalWindowed data sharedTokChunk _ hsize)
           · -- levels 6–8: obs-split candidate, `hwithObs`
             exact hwithObs _ rfl
-      · exact inflate_deflateRawBase data level _ hsize
+      · split
+        · -- levels 4–5: the lazy-tier base candidate, unchanged
+          exact inflate_deflateRawBase data level _ hsize
+        · -- levels 1–3: fused greedy base candidate, byte-identical to
+          -- `deflateRawBase` (`deflateRawBaseF_eq`)
+          rw [Zip.Native.Deflate.deflateRawBaseF_eq data level (by assumption)]
+          exact inflate_deflateRawBase data level _ hsize
 
 /-- Padding decomposition for the compressed-block dispatch. -/
 theorem deflateCompressed_pad (data : ByteArray) (level : UInt8) :
@@ -349,7 +355,12 @@ theorem deflateRaw_pad (data : ByteArray) (level : UInt8) :
                 (deflateDynamicBlocksOptimalWindowed_pad data sharedTokChunk)
           · -- levels 6–8
             exact hwithObs _ rfl
-      · exact deflateRawBase_pad data level
+      · split
+        · -- levels 4–5: lazy-tier base, unchanged
+          exact deflateRawBase_pad data level
+        · -- levels 1–3: fused greedy base (`deflateRawBaseF_eq`)
+          rw [Zip.Native.Deflate.deflateRawBaseF_eq data level (by assumption)]
+          exact deflateRawBase_pad data level
 
 /-- `goR` short-remaining for a fixed-Huffman block over the lazy token stream —
     the level 2-4 path and the level ≥ 5 fixed candidate (both `= deflateLazy`). -/
@@ -576,6 +587,11 @@ theorem deflateRaw_goR_pad (data : ByteArray) (level : UInt8) :
                 (deflateDynamicBlocksOptimalWindowed_goR_pad data sharedTokChunk)
           · -- levels 6–8
             exact hwithObs _ rfl
-      · exact deflateRawBase_goR_pad data level
+      · split
+        · -- levels 4–5: lazy-tier base, unchanged
+          exact deflateRawBase_goR_pad data level
+        · -- levels 1–3: fused greedy base (`deflateRawBaseF_eq`)
+          rw [Zip.Native.Deflate.deflateRawBaseF_eq data level (by assumption)]
+          exact deflateRawBase_goR_pad data level
 
 end Zip.Native.Deflate

--- a/bench/ZipFreqFusion.lean
+++ b/bench/ZipFreqFusion.lean
@@ -1,0 +1,201 @@
+import Zip
+/-! # Stage-0 ceiling probe: fuse token-frequency counting into the greedy matcher
+
+Bench-only scratch (issue: `perf/freq-fusion`). `tokenFreqsP` is a full second
+walk over the packed token array. The greedy matcher already touches every token
+as it pushes it, so counting frequencies *there* would eliminate the re-read.
+This exe measures whether that fusion is worth doing before any proof work:
+
+* **matcher alone**    — `lz77ChainIterPMerged data 4` (the L1 greedy path)
+* **matcher + freqs**  — a copy of the greedy merged loop that also threads the
+                          two histogram arrays, bumping at each `acc.push` site
+                          (same bump helpers `tokenFreqsP` uses)
+* **matcher + separate `tokenFreqsP`** — the status quo: match, then re-walk
+
+The fusion pays iff `matcher+freqs` is meaningfully cheaper than
+`matcher + tokenFreqsP`. The saving is judged against total L1 compress time
+(`deflateRaw data 1`): if it is < 2% of that, STOP (no proofs).
+
+Run pinned: `bench/pin_core.sh lake exe freq-fusion bench/corpora/silesia/mozilla`
+-/
+
+open Zip.Native.Deflate
+
+/-- 286-entry lit/len histogram seeded with the end-of-block pre-count, exactly
+    `tokenFreqsP`'s initialization. -/
+def initLitF : {a : Array Nat // a.size = 286} :=
+  ⟨(Array.replicate 286 0).set! 256 1, by rw [Array.size_set!, Array.size_replicate]⟩
+
+def initDistF : {a : Array Nat // a.size = 30} :=
+  ⟨Array.replicate 30 0, by rw [Array.size_replicate]⟩
+
+/-- Fused twin of `trailingP`: pushes each remaining byte as a literal token and
+    bumps the lit/len histogram at the same site (`bumpLitFreqP`). -/
+partial def fusedTrailing (data : ByteArray) (pos : Nat) (acc : Array UInt32)
+    (litF : {a : Array Nat // a.size = 286}) (distF : {a : Array Nat // a.size = 30}) :
+    Array UInt32 × {a : Array Nat // a.size = 286} × {a : Array Nat // a.size = 30} :=
+  if _h : pos < data.size then
+    let w := packTok (.literal data[pos]!)
+    fusedTrailing data (pos + 1) (acc.push w) (bumpLitFreqP litF w) distF
+  else (acc, litF, distF)
+
+/-- Fused twin of `lz77GreedyMergedLoop`: byte-for-byte the same control flow,
+    but every `acc.push (packTok t)` site is paired with the histogram bump
+    `tokenFreqsP` would perform on that packed word. Literals go through
+    `bumpLitFreqP`; references through `bumpRefLitFreqP` + `bumpRefDistFreqP`.
+    `partial` (this is a throwaway ceiling probe, no termination proof). -/
+partial def fusedGreedyLoop (data : ByteArray)
+    (windowSize hashSize prevSize maxChain insertCap niceLen : Nat)
+    (c : Array Nat) (pos : Nat) (acc : Array UInt32)
+    (litF : {a : Array Nat // a.size = 286}) (distF : {a : Array Nat // a.size = 30}) :
+    Array UInt32 × {a : Array Nat // a.size = 286} × {a : Array Nat // a.size = 30} :=
+  if hlt : pos + 2 < data.size then
+    let h := lz77Greedy.hash3 data pos hashSize hlt
+    let head := headProbeGuarded c (prevSize + h)
+    let c := guardedSet c (prevSize + h) pos
+    let c := guardedSet c (pos &&& 0x7FFF) head
+    let maxLen := min 258 (data.size - pos)
+    have hmaxLenP : pos + maxLen ≤ data.size := by omega
+    let r := chainWalkGuardedPackedU data c windowSize pos maxLen niceLen hmaxLenP head maxChain 0 0
+    let matchLen := r % 512
+    let matchPos := r / 512
+    if hge : matchLen ≥ 3 then
+      if hle : pos + matchLen ≤ data.size then
+        let c := updateHashesMergedGuarded data hashSize prevSize c pos 1 matchLen insertCap
+        let w := packTok (.reference matchLen (pos - matchPos))
+        fusedGreedyLoop data windowSize hashSize prevSize maxChain insertCap niceLen c (pos + matchLen)
+          (acc.push w) (bumpRefLitFreqP litF w) (bumpRefDistFreqP distF w)
+      else
+        let w := packTok (.literal (data[pos]!))
+        fusedGreedyLoop data windowSize hashSize prevSize maxChain insertCap niceLen c (pos + 1)
+          (acc.push w) (bumpLitFreqP litF w) distF
+    else
+      let w := packTok (.literal (data[pos]!))
+      fusedGreedyLoop data windowSize hashSize prevSize maxChain insertCap niceLen c (pos + 1)
+        (acc.push w) (bumpLitFreqP litF w) distF
+  else
+    fusedTrailing data pos acc litF distF
+
+/-- Fused entry mirroring `lz77ChainIterPMerged` at L1 knobs (chain 4, cap 2,
+    niceLen 258). Returns the tokens and the two histograms in one pass. -/
+def fusedMatchWithFreqs (data : ByteArray) (maxChain insertCap niceLen : Nat) :
+    Array UInt32 × {a : Array Nat // a.size = 286} × {a : Array Nat // a.size = 30} :=
+  if data.size < 3 then
+    fusedTrailing data 0 #[] initLitF initDistF
+  else
+    let hashSize := 65536
+    let prevSize := min chainWinSize data.size
+    fusedGreedyLoop data 32768 hashSize prevSize maxChain insertCap niceLen
+      (.replicate (prevSize + hashSize) data.size) 0
+      (Array.emptyWithCapacity data.size) initLitF initDistF
+
+/-! ## Timing harness (mirrors `ZipL1Attrib`) -/
+
+def medianNs (xs : List Nat) : Nat :=
+  let a := xs.toArray.qsort (· < ·)
+  if a.size == 0 then 0 else a[a.size / 2]!
+
+def mbps (bytes nsPerOp : Nat) : Float :=
+  if nsPerOp == 0 then 0.0
+  else (bytes.toFloat / (1024.0 * 1024.0)) / (nsPerOp.toFloat / 1.0e9)
+
+def round1 (f : Float) : Float := (f * 10.0).round / 10.0
+
+/-- Live-sum a histogram pair so the counting work cannot be elided. -/
+def sumFreqs (f : Array Nat × Array Nat) : Nat :=
+  f.1.foldl (· + ·) 0 + f.2.foldl (· + ·) 0
+
+/-! ### Elision-proof timed ops
+
+The three matcher-based operations are pure functions of loop-invariant inputs,
+so a naive `fun _ => expr` thunk lets the optimizer hoist the whole computation
+out of the timing loop (a 51 MB matcher "measured" at 255 ns). Each op is a
+top-level `@[noinline]` function that folds a per-iteration `salt` into its
+result, and the timing loop threads the previous result back in as `salt`
+(`acc := f acc`). That loop-carried dependency through an opaque `@[noinline]`
+call forces a genuine recomputation every iteration. -/
+
+@[noinline] def opAlone (data : ByteArray) (mc ic nl salt : Nat) : Nat :=
+  (lz77ChainIterPMerged data mc 32768 ic nl).size + (salt &&& 1)
+
+@[noinline] def opFused (data : ByteArray) (mc ic nl salt : Nat) : Nat :=
+  let r := fusedMatchWithFreqs data mc ic nl
+  r.1.size + sumFreqs (r.2.1.val, r.2.2.val) + (salt &&& 1)
+
+@[noinline] def opSep (data : ByteArray) (mc ic nl salt : Nat) : Nat :=
+  let t := lz77ChainIterPMerged data mc 32768 ic nl
+  t.size + sumFreqs (tokenFreqsP t) + (salt &&& 1)
+
+@[noinline] def opTotal (data : ByteArray) (salt : Nat) : Nat :=
+  (deflateRaw data 1).size + (salt &&& 1)
+
+/-- Time `f` `iters` times, threading the result back as the next `salt`; ns/op. -/
+@[noinline] def timeOp (iters : Nat) (f : Nat → Nat) : IO Nat := do
+  let t0 ← IO.monoNanosNow
+  let mut acc : Nat := 1
+  for _ in [:iters] do
+    acc := f acc
+  let t1 ← IO.monoNanosNow
+  if acc == 0 then IO.eprintln "unreachable"
+  return (t1 - t0) / (max iters 1)
+
+def analyzeFile (name : String) (data : ByteArray) (iters reps : Nat) : IO Unit := do
+  let size := data.size
+  -- L1 knobs: chain 4, cap 2, niceLen 258.
+  let maxChain := 4
+  let insertCap := 2
+  let niceLen := 258
+  -- Correctness sanity: fused tokens == real matcher tokens, fused freqs ==
+  -- tokenFreqsP over those tokens.
+  let realToks := lz77ChainIterPMerged data maxChain 32768 insertCap niceLen
+  let fused := fusedMatchWithFreqs data maxChain insertCap niceLen
+  let freqRef := tokenFreqsP realToks
+  let toksOk := fused.1 == realToks
+  let freqOk := fused.2.1.val == freqRef.1 && fused.2.2.val == freqRef.2
+  IO.println s!"  {name}: {size} bytes, {realToks.size} tokens; toksOk={toksOk} freqOk={freqOk}"
+  unless toksOk && freqOk do
+    IO.eprintln s!"  !! MISMATCH on {name} (toksOk={toksOk} freqOk={freqOk}) — numbers unreliable"
+
+  -- Interleave the three variants (+ total) within each rep to share drift.
+  let mut aloneT : List Nat := []
+  let mut fusedT : List Nat := []
+  let mut sepT   : List Nat := []
+  let mut totalT : List Nat := []
+  for _ in [:reps] do
+    aloneT := (← timeOp iters (fun s => opAlone data maxChain insertCap niceLen s)) :: aloneT
+    fusedT := (← timeOp iters (fun s => opFused data maxChain insertCap niceLen s)) :: fusedT
+    sepT   := (← timeOp iters (fun s => opSep data maxChain insertCap niceLen s)) :: sepT
+    totalT := (← timeOp iters (fun s => opTotal data s)) :: totalT
+
+  let aloneNs := medianNs aloneT
+  let fusedNs := medianNs fusedT
+  let sepNs := medianNs sepT
+  let totalNs := medianNs totalT
+  let savingNs : Int := (sepNs : Int) - (fusedNs : Int)
+  let savingF : Float := sepNs.toFloat - fusedNs.toFloat
+  let savingPctTotal : Float :=
+    if totalNs == 0 then 0.0 else (savingF / totalNs.toFloat) * 100.0
+  IO.println s!"    matcher alone        : {aloneNs} ns  ({round1 (mbps size aloneNs)} MB/s)"
+  IO.println s!"    matcher + freqs      : {fusedNs} ns  ({round1 (mbps size fusedNs)} MB/s)"
+  IO.println s!"    matcher + tokenFreqsP: {sepNs} ns  ({round1 (mbps size sepNs)} MB/s)"
+  IO.println s!"    total compress (L1)  : {totalNs} ns  ({round1 (mbps size totalNs)} MB/s)"
+  IO.println s!"    tokenFreqsP-alone (sep-alone): {(sepNs : Int) - (aloneNs : Int)} ns"
+  IO.println s!"    saving (sep - fused) : {savingNs} ns  =  {round1 savingPctTotal}% of total compress"
+  IO.println s!"    reps alone={aloneT.reverse} fused={fusedT.reverse} sep={sepT.reverse}"
+  IO.println ""
+
+def main (args : List String) : IO Unit := do
+  let reps := (args[1]? |>.bind (·.toNat?)).getD 4
+  let paths := match args.head? with
+    | some p => [p]
+    | none => ["bench/corpora/silesia/mozilla"]
+  IO.println s!"# Stage-0 freq-fusion ceiling probe (reps={reps})"
+  IO.println ""
+  for p in paths do
+    let path := System.FilePath.mk p
+    unless ← path.pathExists do
+      IO.eprintln s!"not found: {path}"
+      continue
+    let data ← IO.FS.readBinFile path
+    let iters := if data.size ≤ 262144 then 20 else if data.size ≤ 4194304 then 3 else 2
+    analyzeFile (path.fileName.getD p) data iters reps

--- a/bench/ZipFreqFusion.lean
+++ b/bench/ZipFreqFusion.lean
@@ -184,18 +184,74 @@ def analyzeFile (name : String) (data : ByteArray) (iters reps : Nat) : IO Unit 
   IO.println s!"    reps alone={aloneT.reverse} fused={fusedT.reverse} sep={sepT.reverse}"
   IO.println ""
 
-def main (args : List String) : IO Unit := do
-  let reps := (args[1]? |>.bind (·.toNat?)).getD 4
-  let paths := match args.head? with
-    | some p => [p]
-    | none => ["bench/corpora/silesia/mozilla"]
-  IO.println s!"# Stage-0 freq-fusion ceiling probe (reps={reps})"
+/-! ## Stage-1 production A/B: unfused `deflateRawBase` vs fused `deflateRawBaseF`
+
+Both full-compress paths exist in-code (`deflateRawBase` is the pre-fusion path,
+still used at levels 4-5; `deflateRawBaseF` is what `deflateRaw` now dispatches to
+at levels 1-3), so this A/B isolates the fusion on the whole compress inside one
+binary, with a same-binary noise floor (unfused timed twice). -/
+
+@[noinline] def opBaseOld (data : ByteArray) (level : UInt8) (salt : Nat) : Nat :=
+  (deflateRawBase data level).size + (salt &&& 1)
+
+@[noinline] def opBaseNew (data : ByteArray) (level : UInt8) (salt : Nat) : Nat :=
+  (deflateRawBaseF data level).size + (salt &&& 1)
+
+def analyzeProd (name : String) (data : ByteArray) (level : UInt8) (iters reps : Nat) : IO Unit := do
+  let size := data.size
+  -- Byte-identity: the fused path must equal the unfused path exactly.
+  let oldB := deflateRawBase data level
+  let newB := deflateRawBaseF data level
+  let identical := oldB == newB
+  IO.println s!"  {name} L{level}: {size} bytes -> {oldB.size} compressed; byteIdentical={identical}"
+  unless identical do IO.eprintln s!"  !! BYTE MISMATCH on {name} L{level}"
+  let mut oldT : List Nat := []
+  let mut newT : List Nat := []
+  let mut nf   : List Nat := []   -- noise floor: unfused timed a second time
+  for _ in [:reps] do
+    oldT := (← timeOp iters (fun s => opBaseOld data level s)) :: oldT
+    newT := (← timeOp iters (fun s => opBaseNew data level s)) :: newT
+    nf   := (← timeOp iters (fun s => opBaseOld data level s)) :: nf
+  let oldNs := medianNs oldT
+  let newNs := medianNs newT
+  let nfNs := medianNs nf
+  let speedup : Float :=
+    if newNs == 0 then 0.0 else ((oldNs.toFloat - newNs.toFloat) / oldNs.toFloat) * 100.0
+  let nfPct : Float :=
+    if oldNs == 0 then 0.0 else (((oldNs : Int) - (nfNs : Int)).natAbs.toFloat / oldNs.toFloat) * 100.0
+  IO.println s!"    unfused (deflateRawBase) : {oldNs} ns  ({round1 (mbps size oldNs)} MB/s)"
+  IO.println s!"    fused   (deflateRawBaseF): {newNs} ns  ({round1 (mbps size newNs)} MB/s)"
+  IO.println s!"    noise floor (unfused #2) : {nfNs} ns  (|old-nf| = {round1 nfPct}% of old)"
+  IO.println s!"    fusion speedup           : {round1 speedup}% of total compress"
+  IO.println s!"    reps old={oldT.reverse} new={newT.reverse} nf={nf.reverse}"
   IO.println ""
-  for p in paths do
-    let path := System.FilePath.mk p
-    unless ← path.pathExists do
-      IO.eprintln s!"not found: {path}"
-      continue
+
+def main (args : List String) : IO Unit := do
+  match args.head? with
+  | some "prod" =>
+    -- freq-fusion prod <file> <level> [reps]
+    let file := args[1]!
+    let level := (args[2]? |>.bind (·.toNat?)).getD 1 |>.toUInt8
+    let reps := (args[3]? |>.bind (·.toNat?)).getD 3
+    let path := System.FilePath.mk file
+    unless ← path.pathExists do IO.eprintln s!"not found: {path}"; return
     let data ← IO.FS.readBinFile path
     let iters := if data.size ≤ 262144 then 20 else if data.size ≤ 4194304 then 3 else 2
-    analyzeFile (path.fileName.getD p) data iters reps
+    IO.println s!"# Stage-1 production A/B (reps={reps})"
+    IO.println ""
+    analyzeProd (path.fileName.getD file) data level iters reps
+  | _ =>
+    let reps := (args[1]? |>.bind (·.toNat?)).getD 4
+    let paths := match args.head? with
+      | some p => [p]
+      | none => ["bench/corpora/silesia/mozilla"]
+    IO.println s!"# Stage-0 freq-fusion ceiling probe (reps={reps})"
+    IO.println ""
+    for p in paths do
+      let path := System.FilePath.mk p
+      unless ← path.pathExists do
+        IO.eprintln s!"not found: {path}"
+        continue
+      let data ← IO.FS.readBinFile path
+      let iters := if data.size ≤ 262144 then 20 else if data.size ≤ 4194304 then 3 else 2
+      analyzeFile (path.fileName.getD p) data iters reps

--- a/bench/graphs/canterbury_compress_heatmap.svg
+++ b/bench/graphs/canterbury_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#pc73dedf009)">
+   <g clip-path="url(#pbf927d2aeb)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJD0lEQVR4nO3YvYpdVQCG4ZzkjGbMqIOQGIwGQTsFK220t/dCvAIbr8E7EMFeBAtrG0uxURAlSCAKMeZnZjI5PxaCV/Aultk8zxV8m8Xe5z1rtfv7y/0Fni5nD2cvGOfxMp9tf342e8IwqxeuzZ4wxrPPzV4wzuri7AVjPFnue7bUM9vf/X32hGGWeWIAABMJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACA2PrW6u7sDUOcb89mTxjm+vHrsycMc7S7NnvCEKvT+7MnDPPd6U+zJwzxyjNXZ08YZrvbzJ4wxIPNyewJw2z229kThnj3+RuzJwzjBgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABi66OD49kbhtitd7MnDHN04fLsCePcuzV7wRD70/uzJwzz3s33Z08Y4mSz3DN7tNBne/Po7dkThjlfbWZPGGL/2w+zJwzjBgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABi68NLR7M3DHG2PZk9YZzVgrv48guzFwyxWvCZHWw2sycMseQzu7Je5nt25/z27AnDbHbnsycMcePK8ewJwyz3CwIAMInAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgNhq++On+9kj4D+73ewF8K+L/n8+dXw/+B/xBQEAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAIDY+uM/b83eMMT9x9vZE4b5/vaD2ROG+fqjD2ZPGOLlw5uzJwzzzudfzJ4wxIdvvDR7wjC//HU6e8IQh+tLsycM89U3P8+eMMTJZ5/MnjCMGywAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCIrTa7b/ezR4yw3W1mTxjm4mq5XXzp7GT2hDEurWcvGOfR3dkLhtgeX589YZjdfjd7whAHq+W+Z0/2y/xNO9gs87kuXHCDBQCQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAALH1wyf3Zm8YYr/fzZ4wzIuPzmZPGOfBH7MXDLE/fzJ7wjCr196aPWGI8+1y37OlfvevHr46e8IwBw/vzZ4wxP7Or7MnDOMGCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGL/AGKRiPAtkTS0AAAAAElFTkSuQmCC" id="image642e8ba94b" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJGElEQVR4nO3Yz6qd5R2G4b2StdXoVqJgGrSEQh0qHelE5849EI/ASY+hZ1AKnYvQQceddFg6aaG0BBG0EGMSd7Z7rz8OCj2C++Wni+s6gufj5fvWvd7N4bs/Hs/4ebl6Nr1gnR9O89mO11fTE5bZvHZvesIaL748vWCdza3pBWvcnO57dqpndnz05fSEZU7zxAAABgksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAIDY9uHm0fSGJa73V9MTlrl/91fTE5a5ONybnrDE5vmT6QnL/OX5P6YnLPHWC29OT1hmf9hNT1ji6e5yesIyu+N+esIS77/69vSEZdxgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQGx7cX53esMSh+1hesIyF2cvTU9Y5/HD6QVLHJ8/mZ6wzAcPPpyesMTl7nTP7PsTfbZ3Lt6dnrDM9WY3PWGJ43/+Nj1hGTdYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAENveuX0xvWGJq/3l9IR1NifcxS+9Nr1gic0Jn9n5bjc9YYlTPrNXtqf5nn19/dX0hGV2h+vpCUu8/crd6QnLnO4XBABgiMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACA2Gb/998ep0fA/x0O0wvgf275//mz4/vBT4gvCABATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMS2n/734fSGJZ78sJ+esMxfv3o6PWGZLz75aHrCEr+482B6wjK/+f0fpics8fGv35iesMy/vn0+PWGJO9vb0xOW+fxP/5yesMTl7z6bnrCMGywAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCIbXaHPx+nR6ywP+ymJyxza3O6XXz76nJ6whq3t9ML1vn+0fSCJfZ3709PWOZwPExPWOJ8c7rv2c3xNH/Tznen+VxnZ26wAAByAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAILa9vHkyvWGJm8P19IRlXr883Wc7e/rN9IIljtc30xOW2Tx4b3rCEtf7q+kJyzy7eTw9YYk37/xyesIy588eT09Y4vj1v6cnLOMGCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGI/ArfPiPPxwywhAAAAAElFTkSuQmCC" id="image5522453d41" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="me4baf4e8af" d="M 0 0 
+       <path id="mfb7b332f97" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#me4baf4e8af" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfb7b332f97" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#me4baf4e8af" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfb7b332f97" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#me4baf4e8af" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfb7b332f97" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#me4baf4e8af" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfb7b332f97" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#me4baf4e8af" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfb7b332f97" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#me4baf4e8af" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfb7b332f97" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#me4baf4e8af" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfb7b332f97" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#me4baf4e8af" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfb7b332f97" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#me4baf4e8af" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfb7b332f97" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#me4baf4e8af" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfb7b332f97" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#me4baf4e8af" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfb7b332f97" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="m1993f757fc" d="M 0 0 
+       <path id="m1b0a635ea6" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m1993f757fc" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1b0a635ea6" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m1993f757fc" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1b0a635ea6" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m1993f757fc" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1b0a635ea6" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m1993f757fc" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1b0a635ea6" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m1993f757fc" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1b0a635ea6" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m1993f757fc" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1b0a635ea6" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m1993f757fc" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1b0a635ea6" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m1993f757fc" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1b0a635ea6" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1303,7 +1303,7 @@ L 527.435033 49.4355
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_20">
-    <!-- +29 -->
+    <!-- +26 -->
     <g transform="translate(108.442626 68.904519) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-2b" d="M 2944 4013 
@@ -1321,14 +1321,44 @@ L 2419 4013
 L 2944 4013 
 z
 " transform="scale(0.015625)"/>
+      <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_21">
-    <!-- +33 -->
+    <!-- +34 -->
     <g transform="translate(147.693424 68.904519) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-33" d="M 2597 2516 
@@ -1363,16 +1393,6 @@ Q 3450 3153 3228 2886
 Q 3006 2619 2597 2516 
 z
 " transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_22">
-    <!-- -46 -->
-    <g transform="translate(188.495082 68.904519) scale(0.065 -0.065)">
-     <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
 L 2419 1625 
@@ -1392,37 +1412,15 @@ L 313 1709
 L 2253 4666 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-36" d="M 2113 2584 
-Q 1688 2584 1439 2293 
-Q 1191 2003 1191 1497 
-Q 1191 994 1439 701 
-Q 1688 409 2113 409 
-Q 2538 409 2786 701 
-Q 3034 994 3034 1497 
-Q 3034 2003 2786 2293 
-Q 2538 2584 2113 2584 
-z
-M 3366 4563 
-L 3366 3988 
-Q 3128 4100 2886 4159 
-Q 2644 4219 2406 4219 
-Q 1781 4219 1451 3797 
-Q 1122 3375 1075 2522 
-Q 1259 2794 1537 2939 
-Q 1816 3084 2150 3084 
-Q 2853 3084 3261 2657 
-Q 3669 2231 3669 1497 
-Q 3669 778 3244 343 
-Q 2819 -91 2113 -91 
-Q 1303 -91 875 529 
-Q 447 1150 447 2328 
-Q 447 3434 972 4092 
-Q 1497 4750 2381 4750 
-Q 2619 4750 2861 4703 
-Q 3103 4656 3366 4563 
-z
-" transform="scale(0.015625)"/>
      </defs>
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_22">
+    <!-- -46 -->
+    <g transform="translate(188.495082 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
@@ -1512,26 +1510,26 @@ z
     </g>
    </g>
    <g id="text_27">
-    <!-- +44 -->
+    <!-- +45 -->
     <g transform="translate(383.198215 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_28">
-    <!-- -3 -->
+    <!-- -2 -->
     <g transform="translate(426.067685 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_29">
-    <!-- -35 -->
+    <!-- -36 -->
     <g transform="translate(463.250671 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_30">
@@ -2178,18 +2176,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="imagec2b7957b83" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
+iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="image9fbc430177" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="m68d280369d" d="M 0 0 
+       <path id="me3363ae164" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m68d280369d" x="547.779688" y="276.293905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me3363ae164" x="547.779688" y="276.293905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
@@ -2212,7 +2210,7 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m68d280369d" x="547.779688" y="247.808905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me3363ae164" x="547.779688" y="247.808905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
@@ -2226,7 +2224,7 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m68d280369d" x="547.779688" y="219.323905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me3363ae164" x="547.779688" y="219.323905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
@@ -2240,7 +2238,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m68d280369d" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me3363ae164" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
@@ -2253,7 +2251,7 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m68d280369d" x="547.779688" y="162.353904" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me3363ae164" x="547.779688" y="162.353904" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_112">
@@ -2266,7 +2264,7 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m68d280369d" x="547.779688" y="133.868904" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me3363ae164" x="547.779688" y="133.868904" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
@@ -2279,7 +2277,7 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m68d280369d" x="547.779688" y="105.383904" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me3363ae164" x="547.779688" y="105.383904" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
@@ -2940,8 +2938,8 @@ z
    </g>
   </g>
   <g id="text_117">
-   <!-- 2026-07-10T09:54:02Z  ·  Linux chungus2 x86_64  ·  commit da9d9c0e  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(16.847969 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-11T04:15:02Z  ·  Linux chungus2 x86_64  ·  commit e802670f  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(17.448437 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -3008,13 +3006,13 @@ z
     <use xlink:href="#DejaVuSans-37" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-31" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(1027.734375 0)"/>
@@ -3057,109 +3055,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3135.351562 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3196.630859 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3260.253906 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3323.730469 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3387.353516 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3442.333984 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3505.957031 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3567.480469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3599.267578 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3631.054688 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3662.841797 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3694.628906 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3726.416016 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3754.199219 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3815.722656 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3877.001953 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3940.380859 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4003.857422 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4042.720703 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4103.902344 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4163.082031 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4224.605469 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4265.71875 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4299.410156 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4327.193359 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4388.716797 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4449.996094 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4513.375 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4576.998047 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4610.689453 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4669.869141 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4733.492188 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4765.279297 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4828.902344 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4892.525391 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4924.3125 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4987.935547 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5024.019531 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5062.882812 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5117.863281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5181.486328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5213.273438 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5245.060547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5276.847656 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5308.634766 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5340.421875 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5379.630859 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5443.009766 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5481.873047 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5543.054688 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5606.433594 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5669.910156 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5733.289062 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5796.765625 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5860.144531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5899.353516 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5931.140625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6014.929688 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6046.716797 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6144.128906 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6205.652344 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6269.128906 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6296.912109 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6358.191406 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6421.570312 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6453.357422 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6505.457031 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6568.835938 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6630.115234 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6693.591797 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6745.691406 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6809.070312 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6870.251953 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6909.460938 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6943.152344 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6974.939453 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7016.052734 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7077.332031 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7116.541016 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7144.324219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7205.505859 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7237.292969 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7265.076172 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7317.175781 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7348.962891 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7412.439453 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7473.962891 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7513.171875 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7574.695312 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7614.058594 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7711.470703 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7739.253906 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7802.632812 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7830.416016 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7882.515625 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7921.724609 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7949.507812 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3133.398438 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3197.021484 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3260.644531 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3324.267578 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3387.890625 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3451.513672 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3515.136719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3550.341797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3582.128906 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3613.916016 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3645.703125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3677.490234 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3709.277344 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3737.060547 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3798.583984 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3859.863281 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3923.242188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3986.71875 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4025.582031 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4086.763672 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4145.943359 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4207.466797 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4248.580078 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4282.271484 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4310.054688 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4371.578125 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4432.857422 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4496.236328 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4559.859375 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4593.550781 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4652.730469 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4716.353516 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4748.140625 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4811.763672 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4875.386719 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4907.173828 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4970.796875 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5006.880859 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5045.744141 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5100.724609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5164.347656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5196.134766 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5227.921875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5259.708984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5291.496094 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5323.283203 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5362.492188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5425.871094 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5464.734375 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5525.916016 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5589.294922 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5652.771484 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5716.150391 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5779.626953 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5843.005859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5882.214844 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5914.001953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5997.791016 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6029.578125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6126.990234 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6188.513672 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6251.990234 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6279.773438 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6341.052734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6404.431641 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6436.21875 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6488.318359 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6551.697266 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6612.976562 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6676.453125 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6728.552734 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6791.931641 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6853.113281 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6892.322266 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6926.013672 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6957.800781 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6998.914062 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7060.193359 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7099.402344 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7127.185547 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7188.367188 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7220.154297 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7247.9375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7300.037109 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7331.824219 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7395.300781 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7456.824219 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7496.033203 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7557.556641 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7596.919922 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7694.332031 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7722.115234 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7785.494141 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7813.277344 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7865.376953 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7904.585938 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7932.369141 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pc73dedf009">
+  <clipPath id="pbf927d2aeb">
    <rect x="95.67625" y="49.4355" width="431.758783" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_compress_pareto.svg
+++ b/bench/graphs/canterbury_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 79.118387 412.80375 
 L 79.118387 48.323125 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="mccaf00cff5" d="M 0 0 
+       <path id="m7a3c2e627c" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mccaf00cff5" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7a3c2e627c" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -161,11 +161,11 @@ z
      <g id="line2d_3">
       <path d="M 166.481434 412.80375 
 L 166.481434 48.323125 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mccaf00cff5" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7a3c2e627c" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -216,11 +216,11 @@ z
      <g id="line2d_5">
       <path d="M 253.844481 412.80375 
 L 253.844481 48.323125 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#mccaf00cff5" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7a3c2e627c" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -237,11 +237,11 @@ L 253.844481 48.323125
      <g id="line2d_7">
       <path d="M 341.207528 412.80375 
 L 341.207528 48.323125 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#mccaf00cff5" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7a3c2e627c" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -279,11 +279,11 @@ z
      <g id="line2d_9">
       <path d="M 428.570575 412.80375 
 L 428.570575 48.323125 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#mccaf00cff5" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7a3c2e627c" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -332,11 +332,11 @@ z
      <g id="line2d_11">
       <path d="M 515.933622 412.80375 
 L 515.933622 48.323125 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#mccaf00cff5" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7a3c2e627c" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -353,11 +353,11 @@ L 515.933622 48.323125
      <g id="line2d_13">
       <path d="M 603.296669 412.80375 
 L 603.296669 48.323125 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mccaf00cff5" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7a3c2e627c" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -854,16 +854,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 347.786382 
 L 637.2 347.786382 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="ma470114d47" d="M 0 0 
+       <path id="m35279ccf8d" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#ma470114d47" x="49.078125" y="347.786382" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m35279ccf8d" x="49.078125" y="347.786382" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -895,11 +895,11 @@ z
      <g id="line2d_17">
       <path d="M 49.078125 238.646289 
 L 637.2 238.646289 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#ma470114d47" x="49.078125" y="238.646289" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m35279ccf8d" x="49.078125" y="238.646289" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -915,11 +915,11 @@ L 637.2 238.646289
      <g id="line2d_19">
       <path d="M 49.078125 129.506196 
 L 637.2 129.506196 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#ma470114d47" x="49.078125" y="129.506196" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m35279ccf8d" x="49.078125" y="129.506196" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -935,16 +935,16 @@ L 637.2 129.506196
      <g id="line2d_21">
       <path d="M 49.078125 404.853417 
 L 637.2 404.853417 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="md535e77f37" d="M 0 0 
+       <path id="mf0efc75edf" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#md535e77f37" x="49.078125" y="404.853417" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf0efc75edf" x="49.078125" y="404.853417" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -952,11 +952,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 391.217592 
 L 637.2 391.217592 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#md535e77f37" x="49.078125" y="391.217592" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf0efc75edf" x="49.078125" y="391.217592" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -964,11 +964,11 @@ L 637.2 391.217592
      <g id="line2d_25">
       <path d="M 49.078125 380.640824 
 L 637.2 380.640824 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#md535e77f37" x="49.078125" y="380.640824" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf0efc75edf" x="49.078125" y="380.640824" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -976,11 +976,11 @@ L 637.2 380.640824
      <g id="line2d_27">
       <path d="M 49.078125 371.998975 
 L 637.2 371.998975 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#md535e77f37" x="49.078125" y="371.998975" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf0efc75edf" x="49.078125" y="371.998975" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -988,11 +988,11 @@ L 637.2 371.998975
      <g id="line2d_29">
       <path d="M 49.078125 364.692396 
 L 637.2 364.692396 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#md535e77f37" x="49.078125" y="364.692396" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf0efc75edf" x="49.078125" y="364.692396" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1000,11 +1000,11 @@ L 637.2 364.692396
      <g id="line2d_31">
       <path d="M 49.078125 358.36315 
 L 637.2 358.36315 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#md535e77f37" x="49.078125" y="358.36315" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf0efc75edf" x="49.078125" y="358.36315" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1012,11 +1012,11 @@ L 637.2 358.36315
      <g id="line2d_33">
       <path d="M 49.078125 352.780359 
 L 637.2 352.780359 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#md535e77f37" x="49.078125" y="352.780359" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf0efc75edf" x="49.078125" y="352.780359" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1024,11 +1024,11 @@ L 637.2 352.780359
      <g id="line2d_35">
       <path d="M 49.078125 314.93194 
 L 637.2 314.93194 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#md535e77f37" x="49.078125" y="314.93194" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf0efc75edf" x="49.078125" y="314.93194" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1036,11 +1036,11 @@ L 637.2 314.93194
      <g id="line2d_37">
       <path d="M 49.078125 295.713324 
 L 637.2 295.713324 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#md535e77f37" x="49.078125" y="295.713324" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf0efc75edf" x="49.078125" y="295.713324" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1048,11 +1048,11 @@ L 637.2 295.713324
      <g id="line2d_39">
       <path d="M 49.078125 282.077499 
 L 637.2 282.077499 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#md535e77f37" x="49.078125" y="282.077499" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf0efc75edf" x="49.078125" y="282.077499" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1060,11 +1060,11 @@ L 637.2 282.077499
      <g id="line2d_41">
       <path d="M 49.078125 271.500731 
 L 637.2 271.500731 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#md535e77f37" x="49.078125" y="271.500731" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf0efc75edf" x="49.078125" y="271.500731" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1072,11 +1072,11 @@ L 637.2 271.500731
      <g id="line2d_43">
       <path d="M 49.078125 262.858882 
 L 637.2 262.858882 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#md535e77f37" x="49.078125" y="262.858882" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf0efc75edf" x="49.078125" y="262.858882" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1084,11 +1084,11 @@ L 637.2 262.858882
      <g id="line2d_45">
       <path d="M 49.078125 255.552304 
 L 637.2 255.552304 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#md535e77f37" x="49.078125" y="255.552304" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf0efc75edf" x="49.078125" y="255.552304" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1096,11 +1096,11 @@ L 637.2 255.552304
      <g id="line2d_47">
       <path d="M 49.078125 249.223057 
 L 637.2 249.223057 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#md535e77f37" x="49.078125" y="249.223057" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf0efc75edf" x="49.078125" y="249.223057" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1108,11 +1108,11 @@ L 637.2 249.223057
      <g id="line2d_49">
       <path d="M 49.078125 243.640266 
 L 637.2 243.640266 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#md535e77f37" x="49.078125" y="243.640266" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf0efc75edf" x="49.078125" y="243.640266" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1120,11 +1120,11 @@ L 637.2 243.640266
      <g id="line2d_51">
       <path d="M 49.078125 205.791848 
 L 637.2 205.791848 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#md535e77f37" x="49.078125" y="205.791848" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf0efc75edf" x="49.078125" y="205.791848" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1132,11 +1132,11 @@ L 637.2 205.791848
      <g id="line2d_53">
       <path d="M 49.078125 186.573231 
 L 637.2 186.573231 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#md535e77f37" x="49.078125" y="186.573231" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf0efc75edf" x="49.078125" y="186.573231" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1144,11 +1144,11 @@ L 637.2 186.573231
      <g id="line2d_55">
       <path d="M 49.078125 172.937406 
 L 637.2 172.937406 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#md535e77f37" x="49.078125" y="172.937406" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf0efc75edf" x="49.078125" y="172.937406" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1156,11 +1156,11 @@ L 637.2 172.937406
      <g id="line2d_57">
       <path d="M 49.078125 162.360638 
 L 637.2 162.360638 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#md535e77f37" x="49.078125" y="162.360638" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf0efc75edf" x="49.078125" y="162.360638" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1168,11 +1168,11 @@ L 637.2 162.360638
      <g id="line2d_59">
       <path d="M 49.078125 153.71879 
 L 637.2 153.71879 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#md535e77f37" x="49.078125" y="153.71879" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf0efc75edf" x="49.078125" y="153.71879" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1180,11 +1180,11 @@ L 637.2 153.71879
      <g id="line2d_61">
       <path d="M 49.078125 146.412211 
 L 637.2 146.412211 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#md535e77f37" x="49.078125" y="146.412211" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf0efc75edf" x="49.078125" y="146.412211" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1192,11 +1192,11 @@ L 637.2 146.412211
      <g id="line2d_63">
       <path d="M 49.078125 140.082964 
 L 637.2 140.082964 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#md535e77f37" x="49.078125" y="140.082964" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf0efc75edf" x="49.078125" y="140.082964" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1204,11 +1204,11 @@ L 637.2 140.082964
      <g id="line2d_65">
       <path d="M 49.078125 134.500173 
 L 637.2 134.500173 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#md535e77f37" x="49.078125" y="134.500173" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf0efc75edf" x="49.078125" y="134.500173" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1216,11 +1216,11 @@ L 637.2 134.500173
      <g id="line2d_67">
       <path d="M 49.078125 96.651755 
 L 637.2 96.651755 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_68">
       <g>
-       <use xlink:href="#md535e77f37" x="49.078125" y="96.651755" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf0efc75edf" x="49.078125" y="96.651755" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1228,11 +1228,11 @@ L 637.2 96.651755
      <g id="line2d_69">
       <path d="M 49.078125 77.433138 
 L 637.2 77.433138 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_70">
       <g>
-       <use xlink:href="#md535e77f37" x="49.078125" y="77.433138" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf0efc75edf" x="49.078125" y="77.433138" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1240,11 +1240,11 @@ L 637.2 77.433138
      <g id="line2d_71">
       <path d="M 49.078125 63.797313 
 L 637.2 63.797313 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_72">
       <g>
-       <use xlink:href="#md535e77f37" x="49.078125" y="63.797313" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf0efc75edf" x="49.078125" y="63.797313" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1252,11 +1252,11 @@ L 637.2 63.797313
      <g id="line2d_73">
       <path d="M 49.078125 53.220545 
 L 637.2 53.220545 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_74">
       <g>
-       <use xlink:href="#md535e77f37" x="49.078125" y="53.220545" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf0efc75edf" x="49.078125" y="53.220545" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1378,7 +1378,7 @@ L 637.2 48.323125
    </g>
    <g id="text_13">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(294.783126 139.350294) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(294.783126 137.330928) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1410,7 +1410,7 @@ z
    </g>
    <g id="text_14">
     <!-- L10 -->
-    <g style="fill: #d62728" transform="translate(104.775489 295.009319) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(104.775489 294.848343) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1732,23 +1732,23 @@ z
    </g>
    <g id="line2d_75">
     <defs>
-     <path id="m192918e961" d="M -2.5 2.5 
+     <path id="mf3d8523f00" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pdc6bcedf75)">
-     <use xlink:href="#m192918e961" x="355.479835" y="95.382063" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m192918e961" x="308.273931" y="102.754513" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m192918e961" x="271.230161" y="116.528062" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m192918e961" x="217.83458" y="120.013651" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m192918e961" x="177.077692" y="138.43462" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m192918e961" x="162.880539" y="157.778627" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m192918e961" x="160.741445" y="165.196647" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m192918e961" x="153.966678" y="183.405761" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m192918e961" x="151.589614" y="194.488118" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p0c24897947)">
+     <use xlink:href="#mf3d8523f00" x="355.479835" y="95.382063" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf3d8523f00" x="308.273931" y="102.754513" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf3d8523f00" x="271.230161" y="116.528062" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf3d8523f00" x="217.83458" y="120.013651" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf3d8523f00" x="177.077692" y="138.43462" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf3d8523f00" x="162.880539" y="157.778627" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf3d8523f00" x="160.741445" y="165.196647" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf3d8523f00" x="153.966678" y="183.405761" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf3d8523f00" x="151.589614" y="194.488118" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_76">
@@ -1801,7 +1801,7 @@ L 311.2243 102.325849
 L 310.240844 102.469168 
 L 309.257387 102.612055 
 L 308.273931 102.754513 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_77">
     <path d="M 308.273931 102.754513 
@@ -1853,7 +1853,7 @@ L 273.545396 115.775058
 L 272.773651 116.027391 
 L 272.001906 116.278388 
 L 271.230161 116.528062 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_78">
     <path d="M 271.230161 116.528062 
@@ -1905,7 +1905,7 @@ L 221.171803 119.803152
 L 220.059395 119.873422 
 L 218.946988 119.943588 
 L 217.83458 120.013651 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_79">
     <path d="M 217.83458 120.013651 
@@ -1957,7 +1957,7 @@ L 179.624997 137.470928
 L 178.775895 137.79434 
 L 177.926794 138.115561 
 L 177.077692 138.43462 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_80">
     <path d="M 177.077692 138.43462 
@@ -2009,7 +2009,7 @@ L 163.767861 156.775388
 L 163.472087 157.112166 
 L 163.176313 157.446568 
 L 162.880539 157.778627 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_81">
     <path d="M 162.880539 157.778627 
@@ -2061,7 +2061,7 @@ L 160.875139 164.765525
 L 160.830574 164.909668 
 L 160.78601 165.053375 
 L 160.741445 165.196647 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_82">
     <path d="M 160.741445 165.196647 
@@ -2113,7 +2113,7 @@ L 154.390101 182.45125
 L 154.24896 182.771561 
 L 154.107819 183.089721 
 L 153.966678 183.405761 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_83">
     <path d="M 153.966678 183.405761 
@@ -2165,26 +2165,26 @@ L 151.73818 193.866427
 L 151.688658 194.074564 
 L 151.639136 194.281792 
 L 151.589614 194.488118 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_84">
     <defs>
-     <path id="md0c098a835" d="M 0 -2.5 
+     <path id="mfe1247db2c" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pdc6bcedf75)">
-     <use xlink:href="#md0c098a835" x="531.649087" y="75.963093" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md0c098a835" x="283.721324" y="99.020035" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md0c098a835" x="218.882044" y="121.069315" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md0c098a835" x="187.447228" y="127.10685" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md0c098a835" x="176.342474" y="138.36311" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md0c098a835" x="163.054314" y="161.312135" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md0c098a835" x="162.210539" y="168.753955" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md0c098a835" x="159.303811" y="175.753345" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md0c098a835" x="157.793928" y="179.494802" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p0c24897947)">
+     <use xlink:href="#mfe1247db2c" x="531.649087" y="75.963093" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfe1247db2c" x="283.721324" y="99.020035" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfe1247db2c" x="218.882044" y="121.069315" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfe1247db2c" x="187.447228" y="127.10685" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfe1247db2c" x="176.342474" y="138.36311" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfe1247db2c" x="163.054314" y="161.312135" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfe1247db2c" x="162.210539" y="168.753955" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfe1247db2c" x="159.303811" y="175.753345" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfe1247db2c" x="157.793928" y="179.494802" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_85">
@@ -2237,7 +2237,7 @@ L 299.21681 97.864971
 L 294.051648 98.253128 
 L 288.886486 98.638133 
 L 283.721324 99.020035 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_86">
     <path d="M 283.721324 99.020035 
@@ -2289,7 +2289,7 @@ L 222.934499 119.954333
 L 221.583681 120.328916 
 L 220.232863 120.700561 
 L 218.882044 121.069315 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_87">
     <path d="M 218.882044 121.069315 
@@ -2341,7 +2341,7 @@ L 189.411904 126.751217
 L 188.757012 126.870058 
 L 188.10212 126.988602 
 L 187.447228 127.10685 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_88">
     <path d="M 187.447228 127.10685 
@@ -2393,7 +2393,7 @@ L 177.036521 137.732718
 L 176.805172 137.943781 
 L 176.573823 138.153909 
 L 176.342474 138.36311 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_89">
     <path d="M 176.342474 138.36311 
@@ -2445,7 +2445,7 @@ L 163.884824 160.161325
 L 163.607987 160.548041 
 L 163.33115 160.931628 
 L 163.054314 161.312135 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_90">
     <path d="M 163.054314 161.312135 
@@ -2497,7 +2497,7 @@ L 162.263275 168.321549
 L 162.245696 168.466124 
 L 162.228118 168.610258 
 L 162.210539 168.753955 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_91">
     <path d="M 162.210539 168.753955 
@@ -2549,7 +2549,7 @@ L 159.485481 175.344896
 L 159.424925 175.481437 
 L 159.364368 175.617586 
 L 159.303811 175.753345 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_92">
     <path d="M 159.303811 175.753345 
@@ -2601,30 +2601,30 @@ L 157.888296 179.269417
 L 157.85684 179.344665 
 L 157.825384 179.419793 
 L 157.793928 179.494802 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_93">
     <defs>
-     <path id="m9a52e4f24a" d="M -0 3.535534 
+     <path id="m14949d883f" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pdc6bcedf75)">
-     <use xlink:href="#m9a52e4f24a" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9a52e4f24a" x="203.775848" y="81.750179" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9a52e4f24a" x="186.982691" y="88.344921" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9a52e4f24a" x="179.779306" y="91.045312" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9a52e4f24a" x="157.610419" y="99.395085" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9a52e4f24a" x="148.722526" y="107.864022" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9a52e4f24a" x="144.388162" y="121.237794" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9a52e4f24a" x="127.071247" y="144.560664" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9a52e4f24a" x="124.491988" y="152.083585" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9a52e4f24a" x="92.613662" y="207.637263" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9a52e4f24a" x="87.348715" y="225.457654" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9a52e4f24a" x="86.053433" y="242.017529" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p0c24897947)">
+     <use xlink:href="#m14949d883f" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m14949d883f" x="203.775848" y="81.750179" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m14949d883f" x="186.982691" y="88.344921" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m14949d883f" x="179.779306" y="91.045312" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m14949d883f" x="157.610419" y="99.395085" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m14949d883f" x="148.722526" y="107.864022" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m14949d883f" x="144.388162" y="121.237794" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m14949d883f" x="127.071247" y="144.560664" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m14949d883f" x="124.491988" y="152.083585" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m14949d883f" x="92.613662" y="207.637263" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m14949d883f" x="87.348715" y="225.457654" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m14949d883f" x="86.053433" y="242.017529" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_94">
@@ -2677,7 +2677,7 @@ L 206.762331 80.855075
 L 205.766837 81.155325 
 L 204.771342 81.453685 
 L 203.775848 81.750179 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_95">
     <path d="M 203.775848 81.750179 
@@ -2729,7 +2729,7 @@ L 188.032264 87.958568
 L 187.682406 88.087703 
 L 187.332549 88.216487 
 L 186.982691 88.344921 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_96">
     <path d="M 186.982691 88.344921 
@@ -2781,7 +2781,7 @@ L 180.229518 90.88097
 L 180.079447 90.935814 
 L 179.929376 90.990595 
 L 179.779306 91.045312 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_97">
     <path d="M 179.779306 91.045312 
@@ -2833,7 +2833,7 @@ L 158.995974 98.914174
 L 158.534122 99.075021 
 L 158.07227 99.235323 
 L 157.610419 99.395085 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_98">
     <path d="M 157.610419 99.395085 
@@ -2885,7 +2885,7 @@ L 149.27802 107.37681
 L 149.092855 107.539771 
 L 148.907691 107.702174 
 L 148.722526 107.864022 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_99">
     <path d="M 148.722526 107.864022 
@@ -2937,7 +2937,7 @@ L 144.65906 120.50385
 L 144.568761 120.749763 
 L 144.478462 120.994407 
 L 144.388162 121.237794 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_100">
     <path d="M 144.388162 121.237794 
@@ -2989,7 +2989,7 @@ L 128.153555 143.395158
 L 127.792786 143.786853 
 L 127.432016 144.175338 
 L 127.071247 144.560664 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_101">
     <path d="M 127.071247 144.560664 
@@ -3041,7 +3041,7 @@ L 124.653192 151.646811
 L 124.599457 151.79285 
 L 124.545723 151.93844 
 L 124.491988 152.083585 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_102">
     <path d="M 124.491988 152.083585 
@@ -3093,7 +3093,7 @@ L 94.606058 205.546972
 L 93.941926 206.254028 
 L 93.277794 206.950691 
 L 92.613662 207.637263 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_103">
     <path d="M 92.613662 207.637263 
@@ -3145,7 +3145,7 @@ L 87.677774 224.520091
 L 87.568088 224.834677 
 L 87.458402 225.147189 
 L 87.348715 225.457654 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_104">
     <path d="M 87.348715 225.457654 
@@ -3197,23 +3197,23 @@ L 86.134388 241.135848
 L 86.107403 241.431568 
 L 86.080418 241.725454 
 L 86.053433 242.017529 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_105">
     <defs>
-     <path id="ma2c4e2f35f" d="M -0 2.5 
+     <path id="m58db1fb298" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pdc6bcedf75)">
-     <use xlink:href="#ma2c4e2f35f" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p0c24897947)">
+     <use xlink:href="#m58db1fb298" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_106">
     <defs>
-     <path id="mfde07711d1" d="M -0.833333 2.5 
+     <path id="m471ca2777a" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -3228,16 +3228,16 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pdc6bcedf75)">
-     <use xlink:href="#mfde07711d1" x="362.865999" y="115.428618" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfde07711d1" x="278.798176" y="122.858526" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfde07711d1" x="251.17632" y="128.261574" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfde07711d1" x="200.806828" y="131.522849" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfde07711d1" x="169.803221" y="147.931404" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfde07711d1" x="161.916638" y="160.718659" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfde07711d1" x="158.697104" y="167.705569" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfde07711d1" x="154.26679" y="181.026105" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfde07711d1" x="153.096464" y="191.924265" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p0c24897947)">
+     <use xlink:href="#m471ca2777a" x="362.865999" y="115.428618" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m471ca2777a" x="278.798176" y="122.858526" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m471ca2777a" x="251.17632" y="128.261574" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m471ca2777a" x="200.806828" y="131.522849" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m471ca2777a" x="169.803221" y="147.931404" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m471ca2777a" x="161.916638" y="160.718659" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m471ca2777a" x="158.697104" y="167.705569" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m471ca2777a" x="154.26679" y="181.026105" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m471ca2777a" x="153.096464" y="191.924265" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_107">
@@ -3290,7 +3290,7 @@ L 284.052415 122.426763
 L 282.301002 122.571121 
 L 280.549589 122.715042 
 L 278.798176 122.858526 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_108">
     <path d="M 278.798176 122.858526 
@@ -3342,7 +3342,7 @@ L 252.902686 127.94134
 L 252.327231 128.048325 
 L 251.751776 128.155069 
 L 251.17632 128.261574 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_109">
     <path d="M 251.17632 128.261574 
@@ -3394,7 +3394,7 @@ L 203.954921 131.325463
 L 202.905557 131.39135 
 L 201.856192 131.457145 
 L 200.806828 131.522849 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_110">
     <path d="M 200.806828 131.522849 
@@ -3446,7 +3446,7 @@ L 171.740947 147.056528
 L 171.095038 147.349951 
 L 170.44913 147.64157 
 L 169.803221 147.931404 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_111">
     <path d="M 169.803221 147.931404 
@@ -3498,7 +3498,7 @@ L 162.409549 160.012958
 L 162.245246 160.249361 
 L 162.080942 160.484591 
 L 161.916638 160.718659 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_112">
     <path d="M 161.916638 160.718659 
@@ -3550,7 +3550,7 @@ L 158.898325 167.297798
 L 158.831251 167.434112 
 L 158.764178 167.570034 
 L 158.697104 167.705569 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_113">
     <path d="M 158.697104 167.705569 
@@ -3602,7 +3602,7 @@ L 154.543684 180.294711
 L 154.451386 180.539765 
 L 154.359088 180.783558 
 L 154.26679 181.026105 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_114">
     <path d="M 154.26679 181.026105 
@@ -3654,11 +3654,11 @@ L 153.16961 191.311823
 L 153.145228 191.516851 
 L 153.120846 191.720996 
 L 153.096464 191.924265 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_115">
     <defs>
-     <path id="mb65f1be1db" d="M -1.25 2.5 
+     <path id="m8cae01923a" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -3673,16 +3673,16 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pdc6bcedf75)">
-     <use xlink:href="#mb65f1be1db" x="301.619021" y="150.561849" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb65f1be1db" x="250.236474" y="156.671134" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb65f1be1db" x="225.418659" y="160.842551" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb65f1be1db" x="212.328936" y="161.382211" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb65f1be1db" x="209.030149" y="166.25091" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb65f1be1db" x="197.547749" y="171.432451" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb65f1be1db" x="194.819287" y="175.129495" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb65f1be1db" x="193.12279" y="181.606362" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb65f1be1db" x="192.79794" y="189.451167" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p0c24897947)">
+     <use xlink:href="#m8cae01923a" x="301.619021" y="150.561849" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8cae01923a" x="250.236474" y="156.671134" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8cae01923a" x="225.418659" y="160.842551" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8cae01923a" x="212.328936" y="161.382211" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8cae01923a" x="209.030149" y="166.25091" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8cae01923a" x="197.547749" y="171.432451" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8cae01923a" x="194.819287" y="175.129495" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8cae01923a" x="193.12279" y="181.606362" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8cae01923a" x="192.79794" y="189.451167" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_116">
@@ -3735,7 +3735,7 @@ L 253.447883 156.311526
 L 252.377414 156.431699 
 L 251.306944 156.551567 
 L 250.236474 156.671134 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_117">
     <path d="M 250.236474 156.671134 
@@ -3787,7 +3787,7 @@ L 226.969772 160.592321
 L 226.452735 160.675878 
 L 225.935697 160.759287 
 L 225.418659 160.842551 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_118">
     <path d="M 225.418659 160.842551 
@@ -3839,7 +3839,7 @@ L 213.147044 161.348661
 L 212.874341 161.359847 
 L 212.601639 161.37103 
 L 212.328936 161.382211 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_119">
     <path d="M 212.328936 161.382211 
@@ -3891,7 +3891,7 @@ L 209.236323 165.960837
 L 209.167599 166.057725 
 L 209.098874 166.154416 
 L 209.030149 166.25091 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_120">
     <path d="M 209.030149 166.25091 
@@ -3943,7 +3943,7 @@ L 198.265399 171.124681
 L 198.026182 171.227493 
 L 197.786966 171.330083 
 L 197.547749 171.432451 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_121">
     <path d="M 197.547749 171.432451 
@@ -3995,7 +3995,7 @@ L 194.989815 174.906688
 L 194.932972 174.981074 
 L 194.876129 175.055342 
 L 194.819287 175.129495 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_122">
     <path d="M 194.819287 175.129495 
@@ -4047,7 +4047,7 @@ L 193.228821 181.226479
 L 193.193478 181.353445 
 L 193.158134 181.480072 
 L 193.12279 181.606362 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_123">
     <path d="M 193.12279 181.606362 
@@ -4099,11 +4099,11 @@ L 192.818243 188.997124
 L 192.811475 189.148955 
 L 192.804707 189.300302 
 L 192.79794 189.451167 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_124">
     <defs>
-     <path id="mb3b4592e9f" d="M 0 -2.5 
+     <path id="me5581fab54" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -4116,16 +4116,16 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#pdc6bcedf75)">
-     <use xlink:href="#mb3b4592e9f" x="206.45578" y="118.584066" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mb3b4592e9f" x="206.45578" y="118.258949" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mb3b4592e9f" x="206.45578" y="118.759361" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mb3b4592e9f" x="206.45578" y="118.234957" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mb3b4592e9f" x="171.767499" y="134.097889" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mb3b4592e9f" x="163.54283" y="144.663903" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mb3b4592e9f" x="160.174881" y="151.505345" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mb3b4592e9f" x="154.179217" y="169.303726" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mb3b4592e9f" x="152.4406" y="178.584542" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p0c24897947)">
+     <use xlink:href="#me5581fab54" x="206.45578" y="118.584066" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#me5581fab54" x="206.45578" y="118.258949" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#me5581fab54" x="206.45578" y="118.759361" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#me5581fab54" x="206.45578" y="118.234957" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#me5581fab54" x="171.767499" y="134.097889" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#me5581fab54" x="163.54283" y="144.663903" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#me5581fab54" x="160.174881" y="151.505345" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#me5581fab54" x="154.179217" y="169.303726" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#me5581fab54" x="152.4406" y="178.584542" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_125">
@@ -4178,7 +4178,7 @@ L 206.45578 118.279335
 L 206.45578 118.27254 
 L 206.45578 118.265745 
 L 206.45578 118.258949 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_126">
     <path d="M 206.45578 118.258949 
@@ -4230,7 +4230,7 @@ L 206.45578 118.728239
 L 206.45578 118.738615 
 L 206.45578 118.748989 
 L 206.45578 118.759361 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_127">
     <path d="M 206.45578 118.759361 
@@ -4282,7 +4282,7 @@ L 206.45578 118.267903
 L 206.45578 118.256924 
 L 206.45578 118.245942 
 L 206.45578 118.234957 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_128">
     <path d="M 206.45578 118.234957 
@@ -4334,7 +4334,7 @@ L 173.935517 133.247721
 L 173.212844 133.532808 
 L 172.490172 133.816191 
 L 171.767499 134.097889 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_129">
     <path d="M 171.767499 134.097889 
@@ -4386,7 +4386,7 @@ L 164.056872 144.068227
 L 163.885524 144.267619 
 L 163.714177 144.466175 
 L 163.54283 144.663903 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_130">
     <path d="M 163.54283 144.663903 
@@ -4438,7 +4438,7 @@ L 160.385378 151.105499
 L 160.315212 151.239156 
 L 160.245047 151.372438 
 L 160.174881 151.505345 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_131">
     <path d="M 160.174881 151.505345 
@@ -4490,7 +4490,7 @@ L 154.553946 168.367127
 L 154.429036 168.681387 
 L 154.304126 168.993578 
 L 154.179217 169.303726 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_132">
     <path d="M 154.179217 169.303726 
@@ -4542,11 +4542,11 @@ L 152.549264 178.054798
 L 152.513043 178.232038 
 L 152.476822 178.408618 
 L 152.4406 178.584542 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_133">
     <defs>
-     <path id="m422436e7c3" d="M 0 -2.5 
+     <path id="mc3b5d58e6e" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -4555,16 +4555,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pdc6bcedf75)">
-     <use xlink:href="#m422436e7c3" x="610.467188" y="172.829682" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m422436e7c3" x="592.067397" y="173.763838" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m422436e7c3" x="534.807821" y="180.385179" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m422436e7c3" x="327.802209" y="176.172104" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m422436e7c3" x="275.83761" y="186.734601" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m422436e7c3" x="258.25125" y="198.783148" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m422436e7c3" x="256.777056" y="203.737732" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m422436e7c3" x="248.769854" y="217.74136" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m422436e7c3" x="246.264594" y="227.740017" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p0c24897947)">
+     <use xlink:href="#mc3b5d58e6e" x="610.467188" y="172.829682" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc3b5d58e6e" x="592.067397" y="173.763838" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc3b5d58e6e" x="534.807821" y="180.385179" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc3b5d58e6e" x="327.802209" y="176.172104" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc3b5d58e6e" x="275.83761" y="186.734601" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc3b5d58e6e" x="258.25125" y="198.783148" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc3b5d58e6e" x="256.777056" y="203.737732" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc3b5d58e6e" x="248.769854" y="217.74136" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc3b5d58e6e" x="246.264594" y="227.740017" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_134">
@@ -4617,7 +4617,7 @@ L 593.217384 173.705989
 L 592.834055 173.72528 
 L 592.450726 173.744563 
 L 592.067397 173.763838 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_135">
     <path d="M 592.067397 173.763838 
@@ -4669,7 +4669,7 @@ L 538.386544 179.997367
 L 537.193636 180.126991 
 L 536.000728 180.25626 
 L 534.807821 180.385179 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_136">
     <path d="M 534.807821 180.385179 
@@ -4721,7 +4721,7 @@ L 340.74006 176.446681
 L 336.427443 176.355332 
 L 332.114826 176.263806 
 L 327.802209 176.172104 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_137">
     <path d="M 327.802209 176.172104 
@@ -4773,7 +4773,7 @@ L 279.085397 186.139102
 L 278.002801 186.338434 
 L 276.920205 186.536931 
 L 275.83761 186.734601 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_138">
     <path d="M 275.83761 186.734601 
@@ -4825,7 +4825,7 @@ L 259.350398 198.113494
 L 258.984015 198.337765 
 L 258.617633 198.560979 
 L 258.25125 198.783148 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_139">
     <path d="M 258.25125 198.783148 
@@ -4877,7 +4877,7 @@ L 256.869193 203.442789
 L 256.838481 203.541307 
 L 256.807768 203.639621 
 L 256.777056 203.737732 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_140">
     <path d="M 256.777056 203.737732 
@@ -4929,7 +4929,7 @@ L 249.270304 216.977455
 L 249.103487 217.23346 
 L 248.93667 217.48809 
 L 248.769854 217.74136 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_141">
     <path d="M 248.769854 217.74136 
@@ -4981,7 +4981,7 @@ L 246.421172 227.173237
 L 246.368979 227.362918 
 L 246.316786 227.551842 
 L 246.264594 227.740017 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="legend_1">
     <g id="patch_7">
@@ -4999,7 +4999,7 @@ z
     </g>
     <g id="line2d_142">
      <defs>
-      <path id="m7d565b0ced" d="M 0 3.5 
+      <path id="mc914babc9f" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -5012,7 +5012,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m7d565b0ced" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#mc914babc9f" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -5071,7 +5071,7 @@ z
     </g>
     <g id="line2d_143">
      <g>
-      <use xlink:href="#m192918e961" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mf3d8523f00" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -5085,7 +5085,7 @@ z
     </g>
     <g id="line2d_144">
      <g>
-      <use xlink:href="#md0c098a835" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mfe1247db2c" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -5130,7 +5130,7 @@ z
     </g>
     <g id="line2d_145">
      <g>
-      <use xlink:href="#m9a52e4f24a" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m14949d883f" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -5173,7 +5173,7 @@ z
     </g>
     <g id="line2d_146">
      <g>
-      <use xlink:href="#ma2c4e2f35f" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m58db1fb298" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -5189,7 +5189,7 @@ z
     </g>
     <g id="line2d_147">
      <g>
-      <use xlink:href="#mfde07711d1" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m471ca2777a" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -5243,7 +5243,7 @@ z
     </g>
     <g id="line2d_148">
      <g>
-      <use xlink:href="#mb65f1be1db" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m8cae01923a" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -5308,7 +5308,7 @@ z
     </g>
     <g id="line2d_149">
      <g>
-      <use xlink:href="#mb3b4592e9f" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#me5581fab54" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -5346,7 +5346,7 @@ z
     </g>
     <g id="line2d_150">
      <g>
-      <use xlink:href="#m422436e7c3" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mc3b5d58e6e" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -5416,486 +5416,486 @@ z
     </g>
    </g>
    <g id="line2d_151">
-    <g clip-path="url(#pdc6bcedf75)">
-     <use xlink:href="#m7d565b0ced" x="289.783126" y="144.350294" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m7d565b0ced" x="232.839775" y="149.428446" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m7d565b0ced" x="214.084819" y="154.23359" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m7d565b0ced" x="181.367844" y="168.287213" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m7d565b0ced" x="165.308999" y="177.521714" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m7d565b0ced" x="160.074948" y="184.262415" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m7d565b0ced" x="157.029538" y="187.363569" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m7d565b0ced" x="149.72506" y="196.285016" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m7d565b0ced" x="115.00257" y="273.794663" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m7d565b0ced" x="99.775489" y="300.009319" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <g clip-path="url(#p0c24897947)">
+     <use xlink:href="#mc914babc9f" x="289.783126" y="142.330928" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mc914babc9f" x="232.839775" y="147.876362" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mc914babc9f" x="214.084819" y="153.034684" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mc914babc9f" x="181.367844" y="168.3472" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mc914babc9f" x="165.308999" y="177.551546" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mc914babc9f" x="160.074948" y="184.227623" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mc914babc9f" x="157.029538" y="187.304888" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mc914babc9f" x="149.72506" y="196.428799" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mc914babc9f" x="115.00257" y="273.659433" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mc914babc9f" x="99.775489" y="299.848343" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
    <g id="line2d_152">
-    <path d="M 289.783126 144.350294 
-L 288.596807 144.461833 
-L 287.410487 144.573109 
-L 286.224167 144.684126 
-L 285.037847 144.794882 
-L 283.851527 144.905381 
-L 282.665207 145.015623 
-L 281.478888 145.125608 
-L 280.292568 145.235339 
-L 279.106248 145.344817 
-L 277.919928 145.454043 
-L 276.733608 145.563017 
-L 275.547289 145.671741 
-L 274.360969 145.780217 
-L 273.174649 145.888444 
-L 271.988329 145.996426 
-L 270.802009 146.104162 
-L 269.615689 146.211653 
-L 268.42937 146.318901 
-L 267.24305 146.425907 
-L 266.05673 146.532673 
-L 264.87041 146.639198 
-L 263.68409 146.745484 
-L 262.49777 146.851533 
-L 261.311451 146.957344 
-L 260.125131 147.06292 
-L 258.938811 147.168262 
-L 257.752491 147.27337 
-L 256.566171 147.378245 
-L 255.379852 147.482889 
-L 254.193532 147.587302 
-L 253.007212 147.691486 
-L 251.820892 147.795441 
-L 250.634572 147.899169 
-L 249.448252 148.00267 
-L 248.261933 148.105946 
-L 247.075613 148.208997 
-L 245.889293 148.311825 
-L 244.702973 148.41443 
-L 243.516653 148.516813 
-L 242.330333 148.618976 
-L 241.144014 148.720919 
-L 239.957694 148.822643 
-L 238.771374 148.924149 
-L 237.585054 149.025439 
-L 236.398734 149.126512 
-L 235.212415 149.227371 
-L 234.026095 149.328015 
-L 232.839775 149.428446 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 289.783126 142.330928 
+L 288.596807 142.453329 
+L 287.410487 142.575415 
+L 286.224167 142.697188 
+L 285.037847 142.818648 
+L 283.851527 142.939798 
+L 282.665207 143.060639 
+L 281.478888 143.181173 
+L 280.292568 143.301401 
+L 279.106248 143.421325 
+L 277.919928 143.540946 
+L 276.733608 143.660266 
+L 275.547289 143.779287 
+L 274.360969 143.898009 
+L 273.174649 144.016435 
+L 271.988329 144.134565 
+L 270.802009 144.252402 
+L 269.615689 144.369947 
+L 268.42937 144.487201 
+L 267.24305 144.604165 
+L 266.05673 144.720842 
+L 264.87041 144.837232 
+L 263.68409 144.953337 
+L 262.49777 145.069158 
+L 261.311451 145.184697 
+L 260.125131 145.299955 
+L 258.938811 145.414933 
+L 257.752491 145.529634 
+L 256.566171 145.644057 
+L 255.379852 145.758205 
+L 254.193532 145.872078 
+L 253.007212 145.985679 
+L 251.820892 146.099008 
+L 250.634572 146.212066 
+L 249.448252 146.324856 
+L 248.261933 146.437378 
+L 247.075613 146.549633 
+L 245.889293 146.661623 
+L 244.702973 146.77335 
+L 243.516653 146.884813 
+L 242.330333 146.996015 
+L 241.144014 147.106957 
+L 239.957694 147.217639 
+L 238.771374 147.328064 
+L 237.585054 147.438232 
+L 236.398734 147.548145 
+L 235.212415 147.657803 
+L 234.026095 147.767208 
+L 232.839775 147.876362 
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_153">
-    <path d="M 232.839775 149.428446 
-L 232.449047 149.533686 
-L 232.058318 149.638694 
-L 231.66759 149.743469 
-L 231.276862 149.848013 
-L 230.886134 149.952327 
-L 230.495405 150.056412 
-L 230.104677 150.160269 
-L 229.713949 150.263898 
-L 229.323221 150.367302 
-L 228.932492 150.470481 
-L 228.541764 150.573435 
-L 228.151036 150.676167 
-L 227.760308 150.778676 
-L 227.369579 150.880964 
-L 226.978851 150.983032 
-L 226.588123 151.08488 
-L 226.197395 151.18651 
-L 225.806666 151.287923 
-L 225.415938 151.389119 
-L 225.02521 151.490099 
-L 224.634482 151.590865 
-L 224.243753 151.691417 
-L 223.853025 151.791756 
-L 223.462297 151.891883 
-L 223.071569 151.991799 
-L 222.68084 152.091505 
-L 222.290112 152.191002 
-L 221.899384 152.29029 
-L 221.508656 152.389371 
-L 221.117927 152.488245 
-L 220.727199 152.586913 
-L 220.336471 152.685376 
-L 219.945743 152.783636 
-L 219.555014 152.881691 
-L 219.164286 152.979545 
-L 218.773558 153.077197 
-L 218.38283 153.174648 
-L 217.992101 153.271899 
-L 217.601373 153.368951 
-L 217.210645 153.465804 
-L 216.819917 153.56246 
-L 216.429188 153.65892 
-L 216.03846 153.755183 
-L 215.647732 153.851252 
-L 215.257004 153.947126 
-L 214.866275 154.042807 
-L 214.475547 154.138294 
-L 214.084819 154.23359 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 232.839775 147.876362 
+L 232.449047 147.989756 
+L 232.058318 148.102881 
+L 231.66759 148.215736 
+L 231.276862 148.328323 
+L 230.886134 148.440643 
+L 230.495405 148.552697 
+L 230.104677 148.664487 
+L 229.713949 148.776015 
+L 229.323221 148.88728 
+L 228.932492 148.998285 
+L 228.541764 149.10903 
+L 228.151036 149.219518 
+L 227.760308 149.329748 
+L 227.369579 149.439723 
+L 226.978851 149.549443 
+L 226.588123 149.65891 
+L 226.197395 149.768124 
+L 225.806666 149.877087 
+L 225.415938 149.985801 
+L 225.02521 150.094266 
+L 224.634482 150.202483 
+L 224.243753 150.310453 
+L 223.853025 150.418178 
+L 223.462297 150.525659 
+L 223.071569 150.632897 
+L 222.68084 150.739893 
+L 222.290112 150.846647 
+L 221.899384 150.953162 
+L 221.508656 151.059438 
+L 221.117927 151.165476 
+L 220.727199 151.271278 
+L 220.336471 151.376843 
+L 219.945743 151.482175 
+L 219.555014 151.587272 
+L 219.164286 151.692138 
+L 218.773558 151.796771 
+L 218.38283 151.901175 
+L 217.992101 152.005348 
+L 217.601373 152.109294 
+L 217.210645 152.213012 
+L 216.819917 152.316503 
+L 216.429188 152.419769 
+L 216.03846 152.52281 
+L 215.647732 152.625628 
+L 215.257004 152.728224 
+L 214.866275 152.830597 
+L 214.475547 152.932751 
+L 214.084819 153.034684 
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_154">
-    <path d="M 214.084819 154.23359 
-L 213.403215 154.573187 
-L 212.721611 154.910368 
-L 212.040008 155.245167 
-L 211.358404 155.577618 
-L 210.676801 155.907753 
-L 209.995197 156.235605 
-L 209.313593 156.561205 
-L 208.63199 156.884583 
-L 207.950386 157.20577 
-L 207.268782 157.524795 
-L 206.587179 157.841688 
-L 205.905575 158.156476 
-L 205.223971 158.469187 
-L 204.542368 158.779848 
-L 203.860764 159.088486 
-L 203.17916 159.395128 
-L 202.497557 159.699799 
-L 201.815953 160.002524 
-L 201.13435 160.303328 
-L 200.452746 160.602234 
-L 199.771142 160.899268 
-L 199.089539 161.194452 
-L 198.407935 161.487809 
-L 197.726331 161.779361 
-L 197.044728 162.069131 
-L 196.363124 162.357141 
-L 195.68152 162.643411 
-L 194.999917 162.927962 
-L 194.318313 163.210815 
-L 193.636709 163.49199 
-L 192.955106 163.771508 
-L 192.273502 164.049386 
-L 191.591898 164.325645 
-L 190.910295 164.600303 
-L 190.228691 164.873379 
-L 189.547088 165.14489 
-L 188.865484 165.414855 
-L 188.18388 165.683291 
-L 187.502277 165.950216 
-L 186.820673 166.215646 
-L 186.139069 166.479597 
-L 185.457466 166.742087 
-L 184.775862 167.003131 
-L 184.094258 167.262746 
-L 183.412655 167.520946 
-L 182.731051 167.777747 
-L 182.049447 168.033165 
-L 181.367844 168.287213 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 214.084819 153.034684 
+L 213.403215 153.409764 
+L 212.721611 153.781898 
+L 212.040008 154.151134 
+L 211.358404 154.517516 
+L 210.676801 154.881088 
+L 209.995197 155.241891 
+L 209.313593 155.59997 
+L 208.63199 155.955363 
+L 207.950386 156.308111 
+L 207.268782 156.658254 
+L 206.587179 157.005829 
+L 205.905575 157.350874 
+L 205.223971 157.693425 
+L 204.542368 158.033518 
+L 203.860764 158.371189 
+L 203.17916 158.706471 
+L 202.497557 159.039398 
+L 201.815953 159.370002 
+L 201.13435 159.698317 
+L 200.452746 160.024374 
+L 199.771142 160.348202 
+L 199.089539 160.669833 
+L 198.407935 160.989297 
+L 197.726331 161.306622 
+L 197.044728 161.621836 
+L 196.363124 161.934968 
+L 195.68152 162.246045 
+L 194.999917 162.555094 
+L 194.318313 162.862141 
+L 193.636709 163.167211 
+L 192.955106 163.470331 
+L 192.273502 163.771524 
+L 191.591898 164.070816 
+L 190.910295 164.368229 
+L 190.228691 164.663788 
+L 189.547088 164.957516 
+L 188.865484 165.249434 
+L 188.18388 165.539566 
+L 187.502277 165.827932 
+L 186.820673 166.114555 
+L 186.139069 166.399455 
+L 185.457466 166.682653 
+L 184.775862 166.964168 
+L 184.094258 167.244022 
+L 183.412655 167.522233 
+L 182.731051 167.79882 
+L 182.049447 168.073803 
+L 181.367844 168.3472 
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_155">
-    <path d="M 181.367844 168.287213 
-L 181.033285 168.499143 
-L 180.698725 168.71013 
-L 180.364166 168.920183 
-L 180.029607 169.129308 
-L 179.695047 169.337514 
-L 179.360488 169.54481 
-L 179.025929 169.751204 
-L 178.69137 169.956703 
-L 178.35681 170.161314 
-L 178.022251 170.365046 
-L 177.687692 170.567906 
-L 177.353133 170.769902 
-L 177.018573 170.97104 
-L 176.684014 171.171329 
-L 176.349455 171.370774 
-L 176.014895 171.569384 
-L 175.680336 171.767166 
-L 175.345777 171.964125 
-L 175.011218 172.160269 
-L 174.676658 172.355605 
-L 174.342099 172.55014 
-L 174.00754 172.743879 
-L 173.672981 172.936829 
-L 173.338421 173.128998 
-L 173.003862 173.32039 
-L 172.669303 173.511012 
-L 172.334743 173.700871 
-L 172.000184 173.889973 
-L 171.665625 174.078323 
-L 171.331066 174.265928 
-L 170.996506 174.452793 
-L 170.661947 174.638924 
-L 170.327388 174.824327 
-L 169.992829 175.009008 
-L 169.658269 175.192972 
-L 169.32371 175.376224 
-L 168.989151 175.558771 
-L 168.654591 175.740618 
-L 168.320032 175.92177 
-L 167.985473 176.102232 
-L 167.650914 176.282009 
-L 167.316354 176.461107 
-L 166.981795 176.639531 
-L 166.647236 176.817286 
-L 166.312676 176.994377 
-L 165.978117 177.170808 
-L 165.643558 177.346586 
-L 165.308999 177.521714 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 181.367844 168.3472 
+L 181.033285 168.558371 
+L 180.698725 168.768605 
+L 180.364166 168.97791 
+L 180.029607 169.186296 
+L 179.695047 169.393769 
+L 179.360488 169.600338 
+L 179.025929 169.806011 
+L 178.69137 170.010795 
+L 178.35681 170.214699 
+L 178.022251 170.417729 
+L 177.687692 170.619892 
+L 177.353133 170.821198 
+L 177.018573 171.021652 
+L 176.684014 171.221262 
+L 176.349455 171.420034 
+L 176.014895 171.617977 
+L 175.680336 171.815096 
+L 175.345777 172.011399 
+L 175.011218 172.206893 
+L 174.676658 172.401583 
+L 174.342099 172.595477 
+L 174.00754 172.788581 
+L 173.672981 172.980902 
+L 173.338421 173.172445 
+L 173.003862 173.363218 
+L 172.669303 173.553226 
+L 172.334743 173.742475 
+L 172.000184 173.930971 
+L 171.665625 174.118721 
+L 171.331066 174.30573 
+L 170.996506 174.492004 
+L 170.661947 174.677549 
+L 170.327388 174.86237 
+L 169.992829 175.046474 
+L 169.658269 175.229865 
+L 169.32371 175.41255 
+L 168.989151 175.594533 
+L 168.654591 175.77582 
+L 168.320032 175.956416 
+L 167.985473 176.136327 
+L 167.650914 176.315557 
+L 167.316354 176.494113 
+L 166.981795 176.671998 
+L 166.647236 176.849218 
+L 166.312676 177.025778 
+L 165.978117 177.201683 
+L 165.643558 177.376937 
+L 165.308999 177.551546 
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_156">
-    <path d="M 165.308999 177.521714 
-L 165.199956 177.672381 
-L 165.090913 177.822572 
-L 164.98187 177.972288 
-L 164.872828 178.121532 
-L 164.763785 178.270308 
-L 164.654742 178.418619 
-L 164.5457 178.566467 
-L 164.436657 178.713855 
-L 164.327614 178.860786 
-L 164.218571 179.007263 
-L 164.109529 179.153289 
-L 164.000486 179.298867 
-L 163.891443 179.443999 
-L 163.782401 179.588687 
-L 163.673358 179.732936 
-L 163.564315 179.876747 
-L 163.455272 180.020122 
-L 163.34623 180.163066 
-L 163.237187 180.305579 
-L 163.128144 180.447665 
-L 163.019101 180.589327 
-L 162.910059 180.730567 
-L 162.801016 180.871387 
-L 162.691973 181.011789 
-L 162.582931 181.151778 
-L 162.473888 181.291354 
-L 162.364845 181.43052 
-L 162.255802 181.569278 
-L 162.14676 181.707632 
-L 162.037717 181.845583 
-L 161.928674 181.983134 
-L 161.819631 182.120287 
-L 161.710589 182.257043 
-L 161.601546 182.393407 
-L 161.492503 182.529379 
-L 161.383461 182.664963 
-L 161.274418 182.800159 
-L 161.165375 182.934972 
-L 161.056332 183.069401 
-L 160.94729 183.203451 
-L 160.838247 183.337123 
-L 160.729204 183.470418 
-L 160.620161 183.60334 
-L 160.511119 183.73589 
-L 160.402076 183.868071 
-L 160.293033 183.999884 
-L 160.183991 184.131331 
-L 160.074948 184.262415 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 165.308999 177.551546 
+L 165.199956 177.700667 
+L 165.090913 177.849321 
+L 164.98187 177.997511 
+L 164.872828 178.145238 
+L 164.763785 178.292506 
+L 164.654742 178.439318 
+L 164.5457 178.585677 
+L 164.436657 178.731586 
+L 164.327614 178.877046 
+L 164.218571 179.022062 
+L 164.109529 179.166635 
+L 164.000486 179.310768 
+L 163.891443 179.454465 
+L 163.782401 179.597727 
+L 163.673358 179.740558 
+L 163.564315 179.882959 
+L 163.455272 180.024934 
+L 163.34623 180.166485 
+L 163.237187 180.307615 
+L 163.128144 180.448325 
+L 163.019101 180.588619 
+L 162.910059 180.728499 
+L 162.801016 180.867968 
+L 162.691973 181.007027 
+L 162.582931 181.14568 
+L 162.473888 181.283928 
+L 162.364845 181.421774 
+L 162.255802 181.55922 
+L 162.14676 181.696269 
+L 162.037717 181.832923 
+L 161.928674 181.969184 
+L 161.819631 182.105054 
+L 161.710589 182.240536 
+L 161.601546 182.375632 
+L 161.492503 182.510343 
+L 161.383461 182.644674 
+L 161.274418 182.778624 
+L 161.165375 182.912197 
+L 161.056332 183.045395 
+L 160.94729 183.178219 
+L 160.838247 183.310672 
+L 160.729204 183.442756 
+L 160.620161 183.574473 
+L 160.511119 183.705825 
+L 160.402076 183.836814 
+L 160.293033 183.967442 
+L 160.183991 184.097711 
+L 160.074948 184.227623 
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_157">
-    <path d="M 160.074948 184.262415 
-L 160.011502 184.329136 
-L 159.948056 184.395763 
-L 159.88461 184.462296 
-L 159.821164 184.528736 
-L 159.757718 184.595083 
-L 159.694272 184.661338 
-L 159.630826 184.7275 
-L 159.56738 184.79357 
-L 159.503933 184.859547 
-L 159.440487 184.925434 
-L 159.377041 184.991228 
-L 159.313595 185.056932 
-L 159.250149 185.122544 
-L 159.186703 185.188066 
-L 159.123257 185.253497 
-L 159.059811 185.318838 
-L 158.996365 185.384089 
-L 158.932919 185.449251 
-L 158.869473 185.514323 
-L 158.806027 185.579306 
-L 158.742581 185.6442 
-L 158.679135 185.709005 
-L 158.615689 185.773721 
-L 158.552243 185.83835 
-L 158.488797 185.90289 
-L 158.425351 185.967343 
-L 158.361905 186.031708 
-L 158.298459 186.095986 
-L 158.235013 186.160176 
-L 158.171567 186.22428 
-L 158.108121 186.288298 
-L 158.044675 186.352229 
-L 157.981229 186.416074 
-L 157.917783 186.479833 
-L 157.854337 186.543506 
-L 157.790891 186.607094 
-L 157.727444 186.670597 
-L 157.663998 186.734014 
-L 157.600552 186.797348 
-L 157.537106 186.860596 
-L 157.47366 186.92376 
-L 157.410214 186.986841 
-L 157.346768 187.049837 
-L 157.283322 187.11275 
-L 157.219876 187.175579 
-L 157.15643 187.238325 
-L 157.092984 187.300988 
-L 157.029538 187.363569 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 160.074948 184.227623 
+L 160.011502 184.293814 
+L 159.948056 184.359912 
+L 159.88461 184.425918 
+L 159.821164 184.491832 
+L 159.757718 184.557654 
+L 159.694272 184.623386 
+L 159.630826 184.689026 
+L 159.56738 184.754576 
+L 159.503933 184.820035 
+L 159.440487 184.885403 
+L 159.377041 184.950682 
+L 159.313595 185.015871 
+L 159.250149 185.080971 
+L 159.186703 185.145981 
+L 159.123257 185.210902 
+L 159.059811 185.275734 
+L 158.996365 185.340478 
+L 158.932919 185.405133 
+L 158.869473 185.469701 
+L 158.806027 185.53418 
+L 158.742581 185.598572 
+L 158.679135 185.662877 
+L 158.615689 185.727094 
+L 158.552243 185.791225 
+L 158.488797 185.855268 
+L 158.425351 185.919226 
+L 158.361905 185.983097 
+L 158.298459 186.046883 
+L 158.235013 186.110582 
+L 158.171567 186.174196 
+L 158.108121 186.237725 
+L 158.044675 186.301169 
+L 157.981229 186.364528 
+L 157.917783 186.427802 
+L 157.854337 186.490993 
+L 157.790891 186.554099 
+L 157.727444 186.617121 
+L 157.663998 186.680059 
+L 157.600552 186.742914 
+L 157.537106 186.805686 
+L 157.47366 186.868374 
+L 157.410214 186.93098 
+L 157.346768 186.993503 
+L 157.283322 187.055944 
+L 157.219876 187.118303 
+L 157.15643 187.18058 
+L 157.092984 187.242775 
+L 157.029538 187.304888 
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_158">
-    <path d="M 157.029538 187.363569 
-L 156.877361 187.567635 
-L 156.725185 187.770827 
-L 156.573008 187.973151 
-L 156.420832 188.174615 
-L 156.268655 188.375227 
-L 156.116478 188.574993 
-L 155.964302 188.77392 
-L 155.812125 188.972017 
-L 155.659949 189.169288 
-L 155.507772 189.365742 
-L 155.355595 189.561386 
-L 155.203419 189.756225 
-L 155.051242 189.950266 
-L 154.899065 190.143516 
-L 154.746889 190.335982 
-L 154.594712 190.527669 
-L 154.442536 190.718584 
-L 154.290359 190.908734 
-L 154.138182 191.098123 
-L 153.986006 191.286759 
-L 153.833829 191.474647 
-L 153.681652 191.661793 
-L 153.529476 191.848203 
-L 153.377299 192.033883 
-L 153.225123 192.218839 
-L 153.072946 192.403075 
-L 152.920769 192.586598 
-L 152.768593 192.769413 
-L 152.616416 192.951526 
-L 152.46424 193.132942 
-L 152.312063 193.313666 
-L 152.159886 193.493704 
-L 152.00771 193.67306 
-L 151.855533 193.851741 
-L 151.703356 194.02975 
-L 151.55118 194.207093 
-L 151.399003 194.383776 
-L 151.246827 194.559802 
-L 151.09465 194.735176 
-L 150.942473 194.909905 
-L 150.790297 195.083991 
-L 150.63812 195.257441 
-L 150.485943 195.430258 
-L 150.333767 195.602447 
-L 150.18159 195.774013 
-L 150.029414 195.94496 
-L 149.877237 196.115293 
-L 149.72506 196.285016 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 157.029538 187.304888 
+L 156.877361 187.514035 
+L 156.725185 187.722263 
+L 156.573008 187.92958 
+L 156.420832 188.135994 
+L 156.268655 188.341513 
+L 156.116478 188.546145 
+L 155.964302 188.749897 
+L 155.812125 188.952777 
+L 155.659949 189.154793 
+L 155.507772 189.355951 
+L 155.355595 189.556259 
+L 155.203419 189.755724 
+L 155.051242 189.954353 
+L 154.899065 190.152153 
+L 154.746889 190.349131 
+L 154.594712 190.545294 
+L 154.442536 190.740649 
+L 154.290359 190.935202 
+L 154.138182 191.128959 
+L 153.986006 191.321928 
+L 153.833829 191.514114 
+L 153.681652 191.705524 
+L 153.529476 191.896164 
+L 153.377299 192.086041 
+L 153.225123 192.27516 
+L 153.072946 192.463527 
+L 152.920769 192.651149 
+L 152.768593 192.838031 
+L 152.616416 193.024179 
+L 152.46424 193.209598 
+L 152.312063 193.394296 
+L 152.159886 193.578276 
+L 152.00771 193.761545 
+L 151.855533 193.944108 
+L 151.703356 194.125971 
+L 151.55118 194.307139 
+L 151.399003 194.487617 
+L 151.246827 194.66741 
+L 151.09465 194.846523 
+L 150.942473 195.024963 
+L 150.790297 195.202733 
+L 150.63812 195.379839 
+L 150.485943 195.556286 
+L 150.333767 195.732078 
+L 150.18159 195.907221 
+L 150.029414 196.081719 
+L 149.877237 196.255577 
+L 149.72506 196.428799 
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_159">
-    <path d="M 149.72506 196.285016 
-L 149.001675 200.198031 
-L 148.27829 203.812497 
-L 147.554905 207.170759 
-L 146.831519 210.306746 
-L 146.108134 213.248065 
-L 145.384749 216.017477 
-L 144.661364 218.633973 
-L 143.937979 221.113558 
-L 143.214593 223.469852 
-L 142.491208 225.714536 
-L 141.767823 227.857707 
-L 141.044438 229.908151 
-L 140.321052 231.87356 
-L 139.597667 233.760708 
-L 138.874282 235.575588 
-L 138.150897 237.323533 
-L 137.427512 239.009304 
-L 136.704126 240.637173 
-L 135.980741 242.210986 
-L 135.257356 243.734218 
-L 134.533971 245.210018 
-L 133.810585 246.641253 
-L 133.0872 248.030535 
-L 132.363815 249.380253 
-L 131.64043 250.692599 
-L 130.917045 251.969586 
-L 130.193659 253.21307 
-L 129.470274 254.424765 
-L 128.746889 255.606254 
-L 128.023504 256.759008 
-L 127.300118 257.884391 
-L 126.576733 258.983673 
-L 125.853348 260.058037 
-L 125.129963 261.108587 
-L 124.406577 262.136358 
-L 123.683192 263.142315 
-L 122.959807 264.127365 
-L 122.236422 265.09236 
-L 121.513037 266.0381 
-L 120.789651 266.965338 
-L 120.066266 267.874785 
-L 119.342881 268.76711 
-L 118.619496 269.642946 
-L 117.89611 270.502892 
-L 117.172725 271.347514 
-L 116.44934 272.177348 
-L 115.725955 272.992903 
-L 115.00257 273.794663 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 149.72506 196.428799 
+L 149.001675 200.314426 
+L 148.27829 203.905513 
+L 147.554905 207.243585 
+L 146.831519 210.36196 
+L 146.108134 213.287781 
+L 145.384749 216.04345 
+L 144.661364 218.647675 
+L 143.937979 221.116239 
+L 143.214593 223.462577 
+L 142.491208 225.698225 
+L 141.767823 227.833157 
+L 141.044438 229.876059 
+L 140.321052 231.834538 
+L 139.597667 233.715294 
+L 138.874282 235.524264 
+L 138.150897 237.266724 
+L 137.427512 238.947394 
+L 136.704126 240.570506 
+L 135.980741 242.139872 
+L 135.257356 243.658938 
+L 134.533971 245.130828 
+L 133.810585 246.558384 
+L 133.0872 247.944199 
+L 132.363815 249.290645 
+L 131.64043 250.599898 
+L 130.917045 251.873956 
+L 130.193659 253.114662 
+L 129.470274 254.323719 
+L 128.746889 255.502701 
+L 128.023504 256.653067 
+L 127.300118 257.776175 
+L 126.576733 258.873285 
+L 125.853348 259.945575 
+L 125.129963 260.994142 
+L 124.406577 262.020014 
+L 123.683192 263.024153 
+L 122.959807 264.007459 
+L 122.236422 264.97078 
+L 121.513037 265.914913 
+L 120.789651 266.840606 
+L 120.066266 267.748566 
+L 119.342881 268.63946 
+L 118.619496 269.513917 
+L 117.89611 270.372534 
+L 117.172725 271.215873 
+L 116.44934 272.044469 
+L 115.725955 272.858829 
+L 115.00257 273.659433 
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_160">
-    <path d="M 115.00257 273.794663 
-L 114.685339 274.518433 
-L 114.368108 275.231317 
-L 114.050877 275.933637 
-L 113.733646 276.625703 
-L 113.416415 277.30781 
-L 113.099184 277.980239 
-L 112.781954 278.643263 
-L 112.464723 279.297139 
-L 112.147492 279.942118 
-L 111.830261 280.578438 
-L 111.51303 281.206329 
-L 111.195799 281.826011 
-L 110.878569 282.437695 
-L 110.561338 283.041586 
-L 110.244107 283.63788 
-L 109.926876 284.226766 
-L 109.609645 284.808425 
-L 109.292414 285.383032 
-L 108.975184 285.950757 
-L 108.657953 286.511762 
-L 108.340722 287.066206 
-L 108.023491 287.614238 
-L 107.70626 288.156006 
-L 107.389029 288.691652 
-L 107.071799 289.221312 
-L 106.754568 289.745119 
-L 106.437337 290.263201 
-L 106.120106 290.775681 
-L 105.802875 291.282679 
-L 105.485644 291.784311 
-L 105.168414 292.28069 
-L 104.851183 292.771925 
-L 104.533952 293.258121 
-L 104.216721 293.73938 
-L 103.89949 294.215802 
-L 103.582259 294.687483 
-L 103.265028 295.154516 
-L 102.947798 295.616992 
-L 102.630567 296.075 
-L 102.313336 296.528624 
-L 101.996105 296.977948 
-L 101.678874 297.423052 
-L 101.361643 297.864016 
-L 101.044413 298.300914 
-L 100.727182 298.733823 
-L 100.409951 299.162813 
-L 100.09272 299.587956 
-L 99.775489 300.009319 
-" clip-path="url(#pdc6bcedf75)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 115.00257 273.659433 
+L 114.685339 274.382285 
+L 114.368108 275.094278 
+L 114.050877 275.795734 
+L 113.733646 276.48696 
+L 113.416415 277.168251 
+L 113.099184 277.839888 
+L 112.781954 278.502141 
+L 112.464723 279.155268 
+L 112.147492 279.799518 
+L 111.830261 280.435128 
+L 111.51303 281.062328 
+L 111.195799 281.681336 
+L 110.878569 282.292365 
+L 110.561338 282.895617 
+L 110.244107 283.491287 
+L 109.926876 284.079565 
+L 109.609645 284.66063 
+L 109.292414 285.234659 
+L 108.975184 285.801819 
+L 108.657953 286.362273 
+L 108.340722 286.916177 
+L 108.023491 287.463682 
+L 107.70626 288.004936 
+L 107.389029 288.540079 
+L 107.071799 289.069247 
+L 106.754568 289.592573 
+L 106.437337 290.110184 
+L 106.120106 290.622203 
+L 105.802875 291.128751 
+L 105.485644 291.629942 
+L 105.168414 292.125889 
+L 104.851183 292.616701 
+L 104.533952 293.102482 
+L 104.216721 293.583335 
+L 103.89949 294.059359 
+L 103.582259 294.53065 
+L 103.265028 294.997301 
+L 102.947798 295.459402 
+L 102.630567 295.917041 
+L 102.313336 296.370305 
+L 101.996105 296.819275 
+L 101.678874 297.264032 
+L 101.361643 297.704654 
+L 101.044413 298.141218 
+L 100.727182 298.573798 
+L 100.409951 299.002466 
+L 100.09272 299.427291 
+L 99.775489 299.848343 
+" clip-path="url(#p0c24897947)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
   </g>
   <g id="text_25">
@@ -6254,8 +6254,8 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-07-10T09:54:02Z  ·  Linux chungus2 x86_64  ·  commit da9d9c0e  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(43.847969 465.66) scale(0.07 -0.07)">
+   <!-- 2026-07-11T04:15:02Z  ·  Linux chungus2 x86_64  ·  commit e802670f  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(44.448437 465.66) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -6276,36 +6276,6 @@ L 1638 0
 L 1638 4134 
 L -19 4134 
 L -19 4666 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-39" d="M 703 97 
-L 703 672 
-Q 941 559 1184 500 
-Q 1428 441 1663 441 
-Q 2288 441 2617 861 
-Q 2947 1281 2994 2138 
-Q 2813 1869 2534 1725 
-Q 2256 1581 1919 1581 
-Q 1219 1581 811 2004 
-Q 403 2428 403 3163 
-Q 403 3881 828 4315 
-Q 1253 4750 1959 4750 
-Q 2769 4750 3195 4129 
-Q 3622 3509 3622 2328 
-Q 3622 1225 3098 567 
-Q 2575 -91 1691 -91 
-Q 1453 -91 1209 -44 
-Q 966 3 703 97 
-z
-M 1959 2075 
-Q 2384 2075 2632 2365 
-Q 2881 2656 2881 3163 
-Q 2881 3666 2632 3958 
-Q 2384 4250 1959 4250 
-Q 1534 4250 1286 3958 
-Q 1038 3666 1038 3163 
-Q 1038 2656 1286 2365 
-Q 1534 2075 1959 2075 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-3a" d="M 750 794 
@@ -6441,13 +6411,13 @@ z
     <use xlink:href="#DejaVuSans-37" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-31" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(1027.734375 0)"/>
@@ -6490,109 +6460,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3135.351562 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3196.630859 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3260.253906 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3323.730469 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3387.353516 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3442.333984 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3505.957031 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3567.480469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3599.267578 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3631.054688 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3662.841797 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3694.628906 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3726.416016 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3754.199219 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3815.722656 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3877.001953 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3940.380859 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4003.857422 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4042.720703 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4103.902344 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4163.082031 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4224.605469 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4265.71875 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4299.410156 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4327.193359 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4388.716797 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4449.996094 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4513.375 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4576.998047 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4610.689453 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4669.869141 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4733.492188 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4765.279297 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4828.902344 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4892.525391 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4924.3125 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4987.935547 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5024.019531 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5062.882812 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5117.863281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5181.486328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5213.273438 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5245.060547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5276.847656 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5308.634766 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5340.421875 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5379.630859 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5443.009766 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5481.873047 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5543.054688 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5606.433594 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5669.910156 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5733.289062 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5796.765625 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5860.144531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5899.353516 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5931.140625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6014.929688 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6046.716797 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6144.128906 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6205.652344 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6269.128906 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6296.912109 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6358.191406 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6421.570312 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6453.357422 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6505.457031 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6568.835938 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6630.115234 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6693.591797 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6745.691406 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6809.070312 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6870.251953 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6909.460938 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6943.152344 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6974.939453 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7016.052734 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7077.332031 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7116.541016 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7144.324219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7205.505859 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7237.292969 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7265.076172 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7317.175781 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7348.962891 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7412.439453 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7473.962891 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7513.171875 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7574.695312 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7614.058594 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7711.470703 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7739.253906 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7802.632812 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7830.416016 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7882.515625 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7921.724609 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7949.507812 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3133.398438 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3197.021484 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3260.644531 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3324.267578 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3387.890625 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3451.513672 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3515.136719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3550.341797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3582.128906 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3613.916016 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3645.703125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3677.490234 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3709.277344 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3737.060547 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3798.583984 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3859.863281 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3923.242188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3986.71875 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4025.582031 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4086.763672 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4145.943359 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4207.466797 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4248.580078 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4282.271484 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4310.054688 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4371.578125 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4432.857422 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4496.236328 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4559.859375 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4593.550781 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4652.730469 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4716.353516 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4748.140625 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4811.763672 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4875.386719 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4907.173828 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4970.796875 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5006.880859 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5045.744141 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5100.724609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5164.347656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5196.134766 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5227.921875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5259.708984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5291.496094 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5323.283203 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5362.492188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5425.871094 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5464.734375 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5525.916016 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5589.294922 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5652.771484 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5716.150391 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5779.626953 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5843.005859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5882.214844 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5914.001953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5997.791016 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6029.578125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6126.990234 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6188.513672 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6251.990234 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6279.773438 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6341.052734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6404.431641 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6436.21875 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6488.318359 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6551.697266 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6612.976562 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6676.453125 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6728.552734 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6791.931641 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6853.113281 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6892.322266 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6926.013672 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6957.800781 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6998.914062 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7060.193359 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7099.402344 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7127.185547 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7188.367188 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7220.154297 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7247.9375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7300.037109 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7331.824219 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7395.300781 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7456.824219 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7496.033203 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7557.556641 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7596.919922 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7694.332031 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7722.115234 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7785.494141 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7813.277344 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7865.376953 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7904.585938 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7932.369141 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pdc6bcedf75">
+  <clipPath id="p0c24897947">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_ratio_heatmap.svg
+++ b/bench/graphs/canterbury_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#pb59b09e041)">
+   <g clip-path="url(#p16c51a6746)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAI/ElEQVR4nO3YwYqkVx2H4aqe7qZnxAFlEodZCu4kuMjG2bj2TnIFLsW91xG9AUFEdCOKGzfiTrILEmIyxnEmdNdUf+UlTIQT/lLv81zB71DU+V7OfvvXh6fduXn12fSCpU6fn9d5drvd7uOf/Gp6wlIf/fX19ITlfvSLH09PWG7/g/enJ6y1v5hesN7LT6YXrHfzeHrBUr/8zs+nJyx3hv8kAICvTgwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKTt746/Pk2PWO2026YnLLU/w2a9urienrDUYbudnrDc1d/+PD1hueP3n09PWOq4HaYnLPf6+HJ6wnJPzux6ePP4yfSE5c7vKwsA8D8QQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaZdXr7+Y3rDe3ZfTC9Y6bdML1nv4eHrBUtfTA74Gp5evpycsd/WfF9MTlrrajtMTlnt4jvfd7avpBUtdXZ7fjedlCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGn74/bb0/SI1U6nbXrCUtuZnWe32+2uLq6nJyx1fzpOT1juwasX0xPW++a70wuWerMdpics9/ntP6YnLPf07nJ6wlLbt55NT1jOyxAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkHb5l0//OL1huYvdfnrCUu88ejI9Ybn77Tg9YanrBzfTE5b74Pd/mJ6w3M9++L3pCUsdT9v0hOV++qe/T09Y7vmzb0xPWOqD955PT1jOyxAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDS9m/uf3OaHrHa4f52esJSD/c30xN4i8P+OD1huX/ffTY9Yblv3zydnrDUdtqmJyz3xd2n0xOWe3H3yfSEpb77+L3pCct5GQIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAEDaftt+d5oeAfwfOh6mF6x3eT29gLe4vf9yesJyNw8eTU/gLbwMAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIO1yd3+c3rDexZk13v7MzrPb7XZvbqcXrHVxOb1gucPFNj1huevpAaudzu83Om6H6QnL/fPwYnrCUu/cPJuesNwZfmUBAL46MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkPZfKmeKG6wY/4kAAAAASUVORK5CYII=" id="image3f9b7b5bb4" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAI/ElEQVR4nO3YwYqkVx2H4aqe7qZnxAFlEodZCu4kuMjG2bj2TnIFLsW91xG9AUFEdCOKGzfiTrILEmIyxnEmdNdUf+UlTIQT/lLv81zB71DU+V7OfvvXh6fduXn12fSCpU6fn9d5drvd7uOf/Gp6wlIf/fX19ITlfvSLH09PWG7/g/enJ6y1v5hesN7LT6YXrHfzeHrBUr/8zs+nJyx3hv8kAICvTgwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKTt746/Pk2PWO2026YnLLU/w2a9urienrDUYbudnrDc1d/+PD1hueP3n09PWOq4HaYnLPf6+HJ6wnJPzux6ePP4yfSE5c7vKwsA8D8QQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaZdXr7+Y3rDe3ZfTC9Y6bdML1nv4eHrBUtfTA74Gp5evpycsd/WfF9MTlrrajtMTlnt4jvfd7avpBUtdXZ7fjedlCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGn74/bb0/SI1U6nbXrCUtuZnWe32+2uLq6nJyx1fzpOT1juwasX0xPW++a70wuWerMdpics9/ntP6YnLPf07nJ6wlLbt55NT1jOyxAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkHb5l0//OL1huYvdfnrCUu88ejI9Ybn77Tg9YanrBzfTE5b74Pd/mJ6w3M9++L3pCUsdT9v0hOV++qe/T09Y7vmzb0xPWOqD955PT1jOyxAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDS9m/uf3OaHrHa4f52esJSD/c30xN4i8P+OD1huX/ffTY9Yblv3zydnrDUdtqmJyz3xd2n0xOWe3H3yfSEpb77+L3pCct5GQIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAEDaftt+d5oeAfwfOh6mF6x3eT29gLe4vf9yesJyNw8eTU/gLbwMAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIO1yd3+c3rDexZk13v7MzrPb7XZvbqcXrHVxOb1gucPFNj1huevpAaudzu83Om6H6QnL/fPwYnrCUu/cPJuesNwZfmUBAL46MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkPZfKmeKG6wY/4kAAAAASUVORK5CYII=" id="imagef8bb2e754b" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m51645ee128" d="M 0 0 
+       <path id="m105c745f5e" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m51645ee128" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m105c745f5e" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m51645ee128" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m105c745f5e" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m51645ee128" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m105c745f5e" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m51645ee128" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m105c745f5e" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m51645ee128" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m105c745f5e" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m51645ee128" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m105c745f5e" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m51645ee128" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m105c745f5e" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m51645ee128" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m105c745f5e" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m51645ee128" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m105c745f5e" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m51645ee128" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m105c745f5e" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m51645ee128" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m105c745f5e" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="m81a5e29aca" d="M 0 0 
+       <path id="m39ae11d3f0" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m81a5e29aca" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m39ae11d3f0" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m81a5e29aca" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m39ae11d3f0" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m81a5e29aca" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m39ae11d3f0" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m81a5e29aca" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m39ae11d3f0" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m81a5e29aca" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m39ae11d3f0" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m81a5e29aca" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m39ae11d3f0" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m81a5e29aca" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m39ae11d3f0" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m81a5e29aca" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m39ae11d3f0" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -2092,18 +2092,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="imageee45146b2c" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
+iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="image0ead8fd4b4" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="mae384a6071" d="M 0 0 
+       <path id="m96694a7ba4" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mae384a6071" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m96694a7ba4" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
@@ -2129,7 +2129,7 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#mae384a6071" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m96694a7ba4" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
@@ -2146,7 +2146,7 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#mae384a6071" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m96694a7ba4" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
@@ -2163,7 +2163,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#mae384a6071" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m96694a7ba4" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
@@ -2180,7 +2180,7 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mae384a6071" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m96694a7ba4" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_112">
@@ -2196,7 +2196,7 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#mae384a6071" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m96694a7ba4" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
@@ -2212,7 +2212,7 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mae384a6071" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m96694a7ba4" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
@@ -2228,7 +2228,7 @@ z
     <g id="ytick_16">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#mae384a6071" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m96694a7ba4" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_115">
@@ -2244,7 +2244,7 @@ z
     <g id="ytick_17">
      <g id="line2d_28">
       <g>
-       <use xlink:href="#mae384a6071" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m96694a7ba4" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_116">
@@ -2882,8 +2882,8 @@ z
    </g>
   </g>
   <g id="text_119">
-   <!-- 2026-07-10T09:54:02Z  ·  Linux chungus2 x86_64  ·  commit da9d9c0e  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(16.847969 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-11T04:15:02Z  ·  Linux chungus2 x86_64  ·  commit e802670f  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(17.448437 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2950,13 +2950,13 @@ z
     <use xlink:href="#DejaVuSans-37" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-31" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(1027.734375 0)"/>
@@ -2999,109 +2999,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3135.351562 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3196.630859 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3260.253906 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3323.730469 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3387.353516 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3442.333984 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3505.957031 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3567.480469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3599.267578 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3631.054688 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3662.841797 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3694.628906 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3726.416016 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3754.199219 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3815.722656 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3877.001953 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3940.380859 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4003.857422 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4042.720703 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4103.902344 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4163.082031 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4224.605469 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4265.71875 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4299.410156 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4327.193359 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4388.716797 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4449.996094 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4513.375 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4576.998047 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4610.689453 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4669.869141 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4733.492188 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4765.279297 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4828.902344 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4892.525391 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4924.3125 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4987.935547 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5024.019531 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5062.882812 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5117.863281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5181.486328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5213.273438 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5245.060547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5276.847656 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5308.634766 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5340.421875 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5379.630859 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5443.009766 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5481.873047 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5543.054688 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5606.433594 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5669.910156 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5733.289062 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5796.765625 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5860.144531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5899.353516 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5931.140625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6014.929688 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6046.716797 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6144.128906 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6205.652344 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6269.128906 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6296.912109 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6358.191406 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6421.570312 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6453.357422 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6505.457031 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6568.835938 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6630.115234 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6693.591797 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6745.691406 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6809.070312 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6870.251953 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6909.460938 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6943.152344 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6974.939453 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7016.052734 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7077.332031 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7116.541016 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7144.324219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7205.505859 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7237.292969 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7265.076172 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7317.175781 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7348.962891 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7412.439453 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7473.962891 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7513.171875 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7574.695312 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7614.058594 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7711.470703 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7739.253906 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7802.632812 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7830.416016 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7882.515625 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7921.724609 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7949.507812 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3133.398438 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3197.021484 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3260.644531 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3324.267578 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3387.890625 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3451.513672 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3515.136719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3550.341797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3582.128906 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3613.916016 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3645.703125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3677.490234 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3709.277344 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3737.060547 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3798.583984 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3859.863281 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3923.242188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3986.71875 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4025.582031 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4086.763672 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4145.943359 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4207.466797 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4248.580078 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4282.271484 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4310.054688 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4371.578125 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4432.857422 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4496.236328 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4559.859375 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4593.550781 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4652.730469 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4716.353516 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4748.140625 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4811.763672 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4875.386719 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4907.173828 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4970.796875 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5006.880859 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5045.744141 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5100.724609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5164.347656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5196.134766 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5227.921875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5259.708984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5291.496094 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5323.283203 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5362.492188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5425.871094 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5464.734375 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5525.916016 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5589.294922 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5652.771484 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5716.150391 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5779.626953 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5843.005859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5882.214844 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5914.001953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5997.791016 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6029.578125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6126.990234 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6188.513672 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6251.990234 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6279.773438 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6341.052734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6404.431641 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6436.21875 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6488.318359 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6551.697266 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6612.976562 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6676.453125 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6728.552734 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6791.931641 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6853.113281 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6892.322266 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6926.013672 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6957.800781 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6998.914062 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7060.193359 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7099.402344 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7127.185547 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7188.367188 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7220.154297 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7247.9375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7300.037109 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7331.824219 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7395.300781 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7456.824219 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7496.033203 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7557.556641 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7596.919922 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7694.332031 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7722.115234 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7785.494141 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7813.277344 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7865.376953 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7904.585938 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7932.369141 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pb59b09e041">
+  <clipPath id="p16c51a6746">
    <rect x="95.67625" y="49.4355" width="416.571298" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_summary.svg
+++ b/bench/graphs/canterbury_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="574.704063pt" height="386.202469pt" viewBox="0 0 574.704063 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="573.503125pt" height="386.202469pt" viewBox="0 0 573.503125 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,232 +22,232 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 386.202469 
-L 574.704063 386.202469 
-L 574.704063 0 
+L 573.503125 386.202469 
+L 573.503125 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 189.477031 104.1264 
-L 294.102031 104.1264 
-L 294.102031 74.7432 
-L 189.477031 74.7432 
+    <path d="M 188.876563 104.1264 
+L 293.501563 104.1264 
+L 293.501563 74.7432 
+L 188.876563 74.7432 
 z
-" clip-path="url(#pfbb0f83fde)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p46f6e8e4d7)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 294.102031 104.1264 
-L 398.727031 104.1264 
-L 398.727031 74.7432 
-L 294.102031 74.7432 
+    <path d="M 293.501563 104.1264 
+L 398.126563 104.1264 
+L 398.126563 74.7432 
+L 293.501563 74.7432 
 z
-" clip-path="url(#pfbb0f83fde)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p46f6e8e4d7)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 398.727031 104.1264 
-L 503.352031 104.1264 
-L 503.352031 74.7432 
-L 398.727031 74.7432 
+    <path d="M 398.126563 104.1264 
+L 502.751563 104.1264 
+L 502.751563 74.7432 
+L 398.126563 74.7432 
 z
-" clip-path="url(#pfbb0f83fde)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p46f6e8e4d7)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 189.477031 133.5096 
-L 294.102031 133.5096 
-L 294.102031 104.1264 
-L 189.477031 104.1264 
+    <path d="M 188.876563 133.5096 
+L 293.501563 133.5096 
+L 293.501563 104.1264 
+L 188.876563 104.1264 
 z
-" clip-path="url(#pfbb0f83fde)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p46f6e8e4d7)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 294.102031 133.5096 
-L 398.727031 133.5096 
-L 398.727031 104.1264 
-L 294.102031 104.1264 
+    <path d="M 293.501563 133.5096 
+L 398.126563 133.5096 
+L 398.126563 104.1264 
+L 293.501563 104.1264 
 z
-" clip-path="url(#pfbb0f83fde)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p46f6e8e4d7)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 398.727031 133.5096 
-L 503.352031 133.5096 
-L 503.352031 104.1264 
-L 398.727031 104.1264 
+    <path d="M 398.126563 133.5096 
+L 502.751563 133.5096 
+L 502.751563 104.1264 
+L 398.126563 104.1264 
 z
-" clip-path="url(#pfbb0f83fde)" style="fill: #fdb768; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p46f6e8e4d7)" style="fill: #fdb768; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 189.477031 162.8928 
-L 294.102031 162.8928 
-L 294.102031 133.5096 
-L 189.477031 133.5096 
+    <path d="M 188.876563 162.8928 
+L 293.501563 162.8928 
+L 293.501563 133.5096 
+L 188.876563 133.5096 
 z
-" clip-path="url(#pfbb0f83fde)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p46f6e8e4d7)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 294.102031 162.8928 
-L 398.727031 162.8928 
-L 398.727031 133.5096 
-L 294.102031 133.5096 
+    <path d="M 293.501563 162.8928 
+L 398.126563 162.8928 
+L 398.126563 133.5096 
+L 293.501563 133.5096 
 z
-" clip-path="url(#pfbb0f83fde)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p46f6e8e4d7)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 398.727031 162.8928 
-L 503.352031 162.8928 
-L 503.352031 133.5096 
-L 398.727031 133.5096 
+    <path d="M 398.126563 162.8928 
+L 502.751563 162.8928 
+L 502.751563 133.5096 
+L 398.126563 133.5096 
 z
-" clip-path="url(#pfbb0f83fde)" style="fill: #bbe278; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p46f6e8e4d7)" style="fill: #bbe278; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 189.477031 192.276 
-L 294.102031 192.276 
-L 294.102031 162.8928 
-L 189.477031 162.8928 
+    <path d="M 188.876563 192.276 
+L 293.501563 192.276 
+L 293.501563 162.8928 
+L 188.876563 162.8928 
 z
-" clip-path="url(#pfbb0f83fde)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p46f6e8e4d7)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 294.102031 192.276 
-L 398.727031 192.276 
-L 398.727031 162.8928 
-L 294.102031 162.8928 
+    <path d="M 293.501563 192.276 
+L 398.126563 192.276 
+L 398.126563 162.8928 
+L 293.501563 162.8928 
 z
-" clip-path="url(#pfbb0f83fde)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p46f6e8e4d7)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 398.727031 192.276 
-L 503.352031 192.276 
-L 503.352031 162.8928 
-L 398.727031 162.8928 
+    <path d="M 398.126563 192.276 
+L 502.751563 192.276 
+L 502.751563 162.8928 
+L 398.126563 162.8928 
 z
-" clip-path="url(#pfbb0f83fde)" style="fill: #fdc776; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p46f6e8e4d7)" style="fill: #fdc776; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 189.477031 221.6592 
-L 294.102031 221.6592 
-L 294.102031 192.276 
-L 189.477031 192.276 
+    <path d="M 188.876563 221.6592 
+L 293.501563 221.6592 
+L 293.501563 192.276 
+L 188.876563 192.276 
 z
-" clip-path="url(#pfbb0f83fde)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p46f6e8e4d7)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 294.102031 221.6592 
-L 398.727031 221.6592 
-L 398.727031 192.276 
-L 294.102031 192.276 
+    <path d="M 293.501563 221.6592 
+L 398.126563 221.6592 
+L 398.126563 192.276 
+L 293.501563 192.276 
 z
-" clip-path="url(#pfbb0f83fde)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p46f6e8e4d7)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 398.727031 221.6592 
-L 503.352031 221.6592 
-L 503.352031 192.276 
-L 398.727031 192.276 
+    <path d="M 398.126563 221.6592 
+L 502.751563 221.6592 
+L 502.751563 192.276 
+L 398.126563 192.276 
 z
-" clip-path="url(#pfbb0f83fde)" style="fill: #addc6f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p46f6e8e4d7)" style="fill: #addc6f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 189.477031 251.0424 
-L 294.102031 251.0424 
-L 294.102031 221.6592 
-L 189.477031 221.6592 
+    <path d="M 188.876563 251.0424 
+L 293.501563 251.0424 
+L 293.501563 221.6592 
+L 188.876563 221.6592 
 z
-" clip-path="url(#pfbb0f83fde)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p46f6e8e4d7)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 294.102031 251.0424 
-L 398.727031 251.0424 
-L 398.727031 221.6592 
-L 294.102031 221.6592 
+    <path d="M 293.501563 251.0424 
+L 398.126563 251.0424 
+L 398.126563 221.6592 
+L 293.501563 221.6592 
 z
-" clip-path="url(#pfbb0f83fde)" style="fill: #fdbd6d; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p46f6e8e4d7)" style="fill: #fdbd6d; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 398.727031 251.0424 
-L 503.352031 251.0424 
-L 503.352031 221.6592 
-L 398.727031 221.6592 
+    <path d="M 398.126563 251.0424 
+L 502.751563 251.0424 
+L 502.751563 221.6592 
+L 398.126563 221.6592 
 z
-" clip-path="url(#pfbb0f83fde)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p46f6e8e4d7)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 189.477031 280.4256 
-L 294.102031 280.4256 
-L 294.102031 251.0424 
-L 189.477031 251.0424 
+    <path d="M 188.876563 280.4256 
+L 293.501563 280.4256 
+L 293.501563 251.0424 
+L 188.876563 251.0424 
 z
-" clip-path="url(#pfbb0f83fde)" style="fill: #f5fbb2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p46f6e8e4d7)" style="fill: #f5fbb2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 294.102031 280.4256 
-L 398.727031 280.4256 
-L 398.727031 251.0424 
-L 294.102031 251.0424 
+    <path d="M 293.501563 280.4256 
+L 398.126563 280.4256 
+L 398.126563 251.0424 
+L 293.501563 251.0424 
 z
-" clip-path="url(#pfbb0f83fde)" style="fill: #fca55d; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p46f6e8e4d7)" style="fill: #fca55d; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 398.727031 280.4256 
-L 503.352031 280.4256 
-L 503.352031 251.0424 
-L 398.727031 251.0424 
+    <path d="M 398.126563 280.4256 
+L 502.751563 280.4256 
+L 502.751563 251.0424 
+L 398.126563 251.0424 
 z
-" clip-path="url(#pfbb0f83fde)" style="fill: #fca55d; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p46f6e8e4d7)" style="fill: #fca55d; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 189.477031 309.8088 
-L 294.102031 309.8088 
-L 294.102031 280.4256 
-L 189.477031 280.4256 
+    <path d="M 188.876563 309.8088 
+L 293.501563 309.8088 
+L 293.501563 280.4256 
+L 188.876563 280.4256 
 z
-" clip-path="url(#pfbb0f83fde)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p46f6e8e4d7)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 294.102031 309.8088 
-L 398.727031 309.8088 
-L 398.727031 280.4256 
-L 294.102031 280.4256 
+    <path d="M 293.501563 309.8088 
+L 398.126563 309.8088 
+L 398.126563 280.4256 
+L 293.501563 280.4256 
 z
-" clip-path="url(#pfbb0f83fde)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p46f6e8e4d7)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 398.727031 309.8088 
-L 503.352031 309.8088 
-L 503.352031 280.4256 
-L 398.727031 280.4256 
+    <path d="M 398.126563 309.8088 
+L 502.751563 309.8088 
+L 502.751563 280.4256 
+L 398.126563 280.4256 
 z
-" clip-path="url(#pfbb0f83fde)" style="fill: #ee613e; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p46f6e8e4d7)" style="fill: #ee613e; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 189.477031 339.192 
-L 294.102031 339.192 
-L 294.102031 309.8088 
-L 189.477031 309.8088 
+    <path d="M 188.876563 339.192 
+L 293.501563 339.192 
+L 293.501563 309.8088 
+L 188.876563 309.8088 
 z
-" clip-path="url(#pfbb0f83fde)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p46f6e8e4d7)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 294.102031 339.192 
-L 398.727031 339.192 
-L 398.727031 309.8088 
-L 294.102031 309.8088 
+    <path d="M 293.501563 339.192 
+L 398.126563 339.192 
+L 398.126563 309.8088 
+L 293.501563 309.8088 
 z
-" clip-path="url(#pfbb0f83fde)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p46f6e8e4d7)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 398.727031 339.192 
-L 503.352031 339.192 
-L 503.352031 309.8088 
-L 398.727031 309.8088 
+    <path d="M 398.126563 339.192 
+L 502.751563 339.192 
+L 502.751563 309.8088 
+L 398.126563 309.8088 
 z
-" clip-path="url(#pfbb0f83fde)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p46f6e8e4d7)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(122.464297 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(121.863828 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(229.748516 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(229.148047 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(308.320625 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(307.720156 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(406.672344 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(406.071875 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(118.402031 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(117.801563 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.296 -->
-    <g transform="translate(230.338281 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(229.737813 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -946,7 +946,7 @@ z
    </g>
    <g id="text_7">
     <!-- 158 -->
-    <g transform="translate(338.779531 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(338.179063 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -1034,7 +1034,7 @@ z
    </g>
    <g id="text_8">
     <!-- 925 -->
-    <g transform="translate(443.404531 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(442.804063 91.6423) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-39"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
@@ -1042,7 +1042,7 @@ z
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(113.040156 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(112.439688 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1141,7 +1141,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.299 -->
-    <g transform="translate(230.338281 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(229.737813 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1151,7 +1151,7 @@ z
    </g>
    <g id="text_11">
     <!-- 73 -->
-    <g transform="translate(341.324531 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(340.724063 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -1202,7 +1202,7 @@ z
    </g>
    <g id="text_12">
     <!-- 283 -->
-    <g transform="translate(443.404531 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(442.804063 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(127.246094 0)"/>
@@ -1210,7 +1210,7 @@ z
    </g>
    <g id="text_13">
     <!-- zlib -->
-    <g transform="translate(130.303281 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(129.702813 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1234,7 +1234,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.299 -->
-    <g transform="translate(230.338281 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(229.737813 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1244,14 +1244,14 @@ z
    </g>
    <g id="text_15">
     <!-- 55 -->
-    <g transform="translate(341.324531 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(340.724063 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
     <!-- 692 -->
-    <g transform="translate(443.404531 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(442.804063 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-36"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
@@ -1259,7 +1259,7 @@ z
    </g>
    <g id="text_17">
     <!-- Go compress/flate -->
-    <g transform="translate(100.733281 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(100.132813 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -1430,7 +1430,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.299 -->
-    <g transform="translate(230.338281 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(229.737813 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1440,14 +1440,14 @@ z
    </g>
    <g id="text_19">
     <!-- 52 -->
-    <g transform="translate(341.324531 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(340.724063 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
     <!-- 323 -->
-    <g transform="translate(443.404531 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(442.804063 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(127.246094 0)"/>
@@ -1455,7 +1455,7 @@ z
    </g>
    <g id="text_21">
     <!-- miniz_oxide -->
-    <g transform="translate(113.609531 209.06385) scale(0.08 -0.08)">
+    <g transform="translate(113.009063 209.06385) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6e" d="M 3513 2113 
 L 3513 0 
@@ -1514,7 +1514,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.299 -->
-    <g transform="translate(230.338281 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(229.737813 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1524,14 +1524,14 @@ z
    </g>
    <g id="text_23">
     <!-- 51 -->
-    <g transform="translate(341.324531 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(340.724063 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_24">
     <!-- 729 -->
-    <g transform="translate(443.404531 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(442.804063 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-37"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(127.246094 0)"/>
@@ -1539,7 +1539,7 @@ z
    </g>
    <g id="text_25">
     <!-- JS fflate -->
-    <g transform="translate(121.765781 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(121.165313 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1599,7 +1599,7 @@ z
    </g>
    <g id="text_26">
     <!-- 0.307 -->
-    <g transform="translate(230.338281 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(229.737813 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1609,7 +1609,7 @@ z
    </g>
    <g id="text_27">
     <!-- 41 -->
-    <g transform="translate(341.324531 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(340.724063 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1637,14 +1637,14 @@ z
    </g>
    <g id="text_28">
     <!-- 80 -->
-    <g transform="translate(445.949531 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(445.349063 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-38"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_29">
     <!-- lean-zip (native) -->
-    <g transform="translate(100.111406 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(99.510938 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1753,7 +1753,7 @@ z
    </g>
    <g id="text_30">
     <!-- 0.299 -->
-    <g transform="translate(229.137656 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(228.537188 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1844,8 +1844,8 @@ z
     </g>
    </g>
    <g id="text_31">
-    <!-- 31 -->
-    <g transform="translate(340.848281 267.9415) scale(0.08 -0.08)">
+    <!-- 32 -->
+    <g transform="translate(340.247813 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-33" d="M 2981 2516 
 Q 3453 2394 3698 2092 
@@ -1879,28 +1879,14 @@ Q 3834 3144 3618 2883
 Q 3403 2622 2981 2516 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-31" d="M 750 831 
-L 1813 831 
-L 1813 3847 
-L 722 3622 
-L 722 4441 
-L 1806 4666 
-L 2950 4666 
-L 2950 831 
-L 4013 831 
-L 4013 0 
-L 750 0 
-L 750 831 
-z
-" transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-Bold-33"/>
-     <use xlink:href="#DejaVuSans-Bold-31" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-32" transform="translate(69.580078 0)"/>
     </g>
    </g>
    <g id="text_32">
-    <!-- 246 -->
-    <g transform="translate(442.690156 267.9415) scale(0.08 -0.08)">
+    <!-- 244 -->
+    <g transform="translate(442.089688 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-34" d="M 2356 3675 
 L 1038 1722 
@@ -1921,45 +1907,15 @@ L 288 1881
 L 2156 4666 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-36" d="M 2316 2303 
-Q 2000 2303 1842 2098 
-Q 1684 1894 1684 1484 
-Q 1684 1075 1842 870 
-Q 2000 666 2316 666 
-Q 2634 666 2792 870 
-Q 2950 1075 2950 1484 
-Q 2950 1894 2792 2098 
-Q 2634 2303 2316 2303 
-z
-M 3803 4544 
-L 3803 3681 
-Q 3506 3822 3243 3889 
-Q 2981 3956 2731 3956 
-Q 2194 3956 1894 3657 
-Q 1594 3359 1544 2772 
-Q 1750 2925 1990 3001 
-Q 2231 3078 2516 3078 
-Q 3231 3078 3670 2659 
-Q 4109 2241 4109 1563 
-Q 4109 813 3618 361 
-Q 3128 -91 2303 -91 
-Q 1394 -91 895 523 
-Q 397 1138 397 2266 
-Q 397 3422 980 4083 
-Q 1563 4744 2578 4744 
-Q 2900 4744 3203 4694 
-Q 3506 4644 3803 4544 
-z
-" transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-Bold-32"/>
      <use xlink:href="#DejaVuSans-Bold-34" transform="translate(69.580078 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-36" transform="translate(139.160156 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-34" transform="translate(139.160156 0)"/>
     </g>
    </g>
    <g id="text_33">
     <!-- OCaml decompress -->
-    <g transform="translate(98.226406 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(97.625938 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -2024,7 +1980,7 @@ z
    </g>
    <g id="text_34">
     <!-- 0.321 -->
-    <g transform="translate(230.338281 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(229.737813 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -2034,14 +1990,14 @@ z
    </g>
    <g id="text_35">
     <!-- 23 -->
-    <g transform="translate(341.324531 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(340.724063 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_36">
     <!-- 117 -->
-    <g transform="translate(443.404531 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(442.804063 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
@@ -2049,7 +2005,7 @@ z
    </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(126.447656 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(125.847188 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -2060,7 +2016,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.279 -->
-    <g transform="translate(230.338281 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(229.737813 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -2070,13 +2026,13 @@ z
    </g>
    <g id="text_39">
     <!-- 0 -->
-    <g transform="translate(343.869531 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(343.269063 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(447.039531 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(446.439063 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2092,7 +2048,7 @@ z
   </g>
   <g id="text_41">
    <!-- canterbury — geomean over files, level 6 -->
-   <g transform="translate(136.860781 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(136.260313 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-62" d="M 2400 722 
 Q 2759 722 2948 984 
@@ -2231,6 +2187,36 @@ L 653 256
 L 653 1209 
 z
 " transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-36" d="M 2316 2303 
+Q 2000 2303 1842 2098 
+Q 1684 1894 1684 1484 
+Q 1684 1075 1842 870 
+Q 2000 666 2316 666 
+Q 2634 666 2792 870 
+Q 2950 1075 2950 1484 
+Q 2950 1894 2792 2098 
+Q 2634 2303 2316 2303 
+z
+M 3803 4544 
+L 3803 3681 
+Q 3506 3822 3243 3889 
+Q 2981 3956 2731 3956 
+Q 2194 3956 1894 3657 
+Q 1594 3359 1544 2772 
+Q 1750 2925 1990 3001 
+Q 2231 3078 2516 3078 
+Q 3231 3078 3670 2659 
+Q 4109 2241 4109 1563 
+Q 4109 813 3618 361 
+Q 3128 -91 2303 -91 
+Q 1394 -91 895 523 
+Q 397 1138 397 2266 
+Q 397 3422 980 4083 
+Q 1563 4744 2578 4744 
+Q 2900 4744 3203 4694 
+Q 3506 4644 3803 4544 
+z
+" transform="scale(0.015625)"/>
     </defs>
     <use xlink:href="#DejaVuSans-Bold-63"/>
     <use xlink:href="#DejaVuSans-Bold-61" transform="translate(59.277344 0)"/>
@@ -2275,7 +2261,7 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-07-10T09:54:02Z  ·  Linux chungus2 x86_64  ·  commit da9d9c0e  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-07-11T04:15:02Z  ·  Linux chungus2 x86_64  ·  commit e802670f  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2414,13 +2400,13 @@ z
     <use xlink:href="#DejaVuSans-37" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-31" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(1027.734375 0)"/>
@@ -2463,110 +2449,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3135.351562 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3196.630859 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3260.253906 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3323.730469 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3387.353516 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3442.333984 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3505.957031 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3567.480469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3599.267578 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3631.054688 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3662.841797 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3694.628906 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3726.416016 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3754.199219 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3815.722656 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3877.001953 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3940.380859 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4003.857422 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4042.720703 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4103.902344 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4163.082031 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4224.605469 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4265.71875 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4299.410156 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4327.193359 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4388.716797 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4449.996094 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4513.375 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4576.998047 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4610.689453 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4669.869141 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4733.492188 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4765.279297 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4828.902344 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4892.525391 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4924.3125 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4987.935547 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5024.019531 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5062.882812 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5117.863281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5181.486328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5213.273438 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5245.060547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5276.847656 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5308.634766 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5340.421875 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5379.630859 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5443.009766 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5481.873047 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5543.054688 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5606.433594 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5669.910156 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5733.289062 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5796.765625 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5860.144531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5899.353516 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5931.140625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6014.929688 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6046.716797 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6144.128906 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6205.652344 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6269.128906 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6296.912109 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6358.191406 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6421.570312 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6453.357422 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6505.457031 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6568.835938 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6630.115234 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6693.591797 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6745.691406 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6809.070312 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6870.251953 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6909.460938 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6943.152344 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6974.939453 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7016.052734 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7077.332031 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7116.541016 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7144.324219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7205.505859 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7237.292969 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7265.076172 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7317.175781 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7348.962891 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7412.439453 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7473.962891 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7513.171875 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7574.695312 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7614.058594 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7711.470703 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7739.253906 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7802.632812 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7830.416016 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7882.515625 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7921.724609 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7949.507812 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3133.398438 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3197.021484 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3260.644531 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3324.267578 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3387.890625 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3451.513672 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3515.136719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3550.341797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3582.128906 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3613.916016 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3645.703125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3677.490234 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3709.277344 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3737.060547 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3798.583984 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3859.863281 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3923.242188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3986.71875 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4025.582031 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4086.763672 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4145.943359 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4207.466797 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4248.580078 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4282.271484 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4310.054688 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4371.578125 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4432.857422 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4496.236328 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4559.859375 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4593.550781 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4652.730469 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4716.353516 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4748.140625 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4811.763672 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4875.386719 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4907.173828 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4970.796875 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5006.880859 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5045.744141 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5100.724609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5164.347656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5196.134766 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5227.921875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5259.708984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5291.496094 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5323.283203 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5362.492188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5425.871094 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5464.734375 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5525.916016 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5589.294922 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5652.771484 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5716.150391 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5779.626953 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5843.005859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5882.214844 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5914.001953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5997.791016 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6029.578125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6126.990234 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6188.513672 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6251.990234 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6279.773438 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6341.052734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6404.431641 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6436.21875 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6488.318359 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6551.697266 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6612.976562 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6676.453125 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6728.552734 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6791.931641 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6853.113281 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6892.322266 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6926.013672 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6957.800781 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6998.914062 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7060.193359 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7099.402344 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7127.185547 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7188.367188 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7220.154297 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7247.9375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7300.037109 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7331.824219 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7395.300781 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7456.824219 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7496.033203 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7557.556641 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7596.919922 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7694.332031 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7722.115234 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7785.494141 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7813.277344 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7865.376953 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7904.585938 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7932.369141 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pfbb0f83fde">
-   <rect x="84.852031" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="p46f6e8e4d7">
+   <rect x="84.251563" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/graphs/silesia_compress_heatmap.svg
+++ b/bench/graphs/silesia_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.34175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#pb70018102f)">
+   <g clip-path="url(#p90636e5c8b)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAqAAAAGaCAYAAADQNfGTAAAJ+UlEQVR4nO3YsY6c1R2HYe/u7LI2kmMMWdmIJmmiKEVEJBTlNrgOKlquITdAlzIXkCJNCgok0lBSBQlDJATEAssyy+7Mbi4CnfdvPj3PFfxGZ85873xHN//72+2dLbt6Mb1graPj6QVr3eynF6y19fPbX00vWOveg+kFa/30fHoBP8fJ2fSCtbb+/Tw9n16w1MaffgAAvGwEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAqd2n+yfTG5Y6O91NT1jqcn81PWGpx/ffnJ6w1BfPvpyesNT+6DA9Yanf3304PWGp/Svn0xOW+u/zr6YnLHVx92J6wlKXZ/vpCUsd3XkxPWEpb0ABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAIDU7uLexfSGpR6/+tvpCUt98+LJ9ISlHl1u+z/S/df/OD1hqbOT8+kJSx1u9tMTltr6+W3+8x1v+/Ptjt+anrDU+eXl9ISltv10BwDgpSNAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBI7V45uTe9Yamnl19PT1hq6+d3eO3h9ISlvvz+0+kJSz2/vpyesNQ7r70zPWGpq9v99ISlvnj2+fSEpf7w+p+mJyz1ydcfT09Y6u1fb/v8vAEFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASB0dPnr/dnrEUjc30wv4ObZ+fsf+A8KYrd8/v5+/bPv99IKlNn56AAC8bAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAACp3cUnn01vWOrk7GR6wlLffPbt9ISlPnzv7ekJS/3139s+v7+8dX96wlJ//9fn0xOW+uDd301PWOof//lhesJSv3lwd3rCUk9/vJ6esNSfH9+bnrCUN6AAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEDq6Prwz9vpESudXF9NT1jr5Gx6wVr7y+kFa+3OpxesdbKbXrDW7c30grWuN37/jjb+DuZ42/fv+mjb9+90v5+esNTGbx8AAC8bAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQGr37Y9fTW9Y6tHpo+kJS/1w+H56wlK/OuymJ6z17Mn0grUevDm9YKnvDk+nJyz1xuF8esJau7PpBUsddtv+/Tx9tu37d+fVh9MLlvIGFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACD1fxIse8n/hcxeAAAAAElFTkSuQmCC" id="imageeb7a33e592" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="483.84" height="295.2"/>
+iVBORw0KGgoAAAANSUhEUgAAAqAAAAGaCAYAAADQNfGTAAAJ+0lEQVR4nO3YMW5l5R2H4bF9x+Mx0mgYiMUgmtBEUYqISAixjayDKm3WkA2kS5kFpEiTggKJNJRUIDEkEiHJKAyj4ca+trMI9L1/5+h5VvC7+vz5vOcc3fz7D7f3tuzy1fSCtY6OpxesdXOYXrDW1s/vcDm9YK3zx9ML1vrvy+kF/Bgnp9ML1tr63+f9s+kFS2386QcAwF0jQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASO0+Ozyb3rDU6f3d9ISl9ofL6QlLPX309vSEpb568fX0hKUOR9fTE5b6+cMn0xOWOjw4m56w1N9f/m16wlIXDy+mJyy1Pz1MT1jq6N6r6QlL+QIKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkdhfnF9Mblnr62rvTE5b69tWz6QlLvbXf9jvSozd+OT1hqdOTs+kJS13fHKYnLLX189v87zve9u/bHb8zPWGps/1+esJS2366AwBw5whQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSuwcn59Mblnq+/2Z6wlJbP7/r159MT1jq6/98Nj1hqZdX++kJS73/+vvTE5a6vD1MT1jqqxdfTk9Y6hdv/Gp6wlKffvPJ9ISl3vvJts/PF1AAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACA1NH1x7+5nR6x1M3N9AJ+jK2f37F3QBiz9fvn/+f/t8NhesFSGz89AADuGgEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBqd/Hp59Mbljo5PZmesNS3n/9zesJSv//ovekJS/3ur9s+vw/feTQ9Yak//uXL6QlL/fbXP5uesNSfvvhuesJSP338cHrCUs9/uJqesNQHT8+nJyzlCygAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJA6urr+8+30iJVOri6nJ6x1cjq9YK3DfnrBWruz6QVrneymF6x1ezO9YK2rjd+/o41/gzne9v27Otr2/bt/OExPWGrjtw8AgLtGgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkNr944dn0xuWenv31vSEpV7cvJiesNSj642/Iz3YTS9Y62o/vWCpf10/n56w1JvXZ9MT1nrtyfSCpa5uLqcnLHX/+23fv3vnj6cXLLXxpzsAAHeNAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAIPU/NoF9xhk32p8AAAAASUVORK5CYII=" id="image3e8153f7e0" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="483.84" height="295.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m607ba809e9" d="M 0 0 
+       <path id="m9a94b1dfac" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m607ba809e9" x="115.814949" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9a94b1dfac" x="115.814949" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m607ba809e9" x="156.092348" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9a94b1dfac" x="156.092348" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m607ba809e9" x="196.369746" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9a94b1dfac" x="196.369746" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m607ba809e9" x="236.647145" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9a94b1dfac" x="236.647145" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m607ba809e9" x="276.924544" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9a94b1dfac" x="276.924544" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m607ba809e9" x="317.201942" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9a94b1dfac" x="317.201942" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m607ba809e9" x="357.479341" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9a94b1dfac" x="357.479341" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m607ba809e9" x="397.756739" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9a94b1dfac" x="397.756739" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m607ba809e9" x="438.034138" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9a94b1dfac" x="438.034138" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m607ba809e9" x="478.311536" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9a94b1dfac" x="478.311536" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m607ba809e9" x="518.588935" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9a94b1dfac" x="518.588935" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m607ba809e9" x="558.866334" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9a94b1dfac" x="558.866334" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="m5e599a2c66" d="M 0 0 
+       <path id="m78b4f57abb" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m5e599a2c66" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m78b4f57abb" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m5e599a2c66" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m78b4f57abb" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m5e599a2c66" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m78b4f57abb" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m5e599a2c66" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m78b4f57abb" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -836,7 +836,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m5e599a2c66" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m78b4f57abb" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -899,7 +899,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m5e599a2c66" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m78b4f57abb" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -966,7 +966,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m5e599a2c66" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m78b4f57abb" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1047,7 +1047,7 @@ z
     <g id="ytick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m5e599a2c66" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m78b4f57abb" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -1138,7 +1138,7 @@ L 579.005033 49.34175
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_21">
-    <!-- +39 -->
+    <!-- +41 -->
     <g transform="translate(108.955926 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-2b" d="M 2944 4013 
@@ -1156,6 +1156,83 @@ L 2419 4013
 L 2944 4013 
 z
 " transform="scale(0.015625)"/>
+      <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_22">
+    <!-- -12 -->
+    <g transform="translate(150.784184 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_23">
+    <!-- +23 -->
+    <g transform="translate(189.510723 69.553235) scale(0.065 -0.065)">
+     <defs>
       <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
 Q 3559 1806 3559 1356 
@@ -1188,6 +1265,16 @@ Q 3450 3153 3228 2886
 Q 3006 2619 2597 2516 
 z
 " transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_24">
+    <!-- -19 -->
+    <g transform="translate(231.338981 69.553235) scale(0.065 -0.065)">
+     <defs>
       <path id="DejaVuSans-39" d="M 703 97 
 L 703 672 
 Q 941 559 1184 500 
@@ -1219,91 +1306,21 @@ Q 1534 2075 1959 2075
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_22">
-    <!-- -12 -->
-    <g transform="translate(150.784184 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-31" d="M 794 531 
-L 1825 531 
-L 1825 4091 
-L 703 3866 
-L 703 4441 
-L 1819 4666 
-L 2450 4666 
-L 2450 531 
-L 3481 531 
-L 3481 0 
-L 794 0 
-L 794 531 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-32" d="M 1228 531 
-L 3431 531 
-L 3431 0 
-L 469 0 
-L 469 531 
-Q 828 903 1448 1529 
-Q 2069 2156 2228 2338 
-Q 2531 2678 2651 2914 
-Q 2772 3150 2772 3378 
-Q 2772 3750 2511 3984 
-Q 2250 4219 1831 4219 
-Q 1534 4219 1204 4116 
-Q 875 4013 500 3803 
-L 500 4441 
-Q 881 4594 1212 4672 
-Q 1544 4750 1819 4750 
-Q 2544 4750 2975 4387 
-Q 3406 4025 3406 3419 
-Q 3406 3131 3298 2873 
-Q 3191 2616 2906 2266 
-Q 2828 2175 2409 1742 
-Q 1991 1309 1228 531 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
     </g>
    </g>
-   <g id="text_23">
-    <!-- +24 -->
-    <g transform="translate(189.510723 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-34" d="M 2419 4116 
-L 825 1625 
-L 2419 1625 
-L 2419 4116 
-z
-M 2253 4666 
-L 3047 4666 
-L 3047 1625 
-L 3713 1625 
-L 3713 1100 
-L 3047 1100 
-L 3047 0 
-L 2419 0 
-L 2419 1100 
-L 313 1100 
-L 313 1709 
-L 2253 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
+   <g id="text_25">
+    <!-- +1 -->
+    <g transform="translate(272.133333 69.553235) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
     </g>
    </g>
-   <g id="text_24">
-    <!-- -20 -->
-    <g transform="translate(231.338981 69.553235) scale(0.065 -0.065)">
+   <g id="text_26">
+    <!-- -10 -->
+    <g transform="translate(311.893778 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -1328,45 +1345,86 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
     </g>
    </g>
-   <g id="text_25">
-    <!-- -42 -->
-    <g transform="translate(271.616379 69.553235) scale(0.065 -0.065)">
+   <g id="text_27">
+    <!-- +33 -->
+    <g transform="translate(350.620317 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_28">
+    <!-- -22 -->
+    <g transform="translate(392.448575 69.553235) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
     </g>
    </g>
-   <g id="text_26">
+   <g id="text_29">
+    <!-- -1 -->
+    <g transform="translate(434.793786 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_30">
+    <!-- +7 -->
+    <g transform="translate(473.520325 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_31">
+    <!-- -29 -->
+    <g transform="translate(513.280771 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_32">
     <!-- -11 -->
-    <g transform="translate(311.893778 69.553235) scale(0.065 -0.065)">
+    <g transform="translate(553.558169 69.553235) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
     </g>
    </g>
-   <g id="text_27">
-    <!-- +31 -->
-    <g transform="translate(350.620317 69.553235) scale(0.065 -0.065)">
+   <g id="text_33">
+    <!-- +7 -->
+    <g transform="translate(111.023738 106.389018) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
     </g>
    </g>
-   <g id="text_28">
-    <!-- -23 -->
-    <g transform="translate(392.448575 69.553235) scale(0.065 -0.065)">
+   <g id="text_34">
+    <!-- -13 -->
+    <g transform="translate(150.784184 106.389018) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
     </g>
    </g>
-   <g id="text_29">
-    <!-- -15 -->
-    <g transform="translate(432.725974 69.553235) scale(0.065 -0.065)">
+   <g id="text_35">
+    <!-- -5 -->
+    <g transform="translate(193.129395 106.389018) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-35" d="M 691 4666 
 L 3169 4666 
@@ -1395,13 +1453,12 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
     </g>
    </g>
-   <g id="text_30">
-    <!-- +6 -->
-    <g transform="translate(473.520325 69.553235) scale(0.065 -0.065)">
+   <g id="text_36">
+    <!-- -16 -->
+    <g transform="translate(231.338981 106.389018) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -1434,103 +1491,6 @@ Q 3103 4656 3366 4563
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_31">
-    <!-- -28 -->
-    <g transform="translate(513.280771 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-38" d="M 2034 2216 
-Q 1584 2216 1326 1975 
-Q 1069 1734 1069 1313 
-Q 1069 891 1326 650 
-Q 1584 409 2034 409 
-Q 2484 409 2743 651 
-Q 3003 894 3003 1313 
-Q 3003 1734 2745 1975 
-Q 2488 2216 2034 2216 
-z
-M 1403 2484 
-Q 997 2584 770 2862 
-Q 544 3141 544 3541 
-Q 544 4100 942 4425 
-Q 1341 4750 2034 4750 
-Q 2731 4750 3128 4425 
-Q 3525 4100 3525 3541 
-Q 3525 3141 3298 2862 
-Q 3072 2584 2669 2484 
-Q 3125 2378 3379 2068 
-Q 3634 1759 3634 1313 
-Q 3634 634 3220 271 
-Q 2806 -91 2034 -91 
-Q 1263 -91 848 271 
-Q 434 634 434 1313 
-Q 434 1759 690 2068 
-Q 947 2378 1403 2484 
-z
-M 1172 3481 
-Q 1172 3119 1398 2916 
-Q 1625 2713 2034 2713 
-Q 2441 2713 2670 2916 
-Q 2900 3119 2900 3481 
-Q 2900 3844 2670 4047 
-Q 2441 4250 2034 4250 
-Q 1625 4250 1398 4047 
-Q 1172 3844 1172 3481 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_32">
-    <!-- -9 -->
-    <g transform="translate(555.625982 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_33">
-    <!-- +7 -->
-    <g transform="translate(111.023738 106.389018) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_34">
-    <!-- -13 -->
-    <g transform="translate(150.784184 106.389018) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_35">
-    <!-- -5 -->
-    <g transform="translate(193.129395 106.389018) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_36">
-    <!-- -16 -->
-    <g transform="translate(231.338981 106.389018) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
@@ -1643,6 +1603,47 @@ z
    <g id="text_50">
     <!-- +184 -->
     <g transform="translate(308.275106 143.2248) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-38" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
@@ -2192,18 +2193,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB1ElEQVR4nO2b0a3DMAwD7cSzvM3fmI47gvpxCK6ENABhnkQ5aZH5P/7OAGpdFyEzBiQDnija2qSEghnZhIIZCa3NyWQkmZFOKJhRsDXsOopmJJwjaEPOmxHirE3MWjOqhSBr2EAGMyKtMVpc+ynYwe3viNQVbA0LrZDRFbxGbNbWyM3auG0RGbo1Qp0IZCSMiG2OgtNvbL+Oke6BvddIWaQ1qP3RjGSTLXypwdaIMP2ctWb0olAzKkr4LhLMCPvnOJiRbo6CrTWjF4WCGYHWJtU1TKgZvSZkfNAKZhRsDftFa96MkJCRrf29ausyWrOtWiMjmxDH6FAfDJzzIEKctQc60ToDEqJOBLbfZs04RxQjobWOSFXrjM0IdURqIaG1jkhVPmvGOUqOCPLJMdh+6kRk+zFGMtjKOdK13zbZ2EBGMxLOkSz90YygK9tozSbUa6Qu4RxtRifZ2np0jDY32YiOc44gIQo2aI1ZkB2Rb4SiIyJbtcr0Q0IPdCQyIpCQDnZHpC5uQ27uOtJFBBptH2zlHOnab+uaMSK29htXrW2NKK0hOtlrxLaPjIxys4a99x9dRKgTgUK69gsZ9RxVFWzNyIi6RZIZtbXfE+qI1BU8R5i1D2e5X2tFkZmlAAAAAElFTkSuQmCC" id="image5eda6039ca" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-69.84" width="12.96" height="253.44"/>
+iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB1ElEQVR4nO2b0a3DMAwD7cSzvM3fmI47gvpxCK6ENABhnkQ5aZH5P/7OAGpdFyEzBiQDnija2qSEghnZhIIZCa3NyWQkmZFOKJhRsDXsOopmJJwjaEPOmxHirE3MWjOqhSBr2EAGMyKtMVpc+ynYwe3viNQVbA0LrZDRFbxGbNbWyM3auG0RGbo1Qp0IZCSMiG2OgtNvbL+Oke6BvddIWaQ1qP3RjGSTLXypwdaIMP2ctWb0olAzKkr4LhLMCPvnOJiRbo6CrTWjF4WCGYHWJtU1TKgZvSZkfNAKZhRsDftFa96MkJCRrf29ausyWrOtWiMjmxDH6FAfDJzzIEKctQc60ToDEqJOBLbfZs04RxQjobWOSFXrjM0IdURqIaG1jkhVPmvGOUqOCPLJMdh+6kRk+zFGMtjKOdK13zbZ2EBGMxLOkSz90YygK9tozSbUa6Qu4RxtRifZ2np0jDY32YiOc44gIQo2aI1ZkB2Rb4SiIyJbtcr0Q0IPdCQyIpCQDnZHpC5uQ27uOtJFBBptH2zlHOnab+uaMSK29htXrW2NKK0hOtlrxLaPjIxys4a99x9dRKgTgUK69gsZ9RxVFWzNyIi6RZIZtbXfE+qI1BU8R5i1D2e5X2tFkZmlAAAAAElFTkSuQmCC" id="imagece5655bc19" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-69.84" width="12.96" height="253.44"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_21">
       <defs>
-       <path id="m3f9080bbcf" d="M 0 0 
+       <path id="m0acdf9616b" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m3f9080bbcf" x="601.779688" y="322.507463" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0acdf9616b" x="601.779688" y="322.507463" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_117">
@@ -2226,7 +2227,7 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m3f9080bbcf" x="601.779688" y="280.566603" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0acdf9616b" x="601.779688" y="280.566603" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_118">
@@ -2240,7 +2241,7 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m3f9080bbcf" x="601.779688" y="238.625742" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0acdf9616b" x="601.779688" y="238.625742" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_119">
@@ -2254,7 +2255,7 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m3f9080bbcf" x="601.779688" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0acdf9616b" x="601.779688" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_120">
@@ -2267,7 +2268,7 @@ z
     <g id="ytick_13">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m3f9080bbcf" x="601.779688" y="154.74402" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0acdf9616b" x="601.779688" y="154.74402" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_121">
@@ -2280,7 +2281,7 @@ z
     <g id="ytick_14">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m3f9080bbcf" x="601.779688" y="112.803159" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0acdf9616b" x="601.779688" y="112.803159" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_122">
@@ -2293,7 +2294,7 @@ z
     <g id="ytick_15">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#m3f9080bbcf" x="601.779688" y="70.862298" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0acdf9616b" x="601.779688" y="70.862298" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_123">
@@ -2909,8 +2910,8 @@ z
    </g>
   </g>
   <g id="text_126">
-   <!-- 2026-07-10T09:54:02Z  ·  Linux chungus2 x86_64  ·  commit da9d9c0e  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(43.847969 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-11T04:15:02Z  ·  Linux chungus2 x86_64  ·  commit e802670f  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(44.448437 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2999,13 +3000,13 @@ z
     <use xlink:href="#DejaVuSans-37" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-31" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(1027.734375 0)"/>
@@ -3048,109 +3049,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3135.351562 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3196.630859 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3260.253906 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3323.730469 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3387.353516 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3442.333984 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3505.957031 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3567.480469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3599.267578 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3631.054688 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3662.841797 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3694.628906 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3726.416016 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3754.199219 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3815.722656 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3877.001953 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3940.380859 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4003.857422 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4042.720703 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4103.902344 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4163.082031 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4224.605469 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4265.71875 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4299.410156 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4327.193359 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4388.716797 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4449.996094 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4513.375 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4576.998047 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4610.689453 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4669.869141 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4733.492188 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4765.279297 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4828.902344 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4892.525391 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4924.3125 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4987.935547 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5024.019531 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5062.882812 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5117.863281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5181.486328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5213.273438 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5245.060547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5276.847656 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5308.634766 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5340.421875 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5379.630859 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5443.009766 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5481.873047 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5543.054688 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5606.433594 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5669.910156 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5733.289062 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5796.765625 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5860.144531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5899.353516 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5931.140625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6014.929688 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6046.716797 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6144.128906 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6205.652344 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6269.128906 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6296.912109 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6358.191406 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6421.570312 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6453.357422 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6505.457031 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6568.835938 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6630.115234 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6693.591797 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6745.691406 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6809.070312 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6870.251953 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6909.460938 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6943.152344 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6974.939453 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7016.052734 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7077.332031 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7116.541016 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7144.324219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7205.505859 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7237.292969 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7265.076172 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7317.175781 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7348.962891 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7412.439453 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7473.962891 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7513.171875 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7574.695312 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7614.058594 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7711.470703 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7739.253906 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7802.632812 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7830.416016 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7882.515625 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7921.724609 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7949.507812 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3133.398438 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3197.021484 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3260.644531 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3324.267578 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3387.890625 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3451.513672 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3515.136719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3550.341797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3582.128906 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3613.916016 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3645.703125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3677.490234 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3709.277344 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3737.060547 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3798.583984 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3859.863281 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3923.242188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3986.71875 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4025.582031 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4086.763672 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4145.943359 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4207.466797 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4248.580078 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4282.271484 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4310.054688 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4371.578125 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4432.857422 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4496.236328 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4559.859375 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4593.550781 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4652.730469 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4716.353516 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4748.140625 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4811.763672 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4875.386719 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4907.173828 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4970.796875 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5006.880859 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5045.744141 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5100.724609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5164.347656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5196.134766 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5227.921875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5259.708984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5291.496094 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5323.283203 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5362.492188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5425.871094 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5464.734375 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5525.916016 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5589.294922 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5652.771484 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5716.150391 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5779.626953 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5843.005859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5882.214844 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5914.001953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5997.791016 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6029.578125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6126.990234 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6188.513672 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6251.990234 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6279.773438 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6341.052734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6404.431641 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6436.21875 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6488.318359 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6551.697266 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6612.976562 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6676.453125 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6728.552734 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6791.931641 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6853.113281 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6892.322266 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6926.013672 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6957.800781 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6998.914062 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7060.193359 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7099.402344 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7127.185547 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7188.367188 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7220.154297 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7247.9375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7300.037109 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7331.824219 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7395.300781 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7456.824219 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7496.033203 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7557.556641 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7596.919922 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7694.332031 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7722.115234 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7785.494141 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7813.277344 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7865.376953 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7904.585938 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7932.369141 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pb70018102f">
+  <clipPath id="p90636e5c8b">
    <rect x="95.67625" y="49.34175" width="483.328783" height="294.686261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_compress_pareto.svg
+++ b/bench/graphs/silesia_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 61.085542 412.80375 
 L 61.085542 48.323125 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m9073905417" d="M 0 0 
+       <path id="m1da7862f0d" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m9073905417" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1da7862f0d" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -130,11 +130,11 @@ z
      <g id="line2d_3">
       <path d="M 145.270284 412.80375 
 L 145.270284 48.323125 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m9073905417" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1da7862f0d" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -177,11 +177,11 @@ z
      <g id="line2d_5">
       <path d="M 229.455026 412.80375 
 L 229.455026 48.323125 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m9073905417" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1da7862f0d" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -219,11 +219,11 @@ z
      <g id="line2d_7">
       <path d="M 313.639768 412.80375 
 L 313.639768 48.323125 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m9073905417" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1da7862f0d" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -272,11 +272,11 @@ z
      <g id="line2d_9">
       <path d="M 397.82451 412.80375 
 L 397.82451 48.323125 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m9073905417" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1da7862f0d" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -334,11 +334,11 @@ z
      <g id="line2d_11">
       <path d="M 482.009253 412.80375 
 L 482.009253 48.323125 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m9073905417" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1da7862f0d" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -355,11 +355,11 @@ L 482.009253 48.323125
      <g id="line2d_13">
       <path d="M 566.193995 412.80375 
 L 566.193995 48.323125 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m9073905417" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1da7862f0d" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -856,16 +856,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 368.08164 
 L 637.2 368.08164 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="mf883ae410e" d="M 0 0 
+       <path id="m8f9023b7f2" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mf883ae410e" x="49.078125" y="368.08164" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8f9023b7f2" x="49.078125" y="368.08164" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -897,11 +897,11 @@ z
      <g id="line2d_17">
       <path d="M 49.078125 243.439835 
 L 637.2 243.439835 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mf883ae410e" x="49.078125" y="243.439835" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8f9023b7f2" x="49.078125" y="243.439835" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -917,11 +917,11 @@ L 637.2 243.439835
      <g id="line2d_19">
       <path d="M 49.078125 118.798029 
 L 637.2 118.798029 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#mf883ae410e" x="49.078125" y="118.798029" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8f9023b7f2" x="49.078125" y="118.798029" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -937,16 +937,16 @@ L 637.2 118.798029
      <g id="line2d_21">
       <path d="M 49.078125 405.602562 
 L 637.2 405.602562 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="m6cd6e60415" d="M 0 0 
+       <path id="m2e6508a436" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m6cd6e60415" x="49.078125" y="405.602562" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2e6508a436" x="49.078125" y="405.602562" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -954,11 +954,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 395.733268 
 L 637.2 395.733268 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m6cd6e60415" x="49.078125" y="395.733268" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2e6508a436" x="49.078125" y="395.733268" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -966,11 +966,11 @@ L 637.2 395.733268
      <g id="line2d_25">
       <path d="M 49.078125 387.3889 
 L 637.2 387.3889 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m6cd6e60415" x="49.078125" y="387.3889" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2e6508a436" x="49.078125" y="387.3889" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -978,11 +978,11 @@ L 637.2 387.3889
      <g id="line2d_27">
       <path d="M 49.078125 380.160679 
 L 637.2 380.160679 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m6cd6e60415" x="49.078125" y="380.160679" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2e6508a436" x="49.078125" y="380.160679" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -990,11 +990,11 @@ L 637.2 380.160679
      <g id="line2d_29">
       <path d="M 49.078125 373.784936 
 L 637.2 373.784936 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m6cd6e60415" x="49.078125" y="373.784936" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2e6508a436" x="49.078125" y="373.784936" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1002,11 +1002,11 @@ L 637.2 373.784936
      <g id="line2d_31">
       <path d="M 49.078125 330.560718 
 L 637.2 330.560718 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m6cd6e60415" x="49.078125" y="330.560718" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2e6508a436" x="49.078125" y="330.560718" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1014,11 +1014,11 @@ L 637.2 330.560718
      <g id="line2d_33">
       <path d="M 49.078125 308.612385 
 L 637.2 308.612385 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m6cd6e60415" x="49.078125" y="308.612385" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2e6508a436" x="49.078125" y="308.612385" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1026,11 +1026,11 @@ L 637.2 308.612385
      <g id="line2d_35">
       <path d="M 49.078125 293.039796 
 L 637.2 293.039796 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m6cd6e60415" x="49.078125" y="293.039796" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2e6508a436" x="49.078125" y="293.039796" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1038,11 +1038,11 @@ L 637.2 293.039796
      <g id="line2d_37">
       <path d="M 49.078125 280.960757 
 L 637.2 280.960757 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m6cd6e60415" x="49.078125" y="280.960757" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2e6508a436" x="49.078125" y="280.960757" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1050,11 +1050,11 @@ L 637.2 280.960757
      <g id="line2d_39">
       <path d="M 49.078125 271.091463 
 L 637.2 271.091463 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m6cd6e60415" x="49.078125" y="271.091463" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2e6508a436" x="49.078125" y="271.091463" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1062,11 +1062,11 @@ L 637.2 271.091463
      <g id="line2d_41">
       <path d="M 49.078125 262.747094 
 L 637.2 262.747094 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m6cd6e60415" x="49.078125" y="262.747094" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2e6508a436" x="49.078125" y="262.747094" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1074,11 +1074,11 @@ L 637.2 262.747094
      <g id="line2d_43">
       <path d="M 49.078125 255.518874 
 L 637.2 255.518874 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m6cd6e60415" x="49.078125" y="255.518874" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2e6508a436" x="49.078125" y="255.518874" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1086,11 +1086,11 @@ L 637.2 255.518874
      <g id="line2d_45">
       <path d="M 49.078125 249.143131 
 L 637.2 249.143131 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m6cd6e60415" x="49.078125" y="249.143131" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2e6508a436" x="49.078125" y="249.143131" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1098,11 +1098,11 @@ L 637.2 249.143131
      <g id="line2d_47">
       <path d="M 49.078125 205.918912 
 L 637.2 205.918912 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m6cd6e60415" x="49.078125" y="205.918912" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2e6508a436" x="49.078125" y="205.918912" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1110,11 +1110,11 @@ L 637.2 205.918912
      <g id="line2d_49">
       <path d="M 49.078125 183.97058 
 L 637.2 183.97058 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m6cd6e60415" x="49.078125" y="183.97058" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2e6508a436" x="49.078125" y="183.97058" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1122,11 +1122,11 @@ L 637.2 183.97058
      <g id="line2d_51">
       <path d="M 49.078125 168.39799 
 L 637.2 168.39799 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m6cd6e60415" x="49.078125" y="168.39799" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2e6508a436" x="49.078125" y="168.39799" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1134,11 +1134,11 @@ L 637.2 168.39799
      <g id="line2d_53">
       <path d="M 49.078125 156.318951 
 L 637.2 156.318951 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#m6cd6e60415" x="49.078125" y="156.318951" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2e6508a436" x="49.078125" y="156.318951" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1146,11 +1146,11 @@ L 637.2 156.318951
      <g id="line2d_55">
       <path d="M 49.078125 146.449658 
 L 637.2 146.449658 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#m6cd6e60415" x="49.078125" y="146.449658" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2e6508a436" x="49.078125" y="146.449658" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1158,11 +1158,11 @@ L 637.2 146.449658
      <g id="line2d_57">
       <path d="M 49.078125 138.105289 
 L 637.2 138.105289 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#m6cd6e60415" x="49.078125" y="138.105289" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2e6508a436" x="49.078125" y="138.105289" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1170,11 +1170,11 @@ L 637.2 138.105289
      <g id="line2d_59">
       <path d="M 49.078125 130.877068 
 L 637.2 130.877068 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#m6cd6e60415" x="49.078125" y="130.877068" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2e6508a436" x="49.078125" y="130.877068" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1182,11 +1182,11 @@ L 637.2 130.877068
      <g id="line2d_61">
       <path d="M 49.078125 124.501326 
 L 637.2 124.501326 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#m6cd6e60415" x="49.078125" y="124.501326" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2e6508a436" x="49.078125" y="124.501326" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1194,11 +1194,11 @@ L 637.2 124.501326
      <g id="line2d_63">
       <path d="M 49.078125 81.277107 
 L 637.2 81.277107 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#m6cd6e60415" x="49.078125" y="81.277107" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2e6508a436" x="49.078125" y="81.277107" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1206,11 +1206,11 @@ L 637.2 81.277107
      <g id="line2d_65">
       <path d="M 49.078125 59.328775 
 L 637.2 59.328775 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#m6cd6e60415" x="49.078125" y="59.328775" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2e6508a436" x="49.078125" y="59.328775" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1332,7 +1332,7 @@ L 637.2 48.323125
    </g>
    <g id="text_13">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(324.643112 114.941946) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(324.643112 108.896302) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1364,7 +1364,7 @@ z
    </g>
    <g id="text_14">
     <!-- L10 -->
-    <g style="fill: #d62728" transform="translate(102.814287 309.795762) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(102.814287 308.489091) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1686,23 +1686,23 @@ z
    </g>
    <g id="line2d_67">
     <defs>
-     <path id="mc69a122b4f" d="M -2.5 2.5 
+     <path id="m4001f964d7" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pb8e3bdbb30)">
-     <use xlink:href="#mc69a122b4f" x="377.110281" y="104.685421" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc69a122b4f" x="323.801439" y="110.409833" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc69a122b4f" x="272.665744" y="126.308323" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc69a122b4f" x="235.168828" y="128.026741" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc69a122b4f" x="186.228265" y="149.377587" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc69a122b4f" x="158.303164" y="171.457731" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc69a122b4f" x="149.489547" y="182.192614" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc69a122b4f" x="140.563162" y="202.482797" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc69a122b4f" x="138.984853" y="209.328911" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pbb573932c3)">
+     <use xlink:href="#m4001f964d7" x="377.110281" y="104.685421" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4001f964d7" x="323.801439" y="110.409833" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4001f964d7" x="272.665744" y="126.308323" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4001f964d7" x="235.168828" y="128.026741" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4001f964d7" x="186.228265" y="149.377587" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4001f964d7" x="158.303164" y="171.457731" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4001f964d7" x="149.489547" y="182.192614" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4001f964d7" x="140.563162" y="202.482797" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4001f964d7" x="138.984853" y="209.328911" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_68">
@@ -1755,7 +1755,7 @@ L 327.133241 110.069256
 L 326.02264 110.18302 
 L 324.91204 110.296545 
 L 323.801439 110.409833 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_69">
     <path d="M 323.801439 110.409833 
@@ -1807,7 +1807,7 @@ L 275.861725 125.44037
 L 274.796398 125.731236 
 L 273.731071 126.020548 
 L 272.665744 126.308323 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_70">
     <path d="M 272.665744 126.308323 
@@ -1859,7 +1859,7 @@ L 237.512385 127.920923
 L 236.7312 127.956219 
 L 235.950014 127.991491 
 L 235.168828 128.026741 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_71">
     <path d="M 235.168828 128.026741 
@@ -1911,7 +1911,7 @@ L 189.28705 148.263499
 L 188.267455 148.637415 
 L 187.24786 149.008766 
 L 186.228265 149.377587 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_72">
     <path d="M 186.228265 149.377587 
@@ -1963,7 +1963,7 @@ L 160.048483 170.312481
 L 159.46671 170.696929 
 L 158.884937 171.078667 
 L 158.303164 171.457731 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_73">
     <path d="M 158.303164 171.457731 
@@ -2015,7 +2015,7 @@ L 150.040398 181.580576
 L 149.856781 181.785359 
 L 149.673164 181.989369 
 L 149.489547 182.192614 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_74">
     <path d="M 149.489547 182.192614 
@@ -2067,7 +2067,7 @@ L 141.121061 201.414753
 L 140.935095 201.773114 
 L 140.749129 202.129119 
 L 140.563162 202.482797 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_75">
     <path d="M 140.563162 202.482797 
@@ -2119,26 +2119,26 @@ L 139.083497 208.925481
 L 139.050616 209.060292 
 L 139.017734 209.194768 
 L 138.984853 209.328911 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_76">
     <defs>
-     <path id="me8650c2b45" d="M 0 -2.5 
+     <path id="ma29183881d" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pb8e3bdbb30)">
-     <use xlink:href="#me8650c2b45" x="610.467187" y="71.939349" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me8650c2b45" x="319.880958" y="101.884157" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me8650c2b45" x="210.281253" y="129.778154" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me8650c2b45" x="196.287076" y="133.586625" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me8650c2b45" x="176.054419" y="147.38645" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me8650c2b45" x="152.161413" y="174.753272" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me8650c2b45" x="146.720208" y="186.587648" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me8650c2b45" x="143.994022" y="196.356323" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me8650c2b45" x="142.666037" y="200.180971" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pbb573932c3)">
+     <use xlink:href="#ma29183881d" x="610.467187" y="71.939349" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma29183881d" x="319.880958" y="101.884157" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma29183881d" x="210.281253" y="129.778154" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma29183881d" x="196.287076" y="133.586625" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma29183881d" x="176.054419" y="147.38645" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma29183881d" x="152.161413" y="174.753272" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma29183881d" x="146.720208" y="186.587648" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma29183881d" x="143.994022" y="196.356323" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma29183881d" x="142.666037" y="200.180971" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_77">
@@ -2191,7 +2191,7 @@ L 338.042598 100.427247
 L 331.988718 100.917253 
 L 325.934838 101.402864 
 L 319.880958 101.884157 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_78">
     <path d="M 319.880958 101.884157 
@@ -2243,7 +2243,7 @@ L 217.131235 128.398367
 L 214.847908 128.862215 
 L 212.564581 129.322122 
 L 210.281253 129.778154 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_79">
     <path d="M 210.281253 129.778154 
@@ -2295,7 +2295,7 @@ L 197.161712 133.356286
 L 196.870166 133.433175 
 L 196.578621 133.509954 
 L 196.287076 133.586625 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_80">
     <path d="M 196.287076 133.586625 
@@ -2347,7 +2347,7 @@ L 177.31896 146.619719
 L 176.897447 146.876504 
 L 176.475933 147.132078 
 L 176.054419 147.38645 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_81">
     <path d="M 176.054419 147.38645 
@@ -2399,7 +2399,7 @@ L 153.654726 173.393769
 L 153.156955 173.850741 
 L 152.659184 174.303887 
 L 152.161413 174.753272 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_82">
     <path d="M 152.161413 174.753272 
@@ -2451,7 +2451,7 @@ L 147.060283 185.919158
 L 146.946925 186.142906 
 L 146.833566 186.365734 
 L 146.720208 186.587648 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_83">
     <path d="M 146.720208 186.587648 
@@ -2503,7 +2503,7 @@ L 144.164409 195.794799
 L 144.107613 195.982622 
 L 144.050817 196.169795 
 L 143.994022 196.356323 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_84">
     <path d="M 143.994022 196.356323 
@@ -2555,30 +2555,30 @@ L 142.749036 199.949687
 L 142.72137 200.026891 
 L 142.693704 200.103986 
 L 142.666037 200.180971 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_85">
     <defs>
-     <path id="mf9687a0102" d="M -0 3.535534 
+     <path id="m90a1f84f26" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pb8e3bdbb30)">
-     <use xlink:href="#mf9687a0102" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf9687a0102" x="242.839153" y="80.778898" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf9687a0102" x="218.251194" y="86.377096" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf9687a0102" x="197.814984" y="90.309617" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf9687a0102" x="166.378359" y="99.066934" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf9687a0102" x="145.830392" y="110.431955" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf9687a0102" x="134.598477" y="126.026287" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf9687a0102" x="124.077268" y="149.033155" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf9687a0102" x="122.462976" y="157.476606" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf9687a0102" x="81.012077" y="220.06889" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf9687a0102" x="77.44276" y="239.652656" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf9687a0102" x="76.953425" y="252.706566" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pbb573932c3)">
+     <use xlink:href="#m90a1f84f26" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m90a1f84f26" x="242.839153" y="80.778898" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m90a1f84f26" x="218.251194" y="86.377096" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m90a1f84f26" x="197.814984" y="90.309617" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m90a1f84f26" x="166.378359" y="99.066934" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m90a1f84f26" x="145.830392" y="110.431955" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m90a1f84f26" x="134.598477" y="126.026287" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m90a1f84f26" x="124.077268" y="149.033155" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m90a1f84f26" x="122.462976" y="157.476606" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m90a1f84f26" x="81.012077" y="220.06889" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m90a1f84f26" x="77.44276" y="239.652656" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m90a1f84f26" x="76.953425" y="252.706566" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_86">
@@ -2631,7 +2631,7 @@ L 245.91379 79.91142
 L 244.888911 80.202126 
 L 243.864032 80.49128 
 L 242.839153 80.778898 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_87">
     <path d="M 242.839153 80.778898 
@@ -2683,7 +2683,7 @@ L 219.787941 86.043669
 L 219.275692 86.155039 
 L 218.763443 86.266182 
 L 218.251194 86.377096 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_88">
     <path d="M 218.251194 86.377096 
@@ -2735,7 +2735,7 @@ L 199.092247 90.072029
 L 198.666492 90.151341 
 L 198.240738 90.230537 
 L 197.814984 90.309617 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_89">
     <path d="M 197.814984 90.309617 
@@ -2787,7 +2787,7 @@ L 168.343148 98.559208
 L 167.688219 98.72898 
 L 167.033289 98.898221 
 L 166.378359 99.066934 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_90">
     <path d="M 166.378359 99.066934 
@@ -2839,7 +2839,7 @@ L 147.11464 109.78743
 L 146.686557 110.003126 
 L 146.258475 110.217965 
 L 145.830392 110.431955 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_91">
     <path d="M 145.830392 110.431955 
@@ -2891,7 +2891,7 @@ L 135.300472 125.172774
 L 135.066474 125.458776 
 L 134.832476 125.743276 
 L 134.598477 126.026287 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_92">
     <path d="M 134.598477 126.026287 
@@ -2943,7 +2943,7 @@ L 124.734843 147.848882
 L 124.515652 148.246526 
 L 124.29646 148.641269 
 L 124.077268 149.033155 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_93">
     <path d="M 124.077268 149.033155 
@@ -2995,7 +2995,7 @@ L 122.56387 156.985769
 L 122.530239 157.149876 
 L 122.496607 157.313488 
 L 122.462976 157.476606 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_94">
     <path d="M 122.462976 157.476606 
@@ -3047,7 +3047,7 @@ L 83.602758 217.699074
 L 82.739198 218.500595 
 L 81.875637 219.290422 
 L 81.012077 220.06889 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_95">
     <path d="M 81.012077 220.06889 
@@ -3099,7 +3099,7 @@ L 77.665842 238.615761
 L 77.591481 238.963605 
 L 77.517121 239.309227 
 L 77.44276 239.652656 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_96">
     <path d="M 77.44276 239.652656 
@@ -3151,23 +3151,23 @@ L 76.984008 251.97672
 L 76.973814 252.221097 
 L 76.96362 252.464376 
 L 76.953425 252.706566 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_97">
     <defs>
-     <path id="md9980c5813" d="M -0 2.5 
+     <path id="m17f6f47b15" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pb8e3bdbb30)">
-     <use xlink:href="#md9980c5813" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pbb573932c3)">
+     <use xlink:href="#m17f6f47b15" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_98">
     <defs>
-     <path id="m1400f1d6c7" d="M -0.833333 2.5 
+     <path id="mf4a12ef7a6" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -3182,16 +3182,16 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pb8e3bdbb30)">
-     <use xlink:href="#m1400f1d6c7" x="432.495268" y="96.067622" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1400f1d6c7" x="300.62247" y="112.493412" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1400f1d6c7" x="266.967623" y="120.8136" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1400f1d6c7" x="226.040946" y="122.099593" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1400f1d6c7" x="180.985721" y="141.85872" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1400f1d6c7" x="164.441833" y="156.106179" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1400f1d6c7" x="157.761315" y="165.23787" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1400f1d6c7" x="151.269082" y="178.700983" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1400f1d6c7" x="150.327087" y="185.23695" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pbb573932c3)">
+     <use xlink:href="#mf4a12ef7a6" x="432.495268" y="96.067622" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf4a12ef7a6" x="300.62247" y="112.493412" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf4a12ef7a6" x="266.967623" y="120.8136" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf4a12ef7a6" x="226.040946" y="122.099593" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf4a12ef7a6" x="180.985721" y="141.85872" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf4a12ef7a6" x="164.441833" y="156.106179" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf4a12ef7a6" x="157.761315" y="165.23787" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf4a12ef7a6" x="151.269082" y="178.700983" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf4a12ef7a6" x="150.327087" y="185.23695" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_99">
@@ -3244,7 +3244,7 @@ L 308.86452 111.600609
 L 306.11717 111.899849 
 L 303.36982 112.197444 
 L 300.62247 112.493412 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_100">
     <path d="M 300.62247 112.493412 
@@ -3296,7 +3296,7 @@ L 269.071051 120.329422
 L 268.369908 120.491297 
 L 267.668766 120.652688 
 L 266.967623 120.8136 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_101">
     <path d="M 266.967623 120.8136 
@@ -3348,7 +3348,7 @@ L 228.598863 122.020108
 L 227.746224 122.046616 
 L 226.893585 122.073111 
 L 226.040946 122.099593 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_102">
     <path d="M 226.040946 122.099593 
@@ -3400,7 +3400,7 @@ L 183.801673 140.814056
 L 182.863022 141.164522 
 L 181.924372 141.512734 
 L 180.985721 141.85872 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_103">
     <path d="M 180.985721 141.85872 
@@ -3452,7 +3452,7 @@ L 165.475826 155.317544
 L 165.131161 155.581701 
 L 164.786497 155.844575 
 L 164.441833 156.106179 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_104">
     <path d="M 164.441833 156.106179 
@@ -3504,7 +3504,7 @@ L 158.178848 164.710119
 L 158.03967 164.886608 
 L 157.900493 165.062524 
 L 157.761315 165.23787 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_105">
     <path d="M 157.761315 165.23787 
@@ -3556,7 +3556,7 @@ L 151.674847 177.950842
 L 151.539592 178.202046 
 L 151.404337 178.452089 
 L 151.269082 178.700983 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_106">
     <path d="M 151.269082 178.700983 
@@ -3608,11 +3608,11 @@ L 150.385962 184.850776
 L 150.366337 184.979807 
 L 150.346712 185.108531 
 L 150.327087 185.23695 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_107">
     <defs>
-     <path id="m6a686c47c8" d="M -1.25 2.5 
+     <path id="m208c0842f6" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -3627,16 +3627,16 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pb8e3bdbb30)">
-     <use xlink:href="#m6a686c47c8" x="345.030867" y="136.859359" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a686c47c8" x="273.364924" y="143.571257" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a686c47c8" x="240.719951" y="149.310846" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a686c47c8" x="221.353978" y="154.160538" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a686c47c8" x="207.129625" y="156.092215" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a686c47c8" x="181.064802" y="166.758473" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a686c47c8" x="179.282169" y="170.289343" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a686c47c8" x="177.719335" y="175.489948" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a686c47c8" x="177.643939" y="181.552088" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pbb573932c3)">
+     <use xlink:href="#m208c0842f6" x="345.030867" y="136.859359" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m208c0842f6" x="273.364924" y="143.571257" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m208c0842f6" x="240.719951" y="149.310846" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m208c0842f6" x="221.353978" y="154.160538" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m208c0842f6" x="207.129625" y="156.092215" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m208c0842f6" x="181.064802" y="166.758473" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m208c0842f6" x="179.282169" y="170.289343" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m208c0842f6" x="177.719335" y="175.489948" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m208c0842f6" x="177.643939" y="181.552088" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_108">
@@ -3689,7 +3689,7 @@ L 277.844045 143.175283
 L 276.351005 143.307597 
 L 274.857964 143.439587 
 L 273.364924 143.571257 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_109">
     <path d="M 273.364924 143.571257 
@@ -3741,7 +3741,7 @@ L 242.760262 148.96941
 L 242.080158 149.083462 
 L 241.400055 149.197273 
 L 240.719951 149.310846 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_110">
     <path d="M 240.719951 149.310846 
@@ -3793,7 +3793,7 @@ L 222.564351 153.869835
 L 222.160893 153.966909 
 L 221.757435 154.06381 
 L 221.353978 154.160538 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_111">
     <path d="M 221.353978 154.160538 
@@ -3845,7 +3845,7 @@ L 208.018647 155.973483
 L 207.722306 156.013089 
 L 207.425965 156.052666 
 L 207.129625 156.092215 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_112">
     <path d="M 207.129625 156.092215 
@@ -3897,7 +3897,7 @@ L 182.693853 166.149994
 L 182.150836 166.353581 
 L 181.607819 166.556405 
 L 181.064802 166.758473 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_113">
     <path d="M 181.064802 166.758473 
@@ -3949,7 +3949,7 @@ L 179.393584 170.075284
 L 179.356445 170.146731 
 L 179.319307 170.218084 
 L 179.282169 170.289343 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_114">
     <path d="M 179.282169 170.289343 
@@ -4001,7 +4001,7 @@ L 177.817012 175.179146
 L 177.784453 175.282945 
 L 177.751894 175.386546 
 L 177.719335 175.489948 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_115">
     <path d="M 177.719335 175.489948 
@@ -4053,11 +4053,11 @@ L 177.648651 181.192458
 L 177.64708 181.3126 
 L 177.645509 181.432477 
 L 177.643939 181.552088 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_116">
     <defs>
-     <path id="m03ad12ec0a" d="M 0 -2.5 
+     <path id="mdcbf56fb2d" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -4070,16 +4070,16 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#pb8e3bdbb30)">
-     <use xlink:href="#m03ad12ec0a" x="226.871027" y="113.224491" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m03ad12ec0a" x="226.871027" y="113.066324" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m03ad12ec0a" x="226.871027" y="113.178221" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m03ad12ec0a" x="226.871027" y="113.089884" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m03ad12ec0a" x="177.768423" y="132.327899" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m03ad12ec0a" x="160.37503" y="145.652356" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m03ad12ec0a" x="153.995779" y="152.678629" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m03ad12ec0a" x="147.106887" y="168.143801" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m03ad12ec0a" x="145.871703" y="175.118358" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#pbb573932c3)">
+     <use xlink:href="#mdcbf56fb2d" x="226.871027" y="113.224491" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mdcbf56fb2d" x="226.871027" y="113.066324" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mdcbf56fb2d" x="226.871027" y="113.178221" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mdcbf56fb2d" x="226.871027" y="113.089884" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mdcbf56fb2d" x="177.768423" y="132.327899" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mdcbf56fb2d" x="160.37503" y="145.652356" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mdcbf56fb2d" x="153.995779" y="152.678629" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mdcbf56fb2d" x="147.106887" y="168.143801" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mdcbf56fb2d" x="145.871703" y="175.118358" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_117">
@@ -4132,7 +4132,7 @@ L 226.871027 113.076223
 L 226.871027 113.072924 
 L 226.871027 113.069624 
 L 226.871027 113.066324 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_118">
     <path d="M 226.871027 113.066324 
@@ -4184,7 +4184,7 @@ L 226.871027 113.171234
 L 226.871027 113.173563 
 L 226.871027 113.175892 
 L 226.871027 113.178221 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_119">
     <path d="M 226.871027 113.178221 
@@ -4236,7 +4236,7 @@ L 226.871027 113.09541
 L 226.871027 113.093568 
 L 226.871027 113.091726 
 L 226.871027 113.089884 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_120">
     <path d="M 226.871027 113.089884 
@@ -4288,7 +4288,7 @@ L 180.837336 131.306392
 L 179.814365 131.649041 
 L 178.791394 131.989534 
 L 177.768423 132.327899 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_121">
     <path d="M 177.768423 132.327899 
@@ -4340,7 +4340,7 @@ L 161.462117 144.909076
 L 161.099755 145.157972 
 L 160.737393 145.405728 
 L 160.37503 145.652356 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_122">
     <path d="M 160.37503 145.652356 
@@ -4392,7 +4392,7 @@ L 154.394483 152.265218
 L 154.261581 152.403373 
 L 154.12868 152.541176 
 L 153.995779 152.678629 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_123">
     <path d="M 153.995779 152.678629 
@@ -4444,7 +4444,7 @@ L 147.537442 167.296442
 L 147.393924 167.580372 
 L 147.250405 167.862819 
 L 147.106887 168.143801 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_124">
     <path d="M 147.106887 168.143801 
@@ -4496,11 +4496,11 @@ L 145.948902 174.70781
 L 145.923169 174.845005 
 L 145.897436 174.981854 
 L 145.871703 175.118358 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_125">
     <defs>
-     <path id="m3e5242a00f" d="M 0 -2.5 
+     <path id="mc36e2111ec" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -4509,16 +4509,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pb8e3bdbb30)">
-     <use xlink:href="#m3e5242a00f" x="585.66883" y="173.051371" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3e5242a00f" x="527.144592" y="175.326465" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3e5242a00f" x="457.339427" y="183.688849" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3e5242a00f" x="292.124837" y="178.486631" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3e5242a00f" x="243.129344" y="190.369032" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3e5242a00f" x="213.541392" y="204.43395" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3e5242a00f" x="204.551957" y="212.140784" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3e5242a00f" x="195.860087" y="228.582256" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3e5242a00f" x="194.019853" y="234.294862" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pbb573932c3)">
+     <use xlink:href="#mc36e2111ec" x="585.66883" y="173.051371" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc36e2111ec" x="527.144592" y="175.326465" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc36e2111ec" x="457.339427" y="183.688849" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc36e2111ec" x="292.124837" y="178.486631" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc36e2111ec" x="243.129344" y="190.369032" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc36e2111ec" x="213.541392" y="204.43395" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc36e2111ec" x="204.551957" y="212.140784" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc36e2111ec" x="195.860087" y="228.582256" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc36e2111ec" x="194.019853" y="234.294862" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_126">
@@ -4571,7 +4571,7 @@ L 530.802357 175.187039
 L 529.583102 175.233554 
 L 528.363847 175.28003 
 L 527.144592 175.326465 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_127">
     <path d="M 527.144592 175.326465 
@@ -4623,7 +4623,7 @@ L 461.70225 183.20239
 L 460.247976 183.36503 
 L 458.793701 183.527182 
 L 457.339427 183.688849 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_128">
     <path d="M 457.339427 183.688849 
@@ -4675,7 +4675,7 @@ L 302.450749 178.826834
 L 299.008779 178.713671 
 L 295.566808 178.60027 
 L 292.124837 178.486631 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_129">
     <path d="M 292.124837 178.486631 
@@ -4727,7 +4727,7 @@ L 246.191563 189.6981
 L 245.170823 189.922669 
 L 244.150084 190.146311 
 L 243.129344 190.369032 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_130">
     <path d="M 243.129344 190.369032 
@@ -4779,7 +4779,7 @@ L 215.390639 203.654226
 L 214.774224 203.915384 
 L 214.157808 204.175288 
 L 213.541392 204.43395 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_131">
     <path d="M 213.541392 204.43395 
@@ -4831,7 +4831,7 @@ L 205.113797 211.689953
 L 204.926517 211.840648 
 L 204.739237 211.990924 
 L 204.551957 212.140784 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_132">
     <path d="M 204.551957 212.140784 
@@ -4883,7 +4883,7 @@ L 196.403329 227.688717
 L 196.222248 227.988205 
 L 196.041168 228.286045 
 L 195.860087 228.582256 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_133">
     <path d="M 195.860087 228.582256 
@@ -4935,7 +4935,7 @@ L 194.134867 233.954953
 L 194.096529 234.068494 
 L 194.058191 234.181796 
 L 194.019853 234.294862 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="legend_1">
     <g id="patch_7">
@@ -4953,7 +4953,7 @@ z
     </g>
     <g id="line2d_134">
      <defs>
-      <path id="mbee64d757a" d="M 0 3.5 
+      <path id="md6d673790f" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -4966,7 +4966,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#mbee64d757a" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#md6d673790f" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -5025,7 +5025,7 @@ z
     </g>
     <g id="line2d_135">
      <g>
-      <use xlink:href="#mc69a122b4f" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m4001f964d7" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -5039,7 +5039,7 @@ z
     </g>
     <g id="line2d_136">
      <g>
-      <use xlink:href="#me8650c2b45" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#ma29183881d" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -5084,7 +5084,7 @@ z
     </g>
     <g id="line2d_137">
      <g>
-      <use xlink:href="#mf9687a0102" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m90a1f84f26" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -5127,7 +5127,7 @@ z
     </g>
     <g id="line2d_138">
      <g>
-      <use xlink:href="#md9980c5813" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m17f6f47b15" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -5143,7 +5143,7 @@ z
     </g>
     <g id="line2d_139">
      <g>
-      <use xlink:href="#m1400f1d6c7" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mf4a12ef7a6" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -5197,7 +5197,7 @@ z
     </g>
     <g id="line2d_140">
      <g>
-      <use xlink:href="#m6a686c47c8" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m208c0842f6" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -5262,7 +5262,7 @@ z
     </g>
     <g id="line2d_141">
      <g>
-      <use xlink:href="#m03ad12ec0a" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#mdcbf56fb2d" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -5300,7 +5300,7 @@ z
     </g>
     <g id="line2d_142">
      <g>
-      <use xlink:href="#m3e5242a00f" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mc36e2111ec" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -5370,486 +5370,486 @@ z
     </g>
    </g>
    <g id="line2d_143">
-    <g clip-path="url(#pb8e3bdbb30)">
-     <use xlink:href="#mbee64d757a" x="319.643112" y="119.941946" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mbee64d757a" x="263.489417" y="126.397321" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mbee64d757a" x="236.23654" y="133.784936" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mbee64d757a" x="192.820547" y="155.992219" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mbee64d757a" x="180.389901" y="166.07223" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mbee64d757a" x="155.351585" y="175.849425" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mbee64d757a" x="149.634124" y="181.528737" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mbee64d757a" x="139.514773" y="193.820552" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mbee64d757a" x="119.666036" y="287.043858" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mbee64d757a" x="97.814287" y="314.795762" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <g clip-path="url(#pbb573932c3)">
+     <use xlink:href="#md6d673790f" x="319.643112" y="113.896302" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#md6d673790f" x="263.489417" y="121.651517" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#md6d673790f" x="236.23654" y="129.556055" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#md6d673790f" x="192.820547" y="151.29592" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#md6d673790f" x="180.389901" y="162.991723" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#md6d673790f" x="155.351585" y="172.54048" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#md6d673790f" x="149.634124" y="176.907409" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#md6d673790f" x="139.514773" y="190.318146" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#md6d673790f" x="119.666036" y="285.736411" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#md6d673790f" x="97.814287" y="313.489091" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
    <g id="line2d_144">
-    <path d="M 319.643112 119.941946 
-L 318.473243 120.084593 
-L 317.303375 120.226864 
-L 316.133506 120.368763 
-L 314.963637 120.51029 
-L 313.793769 120.651449 
-L 312.6239 120.79224 
-L 311.454031 120.932666 
-L 310.284163 121.072729 
-L 309.114294 121.212431 
-L 307.944425 121.351772 
-L 306.774557 121.490756 
-L 305.604688 121.629384 
-L 304.43482 121.767658 
-L 303.264951 121.90558 
-L 302.095082 122.043151 
-L 300.925214 122.180373 
-L 299.755345 122.317248 
-L 298.585476 122.453778 
-L 297.415608 122.589965 
-L 296.245739 122.72581 
-L 295.07587 122.861315 
-L 293.906002 122.996481 
-L 292.736133 123.131311 
-L 291.566264 123.265805 
-L 290.396396 123.399967 
-L 289.226527 123.533797 
-L 288.056658 123.667296 
-L 286.88679 123.800468 
-L 285.716921 123.933312 
-L 284.547053 124.065831 
-L 283.377184 124.198027 
-L 282.207315 124.3299 
-L 281.037447 124.461453 
-L 279.867578 124.592687 
-L 278.697709 124.723604 
-L 277.527841 124.854205 
-L 276.357972 124.984492 
-L 275.188103 125.114465 
-L 274.018235 125.244128 
-L 272.848366 125.37348 
-L 271.678497 125.502524 
-L 270.508629 125.631261 
-L 269.33876 125.759693 
-L 268.168891 125.887821 
-L 266.999023 126.015646 
-L 265.829154 126.14317 
-L 264.659286 126.270395 
-L 263.489417 126.397321 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 319.643112 113.896302 
+L 318.473243 114.069737 
+L 317.303375 114.242619 
+L 316.133506 114.41495 
+L 314.963637 114.586734 
+L 313.793769 114.757975 
+L 312.6239 114.928676 
+L 311.454031 115.098841 
+L 310.284163 115.268472 
+L 309.114294 115.437573 
+L 307.944425 115.606147 
+L 306.774557 115.774198 
+L 305.604688 115.94173 
+L 304.43482 116.108744 
+L 303.264951 116.275244 
+L 302.095082 116.441234 
+L 300.925214 116.606717 
+L 299.755345 116.771695 
+L 298.585476 116.936172 
+L 297.415608 117.10015 
+L 296.245739 117.263634 
+L 295.07587 117.426625 
+L 293.906002 117.589127 
+L 292.736133 117.751142 
+L 291.566264 117.912674 
+L 290.396396 118.073725 
+L 289.226527 118.234299 
+L 288.056658 118.394398 
+L 286.88679 118.554024 
+L 285.716921 118.713182 
+L 284.547053 118.871872 
+L 283.377184 119.030099 
+L 282.207315 119.187865 
+L 281.037447 119.345172 
+L 279.867578 119.502023 
+L 278.697709 119.658422 
+L 277.527841 119.814369 
+L 276.357972 119.969869 
+L 275.188103 120.124923 
+L 274.018235 120.279535 
+L 272.848366 120.433706 
+L 271.678497 120.587439 
+L 270.508629 120.740737 
+L 269.33876 120.893602 
+L 268.168891 121.046036 
+L 266.999023 121.198042 
+L 265.829154 121.349623 
+L 264.659286 121.500781 
+L 263.489417 121.651517 
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_145">
-    <path d="M 263.489417 126.397321 
-L 262.921649 126.561976 
-L 262.35388 126.726131 
-L 261.786112 126.889791 
-L 261.218344 127.052957 
-L 260.650576 127.215632 
-L 260.082807 127.377821 
-L 259.515039 127.539524 
-L 258.947271 127.700746 
-L 258.379503 127.86149 
-L 257.811734 128.021757 
-L 257.243966 128.181552 
-L 256.676198 128.340876 
-L 256.108429 128.499732 
-L 255.540661 128.658124 
-L 254.972893 128.816053 
-L 254.405125 128.973523 
-L 253.837356 129.130537 
-L 253.269588 129.287096 
-L 252.70182 129.443203 
-L 252.134052 129.598862 
-L 251.566283 129.754075 
-L 250.998515 129.908843 
-L 250.430747 130.063171 
-L 249.862979 130.21706 
-L 249.29521 130.370512 
-L 248.727442 130.523531 
-L 248.159674 130.676118 
-L 247.591906 130.828277 
-L 247.024137 130.980009 
-L 246.456369 131.131316 
-L 245.888601 131.282203 
-L 245.320832 131.432669 
-L 244.753064 131.582719 
-L 244.185296 131.732354 
-L 243.617528 131.881576 
-L 243.049759 132.030388 
-L 242.481991 132.178792 
-L 241.914223 132.32679 
-L 241.346455 132.474385 
-L 240.778686 132.621579 
-L 240.210918 132.768373 
-L 239.64315 132.91477 
-L 239.075382 133.060773 
-L 238.507613 133.206382 
-L 237.939845 133.351602 
-L 237.372077 133.496432 
-L 236.804309 133.640876 
-L 236.23654 133.784936 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 263.489417 121.651517 
+L 262.921649 121.828536 
+L 262.35388 122.004978 
+L 261.786112 122.180847 
+L 261.218344 122.356146 
+L 260.650576 122.530879 
+L 260.082807 122.70505 
+L 259.515039 122.878663 
+L 258.947271 123.05172 
+L 258.379503 123.224226 
+L 257.811734 123.396184 
+L 257.243966 123.567597 
+L 256.676198 123.73847 
+L 256.108429 123.908804 
+L 255.540661 124.078605 
+L 254.972893 124.247874 
+L 254.405125 124.416616 
+L 253.837356 124.584833 
+L 253.269588 124.752529 
+L 252.70182 124.919708 
+L 252.134052 125.086371 
+L 251.566283 125.252523 
+L 250.998515 125.418167 
+L 250.430747 125.583305 
+L 249.862979 125.747941 
+L 249.29521 125.912078 
+L 248.727442 126.075718 
+L 248.159674 126.238866 
+L 247.591906 126.401523 
+L 247.024137 126.563693 
+L 246.456369 126.725378 
+L 245.888601 126.886582 
+L 245.320832 127.047307 
+L 244.753064 127.207557 
+L 244.185296 127.367333 
+L 243.617528 127.52664 
+L 243.049759 127.685478 
+L 242.481991 127.843853 
+L 241.914223 128.001765 
+L 241.346455 128.159217 
+L 240.778686 128.316213 
+L 240.210918 128.472756 
+L 239.64315 128.628846 
+L 239.075382 128.784488 
+L 238.507613 128.939684 
+L 237.939845 129.094436 
+L 237.372077 129.248747 
+L 236.804309 129.402619 
+L 236.23654 129.556055 
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_146">
-    <path d="M 236.23654 133.784936 
-L 235.33204 134.353914 
-L 234.427541 134.916973 
-L 233.523041 135.474236 
-L 232.618541 136.025821 
-L 231.714041 136.571842 
-L 230.809541 137.11241 
-L 229.905041 137.647633 
-L 229.000541 138.177615 
-L 228.096041 138.70246 
-L 227.191542 139.222264 
-L 226.287042 139.737124 
-L 225.382542 140.247133 
-L 224.478042 140.752382 
-L 223.573542 141.252959 
-L 222.669042 141.748949 
-L 221.764542 142.240435 
-L 220.860043 142.727499 
-L 219.955543 143.21022 
-L 219.051043 143.688674 
-L 218.146543 144.162936 
-L 217.242043 144.633079 
-L 216.337543 145.099174 
-L 215.433043 145.56129 
-L 214.528544 146.019494 
-L 213.624044 146.473852 
-L 212.719544 146.924428 
-L 211.815044 147.371285 
-L 210.910544 147.814482 
-L 210.006044 148.254081 
-L 209.101544 148.690139 
-L 208.197044 149.122711 
-L 207.292545 149.551855 
-L 206.388045 149.977623 
-L 205.483545 150.400068 
-L 204.579045 150.819242 
-L 203.674545 151.235195 
-L 202.770045 151.647976 
-L 201.865545 152.057633 
-L 200.961046 152.464213 
-L 200.056546 152.867762 
-L 199.152046 153.268325 
-L 198.247546 153.665946 
-L 197.343046 154.060667 
-L 196.438546 154.452531 
-L 195.534046 154.841578 
-L 194.629546 155.227849 
-L 193.725047 155.611383 
-L 192.820547 155.992219 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 236.23654 129.556055 
+L 235.33204 130.11057 
+L 234.427541 130.659462 
+L 233.523041 131.202845 
+L 232.618541 131.740827 
+L 231.714041 132.273514 
+L 230.809541 132.801011 
+L 229.905041 133.323417 
+L 229.000541 133.84083 
+L 228.096041 134.353344 
+L 227.191542 134.86105 
+L 226.287042 135.36404 
+L 225.382542 135.862398 
+L 224.478042 136.35621 
+L 223.573542 136.845558 
+L 222.669042 137.330521 
+L 221.764542 137.811179 
+L 220.860043 138.287606 
+L 219.955543 138.759876 
+L 219.051043 139.228062 
+L 218.146543 139.692233 
+L 217.242043 140.152458 
+L 216.337543 140.608802 
+L 215.433043 141.061332 
+L 214.528544 141.51011 
+L 213.624044 141.955198 
+L 212.719544 142.396656 
+L 211.815044 142.834543 
+L 210.910544 143.268916 
+L 210.006044 143.699831 
+L 209.101544 144.127343 
+L 208.197044 144.551505 
+L 207.292545 144.97237 
+L 206.388045 145.389987 
+L 205.483545 145.804407 
+L 204.579045 146.215678 
+L 203.674545 146.623849 
+L 202.770045 147.028964 
+L 201.865545 147.43107 
+L 200.961046 147.830212 
+L 200.056546 148.226431 
+L 199.152046 148.619772 
+L 198.247546 149.010275 
+L 197.343046 149.397981 
+L 196.438546 149.78293 
+L 195.534046 150.16516 
+L 194.629546 150.544711 
+L 193.725047 150.921619 
+L 192.820547 151.29592 
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_147">
-    <path d="M 192.820547 155.992219 
-L 192.561575 156.222553 
-L 192.302603 156.451912 
-L 192.043631 156.680302 
-L 191.78466 156.907734 
-L 191.525688 157.134213 
-L 191.266716 157.359749 
-L 191.007744 157.584349 
-L 190.748773 157.808021 
-L 190.489801 158.030773 
-L 190.230829 158.252612 
-L 189.971857 158.473545 
-L 189.712885 158.69358 
-L 189.453914 158.912725 
-L 189.194942 159.130986 
-L 188.93597 159.34837 
-L 188.676998 159.564885 
-L 188.418027 159.780537 
-L 188.159055 159.995334 
-L 187.900083 160.209281 
-L 187.641111 160.422387 
-L 187.382139 160.634656 
-L 187.123168 160.846097 
-L 186.864196 161.056715 
-L 186.605224 161.266516 
-L 186.346252 161.475508 
-L 186.087281 161.683696 
-L 185.828309 161.891086 
-L 185.569337 162.097684 
-L 185.310365 162.303497 
-L 185.051393 162.508531 
-L 184.792422 162.712791 
-L 184.53345 162.916283 
-L 184.274478 163.119013 
-L 184.015506 163.320986 
-L 183.756535 163.522209 
-L 183.497563 163.722686 
-L 183.238591 163.922424 
-L 182.979619 164.121427 
-L 182.720647 164.319702 
-L 182.461676 164.517253 
-L 182.202704 164.714085 
-L 181.943732 164.910205 
-L 181.68476 165.105616 
-L 181.425789 165.300324 
-L 181.166817 165.494335 
-L 180.907845 165.687653 
-L 180.648873 165.880283 
-L 180.389901 166.07223 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 192.820547 151.29592 
+L 192.561575 151.567228 
+L 192.302603 151.837183 
+L 192.043631 152.105798 
+L 191.78466 152.373086 
+L 191.525688 152.639062 
+L 191.266716 152.903737 
+L 191.007744 153.167124 
+L 190.748773 153.429235 
+L 190.489801 153.690084 
+L 190.230829 153.949682 
+L 189.971857 154.20804 
+L 189.712885 154.465172 
+L 189.453914 154.721087 
+L 189.194942 154.975799 
+L 188.93597 155.229318 
+L 188.676998 155.481654 
+L 188.418027 155.73282 
+L 188.159055 155.982826 
+L 187.900083 156.231683 
+L 187.641111 156.479401 
+L 187.382139 156.72599 
+L 187.123168 156.971461 
+L 186.864196 157.215824 
+L 186.605224 157.459089 
+L 186.346252 157.701266 
+L 186.087281 157.942364 
+L 185.828309 158.182392 
+L 185.569337 158.421362 
+L 185.310365 158.65928 
+L 185.051393 158.896158 
+L 184.792422 159.132004 
+L 184.53345 159.366826 
+L 184.274478 159.600635 
+L 184.015506 159.833437 
+L 183.756535 160.065243 
+L 183.497563 160.29606 
+L 183.238591 160.525898 
+L 182.979619 160.754763 
+L 182.720647 160.982665 
+L 182.461676 161.209612 
+L 182.202704 161.435611 
+L 181.943732 161.66067 
+L 181.68476 161.884798 
+L 181.425789 162.108001 
+L 181.166817 162.330288 
+L 180.907845 162.551666 
+L 180.648873 162.772142 
+L 180.389901 162.991723 
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_148">
-    <path d="M 180.389901 166.07223 
-L 179.86827 166.295017 
-L 179.346638 166.516891 
-L 178.825007 166.737859 
-L 178.303375 166.957929 
-L 177.781744 167.177108 
-L 177.260112 167.395404 
-L 176.73848 167.612822 
-L 176.216849 167.82937 
-L 175.695217 168.045056 
-L 175.173586 168.259886 
-L 174.651954 168.473866 
-L 174.130322 168.687004 
-L 173.608691 168.899306 
-L 173.087059 169.110779 
-L 172.565428 169.321429 
-L 172.043796 169.531262 
-L 171.522165 169.740285 
-L 171.000533 169.948504 
-L 170.478901 170.155925 
-L 169.95727 170.362554 
-L 169.435638 170.568398 
-L 168.914007 170.773461 
-L 168.392375 170.977751 
-L 167.870743 171.181273 
-L 167.349112 171.384032 
-L 166.82748 171.586035 
-L 166.305849 171.787287 
-L 165.784217 171.987793 
-L 165.262586 172.187559 
-L 164.740954 172.386591 
-L 164.219322 172.584894 
-L 163.697691 172.782473 
-L 163.176059 172.979333 
-L 162.654428 173.17548 
-L 162.132796 173.370919 
-L 161.611164 173.565655 
-L 161.089533 173.759692 
-L 160.567901 173.953037 
-L 160.04627 174.145694 
-L 159.524638 174.337667 
-L 159.003007 174.528962 
-L 158.481375 174.719583 
-L 157.959743 174.909535 
-L 157.438112 175.098823 
-L 156.91648 175.287452 
-L 156.394849 175.475425 
-L 155.873217 175.662748 
-L 155.351585 175.849425 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 180.389901 162.991723 
+L 179.86827 163.208845 
+L 179.346638 163.425098 
+L 178.825007 163.640492 
+L 178.303375 163.855031 
+L 177.781744 164.068724 
+L 177.260112 164.281576 
+L 176.73848 164.493595 
+L 176.216849 164.704786 
+L 175.695217 164.915157 
+L 175.173586 165.124713 
+L 174.651954 165.333461 
+L 174.130322 165.541408 
+L 173.608691 165.748558 
+L 173.087059 165.954919 
+L 172.565428 166.160496 
+L 172.043796 166.365295 
+L 171.522165 166.569323 
+L 171.000533 166.772584 
+L 170.478901 166.975085 
+L 169.95727 167.176831 
+L 169.435638 167.377828 
+L 168.914007 167.578082 
+L 168.392375 167.777597 
+L 167.870743 167.97638 
+L 167.349112 168.174435 
+L 166.82748 168.371769 
+L 166.305849 168.568385 
+L 165.784217 168.76429 
+L 165.262586 168.959489 
+L 164.740954 169.153986 
+L 164.219322 169.347787 
+L 163.697691 169.540897 
+L 163.176059 169.73332 
+L 162.654428 169.925061 
+L 162.132796 170.116126 
+L 161.611164 170.306519 
+L 161.089533 170.496244 
+L 160.567901 170.685307 
+L 160.04627 170.873712 
+L 159.524638 171.061463 
+L 159.003007 171.248565 
+L 158.481375 171.435023 
+L 157.959743 171.620841 
+L 157.438112 171.806023 
+L 156.91648 171.990574 
+L 156.394849 172.174497 
+L 155.873217 172.357798 
+L 155.351585 172.54048 
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_149">
-    <path d="M 155.351585 175.849425 
-L 155.232472 175.97403 
-L 155.113358 176.098349 
-L 154.994244 176.222384 
-L 154.87513 176.346134 
-L 154.756017 176.469603 
-L 154.636903 176.59279 
-L 154.517789 176.715698 
-L 154.398675 176.838327 
-L 154.279561 176.960679 
-L 154.160448 177.082755 
-L 154.041334 177.204557 
-L 153.92222 177.326085 
-L 153.803106 177.44734 
-L 153.683992 177.568325 
-L 153.564879 177.68904 
-L 153.445765 177.809486 
-L 153.326651 177.929665 
-L 153.207537 178.049578 
-L 153.088424 178.169226 
-L 152.96931 178.28861 
-L 152.850196 178.407731 
-L 152.731082 178.52659 
-L 152.611968 178.645189 
-L 152.492855 178.763529 
-L 152.373741 178.881611 
-L 152.254627 178.999436 
-L 152.135513 179.117004 
-L 152.016399 179.234318 
-L 151.897286 179.351379 
-L 151.778172 179.468186 
-L 151.659058 179.584742 
-L 151.539944 179.701048 
-L 151.420831 179.817104 
-L 151.301717 179.932913 
-L 151.182603 180.048473 
-L 151.063489 180.163788 
-L 150.944375 180.278858 
-L 150.825262 180.393683 
-L 150.706148 180.508265 
-L 150.587034 180.622606 
-L 150.46792 180.736705 
-L 150.348806 180.850565 
-L 150.229693 180.964185 
-L 150.110579 181.077567 
-L 149.991465 181.190713 
-L 149.872351 181.303622 
-L 149.753238 181.416296 
-L 149.634124 181.528737 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 155.351585 172.54048 
+L 155.232472 172.635146 
+L 155.113358 172.729646 
+L 154.994244 172.823981 
+L 154.87513 172.918152 
+L 154.756017 173.01216 
+L 154.636903 173.106005 
+L 154.517789 173.199687 
+L 154.398675 173.293207 
+L 154.279561 173.386566 
+L 154.160448 173.479765 
+L 154.041334 173.572803 
+L 153.92222 173.665682 
+L 153.803106 173.758401 
+L 153.683992 173.850962 
+L 153.564879 173.943365 
+L 153.445765 174.035611 
+L 153.326651 174.127699 
+L 153.207537 174.219631 
+L 153.088424 174.311408 
+L 152.96931 174.403029 
+L 152.850196 174.494495 
+L 152.731082 174.585807 
+L 152.611968 174.676965 
+L 152.492855 174.767969 
+L 152.373741 174.858822 
+L 152.254627 174.949521 
+L 152.135513 175.04007 
+L 152.016399 175.130466 
+L 151.897286 175.220713 
+L 151.778172 175.310809 
+L 151.659058 175.400755 
+L 151.539944 175.490552 
+L 151.420831 175.580201 
+L 151.301717 175.669701 
+L 151.182603 175.759053 
+L 151.063489 175.848258 
+L 150.944375 175.937317 
+L 150.825262 176.026229 
+L 150.706148 176.114995 
+L 150.587034 176.203616 
+L 150.46792 176.292092 
+L 150.348806 176.380424 
+L 150.229693 176.468612 
+L 150.110579 176.556656 
+L 149.991465 176.644558 
+L 149.872351 176.732317 
+L 149.753238 176.819934 
+L 149.634124 176.907409 
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_150">
-    <path d="M 149.634124 181.528737 
-L 149.423304 181.815462 
-L 149.212484 182.100676 
-L 149.001664 182.384395 
-L 148.790845 182.666635 
-L 148.580025 182.947411 
-L 148.369205 183.226738 
-L 148.158385 183.504631 
-L 147.947565 183.781104 
-L 147.736745 184.056173 
-L 147.525926 184.329851 
-L 147.315106 184.602153 
-L 147.104286 184.873091 
-L 146.893466 185.14268 
-L 146.682646 185.410934 
-L 146.471827 185.677864 
-L 146.261007 185.943484 
-L 146.050187 186.207808 
-L 145.839367 186.470847 
-L 145.628547 186.732614 
-L 145.417728 186.993121 
-L 145.206908 187.252381 
-L 144.996088 187.510405 
-L 144.785268 187.767205 
-L 144.574448 188.022792 
-L 144.363629 188.277178 
-L 144.152809 188.530374 
-L 143.941989 188.782391 
-L 143.731169 189.033241 
-L 143.520349 189.282933 
-L 143.30953 189.531479 
-L 143.09871 189.778889 
-L 142.88789 190.025174 
-L 142.67707 190.270343 
-L 142.46625 190.514406 
-L 142.25543 190.757374 
-L 142.044611 190.999256 
-L 141.833791 191.240063 
-L 141.622971 191.479802 
-L 141.412151 191.718485 
-L 141.201331 191.95612 
-L 140.990512 192.192716 
-L 140.779692 192.428283 
-L 140.568872 192.662828 
-L 140.358052 192.896363 
-L 140.147232 193.128893 
-L 139.936413 193.36043 
-L 139.725593 193.59098 
-L 139.514773 193.820552 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 149.634124 176.907409 
+L 149.423304 177.223528 
+L 149.212484 177.537811 
+L 149.001664 177.85028 
+L 148.790845 178.160955 
+L 148.580025 178.469858 
+L 148.369205 178.777008 
+L 148.158385 179.082425 
+L 147.947565 179.386128 
+L 147.736745 179.688137 
+L 147.525926 179.98847 
+L 147.315106 180.287146 
+L 147.104286 180.584184 
+L 146.893466 180.8796 
+L 146.682646 181.173412 
+L 146.471827 181.465639 
+L 146.261007 181.756296 
+L 146.050187 182.045402 
+L 145.839367 182.332971 
+L 145.628547 182.61902 
+L 145.417728 182.903566 
+L 145.206908 183.186624 
+L 144.996088 183.46821 
+L 144.785268 183.748338 
+L 144.574448 184.027025 
+L 144.363629 184.304283 
+L 144.152809 184.580129 
+L 143.941989 184.854577 
+L 143.731169 185.12764 
+L 143.520349 185.399332 
+L 143.30953 185.669667 
+L 143.09871 185.938659 
+L 142.88789 186.206322 
+L 142.67707 186.472667 
+L 142.46625 186.737708 
+L 142.25543 187.001457 
+L 142.044611 187.263928 
+L 141.833791 187.525132 
+L 141.622971 187.785082 
+L 141.412151 188.043789 
+L 141.201331 188.301266 
+L 140.990512 188.557524 
+L 140.779692 188.812575 
+L 140.568872 189.066429 
+L 140.358052 189.319099 
+L 140.147232 189.570594 
+L 139.936413 189.820927 
+L 139.725593 190.070107 
+L 139.514773 190.318146 
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_151">
-    <path d="M 139.514773 193.820552 
-L 139.101258 198.770952 
-L 138.687742 203.306319 
-L 138.274227 207.490894 
-L 137.860712 211.375067 
-L 137.447196 214.999095 
-L 137.033681 218.395648 
-L 136.620165 221.591604 
-L 136.20665 224.60934 
-L 135.793135 227.467689 
-L 135.379619 230.182646 
-L 134.966104 232.767913 
-L 134.552589 235.235316 
-L 134.139073 237.595137 
-L 133.725558 239.856367 
-L 133.312043 242.026912 
-L 132.898527 244.113769 
-L 132.485012 246.123151 
-L 132.071496 248.060606 
-L 131.657981 249.931106 
-L 131.244466 251.739123 
-L 130.83095 253.488699 
-L 130.417435 255.183492 
-L 130.00392 256.82683 
-L 129.590404 258.421746 
-L 129.176889 259.97101 
-L 128.763374 261.477165 
-L 128.349858 262.942545 
-L 127.936343 264.369299 
-L 127.522827 265.759411 
-L 127.109312 267.114716 
-L 126.695797 268.436916 
-L 126.282281 269.727588 
-L 125.868766 270.988201 
-L 125.455251 272.220125 
-L 125.041735 273.424634 
-L 124.62822 274.602924 
-L 124.214705 275.756111 
-L 123.801189 276.885242 
-L 123.387674 277.991301 
-L 122.974158 279.075213 
-L 122.560643 280.137845 
-L 122.147128 281.180018 
-L 121.733612 282.202505 
-L 121.320097 283.206036 
-L 120.906582 284.191301 
-L 120.493066 285.158952 
-L 120.079551 286.109609 
-L 119.666036 287.043858 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 139.514773 190.318146 
+L 139.101258 195.506382 
+L 138.687742 200.240552 
+L 138.274227 204.593778 
+L 137.860712 208.622827 
+L 137.447196 212.372652 
+L 137.033681 215.87946 
+L 136.620165 219.172841 
+L 136.20665 222.277291 
+L 135.793135 225.213314 
+L 135.379619 227.998251 
+L 134.966104 230.646892 
+L 134.552589 233.171958 
+L 134.139073 235.584468 
+L 133.725558 237.894029 
+L 133.312043 240.10907 
+L 132.898527 242.237024 
+L 132.485012 244.28448 
+L 132.071496 246.257308 
+L 131.657981 248.160756 
+L 131.244466 249.99954 
+L 130.83095 251.777909 
+L 130.417435 253.499707 
+L 130.00392 255.168422 
+L 129.590404 256.787231 
+L 129.176889 258.35903 
+L 128.763374 259.886475 
+L 128.349858 261.371999 
+L 127.936343 262.817842 
+L 127.522827 264.22607 
+L 127.109312 265.598589 
+L 126.695797 266.937167 
+L 126.282281 268.243441 
+L 125.868766 269.518933 
+L 125.455251 270.765062 
+L 125.041735 271.983149 
+L 124.62822 273.174428 
+L 124.214705 274.340053 
+L 123.801189 275.481107 
+L 123.387674 276.598604 
+L 122.974158 277.693497 
+L 122.560643 278.766683 
+L 122.147128 279.819005 
+L 121.733612 280.851259 
+L 121.320097 281.864196 
+L 120.906582 282.858526 
+L 120.493066 283.83492 
+L 120.079551 284.794015 
+L 119.666036 285.736411 
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_152">
-    <path d="M 119.666036 287.043858 
-L 119.210791 287.793945 
-L 118.755546 288.53378 
-L 118.300301 289.26364 
-L 117.845056 289.983789 
-L 117.389812 290.694484 
-L 116.934567 291.395968 
-L 116.479322 292.088478 
-L 116.024077 292.772241 
-L 115.568833 293.447474 
-L 115.113588 294.114388 
-L 114.658343 294.773185 
-L 114.203098 295.424061 
-L 113.747854 296.067204 
-L 113.292609 296.702794 
-L 112.837364 297.331009 
-L 112.382119 297.952016 
-L 111.926875 298.56598 
-L 111.47163 299.173058 
-L 111.016385 299.773403 
-L 110.56114 300.367164 
-L 110.105895 300.954481 
-L 109.650651 301.535495 
-L 109.195406 302.110339 
-L 108.740161 302.679142 
-L 108.284916 303.24203 
-L 107.829672 303.799126 
-L 107.374427 304.350546 
-L 106.919182 304.896406 
-L 106.463937 305.436816 
-L 106.008693 305.971884 
-L 105.553448 306.501716 
-L 105.098203 307.026411 
-L 104.642958 307.546069 
-L 104.187713 308.060787 
-L 103.732469 308.570655 
-L 103.277224 309.075766 
-L 102.821979 309.576208 
-L 102.366734 310.072065 
-L 101.91149 310.563421 
-L 101.456245 311.050357 
-L 101.001 311.532952 
-L 100.545755 312.011283 
-L 100.090511 312.485423 
-L 99.635266 312.955447 
-L 99.180021 313.421425 
-L 98.724776 313.883425 
-L 98.269531 314.341516 
-L 97.814287 314.795762 
-" clip-path="url(#pb8e3bdbb30)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 119.666036 285.736411 
+L 119.210791 286.486525 
+L 118.755546 287.226385 
+L 118.300301 287.95627 
+L 117.845056 288.676444 
+L 117.389812 289.387163 
+L 116.934567 290.08867 
+L 116.479322 290.781203 
+L 116.024077 291.464988 
+L 115.568833 292.140242 
+L 115.113588 292.807177 
+L 114.658343 293.465995 
+L 114.203098 294.116891 
+L 113.747854 294.760053 
+L 113.292609 295.395663 
+L 112.837364 296.023896 
+L 112.382119 296.644922 
+L 111.926875 297.258903 
+L 111.47163 297.865999 
+L 111.016385 298.466361 
+L 110.56114 299.060138 
+L 110.105895 299.647472 
+L 109.650651 300.228502 
+L 109.195406 300.803361 
+L 108.740161 301.37218 
+L 108.284916 301.935083 
+L 107.829672 302.492193 
+L 107.374427 303.043628 
+L 106.919182 303.589502 
+L 106.463937 304.129926 
+L 106.008693 304.665008 
+L 105.553448 305.194852 
+L 105.098203 305.719561 
+L 104.642958 306.239232 
+L 104.187713 306.753961 
+L 103.732469 307.263842 
+L 103.277224 307.768966 
+L 102.821979 308.269419 
+L 102.366734 308.765288 
+L 101.91149 309.256655 
+L 101.456245 309.743602 
+L 101.001 310.226208 
+L 100.545755 310.70455 
+L 100.090511 311.178701 
+L 99.635266 311.648735 
+L 99.180021 312.114723 
+L 98.724776 312.576734 
+L 98.269531 313.034834 
+L 97.814287 313.489091 
+" clip-path="url(#pbb573932c3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
   </g>
   <g id="text_25">
@@ -6166,8 +6166,8 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-07-10T09:54:02Z  ·  Linux chungus2 x86_64  ·  commit da9d9c0e  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(43.847969 465.66) scale(0.07 -0.07)">
+   <!-- 2026-07-11T04:15:02Z  ·  Linux chungus2 x86_64  ·  commit e802670f  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(44.448437 465.66) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -6188,36 +6188,6 @@ L 1638 0
 L 1638 4134 
 L -19 4134 
 L -19 4666 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-39" d="M 703 97 
-L 703 672 
-Q 941 559 1184 500 
-Q 1428 441 1663 441 
-Q 2288 441 2617 861 
-Q 2947 1281 2994 2138 
-Q 2813 1869 2534 1725 
-Q 2256 1581 1919 1581 
-Q 1219 1581 811 2004 
-Q 403 2428 403 3163 
-Q 403 3881 828 4315 
-Q 1253 4750 1959 4750 
-Q 2769 4750 3195 4129 
-Q 3622 3509 3622 2328 
-Q 3622 1225 3098 567 
-Q 2575 -91 1691 -91 
-Q 1453 -91 1209 -44 
-Q 966 3 703 97 
-z
-M 1959 2075 
-Q 2384 2075 2632 2365 
-Q 2881 2656 2881 3163 
-Q 2881 3666 2632 3958 
-Q 2384 4250 1959 4250 
-Q 1534 4250 1286 3958 
-Q 1038 3666 1038 3163 
-Q 1038 2656 1286 2365 
-Q 1534 2075 1959 2075 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-3a" d="M 750 794 
@@ -6353,13 +6323,13 @@ z
     <use xlink:href="#DejaVuSans-37" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-31" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(1027.734375 0)"/>
@@ -6402,109 +6372,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3135.351562 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3196.630859 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3260.253906 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3323.730469 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3387.353516 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3442.333984 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3505.957031 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3567.480469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3599.267578 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3631.054688 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3662.841797 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3694.628906 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3726.416016 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3754.199219 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3815.722656 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3877.001953 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3940.380859 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4003.857422 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4042.720703 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4103.902344 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4163.082031 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4224.605469 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4265.71875 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4299.410156 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4327.193359 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4388.716797 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4449.996094 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4513.375 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4576.998047 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4610.689453 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4669.869141 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4733.492188 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4765.279297 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4828.902344 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4892.525391 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4924.3125 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4987.935547 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5024.019531 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5062.882812 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5117.863281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5181.486328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5213.273438 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5245.060547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5276.847656 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5308.634766 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5340.421875 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5379.630859 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5443.009766 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5481.873047 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5543.054688 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5606.433594 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5669.910156 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5733.289062 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5796.765625 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5860.144531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5899.353516 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5931.140625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6014.929688 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6046.716797 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6144.128906 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6205.652344 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6269.128906 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6296.912109 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6358.191406 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6421.570312 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6453.357422 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6505.457031 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6568.835938 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6630.115234 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6693.591797 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6745.691406 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6809.070312 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6870.251953 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6909.460938 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6943.152344 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6974.939453 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7016.052734 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7077.332031 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7116.541016 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7144.324219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7205.505859 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7237.292969 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7265.076172 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7317.175781 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7348.962891 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7412.439453 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7473.962891 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7513.171875 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7574.695312 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7614.058594 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7711.470703 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7739.253906 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7802.632812 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7830.416016 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7882.515625 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7921.724609 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7949.507812 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3133.398438 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3197.021484 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3260.644531 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3324.267578 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3387.890625 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3451.513672 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3515.136719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3550.341797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3582.128906 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3613.916016 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3645.703125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3677.490234 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3709.277344 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3737.060547 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3798.583984 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3859.863281 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3923.242188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3986.71875 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4025.582031 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4086.763672 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4145.943359 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4207.466797 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4248.580078 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4282.271484 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4310.054688 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4371.578125 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4432.857422 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4496.236328 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4559.859375 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4593.550781 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4652.730469 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4716.353516 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4748.140625 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4811.763672 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4875.386719 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4907.173828 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4970.796875 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5006.880859 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5045.744141 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5100.724609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5164.347656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5196.134766 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5227.921875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5259.708984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5291.496094 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5323.283203 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5362.492188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5425.871094 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5464.734375 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5525.916016 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5589.294922 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5652.771484 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5716.150391 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5779.626953 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5843.005859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5882.214844 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5914.001953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5997.791016 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6029.578125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6126.990234 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6188.513672 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6251.990234 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6279.773438 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6341.052734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6404.431641 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6436.21875 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6488.318359 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6551.697266 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6612.976562 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6676.453125 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6728.552734 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6791.931641 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6853.113281 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6892.322266 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6926.013672 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6957.800781 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6998.914062 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7060.193359 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7099.402344 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7127.185547 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7188.367188 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7220.154297 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7247.9375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7300.037109 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7331.824219 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7395.300781 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7456.824219 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7496.033203 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7557.556641 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7596.919922 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7694.332031 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7722.115234 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7785.494141 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7813.277344 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7865.376953 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7904.585938 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7932.369141 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pb8e3bdbb30">
+  <clipPath id="pbb573932c3">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_decode_density.svg
+++ b/bench/graphs/silesia_decode_density.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 82.373685 412.80375 
 L 82.373685 47.3475 
-" clip-path="url(#p09135f412f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5e056e5ead)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m6d7c0d1745" d="M 0 0 
+       <path id="ma2dbaddb45" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m6d7c0d1745" x="82.373685" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma2dbaddb45" x="82.373685" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -111,11 +111,11 @@ z
      <g id="line2d_3">
       <path d="M 165.44644 412.80375 
 L 165.44644 47.3475 
-" clip-path="url(#p09135f412f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5e056e5ead)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m6d7c0d1745" x="165.44644" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma2dbaddb45" x="165.44644" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -157,11 +157,11 @@ z
      <g id="line2d_5">
       <path d="M 248.519195 412.80375 
 L 248.519195 47.3475 
-" clip-path="url(#p09135f412f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5e056e5ead)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m6d7c0d1745" x="248.519195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma2dbaddb45" x="248.519195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -211,11 +211,11 @@ z
      <g id="line2d_7">
       <path d="M 331.59195 412.80375 
 L 331.59195 47.3475 
-" clip-path="url(#p09135f412f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5e056e5ead)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m6d7c0d1745" x="331.59195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma2dbaddb45" x="331.59195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -252,11 +252,11 @@ z
      <g id="line2d_9">
       <path d="M 414.664704 412.80375 
 L 414.664704 47.3475 
-" clip-path="url(#p09135f412f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5e056e5ead)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m6d7c0d1745" x="414.664704" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma2dbaddb45" x="414.664704" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -299,11 +299,11 @@ z
      <g id="line2d_11">
       <path d="M 497.737459 412.80375 
 L 497.737459 47.3475 
-" clip-path="url(#p09135f412f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5e056e5ead)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m6d7c0d1745" x="497.737459" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma2dbaddb45" x="497.737459" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -351,11 +351,11 @@ z
      <g id="line2d_13">
       <path d="M 580.810214 412.80375 
 L 580.810214 47.3475 
-" clip-path="url(#p09135f412f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5e056e5ead)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m6d7c0d1745" x="580.810214" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma2dbaddb45" x="580.810214" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -897,16 +897,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 391.323447 
 L 637.2 391.323447 
-" clip-path="url(#p09135f412f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5e056e5ead)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="m8b20d7d560" d="M 0 0 
+       <path id="mc2cfd28e84" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m8b20d7d560" x="49.078125" y="391.323447" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc2cfd28e84" x="49.078125" y="391.323447" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -922,11 +922,11 @@ L -3.5 0
      <g id="line2d_17">
       <path d="M 49.078125 263.552396 
 L 637.2 263.552396 
-" clip-path="url(#p09135f412f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5e056e5ead)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m8b20d7d560" x="49.078125" y="263.552396" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc2cfd28e84" x="49.078125" y="263.552396" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -942,11 +942,11 @@ L 637.2 263.552396
      <g id="line2d_19">
       <path d="M 49.078125 135.781345 
 L 637.2 135.781345 
-" clip-path="url(#p09135f412f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5e056e5ead)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m8b20d7d560" x="49.078125" y="135.781345" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc2cfd28e84" x="49.078125" y="135.781345" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -962,16 +962,16 @@ L 637.2 135.781345
      <g id="line2d_21">
       <path d="M 49.078125 411.115433 
 L 637.2 411.115433 
-" clip-path="url(#p09135f412f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5e056e5ead)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="mc7efb2cc29" d="M 0 0 
+       <path id="m305e82df09" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#mc7efb2cc29" x="49.078125" y="411.115433" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m305e82df09" x="49.078125" y="411.115433" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -979,11 +979,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 403.705741 
 L 637.2 403.705741 
-" clip-path="url(#p09135f412f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5e056e5ead)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mc7efb2cc29" x="49.078125" y="403.705741" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m305e82df09" x="49.078125" y="403.705741" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -991,11 +991,11 @@ L 637.2 403.705741
      <g id="line2d_25">
       <path d="M 49.078125 397.16993 
 L 637.2 397.16993 
-" clip-path="url(#p09135f412f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5e056e5ead)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mc7efb2cc29" x="49.078125" y="397.16993" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m305e82df09" x="49.078125" y="397.16993" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1003,11 +1003,11 @@ L 637.2 397.16993
      <g id="line2d_27">
       <path d="M 49.078125 352.860528 
 L 637.2 352.860528 
-" clip-path="url(#p09135f412f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5e056e5ead)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#mc7efb2cc29" x="49.078125" y="352.860528" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m305e82df09" x="49.078125" y="352.860528" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1015,11 +1015,11 @@ L 637.2 352.860528
      <g id="line2d_29">
       <path d="M 49.078125 330.361163 
 L 637.2 330.361163 
-" clip-path="url(#p09135f412f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5e056e5ead)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#mc7efb2cc29" x="49.078125" y="330.361163" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m305e82df09" x="49.078125" y="330.361163" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1027,11 +1027,11 @@ L 637.2 330.361163
      <g id="line2d_31">
       <path d="M 49.078125 314.397609 
 L 637.2 314.397609 
-" clip-path="url(#p09135f412f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5e056e5ead)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#mc7efb2cc29" x="49.078125" y="314.397609" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m305e82df09" x="49.078125" y="314.397609" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1039,11 +1039,11 @@ L 637.2 314.397609
      <g id="line2d_33">
       <path d="M 49.078125 302.015315 
 L 637.2 302.015315 
-" clip-path="url(#p09135f412f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5e056e5ead)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#mc7efb2cc29" x="49.078125" y="302.015315" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m305e82df09" x="49.078125" y="302.015315" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1051,11 +1051,11 @@ L 637.2 302.015315
      <g id="line2d_35">
       <path d="M 49.078125 291.898244 
 L 637.2 291.898244 
-" clip-path="url(#p09135f412f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5e056e5ead)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#mc7efb2cc29" x="49.078125" y="291.898244" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m305e82df09" x="49.078125" y="291.898244" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1063,11 +1063,11 @@ L 637.2 291.898244
      <g id="line2d_37">
       <path d="M 49.078125 283.344382 
 L 637.2 283.344382 
-" clip-path="url(#p09135f412f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5e056e5ead)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#mc7efb2cc29" x="49.078125" y="283.344382" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m305e82df09" x="49.078125" y="283.344382" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1075,11 +1075,11 @@ L 637.2 283.344382
      <g id="line2d_39">
       <path d="M 49.078125 275.93469 
 L 637.2 275.93469 
-" clip-path="url(#p09135f412f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5e056e5ead)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#mc7efb2cc29" x="49.078125" y="275.93469" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m305e82df09" x="49.078125" y="275.93469" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1087,11 +1087,11 @@ L 637.2 275.93469
      <g id="line2d_41">
       <path d="M 49.078125 269.398879 
 L 637.2 269.398879 
-" clip-path="url(#p09135f412f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5e056e5ead)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#mc7efb2cc29" x="49.078125" y="269.398879" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m305e82df09" x="49.078125" y="269.398879" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1099,11 +1099,11 @@ L 637.2 269.398879
      <g id="line2d_43">
       <path d="M 49.078125 225.089477 
 L 637.2 225.089477 
-" clip-path="url(#p09135f412f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5e056e5ead)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#mc7efb2cc29" x="49.078125" y="225.089477" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m305e82df09" x="49.078125" y="225.089477" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1111,11 +1111,11 @@ L 637.2 225.089477
      <g id="line2d_45">
       <path d="M 49.078125 202.590112 
 L 637.2 202.590112 
-" clip-path="url(#p09135f412f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5e056e5ead)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#mc7efb2cc29" x="49.078125" y="202.590112" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m305e82df09" x="49.078125" y="202.590112" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1123,11 +1123,11 @@ L 637.2 202.590112
      <g id="line2d_47">
       <path d="M 49.078125 186.626558 
 L 637.2 186.626558 
-" clip-path="url(#p09135f412f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5e056e5ead)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#mc7efb2cc29" x="49.078125" y="186.626558" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m305e82df09" x="49.078125" y="186.626558" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1135,11 +1135,11 @@ L 637.2 186.626558
      <g id="line2d_49">
       <path d="M 49.078125 174.244264 
 L 637.2 174.244264 
-" clip-path="url(#p09135f412f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5e056e5ead)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#mc7efb2cc29" x="49.078125" y="174.244264" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m305e82df09" x="49.078125" y="174.244264" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1147,11 +1147,11 @@ L 637.2 174.244264
      <g id="line2d_51">
       <path d="M 49.078125 164.127193 
 L 637.2 164.127193 
-" clip-path="url(#p09135f412f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5e056e5ead)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#mc7efb2cc29" x="49.078125" y="164.127193" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m305e82df09" x="49.078125" y="164.127193" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1159,11 +1159,11 @@ L 637.2 164.127193
      <g id="line2d_53">
       <path d="M 49.078125 155.573332 
 L 637.2 155.573332 
-" clip-path="url(#p09135f412f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5e056e5ead)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#mc7efb2cc29" x="49.078125" y="155.573332" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m305e82df09" x="49.078125" y="155.573332" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1171,11 +1171,11 @@ L 637.2 155.573332
      <g id="line2d_55">
       <path d="M 49.078125 148.16364 
 L 637.2 148.16364 
-" clip-path="url(#p09135f412f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5e056e5ead)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#mc7efb2cc29" x="49.078125" y="148.16364" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m305e82df09" x="49.078125" y="148.16364" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1183,11 +1183,11 @@ L 637.2 148.16364
      <g id="line2d_57">
       <path d="M 49.078125 141.627828 
 L 637.2 141.627828 
-" clip-path="url(#p09135f412f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5e056e5ead)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#mc7efb2cc29" x="49.078125" y="141.627828" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m305e82df09" x="49.078125" y="141.627828" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1195,11 +1195,11 @@ L 637.2 141.627828
      <g id="line2d_59">
       <path d="M 49.078125 97.318426 
 L 637.2 97.318426 
-" clip-path="url(#p09135f412f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5e056e5ead)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#mc7efb2cc29" x="49.078125" y="97.318426" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m305e82df09" x="49.078125" y="97.318426" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1207,11 +1207,11 @@ L 637.2 97.318426
      <g id="line2d_61">
       <path d="M 49.078125 74.819061 
 L 637.2 74.819061 
-" clip-path="url(#p09135f412f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5e056e5ead)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#mc7efb2cc29" x="49.078125" y="74.819061" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m305e82df09" x="49.078125" y="74.819061" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1219,11 +1219,11 @@ L 637.2 74.819061
      <g id="line2d_63">
       <path d="M 49.078125 58.855508 
 L 637.2 58.855508 
-" clip-path="url(#p09135f412f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5e056e5ead)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#mc7efb2cc29" x="49.078125" y="58.855508" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m305e82df09" x="49.078125" y="58.855508" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1386,7 +1386,7 @@ z
    <g id="line2d_65">
     <path d="M 49.078125 63.959148 
 L 637.2 63.959148 
-" clip-path="url(#p09135f412f)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
+" clip-path="url(#p5e056e5ead)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
    </g>
    <g id="patch_3">
     <path d="M 49.078125 412.80375 
@@ -1750,78 +1750,78 @@ z
    </g>
    <g id="line2d_66">
     <defs>
-     <path id="mad332c4711" d="M -2.5 2.5 
+     <path id="m105df03160" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p09135f412f)">
-     <use xlink:href="#mad332c4711" x="75.810937" y="261.499418" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mad332c4711" x="105.634056" y="267.789789" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mad332c4711" x="204.490635" y="300.141767" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mad332c4711" x="234.479899" y="305.825518" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mad332c4711" x="242.537956" y="315.036638" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mad332c4711" x="300.771958" y="297.144782" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mad332c4711" x="303.26414" y="308.187059" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mad332c4711" x="304.261013" y="317.962594" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mad332c4711" x="313.897453" y="317.915276" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mad332c4711" x="414.166268" y="334.703269" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mad332c4711" x="587.289889" y="327.69079" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mad332c4711" x="610.467187" y="318.226537" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p5e056e5ead)">
+     <use xlink:href="#m105df03160" x="75.810937" y="261.499418" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m105df03160" x="105.634056" y="267.789789" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m105df03160" x="204.490635" y="300.141767" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m105df03160" x="234.479899" y="305.825518" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m105df03160" x="242.537956" y="315.036638" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m105df03160" x="300.771958" y="297.144782" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m105df03160" x="303.26414" y="308.187059" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m105df03160" x="304.261013" y="317.962594" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m105df03160" x="313.897453" y="317.915276" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m105df03160" x="414.166268" y="334.703269" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m105df03160" x="587.289889" y="327.69079" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m105df03160" x="610.467187" y="318.226537" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_67">
     <defs>
-     <path id="m490aaa6b28" d="M 0 -2.5 
+     <path id="m4665cdf377" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p09135f412f)">
-     <use xlink:href="#m490aaa6b28" x="75.810937" y="260.530934" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m490aaa6b28" x="105.634056" y="253.086833" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m490aaa6b28" x="204.490635" y="298.70349" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m490aaa6b28" x="234.479899" y="296.22935" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m490aaa6b28" x="242.537956" y="305.176737" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m490aaa6b28" x="300.771958" y="285.410956" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m490aaa6b28" x="303.26414" y="298.378247" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m490aaa6b28" x="304.261013" y="313.133077" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m490aaa6b28" x="313.897453" y="305.293171" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m490aaa6b28" x="414.166268" y="324.077479" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m490aaa6b28" x="587.289889" y="327.012757" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m490aaa6b28" x="610.467187" y="316.190866" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p5e056e5ead)">
+     <use xlink:href="#m4665cdf377" x="75.810937" y="260.530934" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4665cdf377" x="105.634056" y="253.086833" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4665cdf377" x="204.490635" y="298.70349" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4665cdf377" x="234.479899" y="296.22935" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4665cdf377" x="242.537956" y="305.176737" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4665cdf377" x="300.771958" y="285.410956" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4665cdf377" x="303.26414" y="298.378247" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4665cdf377" x="304.261013" y="313.133077" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4665cdf377" x="313.897453" y="305.293171" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4665cdf377" x="414.166268" y="324.077479" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4665cdf377" x="587.289889" y="327.012757" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4665cdf377" x="610.467187" y="316.190866" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_68">
     <defs>
-     <path id="m0e8c4881d0" d="M -0 3.535534 
+     <path id="mefe39920c9" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p09135f412f)">
-     <use xlink:href="#m0e8c4881d0" x="75.810937" y="227.388814" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0e8c4881d0" x="105.634056" y="230.25942" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0e8c4881d0" x="204.490635" y="258.634614" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0e8c4881d0" x="234.479899" y="259.9616" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0e8c4881d0" x="242.537956" y="271.375201" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0e8c4881d0" x="300.771958" y="257.414579" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0e8c4881d0" x="303.26414" y="268.600048" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0e8c4881d0" x="304.261013" y="280.21882" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0e8c4881d0" x="313.897453" y="276.166151" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0e8c4881d0" x="414.166268" y="294.866345" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0e8c4881d0" x="587.289889" y="301.289826" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0e8c4881d0" x="610.467187" y="295.675174" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p5e056e5ead)">
+     <use xlink:href="#mefe39920c9" x="75.810937" y="227.388814" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mefe39920c9" x="105.634056" y="230.25942" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mefe39920c9" x="204.490635" y="258.634614" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mefe39920c9" x="234.479899" y="259.9616" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mefe39920c9" x="242.537956" y="271.375201" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mefe39920c9" x="300.771958" y="257.414579" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mefe39920c9" x="303.26414" y="268.600048" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mefe39920c9" x="304.261013" y="280.21882" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mefe39920c9" x="313.897453" y="276.166151" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mefe39920c9" x="414.166268" y="294.866345" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mefe39920c9" x="587.289889" y="301.289826" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mefe39920c9" x="610.467187" y="295.675174" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_69">
     <defs>
-     <path id="md37ea35511" d="M -0.833333 2.5 
+     <path id="mf6075972d2" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -1836,24 +1836,24 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p09135f412f)">
-     <use xlink:href="#md37ea35511" x="75.810937" y="285.710438" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md37ea35511" x="105.634056" y="293.592247" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md37ea35511" x="204.490635" y="326.133408" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md37ea35511" x="234.479899" y="337.73493" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md37ea35511" x="242.537956" y="340.932892" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md37ea35511" x="300.771958" y="336.31256" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md37ea35511" x="303.26414" y="344.605532" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md37ea35511" x="304.261013" y="344.457488" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md37ea35511" x="313.897453" y="351.398372" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md37ea35511" x="414.166268" y="363.200005" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md37ea35511" x="587.289889" y="368.07815" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md37ea35511" x="610.467187" y="356.863633" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p5e056e5ead)">
+     <use xlink:href="#mf6075972d2" x="75.810937" y="285.710438" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf6075972d2" x="105.634056" y="293.592247" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf6075972d2" x="204.490635" y="326.133408" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf6075972d2" x="234.479899" y="337.73493" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf6075972d2" x="242.537956" y="340.932892" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf6075972d2" x="300.771958" y="336.31256" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf6075972d2" x="303.26414" y="344.605532" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf6075972d2" x="304.261013" y="344.457488" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf6075972d2" x="313.897453" y="351.398372" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf6075972d2" x="414.166268" y="363.200005" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf6075972d2" x="587.289889" y="368.07815" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf6075972d2" x="610.467187" y="356.863633" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_70">
     <defs>
-     <path id="mbc2e97cd45" d="M -1.25 2.5 
+     <path id="mebec333f34" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -1868,24 +1868,24 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p09135f412f)">
-     <use xlink:href="#mbc2e97cd45" x="75.810937" y="327.525336" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbc2e97cd45" x="105.634056" y="342.492009" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbc2e97cd45" x="204.490635" y="362.75387" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbc2e97cd45" x="234.479899" y="371.266849" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbc2e97cd45" x="242.537956" y="367.162311" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbc2e97cd45" x="300.771958" y="359.922516" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbc2e97cd45" x="303.26414" y="374.621262" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbc2e97cd45" x="304.261013" y="357.345835" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbc2e97cd45" x="313.897453" y="374.526887" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbc2e97cd45" x="414.166268" y="384.995187" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbc2e97cd45" x="587.289889" y="394.327659" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbc2e97cd45" x="610.467187" y="391.234733" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p5e056e5ead)">
+     <use xlink:href="#mebec333f34" x="75.810937" y="327.525336" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mebec333f34" x="105.634056" y="342.492009" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mebec333f34" x="204.490635" y="362.75387" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mebec333f34" x="234.479899" y="371.266849" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mebec333f34" x="242.537956" y="367.162311" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mebec333f34" x="300.771958" y="359.922516" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mebec333f34" x="303.26414" y="374.621262" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mebec333f34" x="304.261013" y="357.345835" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mebec333f34" x="313.897453" y="374.526887" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mebec333f34" x="414.166268" y="384.995187" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mebec333f34" x="587.289889" y="394.327659" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mebec333f34" x="610.467187" y="391.234733" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_71">
     <defs>
-     <path id="m21332fd4d6" d="M 0 -2.5 
+     <path id="m87d9b8ba24" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -1898,24 +1898,24 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p09135f412f)">
-     <use xlink:href="#m21332fd4d6" x="75.810937" y="273.42452" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m21332fd4d6" x="105.634056" y="285.910165" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m21332fd4d6" x="204.490635" y="319.387555" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m21332fd4d6" x="234.479899" y="320.971757" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m21332fd4d6" x="242.537956" y="325.718465" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m21332fd4d6" x="300.771958" y="332.867753" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m21332fd4d6" x="303.26414" y="336.779875" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m21332fd4d6" x="304.261013" y="345.614079" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m21332fd4d6" x="313.897453" y="336.582957" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m21332fd4d6" x="414.166268" y="357.342827" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m21332fd4d6" x="587.289889" y="366.194267" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m21332fd4d6" x="610.467187" y="360.776693" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p5e056e5ead)">
+     <use xlink:href="#m87d9b8ba24" x="75.810937" y="273.42452" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m87d9b8ba24" x="105.634056" y="285.910165" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m87d9b8ba24" x="204.490635" y="319.387555" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m87d9b8ba24" x="234.479899" y="320.971757" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m87d9b8ba24" x="242.537956" y="325.718465" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m87d9b8ba24" x="300.771958" y="332.867753" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m87d9b8ba24" x="303.26414" y="336.779875" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m87d9b8ba24" x="304.261013" y="345.614079" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m87d9b8ba24" x="313.897453" y="336.582957" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m87d9b8ba24" x="414.166268" y="357.342827" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m87d9b8ba24" x="587.289889" y="366.194267" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m87d9b8ba24" x="610.467187" y="360.776693" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_72">
     <defs>
-     <path id="m0c38bb831f" d="M 0 -2.5 
+     <path id="mc5c3248a37" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -1924,19 +1924,19 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p09135f412f)">
-     <use xlink:href="#m0c38bb831f" x="75.810937" y="347.034581" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0c38bb831f" x="105.634056" y="348.566824" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0c38bb831f" x="204.490635" y="367.234161" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0c38bb831f" x="234.479899" y="372.966525" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0c38bb831f" x="242.537956" y="379.953597" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0c38bb831f" x="300.771958" y="370.457094" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0c38bb831f" x="303.26414" y="375.315519" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0c38bb831f" x="304.261013" y="382.991991" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0c38bb831f" x="313.897453" y="385.183642" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0c38bb831f" x="414.166268" y="391.635066" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0c38bb831f" x="587.289889" y="396.192102" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0c38bb831f" x="610.467187" y="383.674277" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p5e056e5ead)">
+     <use xlink:href="#mc5c3248a37" x="75.810937" y="347.034581" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc5c3248a37" x="105.634056" y="348.566824" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc5c3248a37" x="204.490635" y="367.234161" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc5c3248a37" x="234.479899" y="372.966525" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc5c3248a37" x="242.537956" y="379.953597" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc5c3248a37" x="300.771958" y="370.457094" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc5c3248a37" x="303.26414" y="375.315519" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc5c3248a37" x="304.261013" y="382.991991" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc5c3248a37" x="313.897453" y="385.183642" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc5c3248a37" x="414.166268" y="391.635066" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc5c3248a37" x="587.289889" y="396.192102" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc5c3248a37" x="610.467187" y="383.674277" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="legend_1">
@@ -1955,7 +1955,7 @@ z
     </g>
     <g id="line2d_73">
      <defs>
-      <path id="m141c38aff2" d="M 0 3.5 
+      <path id="m31cac17edf" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -1968,7 +1968,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m141c38aff2" x="434.04625" y="211.758125" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m31cac17edf" x="434.04625" y="211.758125" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_15">
@@ -2027,7 +2027,7 @@ z
     </g>
     <g id="line2d_74">
      <g>
-      <use xlink:href="#mad332c4711" x="434.04625" y="223.500625" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m105df03160" x="434.04625" y="223.500625" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_16">
@@ -2041,7 +2041,7 @@ z
     </g>
     <g id="line2d_75">
      <g>
-      <use xlink:href="#m490aaa6b28" x="434.04625" y="235.243125" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m4665cdf377" x="434.04625" y="235.243125" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -2086,7 +2086,7 @@ z
     </g>
     <g id="line2d_76">
      <g>
-      <use xlink:href="#m0e8c4881d0" x="434.04625" y="247.208125" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mefe39920c9" x="434.04625" y="247.208125" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -2106,7 +2106,7 @@ z
     </g>
     <g id="line2d_77">
      <g>
-      <use xlink:href="#md37ea35511" x="537.72375" y="211.758125" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mf6075972d2" x="537.72375" y="211.758125" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -2133,7 +2133,7 @@ z
     </g>
     <g id="line2d_78">
      <g>
-      <use xlink:href="#mbc2e97cd45" x="537.72375" y="223.500625" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mebec333f34" x="537.72375" y="223.500625" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -2198,7 +2198,7 @@ z
     </g>
     <g id="line2d_79">
      <g>
-      <use xlink:href="#m21332fd4d6" x="537.72375" y="235.243125" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#m87d9b8ba24" x="537.72375" y="235.243125" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_21">
@@ -2236,7 +2236,7 @@ z
     </g>
     <g id="line2d_80">
      <g>
-      <use xlink:href="#m0c38bb831f" x="537.72375" y="246.985625" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mc5c3248a37" x="537.72375" y="246.985625" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -2306,19 +2306,19 @@ z
     </g>
    </g>
    <g id="line2d_81">
-    <g clip-path="url(#p09135f412f)">
-     <use xlink:href="#m141c38aff2" x="75.810937" y="271.412271" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m141c38aff2" x="105.634056" y="288.483705" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m141c38aff2" x="204.490635" y="322.051997" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m141c38aff2" x="234.479899" y="323.836862" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m141c38aff2" x="242.537956" y="323.417459" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m141c38aff2" x="300.771958" y="312.420349" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m141c38aff2" x="303.26414" y="331.455799" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m141c38aff2" x="304.261013" y="352.291902" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m141c38aff2" x="313.897453" y="337.639947" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m141c38aff2" x="414.166268" y="356.780198" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m141c38aff2" x="587.289889" y="359.564452" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m141c38aff2" x="610.467187" y="343.056471" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <g clip-path="url(#p5e056e5ead)">
+     <use xlink:href="#m31cac17edf" x="75.810937" y="271.412271" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m31cac17edf" x="105.634056" y="288.483705" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m31cac17edf" x="204.490635" y="322.051997" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m31cac17edf" x="234.479899" y="323.836862" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m31cac17edf" x="242.537956" y="323.417459" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m31cac17edf" x="300.771958" y="312.420349" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m31cac17edf" x="303.26414" y="331.455799" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m31cac17edf" x="304.261013" y="352.291902" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m31cac17edf" x="313.897453" y="337.639947" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m31cac17edf" x="414.166268" y="356.780198" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m31cac17edf" x="587.289889" y="359.564452" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m31cac17edf" x="610.467187" y="343.056471" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
   </g>
@@ -3172,7 +3172,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p09135f412f">
+  <clipPath id="p5e056e5ead">
    <rect x="49.078125" y="47.3475" width="588.121875" height="365.45625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_decode_ranking.svg
+++ b/bench/graphs/silesia_decode_ranking.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 292.711764 308.04375 
 L 292.711764 56.7075 
-" clip-path="url(#p670f689203)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p002b517547)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m072fd7e29c" d="M 0 0 
+       <path id="md9be1940e7" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m072fd7e29c" x="292.711764" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md9be1940e7" x="292.711764" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -136,11 +136,11 @@ z
      <g id="line2d_3">
       <path d="M 450.890649 308.04375 
 L 450.890649 56.7075 
-" clip-path="url(#p670f689203)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p002b517547)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m072fd7e29c" x="450.890649" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md9be1940e7" x="450.890649" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -177,16 +177,16 @@ z
      <g id="line2d_5">
       <path d="M 182.149468 308.04375 
 L 182.149468 56.7075 
-" clip-path="url(#p670f689203)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p002b517547)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <defs>
-       <path id="m68252638c1" d="M 0 0 
+       <path id="m0508e6abe1" d="M 0 0 
 L 0 2 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m68252638c1" x="182.149468" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0508e6abe1" x="182.149468" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -194,11 +194,11 @@ L 0 2
      <g id="line2d_7">
       <path d="M 210.003387 308.04375 
 L 210.003387 56.7075 
-" clip-path="url(#p670f689203)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p002b517547)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m68252638c1" x="210.003387" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0508e6abe1" x="210.003387" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -206,11 +206,11 @@ L 210.003387 56.7075
      <g id="line2d_9">
       <path d="M 229.766057 308.04375 
 L 229.766057 56.7075 
-" clip-path="url(#p670f689203)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p002b517547)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m68252638c1" x="229.766057" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0508e6abe1" x="229.766057" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -218,11 +218,11 @@ L 229.766057 56.7075
      <g id="line2d_11">
       <path d="M 245.095175 308.04375 
 L 245.095175 56.7075 
-" clip-path="url(#p670f689203)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p002b517547)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m68252638c1" x="245.095175" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0508e6abe1" x="245.095175" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -230,11 +230,11 @@ L 245.095175 56.7075
      <g id="line2d_13">
       <path d="M 257.619976 308.04375 
 L 257.619976 56.7075 
-" clip-path="url(#p670f689203)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p002b517547)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m68252638c1" x="257.619976" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0508e6abe1" x="257.619976" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -242,11 +242,11 @@ L 257.619976 56.7075
      <g id="line2d_15">
       <path d="M 268.209544 308.04375 
 L 268.209544 56.7075 
-" clip-path="url(#p670f689203)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p002b517547)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m68252638c1" x="268.209544" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0508e6abe1" x="268.209544" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -254,11 +254,11 @@ L 268.209544 56.7075
      <g id="line2d_17">
       <path d="M 277.382646 308.04375 
 L 277.382646 56.7075 
-" clip-path="url(#p670f689203)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p002b517547)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m68252638c1" x="277.382646" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0508e6abe1" x="277.382646" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -266,11 +266,11 @@ L 277.382646 56.7075
      <g id="line2d_19">
       <path d="M 285.473895 308.04375 
 L 285.473895 56.7075 
-" clip-path="url(#p670f689203)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p002b517547)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m68252638c1" x="285.473895" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0508e6abe1" x="285.473895" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -278,11 +278,11 @@ L 285.473895 56.7075
      <g id="line2d_21">
       <path d="M 340.328353 308.04375 
 L 340.328353 56.7075 
-" clip-path="url(#p670f689203)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p002b517547)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m68252638c1" x="340.328353" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0508e6abe1" x="340.328353" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -290,11 +290,11 @@ L 340.328353 56.7075
      <g id="line2d_23">
       <path d="M 368.182272 308.04375 
 L 368.182272 56.7075 
-" clip-path="url(#p670f689203)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p002b517547)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m68252638c1" x="368.182272" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0508e6abe1" x="368.182272" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -302,11 +302,11 @@ L 368.182272 56.7075
      <g id="line2d_25">
       <path d="M 387.944942 308.04375 
 L 387.944942 56.7075 
-" clip-path="url(#p670f689203)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p002b517547)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m68252638c1" x="387.944942" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0508e6abe1" x="387.944942" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -314,11 +314,11 @@ L 387.944942 56.7075
      <g id="line2d_27">
       <path d="M 403.27406 308.04375 
 L 403.27406 56.7075 
-" clip-path="url(#p670f689203)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p002b517547)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m68252638c1" x="403.27406" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0508e6abe1" x="403.27406" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -326,11 +326,11 @@ L 403.27406 56.7075
      <g id="line2d_29">
       <path d="M 415.798861 308.04375 
 L 415.798861 56.7075 
-" clip-path="url(#p670f689203)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p002b517547)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m68252638c1" x="415.798861" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0508e6abe1" x="415.798861" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -338,11 +338,11 @@ L 415.798861 56.7075
      <g id="line2d_31">
       <path d="M 426.38843 308.04375 
 L 426.38843 56.7075 
-" clip-path="url(#p670f689203)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p002b517547)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m68252638c1" x="426.38843" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0508e6abe1" x="426.38843" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -350,11 +350,11 @@ L 426.38843 56.7075
      <g id="line2d_33">
       <path d="M 435.561531 308.04375 
 L 435.561531 56.7075 
-" clip-path="url(#p670f689203)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p002b517547)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m68252638c1" x="435.561531" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0508e6abe1" x="435.561531" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -362,11 +362,11 @@ L 435.561531 56.7075
      <g id="line2d_35">
       <path d="M 443.65278 308.04375 
 L 443.65278 56.7075 
-" clip-path="url(#p670f689203)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p002b517547)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m68252638c1" x="443.65278" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0508e6abe1" x="443.65278" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -374,11 +374,11 @@ L 443.65278 56.7075
      <g id="line2d_37">
       <path d="M 498.507238 308.04375 
 L 498.507238 56.7075 
-" clip-path="url(#p670f689203)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p002b517547)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m68252638c1" x="498.507238" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0508e6abe1" x="498.507238" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -386,11 +386,11 @@ L 498.507238 56.7075
      <g id="line2d_39">
       <path d="M 526.361157 308.04375 
 L 526.361157 56.7075 
-" clip-path="url(#p670f689203)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p002b517547)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m68252638c1" x="526.361157" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0508e6abe1" x="526.361157" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -398,11 +398,11 @@ L 526.361157 56.7075
      <g id="line2d_41">
       <path d="M 546.123827 308.04375 
 L 546.123827 56.7075 
-" clip-path="url(#p670f689203)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p002b517547)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m68252638c1" x="546.123827" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0508e6abe1" x="546.123827" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -410,11 +410,11 @@ L 546.123827 56.7075
      <g id="line2d_43">
       <path d="M 561.452945 308.04375 
 L 561.452945 56.7075 
-" clip-path="url(#p670f689203)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p002b517547)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m68252638c1" x="561.452945" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0508e6abe1" x="561.452945" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1016,12 +1016,12 @@ z
     <g id="ytick_1">
      <g id="line2d_45">
       <defs>
-       <path id="mc35861ad4a" d="M 0 0 
+       <path id="mba2c1d3836" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mc35861ad4a" x="139.360469" y="296.619375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mba2c1d3836" x="139.360469" y="296.619375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -1093,7 +1093,7 @@ z
     <g id="ytick_2">
      <g id="line2d_46">
       <g>
-       <use xlink:href="#mc35861ad4a" x="139.360469" y="263.978304" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mba2c1d3836" x="139.360469" y="263.978304" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -1160,7 +1160,7 @@ z
     <g id="ytick_3">
      <g id="line2d_47">
       <g>
-       <use xlink:href="#mc35861ad4a" x="139.360469" y="231.337232" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mba2c1d3836" x="139.360469" y="231.337232" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -1216,7 +1216,7 @@ z
     <g id="ytick_4">
      <g id="line2d_48">
       <g>
-       <use xlink:href="#mc35861ad4a" x="139.360469" y="198.696161" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mba2c1d3836" x="139.360469" y="198.696161" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -1263,7 +1263,7 @@ z
     <g id="ytick_5">
      <g id="line2d_49">
       <g>
-       <use xlink:href="#mc35861ad4a" x="139.360469" y="166.055089" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mba2c1d3836" x="139.360469" y="166.055089" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -1376,7 +1376,7 @@ z
     <g id="ytick_6">
      <g id="line2d_50">
       <g>
-       <use xlink:href="#mc35861ad4a" x="139.360469" y="133.414018" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mba2c1d3836" x="139.360469" y="133.414018" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -1392,7 +1392,7 @@ z
     <g id="ytick_7">
      <g id="line2d_51">
       <g>
-       <use xlink:href="#mc35861ad4a" x="139.360469" y="100.772946" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mba2c1d3836" x="139.360469" y="100.772946" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -1439,7 +1439,7 @@ z
     <g id="ytick_8">
      <g id="line2d_52">
       <g>
-       <use xlink:href="#mc35861ad4a" x="139.360469" y="68.131875" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mba2c1d3836" x="139.360469" y="68.131875" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -1462,47 +1462,47 @@ z
    <g id="LineCollection_1">
     <path d="M 139.360469 296.619375 
 L 154.689587 296.619375 
-" clip-path="url(#p670f689203)" style="fill: none; stroke: #17becf; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p002b517547)" style="fill: none; stroke: #17becf; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_2">
     <path d="M 139.360469 263.978304 
 L 161.205974 263.978304 
-" clip-path="url(#p670f689203)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p002b517547)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_3">
     <path d="M 139.360469 231.337232 
 L 200.830675 231.337232 
-" clip-path="url(#p670f689203)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p002b517547)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_4">
     <path d="M 139.360469 198.696161 
 L 208.626886 198.696161 
-" clip-path="url(#p670f689203)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p002b517547)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_5">
     <path d="M 139.360469 166.055089 
 L 213.069162 166.055089 
-" clip-path="url(#p670f689203)" style="fill: none; stroke: #d62728; stroke-opacity: 0.9; stroke-width: 2.4"/>
+" clip-path="url(#p002b517547)" style="fill: none; stroke: #d62728; stroke-opacity: 0.9; stroke-width: 2.4"/>
    </g>
    <g id="LineCollection_6">
     <path d="M 139.360469 133.414018 
 L 240.46049 133.414018 
-" clip-path="url(#p670f689203)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p002b517547)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_7">
     <path d="M 139.360469 100.772946 
 L 249.06205 100.772946 
-" clip-path="url(#p670f689203)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p002b517547)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_8">
     <path d="M 139.360469 68.131875 
 L 286.244503 68.131875 
-" clip-path="url(#p670f689203)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p002b517547)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="line2d_53">
     <path d="M 542.08563 308.04375 
 L 542.08563 56.7075 
-" clip-path="url(#p670f689203)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
+" clip-path="url(#p002b517547)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
    </g>
    <g id="patch_3">
     <path d="M 139.360469 308.04375 
@@ -1905,7 +1905,7 @@ z
    </g>
    <g id="line2d_54">
     <defs>
-     <path id="mff8e59f819" d="M 0 3 
+     <path id="m1e52893163" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1917,13 +1917,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #17becf"/>
     </defs>
-    <g clip-path="url(#p670f689203)">
-     <use xlink:href="#mff8e59f819" x="154.689587" y="296.619375" style="fill: #17becf; stroke: #17becf"/>
+    <g clip-path="url(#p002b517547)">
+     <use xlink:href="#m1e52893163" x="154.689587" y="296.619375" style="fill: #17becf; stroke: #17becf"/>
     </g>
    </g>
    <g id="line2d_55">
     <defs>
-     <path id="m738e5657cd" d="M 0 3 
+     <path id="m56d5462e60" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1935,13 +1935,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #e377c2"/>
     </defs>
-    <g clip-path="url(#p670f689203)">
-     <use xlink:href="#m738e5657cd" x="161.205974" y="263.978304" style="fill: #e377c2; stroke: #e377c2"/>
+    <g clip-path="url(#p002b517547)">
+     <use xlink:href="#m56d5462e60" x="161.205974" y="263.978304" style="fill: #e377c2; stroke: #e377c2"/>
     </g>
    </g>
    <g id="line2d_56">
     <defs>
-     <path id="m448d1563f5" d="M 0 3 
+     <path id="m962e90e686" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1953,13 +1953,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #8c564b"/>
     </defs>
-    <g clip-path="url(#p670f689203)">
-     <use xlink:href="#m448d1563f5" x="200.830675" y="231.337232" style="fill: #8c564b; stroke: #8c564b"/>
+    <g clip-path="url(#p002b517547)">
+     <use xlink:href="#m962e90e686" x="200.830675" y="231.337232" style="fill: #8c564b; stroke: #8c564b"/>
     </g>
    </g>
    <g id="line2d_57">
     <defs>
-     <path id="m4727411a9b" d="M 0 3 
+     <path id="m8cb54728b1" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1971,13 +1971,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #bcbd22"/>
     </defs>
-    <g clip-path="url(#p670f689203)">
-     <use xlink:href="#m4727411a9b" x="208.626886" y="198.696161" style="fill: #bcbd22; stroke: #bcbd22"/>
+    <g clip-path="url(#p002b517547)">
+     <use xlink:href="#m8cb54728b1" x="208.626886" y="198.696161" style="fill: #bcbd22; stroke: #bcbd22"/>
     </g>
    </g>
    <g id="line2d_58">
     <defs>
-     <path id="m8fa684deaf" d="M 0 5 
+     <path id="ma70151365a" d="M 0 5 
 C 1.326016 5 2.597899 4.473168 3.535534 3.535534 
 C 4.473168 2.597899 5 1.326016 5 0 
 C 5 -1.326016 4.473168 -2.597899 3.535534 -3.535534 
@@ -1989,13 +1989,13 @@ C -2.597899 4.473168 -1.326016 5 0 5
 z
 " style="stroke: #d62728"/>
     </defs>
-    <g clip-path="url(#p670f689203)">
-     <use xlink:href="#m8fa684deaf" x="213.069162" y="166.055089" style="fill: #d62728; stroke: #d62728"/>
+    <g clip-path="url(#p002b517547)">
+     <use xlink:href="#ma70151365a" x="213.069162" y="166.055089" style="fill: #d62728; stroke: #d62728"/>
     </g>
    </g>
    <g id="line2d_59">
     <defs>
-     <path id="m1d661488c6" d="M 0 3 
+     <path id="m4ab44bc3f0" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -2007,13 +2007,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #1f77b4"/>
     </defs>
-    <g clip-path="url(#p670f689203)">
-     <use xlink:href="#m1d661488c6" x="240.46049" y="133.414018" style="fill: #1f77b4; stroke: #1f77b4"/>
+    <g clip-path="url(#p002b517547)">
+     <use xlink:href="#m4ab44bc3f0" x="240.46049" y="133.414018" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_60">
     <defs>
-     <path id="mc08062b8e1" d="M 0 3 
+     <path id="m82aa36b1de" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -2025,13 +2025,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #2ca02c"/>
     </defs>
-    <g clip-path="url(#p670f689203)">
-     <use xlink:href="#mc08062b8e1" x="249.06205" y="100.772946" style="fill: #2ca02c; stroke: #2ca02c"/>
+    <g clip-path="url(#p002b517547)">
+     <use xlink:href="#m82aa36b1de" x="249.06205" y="100.772946" style="fill: #2ca02c; stroke: #2ca02c"/>
     </g>
    </g>
    <g id="line2d_61">
     <defs>
-     <path id="mae54c62782" d="M 0 3 
+     <path id="m84d144b693" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -2043,8 +2043,8 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #9467bd"/>
     </defs>
-    <g clip-path="url(#p670f689203)">
-     <use xlink:href="#mae54c62782" x="286.244503" y="68.131875" style="fill: #9467bd; stroke: #9467bd"/>
+    <g clip-path="url(#p002b517547)">
+     <use xlink:href="#m84d144b693" x="286.244503" y="68.131875" style="fill: #9467bd; stroke: #9467bd"/>
     </g>
    </g>
   </g>
@@ -2984,7 +2984,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p670f689203">
+  <clipPath id="p002b517547">
    <rect x="139.360469" y="56.7075" width="425.839531" height="251.33625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_ratio_heatmap.svg
+++ b/bench/graphs/silesia_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.34175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#pcbc804194d)">
+   <g clip-path="url(#pac92c90bb9)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAosAAAGaCAYAAABniAm0AAAJ80lEQVR4nO3YO44dZhnH4TOe8UUe22NbECICAuGIghAoUSioUiEoWAMroKGiQuyAig3QoYjSTUqkcCdURISLuMgaYnzBcuzxzBxW8CtQ9OlFR8+zgr80Z97zO9/e+b0fbTc76OTHd6cnLHHxzdenJyyz99Inpycssf3t76YnLLH3pdemJyyxffp4esIyx999a3rCEi/94BvTE5bYu/2J6QlrnDydXrDM+c93895fmB4AAMD/L7EIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEDa+8/JW9vpESsc/vt4esISH9y4Oj1hmQ9Pn0xPWOLTj06mJyzx6OMvT09Y4nx7Pj1hmVsHt6cnrHH/L9MLlnh8azf/Xtf//IfpCctsP/+V6QlLeFkEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACAdHN6/N71hjas3pxcssd2eTE9Y5lNv/3J6whpvfn16wRJHH/xzesIa56fTC9Y53NH7cfna9IIlbvxrN7+fH3zmzvSEZW797d3pCUt4WQQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAADS3ouzu9vpESvsH/9pesIS965fmp6wzJMXD6cnLHHnrw+nJyxx+sWvTk9Y4unp4+kJyxzt35yesMT2/V9MT1ji2eden56wxJV335mesMzzL78xPWEJL4sAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA2vvp+9/ZTo9Y4faVw+kJS7z38P70hGW+/cNfT09Y4jff/+b0hCWOLh9NT1jiez/71fSEZb72ypXpCUt8684b0xOWePvv70xPWOLaxd38HG42m81P/vhgesISXhYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAtPfi7O52esQKD54fT09Y4vDgxvSEZd57+PvpCUu8evO16QlLbLfn0xOWuHa6u7+h/3G+m3fxlcNXpycs8ezs6fSEJXb1dmw2m83+hYPpCUvs7lUEAOAjE4sAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAOtjfO5jesMTH9m9PT1hj/9L0gmWOLh9NT1ji8ODG9IQlzran0xOWOL+4u7+hX95enZ7A/2BXv59Pts+mJyzz+Pnx9IQldvcqAgDwkYlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAADSwWZ7Pr1hiUfbJ9MTljg4uzQ9YZnPXv/C9IQlzran0xOW+PB0N//Hrm2uTE9Y5tmF3bz3+9MDFrm4v5v3fv/CwfSEZQ73rk5PWMLLIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJD+C2EVlmm8G2EiAAAAAElFTkSuQmCC" id="image4fd578aa78" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="468.72" height="295.2"/>
+iVBORw0KGgoAAAANSUhEUgAAAosAAAGaCAYAAABniAm0AAAJ80lEQVR4nO3YO44dZhnH4TOe8UUe22NbECICAuGIghAoUSioUiEoWAMroKGiQuyAig3QoYjSTUqkcCdURISLuMgaYnzBcuzxzBxW8CtQ9OlFR8+zgr80Z97zO9/e+b0fbTc76OTHd6cnLHHxzdenJyyz99Inpycssf3t76YnLLH3pdemJyyxffp4esIyx999a3rCEi/94BvTE5bYu/2J6QlrnDydXrDM+c93895fmB4AAMD/L7EIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEDa+8/JW9vpESsc/vt4esISH9y4Oj1hmQ9Pn0xPWOLTj06mJyzx6OMvT09Y4nx7Pj1hmVsHt6cnrHH/L9MLlnh8azf/Xtf//IfpCctsP/+V6QlLeFkEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACAdHN6/N71hjas3pxcssd2eTE9Y5lNv/3J6whpvfn16wRJHH/xzesIa56fTC9Y53NH7cfna9IIlbvxrN7+fH3zmzvSEZW797d3pCUt4WQQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAADS3ouzu9vpESvsH/9pesIS965fmp6wzJMXD6cnLHHnrw+nJyxx+sWvTk9Y4unp4+kJyxzt35yesMT2/V9MT1ji2eden56wxJV335mesMzzL78xPWEJL4sAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA2vvp+9/ZTo9Y4faVw+kJS7z38P70hGW+/cNfT09Y4jff/+b0hCWOLh9NT1jiez/71fSEZb72ypXpCUt8684b0xOWePvv70xPWOLaxd38HG42m81P/vhgesISXhYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAtPfi7O52esQKD54fT09Y4vDgxvSEZd57+PvpCUu8evO16QlLbLfn0xOWuHa6u7+h/3G+m3fxlcNXpycs8ezs6fSEJXb1dmw2m83+hYPpCUvs7lUEAOAjE4sAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAOtjfO5jesMTH9m9PT1hj/9L0gmWOLh9NT1ji8ODG9IQlzran0xOWOL+4u7+hX95enZ7A/2BXv59Pts+mJyzz+Pnx9IQldvcqAgDwkYlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAADSwWZ7Pr1hiUfbJ9MTljg4uzQ9YZnPXv/C9IQlzran0xOW+PB0N//Hrm2uTE9Y5tmF3bz3+9MDFrm4v5v3fv/CwfSEZQ73rk5PWMLLIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJD+C2EVlmm8G2EiAAAAAElFTkSuQmCC" id="imaged8c3aef41e" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="468.72" height="295.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="md0296b3468" d="M 0 0 
+       <path id="m714fa5b87f" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#md0296b3468" x="115.182137" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m714fa5b87f" x="115.182137" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#md0296b3468" x="154.193912" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m714fa5b87f" x="154.193912" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#md0296b3468" x="193.205687" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m714fa5b87f" x="193.205687" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#md0296b3468" x="232.217462" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m714fa5b87f" x="232.217462" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#md0296b3468" x="271.229237" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m714fa5b87f" x="271.229237" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#md0296b3468" x="310.241012" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m714fa5b87f" x="310.241012" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#md0296b3468" x="349.252787" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m714fa5b87f" x="349.252787" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#md0296b3468" x="388.264562" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m714fa5b87f" x="388.264562" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#md0296b3468" x="427.276336" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m714fa5b87f" x="427.276336" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#md0296b3468" x="466.288111" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m714fa5b87f" x="466.288111" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#md0296b3468" x="505.299886" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m714fa5b87f" x="505.299886" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#md0296b3468" x="544.311661" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m714fa5b87f" x="544.311661" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="mf72de18c04" d="M 0 0 
+       <path id="mae493d92a5" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mf72de18c04" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mae493d92a5" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mf72de18c04" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mae493d92a5" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#mf72de18c04" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mae493d92a5" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#mf72de18c04" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mae493d92a5" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -836,7 +836,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#mf72de18c04" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mae493d92a5" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -899,7 +899,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mf72de18c04" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mae493d92a5" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -966,7 +966,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#mf72de18c04" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mae493d92a5" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1047,7 +1047,7 @@ z
     <g id="ytick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#mf72de18c04" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mae493d92a5" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -2060,18 +2060,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABEAAAFUCAYAAADCj9eRAAAB2ElEQVR4nO2aQY7EIAwEIeFP+6X9/33C3MPcKKSS1TygZRftNlLS2//fbJtn9KvvajAi17ZCM7Uzeg+TEyJhsh4TE8D25ZhYRMJkPSYmmZ0zIhfQEMPkJq74JpgQlUBMABkIrOV2KLMRItXMhrQjqcQUSszsbGuomFSbHULEAlblE0klor1zMaG0XwnDBDAsBVY0O4CIBizlE4ntEbCijK3mE8vKUPkEEIF8YslYje2RZFP5BJkdCxOonf1i6jEhRICOyjEBzFaPiWd2iChoYbKKhMkqgmSsh4kkHkU+6UyeACJEJaLZ6QQTzy7WtGPyicX2Kp/c+yKaATTliSWoTXsnPllEEtTLGX37f+7WRpuPQ4RhomlntCdMTohATIDbKceEaGfOD1BJZueIiImJZQBNTCxgw2Q91N7Zf7RBsxMmR0TqMdmvxPRmI0TmDJNVJExWkTBZRcJkFSnFZH6Q5aVhQrQzkYUOVEIxIXxSjAnRDjQ7mndsZud9VEwsPtFcsWjvaNZofHKoEpFPELCPJmORdqblMWxiYjEbw+QJk/dR+SQD+BbROFbEJAP4Q4RgQpiNCupKIhAT4gewakws7YTJIREoY4FPeNWYaNoJk18iQNqXY1LKJ1/07Ct/l+QCQgAAAABJRU5ErkJggg==" id="imagee31516b2c1" transform="scale(1 -1) translate(0 -244.8)" x="573.84" y="-74.16" width="12.24" height="244.8"/>
+iVBORw0KGgoAAAANSUhEUgAAABEAAAFUCAYAAADCj9eRAAAB2ElEQVR4nO2aQY7EIAwEIeFP+6X9/33C3MPcKKSS1TygZRftNlLS2//fbJtn9KvvajAi17ZCM7Uzeg+TEyJhsh4TE8D25ZhYRMJkPSYmmZ0zIhfQEMPkJq74JpgQlUBMABkIrOV2KLMRItXMhrQjqcQUSszsbGuomFSbHULEAlblE0klor1zMaG0XwnDBDAsBVY0O4CIBizlE4ntEbCijK3mE8vKUPkEEIF8YslYje2RZFP5BJkdCxOonf1i6jEhRICOyjEBzFaPiWd2iChoYbKKhMkqgmSsh4kkHkU+6UyeACJEJaLZ6QQTzy7WtGPyicX2Kp/c+yKaATTliSWoTXsnPllEEtTLGX37f+7WRpuPQ4RhomlntCdMTohATIDbKceEaGfOD1BJZueIiImJZQBNTCxgw2Q91N7Zf7RBsxMmR0TqMdmvxPRmI0TmDJNVJExWkTBZRcJkFSnFZH6Q5aVhQrQzkYUOVEIxIXxSjAnRDjQ7mndsZud9VEwsPtFcsWjvaNZofHKoEpFPELCPJmORdqblMWxiYjEbw+QJk/dR+SQD+BbROFbEJAP4Q4RgQpiNCupKIhAT4gewakws7YTJIREoY4FPeNWYaNoJk18iQNqXY1LKJ1/07Ct/l+QCQgAAAABJRU5ErkJggg==" id="imagee83f230946" transform="scale(1 -1) translate(0 -244.8)" x="573.84" y="-74.16" width="12.24" height="244.8"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_21">
       <defs>
-       <path id="m4cc71a2960" d="M 0 0 
+       <path id="m3d30db1bf7" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m4cc71a2960" x="585.876562" y="282.022672" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3d30db1bf7" x="585.876562" y="282.022672" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_117">
@@ -2097,7 +2097,7 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m4cc71a2960" x="585.876562" y="239.353777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3d30db1bf7" x="585.876562" y="239.353777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_118">
@@ -2114,7 +2114,7 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m4cc71a2960" x="585.876562" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3d30db1bf7" x="585.876562" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_119">
@@ -2130,7 +2130,7 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m4cc71a2960" x="585.876562" y="154.015985" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3d30db1bf7" x="585.876562" y="154.015985" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_120">
@@ -2146,7 +2146,7 @@ z
     <g id="ytick_13">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m4cc71a2960" x="585.876562" y="111.347089" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3d30db1bf7" x="585.876562" y="111.347089" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_121">
@@ -2739,8 +2739,8 @@ z
    </g>
   </g>
   <g id="text_124">
-   <!-- 2026-07-10T09:54:02Z  ·  Linux chungus2 x86_64  ·  commit da9d9c0e  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(43.847969 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-11T04:15:02Z  ·  Linux chungus2 x86_64  ·  commit e802670f  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(44.448437 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2868,13 +2868,13 @@ z
     <use xlink:href="#DejaVuSans-37" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-31" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(1027.734375 0)"/>
@@ -2917,109 +2917,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3135.351562 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3196.630859 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3260.253906 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3323.730469 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3387.353516 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3442.333984 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3505.957031 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3567.480469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3599.267578 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3631.054688 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3662.841797 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3694.628906 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3726.416016 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3754.199219 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3815.722656 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3877.001953 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3940.380859 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4003.857422 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4042.720703 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4103.902344 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4163.082031 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4224.605469 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4265.71875 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4299.410156 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4327.193359 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4388.716797 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4449.996094 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4513.375 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4576.998047 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4610.689453 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4669.869141 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4733.492188 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4765.279297 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4828.902344 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4892.525391 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4924.3125 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4987.935547 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5024.019531 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5062.882812 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5117.863281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5181.486328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5213.273438 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5245.060547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5276.847656 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5308.634766 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5340.421875 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5379.630859 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5443.009766 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5481.873047 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5543.054688 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5606.433594 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5669.910156 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5733.289062 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5796.765625 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5860.144531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5899.353516 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5931.140625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6014.929688 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6046.716797 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6144.128906 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6205.652344 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6269.128906 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6296.912109 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6358.191406 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6421.570312 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6453.357422 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6505.457031 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6568.835938 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6630.115234 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6693.591797 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6745.691406 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6809.070312 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6870.251953 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6909.460938 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6943.152344 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6974.939453 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7016.052734 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7077.332031 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7116.541016 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7144.324219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7205.505859 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7237.292969 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7265.076172 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7317.175781 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7348.962891 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7412.439453 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7473.962891 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7513.171875 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7574.695312 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7614.058594 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7711.470703 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7739.253906 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7802.632812 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7830.416016 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7882.515625 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7921.724609 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7949.507812 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3133.398438 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3197.021484 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3260.644531 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3324.267578 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3387.890625 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3451.513672 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3515.136719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3550.341797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3582.128906 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3613.916016 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3645.703125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3677.490234 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3709.277344 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3737.060547 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3798.583984 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3859.863281 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3923.242188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3986.71875 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4025.582031 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4086.763672 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4145.943359 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4207.466797 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4248.580078 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4282.271484 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4310.054688 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4371.578125 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4432.857422 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4496.236328 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4559.859375 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4593.550781 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4652.730469 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4716.353516 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4748.140625 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4811.763672 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4875.386719 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4907.173828 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4970.796875 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5006.880859 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5045.744141 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5100.724609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5164.347656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5196.134766 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5227.921875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5259.708984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5291.496094 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5323.283203 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5362.492188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5425.871094 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5464.734375 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5525.916016 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5589.294922 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5652.771484 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5716.150391 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5779.626953 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5843.005859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5882.214844 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5914.001953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5997.791016 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6029.578125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6126.990234 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6188.513672 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6251.990234 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6279.773438 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6341.052734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6404.431641 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6436.21875 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6488.318359 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6551.697266 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6612.976562 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6676.453125 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6728.552734 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6791.931641 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6853.113281 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6892.322266 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6926.013672 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6957.800781 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6998.914062 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7060.193359 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7099.402344 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7127.185547 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7188.367188 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7220.154297 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7247.9375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7300.037109 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7331.824219 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7395.300781 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7456.824219 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7496.033203 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7557.556641 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7596.919922 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7694.332031 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7722.115234 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7785.494141 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7813.277344 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7865.376953 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7904.585938 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7932.369141 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pcbc804194d">
+  <clipPath id="pac92c90bb9">
    <rect x="95.67625" y="49.34175" width="468.141298" height="294.686261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_summary.svg
+++ b/bench/graphs/silesia_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="574.704063pt" height="386.202469pt" viewBox="0 0 574.704063 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="573.503125pt" height="386.202469pt" viewBox="0 0 573.503125 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,232 +22,232 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 386.202469 
-L 574.704063 386.202469 
-L 574.704063 0 
+L 573.503125 386.202469 
+L 573.503125 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 189.477031 104.1264 
-L 294.102031 104.1264 
-L 294.102031 74.7432 
-L 189.477031 74.7432 
+    <path d="M 188.876563 104.1264 
+L 293.501563 104.1264 
+L 293.501563 74.7432 
+L 188.876563 74.7432 
 z
-" clip-path="url(#p5f34ff9847)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9be7089005)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 294.102031 104.1264 
-L 398.727031 104.1264 
-L 398.727031 74.7432 
-L 294.102031 74.7432 
+    <path d="M 293.501563 104.1264 
+L 398.126563 104.1264 
+L 398.126563 74.7432 
+L 293.501563 74.7432 
 z
-" clip-path="url(#p5f34ff9847)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9be7089005)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 398.727031 104.1264 
-L 503.352031 104.1264 
-L 503.352031 74.7432 
-L 398.727031 74.7432 
+    <path d="M 398.126563 104.1264 
+L 502.751563 104.1264 
+L 502.751563 74.7432 
+L 398.126563 74.7432 
 z
-" clip-path="url(#p5f34ff9847)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9be7089005)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 189.477031 133.5096 
-L 294.102031 133.5096 
-L 294.102031 104.1264 
-L 189.477031 104.1264 
+    <path d="M 188.876563 133.5096 
+L 293.501563 133.5096 
+L 293.501563 104.1264 
+L 188.876563 104.1264 
 z
-" clip-path="url(#p5f34ff9847)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9be7089005)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 294.102031 133.5096 
-L 398.727031 133.5096 
-L 398.727031 104.1264 
-L 294.102031 104.1264 
+    <path d="M 293.501563 133.5096 
+L 398.126563 133.5096 
+L 398.126563 104.1264 
+L 293.501563 104.1264 
 z
-" clip-path="url(#p5f34ff9847)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9be7089005)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 398.727031 133.5096 
-L 503.352031 133.5096 
-L 503.352031 104.1264 
-L 398.727031 104.1264 
+    <path d="M 398.126563 133.5096 
+L 502.751563 133.5096 
+L 502.751563 104.1264 
+L 398.126563 104.1264 
 z
-" clip-path="url(#p5f34ff9847)" style="fill: #fece7c; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9be7089005)" style="fill: #fece7c; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 189.477031 162.8928 
-L 294.102031 162.8928 
-L 294.102031 133.5096 
-L 189.477031 133.5096 
+    <path d="M 188.876563 162.8928 
+L 293.501563 162.8928 
+L 293.501563 133.5096 
+L 188.876563 133.5096 
 z
-" clip-path="url(#p5f34ff9847)" style="fill: #fee08b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9be7089005)" style="fill: #fee08b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 294.102031 162.8928 
-L 398.727031 162.8928 
-L 398.727031 133.5096 
-L 294.102031 133.5096 
+    <path d="M 293.501563 162.8928 
+L 398.126563 162.8928 
+L 398.126563 133.5096 
+L 293.501563 133.5096 
 z
-" clip-path="url(#p5f34ff9847)" style="fill: #feefa3; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9be7089005)" style="fill: #feefa3; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 398.727031 162.8928 
-L 503.352031 162.8928 
-L 503.352031 133.5096 
-L 398.727031 133.5096 
+    <path d="M 398.126563 162.8928 
+L 502.751563 162.8928 
+L 502.751563 133.5096 
+L 398.126563 133.5096 
 z
-" clip-path="url(#p5f34ff9847)" style="fill: #fdbf6f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9be7089005)" style="fill: #fdbf6f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 189.477031 192.276 
-L 294.102031 192.276 
-L 294.102031 162.8928 
-L 189.477031 162.8928 
+    <path d="M 188.876563 192.276 
+L 293.501563 192.276 
+L 293.501563 162.8928 
+L 188.876563 162.8928 
 z
-" clip-path="url(#p5f34ff9847)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9be7089005)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 294.102031 192.276 
-L 398.727031 192.276 
-L 398.727031 162.8928 
-L 294.102031 162.8928 
+    <path d="M 293.501563 192.276 
+L 398.126563 192.276 
+L 398.126563 162.8928 
+L 293.501563 162.8928 
 z
-" clip-path="url(#p5f34ff9847)" style="fill: #fede89; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9be7089005)" style="fill: #fede89; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 398.727031 192.276 
-L 503.352031 192.276 
-L 503.352031 162.8928 
-L 398.727031 162.8928 
+    <path d="M 398.126563 192.276 
+L 502.751563 192.276 
+L 502.751563 162.8928 
+L 398.126563 162.8928 
 z
-" clip-path="url(#p5f34ff9847)" style="fill: #f7814c; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9be7089005)" style="fill: #f7814c; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 189.477031 221.6592 
-L 294.102031 221.6592 
-L 294.102031 192.276 
-L 189.477031 192.276 
+    <path d="M 188.876563 221.6592 
+L 293.501563 221.6592 
+L 293.501563 192.276 
+L 188.876563 192.276 
 z
-" clip-path="url(#p5f34ff9847)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9be7089005)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 294.102031 221.6592 
-L 398.727031 221.6592 
-L 398.727031 192.276 
-L 294.102031 192.276 
+    <path d="M 293.501563 221.6592 
+L 398.126563 221.6592 
+L 398.126563 192.276 
+L 293.501563 192.276 
 z
-" clip-path="url(#p5f34ff9847)" style="fill: #fed27f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9be7089005)" style="fill: #fed27f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 398.727031 221.6592 
-L 503.352031 221.6592 
-L 503.352031 192.276 
-L 398.727031 192.276 
+    <path d="M 398.126563 221.6592 
+L 502.751563 221.6592 
+L 502.751563 192.276 
+L 398.126563 192.276 
 z
-" clip-path="url(#p5f34ff9847)" style="fill: #fffcba; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9be7089005)" style="fill: #fffcba; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 189.477031 251.0424 
-L 294.102031 251.0424 
-L 294.102031 221.6592 
-L 189.477031 221.6592 
+    <path d="M 188.876563 251.0424 
+L 293.501563 251.0424 
+L 293.501563 221.6592 
+L 188.876563 221.6592 
 z
-" clip-path="url(#p5f34ff9847)" style="fill: #fff3ac; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9be7089005)" style="fill: #feefa3; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 294.102031 251.0424 
-L 398.727031 251.0424 
-L 398.727031 221.6592 
-L 294.102031 221.6592 
+    <path d="M 293.501563 251.0424 
+L 398.126563 251.0424 
+L 398.126563 221.6592 
+L 293.501563 221.6592 
 z
-" clip-path="url(#p5f34ff9847)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9be7089005)" style="fill: #fed07e; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 398.727031 251.0424 
-L 503.352031 251.0424 
-L 503.352031 221.6592 
-L 398.727031 221.6592 
+    <path d="M 398.126563 251.0424 
+L 502.751563 251.0424 
+L 502.751563 221.6592 
+L 398.126563 221.6592 
 z
-" clip-path="url(#p5f34ff9847)" style="fill: #e8f59f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9be7089005)" style="fill: #fdc776; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 189.477031 280.4256 
-L 294.102031 280.4256 
-L 294.102031 251.0424 
-L 189.477031 251.0424 
+    <path d="M 188.876563 280.4256 
+L 293.501563 280.4256 
+L 293.501563 251.0424 
+L 188.876563 251.0424 
 z
-" clip-path="url(#p5f34ff9847)" style="fill: #feefa3; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9be7089005)" style="fill: #fff3ac; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 294.102031 280.4256 
-L 398.727031 280.4256 
-L 398.727031 251.0424 
-L 294.102031 251.0424 
+    <path d="M 293.501563 280.4256 
+L 398.126563 280.4256 
+L 398.126563 251.0424 
+L 293.501563 251.0424 
 z
-" clip-path="url(#p5f34ff9847)" style="fill: #feca79; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9be7089005)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 398.727031 280.4256 
-L 503.352031 280.4256 
-L 503.352031 251.0424 
-L 398.727031 251.0424 
+    <path d="M 398.126563 280.4256 
+L 502.751563 280.4256 
+L 502.751563 251.0424 
+L 398.126563 251.0424 
 z
-" clip-path="url(#p5f34ff9847)" style="fill: #fdc171; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9be7089005)" style="fill: #e8f59f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 189.477031 309.8088 
-L 294.102031 309.8088 
-L 294.102031 280.4256 
-L 189.477031 280.4256 
+    <path d="M 188.876563 309.8088 
+L 293.501563 309.8088 
+L 293.501563 280.4256 
+L 188.876563 280.4256 
 z
-" clip-path="url(#p5f34ff9847)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9be7089005)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 294.102031 309.8088 
-L 398.727031 309.8088 
-L 398.727031 280.4256 
-L 294.102031 280.4256 
+    <path d="M 293.501563 309.8088 
+L 398.126563 309.8088 
+L 398.126563 280.4256 
+L 293.501563 280.4256 
 z
-" clip-path="url(#p5f34ff9847)" style="fill: #fa9b58; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9be7089005)" style="fill: #fa9b58; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 398.727031 309.8088 
-L 503.352031 309.8088 
-L 503.352031 280.4256 
-L 398.727031 280.4256 
+    <path d="M 398.126563 309.8088 
+L 502.751563 309.8088 
+L 502.751563 280.4256 
+L 398.126563 280.4256 
 z
-" clip-path="url(#p5f34ff9847)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9be7089005)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 189.477031 339.192 
-L 294.102031 339.192 
-L 294.102031 309.8088 
-L 189.477031 309.8088 
+    <path d="M 188.876563 339.192 
+L 293.501563 339.192 
+L 293.501563 309.8088 
+L 188.876563 309.8088 
 z
-" clip-path="url(#p5f34ff9847)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9be7089005)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 294.102031 339.192 
-L 398.727031 339.192 
-L 398.727031 309.8088 
-L 294.102031 309.8088 
+    <path d="M 293.501563 339.192 
+L 398.126563 339.192 
+L 398.126563 309.8088 
+L 293.501563 309.8088 
 z
-" clip-path="url(#p5f34ff9847)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9be7089005)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 398.727031 339.192 
-L 503.352031 339.192 
-L 503.352031 309.8088 
-L 398.727031 309.8088 
+    <path d="M 398.126563 339.192 
+L 502.751563 339.192 
+L 502.751563 309.8088 
+L 398.126563 309.8088 
 z
-" clip-path="url(#p5f34ff9847)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9be7089005)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(122.464297 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(121.863828 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(229.748516 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(229.148047 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(308.320625 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(307.720156 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(406.672344 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(406.071875 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(118.402031 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(117.801563 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.320 -->
-    <g transform="translate(230.338281 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(229.737813 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -918,7 +918,7 @@ z
    </g>
    <g id="text_7">
     <!-- 117 -->
-    <g transform="translate(338.779531 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(338.179063 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -952,7 +952,7 @@ z
    </g>
    <g id="text_8">
     <!-- 852 -->
-    <g transform="translate(443.404531 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(442.804063 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -1026,7 +1026,7 @@ z
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(113.040156 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(112.439688 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1125,7 +1125,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.324 -->
-    <g transform="translate(230.338281 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(229.737813 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1156,7 +1156,7 @@ z
    </g>
    <g id="text_11">
     <!-- 61 -->
-    <g transform="translate(341.324531 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(340.724063 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -1195,7 +1195,7 @@ z
    </g>
    <g id="text_12">
     <!-- 312 -->
-    <g transform="translate(443.404531 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(442.804063 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
@@ -1203,7 +1203,7 @@ z
    </g>
    <g id="text_13">
     <!-- Go compress/flate -->
-    <g transform="translate(100.733281 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(100.132813 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -1374,7 +1374,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.325 -->
-    <g transform="translate(230.338281 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(229.737813 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1384,14 +1384,14 @@ z
    </g>
    <g id="text_15">
     <!-- 50 -->
-    <g transform="translate(341.324531 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(340.724063 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
     <!-- 275 -->
-    <g transform="translate(443.404531 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(442.804063 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
@@ -1399,7 +1399,7 @@ z
    </g>
    <g id="text_17">
     <!-- JS fflate -->
-    <g transform="translate(121.765781 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(121.165313 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1459,7 +1459,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.329 -->
-    <g transform="translate(230.338281 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(229.737813 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-39" d="M 703 97 
 L 703 672 
@@ -1501,14 +1501,14 @@ z
    </g>
    <g id="text_19">
     <!-- 41 -->
-    <g transform="translate(341.324531 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(340.724063 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
     <!-- 160 -->
-    <g transform="translate(443.404531 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(442.804063 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -1516,7 +1516,7 @@ z
    </g>
    <g id="text_21">
     <!-- zlib -->
-    <g transform="translate(130.303281 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(129.702813 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1540,7 +1540,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.323 -->
-    <g transform="translate(230.338281 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(229.737813 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1550,106 +1550,22 @@ z
    </g>
    <g id="text_23">
     <!-- 38 -->
-    <g transform="translate(341.324531 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(340.724063 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_24">
     <!-- 448 -->
-    <g transform="translate(443.404531 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(442.804063 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_25">
-    <!-- miniz_oxide -->
-    <g transform="translate(113.609531 238.44705) scale(0.08 -0.08)">
-     <defs>
-      <path id="DejaVuSans-6e" d="M 3513 2113 
-L 3513 0 
-L 2938 0 
-L 2938 2094 
-Q 2938 2591 2744 2837 
-Q 2550 3084 2163 3084 
-Q 1697 3084 1428 2787 
-Q 1159 2491 1159 1978 
-L 1159 0 
-L 581 0 
-L 581 3500 
-L 1159 3500 
-L 1159 2956 
-Q 1366 3272 1645 3428 
-Q 1925 3584 2291 3584 
-Q 2894 3584 3203 3211 
-Q 3513 2838 3513 2113 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-5f" d="M 3263 -1063 
-L 3263 -1509 
-L -63 -1509 
-L -63 -1063 
-L 3263 -1063 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-78" d="M 3513 3500 
-L 2247 1797 
-L 3578 0 
-L 2900 0 
-L 1881 1375 
-L 863 0 
-L 184 0 
-L 1544 1831 
-L 300 3500 
-L 978 3500 
-L 1906 2253 
-L 2834 3500 
-L 3513 3500 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-6d"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(97.412109 0)"/>
-     <use xlink:href="#DejaVuSans-6e" transform="translate(125.195312 0)"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(188.574219 0)"/>
-     <use xlink:href="#DejaVuSans-7a" transform="translate(216.357422 0)"/>
-     <use xlink:href="#DejaVuSans-5f" transform="translate(268.847656 0)"/>
-     <use xlink:href="#DejaVuSans-6f" transform="translate(318.847656 0)"/>
-     <use xlink:href="#DejaVuSans-78" transform="translate(376.904297 0)"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(436.083984 0)"/>
-     <use xlink:href="#DejaVuSans-64" transform="translate(463.867188 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(527.34375 0)"/>
-    </g>
-   </g>
-   <g id="text_26">
-    <!-- 0.322 -->
-    <g transform="translate(230.338281 238.5583) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-30"/>
-     <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(159.033203 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(222.65625 0)"/>
-    </g>
-   </g>
-   <g id="text_27">
-    <!-- 36 -->
-    <g transform="translate(341.324531 238.5583) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-33"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
-    </g>
-   </g>
-   <g id="text_28">
-    <!-- 527 -->
-    <g transform="translate(443.404531 238.5583) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
-    </g>
-   </g>
-   <g id="text_29">
     <!-- lean-zip (native) -->
-    <g transform="translate(100.111406 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(99.510938 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1756,9 +1672,9 @@ z
      <use xlink:href="#DejaVuSans-Bold-29" transform="translate(880.615234 0)"/>
     </g>
    </g>
-   <g id="text_30">
+   <g id="text_26">
     <!-- 0.322 -->
-    <g transform="translate(229.137656 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(228.537188 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1850,106 +1766,152 @@ z
      <use xlink:href="#DejaVuSans-Bold-32" transform="translate(246.728516 0)"/>
     </g>
    </g>
-   <g id="text_31">
-    <!-- 35 -->
-    <g transform="translate(340.848281 267.9415) scale(0.08 -0.08)">
+   <g id="text_27">
+    <!-- 37 -->
+    <g transform="translate(340.247813 238.5583) scale(0.08 -0.08)">
      <defs>
-      <path id="DejaVuSans-Bold-35" d="M 678 4666 
-L 3669 4666 
-L 3669 3781 
-L 1638 3781 
-L 1638 3059 
-Q 1775 3097 1914 3117 
-Q 2053 3138 2203 3138 
-Q 3056 3138 3531 2711 
-Q 4006 2284 4006 1522 
-Q 4006 766 3489 337 
-Q 2972 -91 2053 -91 
-Q 1656 -91 1267 -14 
-Q 878 63 494 219 
-L 494 1166 
-Q 875 947 1217 837 
-Q 1559 728 1863 728 
-Q 2300 728 2551 942 
-Q 2803 1156 2803 1522 
-Q 2803 1891 2551 2103 
-Q 2300 2316 1863 2316 
-Q 1603 2316 1309 2248 
-Q 1016 2181 678 2041 
-L 678 4666 
+      <path id="DejaVuSans-Bold-37" d="M 428 4666 
+L 3944 4666 
+L 3944 3988 
+L 2125 0 
+L 953 0 
+L 2675 3781 
+L 428 3781 
+L 428 4666 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-Bold-33"/>
-     <use xlink:href="#DejaVuSans-Bold-35" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-37" transform="translate(69.580078 0)"/>
     </g>
    </g>
-   <g id="text_32">
-    <!-- 281 -->
-    <g transform="translate(442.690156 267.9415) scale(0.08 -0.08)">
+   <g id="text_28">
+    <!-- 292 -->
+    <g transform="translate(442.089688 238.5583) scale(0.08 -0.08)">
      <defs>
-      <path id="DejaVuSans-Bold-38" d="M 2228 2088 
-Q 1891 2088 1709 1903 
-Q 1528 1719 1528 1375 
-Q 1528 1031 1709 848 
-Q 1891 666 2228 666 
-Q 2563 666 2741 848 
-Q 2919 1031 2919 1375 
-Q 2919 1722 2741 1905 
-Q 2563 2088 2228 2088 
+      <path id="DejaVuSans-Bold-39" d="M 641 103 
+L 641 966 
+Q 928 831 1190 764 
+Q 1453 697 1709 697 
+Q 2247 697 2547 995 
+Q 2847 1294 2900 1881 
+Q 2688 1725 2447 1647 
+Q 2206 1569 1925 1569 
+Q 1209 1569 770 1986 
+Q 331 2403 331 3084 
+Q 331 3838 820 4291 
+Q 1309 4744 2131 4744 
+Q 3044 4744 3544 4128 
+Q 4044 3513 4044 2388 
+Q 4044 1231 3459 570 
+Q 2875 -91 1856 -91 
+Q 1528 -91 1228 -42 
+Q 928 6 641 103 
 z
-M 1350 2484 
-Q 925 2613 709 2878 
-Q 494 3144 494 3541 
-Q 494 4131 934 4440 
-Q 1375 4750 2228 4750 
-Q 3075 4750 3515 4442 
-Q 3956 4134 3956 3541 
-Q 3956 3144 3739 2878 
-Q 3522 2613 3097 2484 
-Q 3572 2353 3814 2058 
-Q 4056 1763 4056 1313 
-Q 4056 619 3595 264 
-Q 3134 -91 2228 -91 
-Q 1319 -91 855 264 
-Q 391 619 391 1313 
-Q 391 1763 633 2058 
-Q 875 2353 1350 2484 
-z
-M 1631 3419 
-Q 1631 3141 1786 2991 
-Q 1941 2841 2228 2841 
-Q 2509 2841 2662 2991 
-Q 2816 3141 2816 3419 
-Q 2816 3697 2662 3845 
-Q 2509 3994 2228 3994 
-Q 1941 3994 1786 3844 
-Q 1631 3694 1631 3419 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-31" d="M 750 831 
-L 1813 831 
-L 1813 3847 
-L 722 3622 
-L 722 4441 
-L 1806 4666 
-L 2950 4666 
-L 2950 831 
-L 4013 831 
-L 4013 0 
-L 750 0 
-L 750 831 
+M 2125 2350 
+Q 2441 2350 2600 2554 
+Q 2759 2759 2759 3169 
+Q 2759 3575 2600 3781 
+Q 2441 3988 2125 3988 
+Q 1809 3988 1650 3781 
+Q 1491 3575 1491 3169 
+Q 1491 2759 1650 2554 
+Q 1809 2350 2125 2350 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-Bold-32"/>
-     <use xlink:href="#DejaVuSans-Bold-38" transform="translate(69.580078 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-31" transform="translate(139.160156 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-39" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-32" transform="translate(139.160156 0)"/>
+    </g>
+   </g>
+   <g id="text_29">
+    <!-- miniz_oxide -->
+    <g transform="translate(113.009063 267.83025) scale(0.08 -0.08)">
+     <defs>
+      <path id="DejaVuSans-6e" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-5f" d="M 3263 -1063 
+L 3263 -1509 
+L -63 -1509 
+L -63 -1063 
+L 3263 -1063 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-78" d="M 3513 3500 
+L 2247 1797 
+L 3578 0 
+L 2900 0 
+L 1881 1375 
+L 863 0 
+L 184 0 
+L 1544 1831 
+L 300 3500 
+L 978 3500 
+L 1906 2253 
+L 2834 3500 
+L 3513 3500 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-6d"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(97.412109 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(125.195312 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(188.574219 0)"/>
+     <use xlink:href="#DejaVuSans-7a" transform="translate(216.357422 0)"/>
+     <use xlink:href="#DejaVuSans-5f" transform="translate(268.847656 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(318.847656 0)"/>
+     <use xlink:href="#DejaVuSans-78" transform="translate(376.904297 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(436.083984 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(463.867188 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(527.34375 0)"/>
+    </g>
+   </g>
+   <g id="text_30">
+    <!-- 0.322 -->
+    <g transform="translate(229.737813 267.9415) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-30"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(159.033203 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(222.65625 0)"/>
+    </g>
+   </g>
+   <g id="text_31">
+    <!-- 36 -->
+    <g transform="translate(340.724063 267.9415) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-33"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
+    </g>
+   </g>
+   <g id="text_32">
+    <!-- 527 -->
+    <g transform="translate(442.804063 267.9415) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-35"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_33">
     <!-- OCaml decompress -->
-    <g transform="translate(98.226406 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(97.625938 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -2014,7 +1976,7 @@ z
    </g>
    <g id="text_34">
     <!-- 0.336 -->
-    <g transform="translate(230.338281 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(229.737813 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -2024,21 +1986,21 @@ z
    </g>
    <g id="text_35">
     <!-- 21 -->
-    <g transform="translate(341.324531 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(340.724063 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_36">
     <!-- 69 -->
-    <g transform="translate(445.949531 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(445.349063 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-36"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(126.447656 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(125.847188 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -2049,7 +2011,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.303 -->
-    <g transform="translate(230.338281 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(229.737813 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -2059,13 +2021,13 @@ z
    </g>
    <g id="text_39">
     <!-- 1 -->
-    <g transform="translate(343.869531 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(343.269063 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(447.039531 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(446.439063 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2081,7 +2043,7 @@ z
   </g>
   <g id="text_41">
    <!-- silesia — geomean over files, level 6 -->
-   <g transform="translate(153.95375 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(153.353281 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-2014" d="M 344 2156 
 L 6056 2156 
@@ -2225,7 +2187,7 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-07-10T09:54:02Z  ·  Linux chungus2 x86_64  ·  commit da9d9c0e  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-07-11T04:15:02Z  ·  Linux chungus2 x86_64  ·  commit e802670f  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2364,13 +2326,13 @@ z
     <use xlink:href="#DejaVuSans-37" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-31" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(1027.734375 0)"/>
@@ -2413,110 +2375,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3135.351562 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3196.630859 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3260.253906 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3323.730469 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3387.353516 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3442.333984 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3505.957031 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3567.480469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3599.267578 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3631.054688 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3662.841797 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3694.628906 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3726.416016 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3754.199219 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3815.722656 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3877.001953 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3940.380859 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4003.857422 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4042.720703 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4103.902344 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4163.082031 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4224.605469 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4265.71875 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4299.410156 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4327.193359 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4388.716797 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4449.996094 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4513.375 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4576.998047 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4610.689453 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4669.869141 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4733.492188 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4765.279297 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4828.902344 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4892.525391 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4924.3125 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4987.935547 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5024.019531 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5062.882812 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5117.863281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5181.486328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5213.273438 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5245.060547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5276.847656 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5308.634766 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5340.421875 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5379.630859 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5443.009766 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5481.873047 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5543.054688 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5606.433594 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5669.910156 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5733.289062 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5796.765625 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5860.144531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5899.353516 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5931.140625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6014.929688 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6046.716797 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6144.128906 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6205.652344 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6269.128906 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6296.912109 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6358.191406 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6421.570312 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6453.357422 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6505.457031 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6568.835938 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6630.115234 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6693.591797 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6745.691406 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6809.070312 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6870.251953 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6909.460938 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6943.152344 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6974.939453 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7016.052734 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7077.332031 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7116.541016 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7144.324219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7205.505859 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7237.292969 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7265.076172 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7317.175781 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7348.962891 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7412.439453 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7473.962891 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7513.171875 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7574.695312 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7614.058594 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7711.470703 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7739.253906 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7802.632812 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7830.416016 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7882.515625 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7921.724609 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7949.507812 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3133.398438 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3197.021484 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3260.644531 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3324.267578 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3387.890625 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3451.513672 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3515.136719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3550.341797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3582.128906 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3613.916016 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3645.703125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3677.490234 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3709.277344 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3737.060547 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3798.583984 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3859.863281 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3923.242188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3986.71875 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4025.582031 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4086.763672 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4145.943359 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4207.466797 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4248.580078 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4282.271484 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4310.054688 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4371.578125 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4432.857422 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4496.236328 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4559.859375 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4593.550781 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4652.730469 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4716.353516 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4748.140625 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4811.763672 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4875.386719 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4907.173828 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4970.796875 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5006.880859 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5045.744141 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5100.724609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5164.347656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5196.134766 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5227.921875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5259.708984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5291.496094 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5323.283203 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5362.492188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5425.871094 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5464.734375 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5525.916016 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5589.294922 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5652.771484 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5716.150391 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5779.626953 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5843.005859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5882.214844 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5914.001953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5997.791016 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6029.578125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6126.990234 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6188.513672 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6251.990234 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6279.773438 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6341.052734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6404.431641 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6436.21875 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6488.318359 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6551.697266 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6612.976562 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6676.453125 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6728.552734 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6791.931641 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6853.113281 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6892.322266 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6926.013672 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6957.800781 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6998.914062 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7060.193359 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7099.402344 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7127.185547 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7188.367188 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7220.154297 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7247.9375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7300.037109 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7331.824219 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7395.300781 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7456.824219 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7496.033203 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7557.556641 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7596.919922 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7694.332031 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7722.115234 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7785.494141 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7813.277344 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7865.376953 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7904.585938 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7932.369141 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p5f34ff9847">
-   <rect x="84.852031" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="p9be7089005">
+   <rect x="84.251563" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/lakefile.lean
+++ b/bench/lakefile.lean
@@ -356,6 +356,10 @@ lean_exe «gate-sweep» where
 lean_exe «huff-bench» where
   root := `ZipHuffBench
 
+@[default_target]
+lean_exe «freq-fusion» where
+  root := `ZipFreqFusion
+
 -- Single-decoder inflate profiling driver: `decode` mode runs native inflate
 -- alone, so a `perf record` of that process attributes cleanly (see bench/README.md).
 @[default_target]

--- a/bench/results/latest.json
+++ b/bench/results/latest.json
@@ -1,8 +1,8 @@
 {
  "meta": {
-  "date": "2026-07-10T09:54:02Z",
+  "date": "2026-07-11T04:15:02Z",
   "machine": "Linux chungus2 x86_64",
-  "git_commit": "da9d9c0e",
+  "git_commit": "e802670f",
   "toolchain": "leanprover/lean4:v4.30.0-rc2",
   "note": "compress_mbps/decompress_mbps are a median-of-5 snapshot on the machine above; ratio is deterministic"
  },
@@ -14,8 +14,8 @@
    "level": 1,
    "out_size": 60455,
    "ratio": 0.3975,
-   "compress_mbps": 82.21,
-   "decompress_mbps": 212.36
+   "compress_mbps": 87.12,
+   "decompress_mbps": 213.99
   },
   {
    "compressor": "native",
@@ -24,8 +24,8 @@
    "level": 2,
    "out_size": 57095,
    "ratio": 0.3754,
-   "compress_mbps": 69.61,
-   "decompress_mbps": 243.9
+   "compress_mbps": 72.13,
+   "decompress_mbps": 243.5
   },
   {
    "compressor": "native",
@@ -34,8 +34,8 @@
    "level": 3,
    "out_size": 56050,
    "ratio": 0.3685,
-   "compress_mbps": 59.98,
-   "decompress_mbps": 264.35
+   "compress_mbps": 61.65,
+   "decompress_mbps": 265.83
   },
   {
    "compressor": "native",
@@ -44,8 +44,8 @@
    "level": 4,
    "out_size": 54357,
    "ratio": 0.3574,
-   "compress_mbps": 39.73,
-   "decompress_mbps": 270.35
+   "compress_mbps": 38.68,
+   "decompress_mbps": 271.59
   },
   {
    "compressor": "native",
@@ -54,8 +54,8 @@
    "level": 5,
    "out_size": 54078,
    "ratio": 0.3556,
-   "compress_mbps": 31.78,
-   "decompress_mbps": 271.25
+   "compress_mbps": 31.06,
+   "decompress_mbps": 272.66
   },
   {
    "compressor": "native",
@@ -64,8 +64,8 @@
    "level": 6,
    "out_size": 54593,
    "ratio": 0.359,
-   "compress_mbps": 32.93,
-   "decompress_mbps": 278.17
+   "compress_mbps": 32.15,
+   "decompress_mbps": 279.03
   },
   {
    "compressor": "native",
@@ -74,8 +74,8 @@
    "level": 7,
    "out_size": 54469,
    "ratio": 0.3581,
-   "compress_mbps": 30.01,
-   "decompress_mbps": 279.27
+   "compress_mbps": 29.02,
+   "decompress_mbps": 279.28
   },
   {
    "compressor": "native",
@@ -84,8 +84,8 @@
    "level": 8,
    "out_size": 54216,
    "ratio": 0.3565,
-   "compress_mbps": 23.9,
-   "decompress_mbps": 278.44
+   "compress_mbps": 23.0,
+   "decompress_mbps": 279.68
   },
   {
    "compressor": "native",
@@ -94,8 +94,8 @@
    "level": 9,
    "out_size": 52732,
    "ratio": 0.3467,
-   "compress_mbps": 4.33,
-   "decompress_mbps": 278.89
+   "compress_mbps": 4.31,
+   "decompress_mbps": 277.8
   },
   {
    "compressor": "native",
@@ -104,7 +104,7 @@
    "level": 10,
    "out_size": 52078,
    "ratio": 0.3424,
-   "compress_mbps": 2.41,
+   "compress_mbps": 2.4,
    "decompress_mbps": null
   },
   {
@@ -114,8 +114,8 @@
    "level": 1,
    "out_size": 53135,
    "ratio": 0.4245,
-   "compress_mbps": 74.82,
-   "decompress_mbps": 205.47
+   "compress_mbps": 79.76,
+   "decompress_mbps": 205.57
   },
   {
    "compressor": "native",
@@ -124,8 +124,8 @@
    "level": 2,
    "out_size": 50676,
    "ratio": 0.4048,
-   "compress_mbps": 64.34,
-   "decompress_mbps": 223.57
+   "compress_mbps": 66.76,
+   "decompress_mbps": 224.06
   },
   {
    "compressor": "native",
@@ -134,8 +134,8 @@
    "level": 3,
    "out_size": 50023,
    "ratio": 0.3996,
-   "compress_mbps": 56.6,
-   "decompress_mbps": 243.64
+   "compress_mbps": 58.25,
+   "decompress_mbps": 243.76
   },
   {
    "compressor": "native",
@@ -144,8 +144,8 @@
    "level": 4,
    "out_size": 48687,
    "ratio": 0.3889,
-   "compress_mbps": 35.94,
-   "decompress_mbps": 245.83
+   "compress_mbps": 36.04,
+   "decompress_mbps": 247.42
   },
   {
    "compressor": "native",
@@ -154,8 +154,8 @@
    "level": 5,
    "out_size": 48586,
    "ratio": 0.3881,
-   "compress_mbps": 30.98,
-   "decompress_mbps": 248.24
+   "compress_mbps": 31.01,
+   "decompress_mbps": 247.58
   },
   {
    "compressor": "native",
@@ -164,8 +164,8 @@
    "level": 6,
    "out_size": 49005,
    "ratio": 0.3915,
-   "compress_mbps": 30.26,
-   "decompress_mbps": 252.82
+   "compress_mbps": 30.61,
+   "decompress_mbps": 252.15
   },
   {
    "compressor": "native",
@@ -174,8 +174,8 @@
    "level": 7,
    "out_size": 48910,
    "ratio": 0.3907,
-   "compress_mbps": 27.71,
-   "decompress_mbps": 252.18
+   "compress_mbps": 27.69,
+   "decompress_mbps": 252.06
   },
   {
    "compressor": "native",
@@ -184,8 +184,8 @@
    "level": 8,
    "out_size": 48839,
    "ratio": 0.3902,
-   "compress_mbps": 24.69,
-   "decompress_mbps": 253.28
+   "compress_mbps": 24.79,
+   "decompress_mbps": 253.25
   },
   {
    "compressor": "native",
@@ -194,8 +194,8 @@
    "level": 9,
    "out_size": 47433,
    "ratio": 0.3789,
-   "compress_mbps": 4.64,
-   "decompress_mbps": 252.78
+   "compress_mbps": 4.61,
+   "decompress_mbps": 254.13
   },
   {
    "compressor": "native",
@@ -204,7 +204,7 @@
    "level": 10,
    "out_size": 46866,
    "ratio": 0.3744,
-   "compress_mbps": 2.8,
+   "compress_mbps": 2.81,
    "decompress_mbps": null
   },
   {
@@ -214,8 +214,8 @@
    "level": 1,
    "out_size": 8476,
    "ratio": 0.3445,
-   "compress_mbps": 70.71,
-   "decompress_mbps": 266.15
+   "compress_mbps": 74.04,
+   "decompress_mbps": 265.91
   },
   {
    "compressor": "native",
@@ -224,8 +224,8 @@
    "level": 2,
    "out_size": 8249,
    "ratio": 0.3353,
-   "compress_mbps": 65.82,
-   "decompress_mbps": 278.12
+   "compress_mbps": 68.74,
+   "decompress_mbps": 274.93
   },
   {
    "compressor": "native",
@@ -234,8 +234,8 @@
    "level": 3,
    "out_size": 8112,
    "ratio": 0.3297,
-   "compress_mbps": 60.93,
-   "decompress_mbps": 283.12
+   "compress_mbps": 63.3,
+   "decompress_mbps": 281.37
   },
   {
    "compressor": "native",
@@ -244,8 +244,8 @@
    "level": 4,
    "out_size": 7948,
    "ratio": 0.3231,
-   "compress_mbps": 49.61,
-   "decompress_mbps": 290.2
+   "compress_mbps": 50.14,
+   "decompress_mbps": 291.22
   },
   {
    "compressor": "native",
@@ -254,8 +254,8 @@
    "level": 5,
    "out_size": 7899,
    "ratio": 0.3211,
-   "compress_mbps": 42.21,
-   "decompress_mbps": 299.67
+   "compress_mbps": 42.56,
+   "decompress_mbps": 297.39
   },
   {
    "compressor": "native",
@@ -264,8 +264,8 @@
    "level": 6,
    "out_size": 7962,
    "ratio": 0.3236,
-   "compress_mbps": 37.35,
-   "decompress_mbps": 297.23
+   "compress_mbps": 37.45,
+   "decompress_mbps": 295.38
   },
   {
    "compressor": "native",
@@ -274,8 +274,8 @@
    "level": 7,
    "out_size": 7950,
    "ratio": 0.3231,
-   "compress_mbps": 35.56,
-   "decompress_mbps": 305.89
+   "compress_mbps": 35.58,
+   "decompress_mbps": 302.49
   },
   {
    "compressor": "native",
@@ -284,8 +284,8 @@
    "level": 8,
    "out_size": 7934,
    "ratio": 0.3225,
-   "compress_mbps": 32.24,
-   "decompress_mbps": 305.23
+   "compress_mbps": 32.42,
+   "decompress_mbps": 303.23
   },
   {
    "compressor": "native",
@@ -294,8 +294,8 @@
    "level": 9,
    "out_size": 7803,
    "ratio": 0.3172,
-   "compress_mbps": 5.01,
-   "decompress_mbps": 305.83
+   "compress_mbps": 5.02,
+   "decompress_mbps": 302.07
   },
   {
    "compressor": "native",
@@ -304,7 +304,7 @@
    "level": 10,
    "out_size": 7737,
    "ratio": 0.3145,
-   "compress_mbps": 2.95,
+   "compress_mbps": 2.96,
    "decompress_mbps": null
   },
   {
@@ -314,8 +314,8 @@
    "level": 1,
    "out_size": 3509,
    "ratio": 0.3147,
-   "compress_mbps": 53.0,
-   "decompress_mbps": 187.86
+   "compress_mbps": 54.46,
+   "decompress_mbps": 187.44
   },
   {
    "compressor": "native",
@@ -324,8 +324,8 @@
    "level": 2,
    "out_size": 3317,
    "ratio": 0.2975,
-   "compress_mbps": 50.52,
-   "decompress_mbps": 190.13
+   "compress_mbps": 51.59,
+   "decompress_mbps": 189.95
   },
   {
    "compressor": "native",
@@ -334,8 +334,8 @@
    "level": 3,
    "out_size": 3227,
    "ratio": 0.2894,
-   "compress_mbps": 48.05,
-   "decompress_mbps": 194.75
+   "compress_mbps": 48.98,
+   "decompress_mbps": 193.85
   },
   {
    "compressor": "native",
@@ -344,8 +344,8 @@
    "level": 4,
    "out_size": 3128,
    "ratio": 0.2805,
-   "compress_mbps": 40.56,
-   "decompress_mbps": 200.3
+   "compress_mbps": 40.99,
+   "decompress_mbps": 198.23
   },
   {
    "compressor": "native",
@@ -354,8 +354,8 @@
    "level": 5,
    "out_size": 3112,
    "ratio": 0.2791,
-   "compress_mbps": 36.25,
-   "decompress_mbps": 200.62
+   "compress_mbps": 36.65,
+   "decompress_mbps": 198.25
   },
   {
    "compressor": "native",
@@ -364,8 +364,8 @@
    "level": 6,
    "out_size": 3136,
    "ratio": 0.2813,
-   "compress_mbps": 34.19,
-   "decompress_mbps": 201.31
+   "compress_mbps": 34.47,
+   "decompress_mbps": 197.87
   },
   {
    "compressor": "native",
@@ -374,8 +374,8 @@
    "level": 7,
    "out_size": 3122,
    "ratio": 0.28,
-   "compress_mbps": 33.05,
-   "decompress_mbps": 202.49
+   "compress_mbps": 33.18,
+   "decompress_mbps": 198.92
   },
   {
    "compressor": "native",
@@ -384,8 +384,8 @@
    "level": 8,
    "out_size": 3117,
    "ratio": 0.2796,
-   "compress_mbps": 30.79,
-   "decompress_mbps": 202.95
+   "compress_mbps": 30.93,
+   "decompress_mbps": 199.11
   },
   {
    "compressor": "native",
@@ -395,7 +395,7 @@
    "out_size": 3056,
    "ratio": 0.2741,
    "compress_mbps": 5.54,
-   "decompress_mbps": 202.57
+   "decompress_mbps": 199.23
   },
   {
    "compressor": "native",
@@ -404,7 +404,7 @@
    "level": 10,
    "out_size": 3031,
    "ratio": 0.2718,
-   "compress_mbps": 3.1,
+   "compress_mbps": 3.08,
    "decompress_mbps": null
   },
   {
@@ -414,8 +414,8 @@
    "level": 1,
    "out_size": 1283,
    "ratio": 0.3448,
-   "compress_mbps": 26.02,
-   "decompress_mbps": 87.49
+   "compress_mbps": 26.36,
+   "decompress_mbps": 86.04
   },
   {
    "compressor": "native",
@@ -424,8 +424,8 @@
    "level": 2,
    "out_size": 1234,
    "ratio": 0.3316,
-   "compress_mbps": 25.72,
-   "decompress_mbps": 88.47
+   "compress_mbps": 26.11,
+   "decompress_mbps": 86.89
   },
   {
    "compressor": "native",
@@ -434,8 +434,8 @@
    "level": 3,
    "out_size": 1223,
    "ratio": 0.3287,
-   "compress_mbps": 25.38,
-   "decompress_mbps": 87.77
+   "compress_mbps": 25.6,
+   "decompress_mbps": 86.79
   },
   {
    "compressor": "native",
@@ -444,8 +444,8 @@
    "level": 4,
    "out_size": 1213,
    "ratio": 0.326,
-   "compress_mbps": 22.14,
-   "decompress_mbps": 88.65
+   "compress_mbps": 22.22,
+   "decompress_mbps": 87.29
   },
   {
    "compressor": "native",
@@ -454,8 +454,8 @@
    "level": 5,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 21.56,
-   "decompress_mbps": 88.38
+   "compress_mbps": 21.77,
+   "decompress_mbps": 87.33
   },
   {
    "compressor": "native",
@@ -464,8 +464,8 @@
    "level": 6,
    "out_size": 1220,
    "ratio": 0.3279,
-   "compress_mbps": 19.92,
-   "decompress_mbps": 88.91
+   "compress_mbps": 19.99,
+   "decompress_mbps": 87.5
   },
   {
    "compressor": "native",
@@ -474,8 +474,8 @@
    "level": 7,
    "out_size": 1219,
    "ratio": 0.3276,
-   "compress_mbps": 19.77,
-   "decompress_mbps": 88.6
+   "compress_mbps": 19.82,
+   "decompress_mbps": 87.65
   },
   {
    "compressor": "native",
@@ -484,8 +484,8 @@
    "level": 8,
    "out_size": 1219,
    "ratio": 0.3276,
-   "compress_mbps": 19.59,
-   "decompress_mbps": 88.7
+   "compress_mbps": 19.57,
+   "decompress_mbps": 87.84
   },
   {
    "compressor": "native",
@@ -494,8 +494,8 @@
    "level": 9,
    "out_size": 1205,
    "ratio": 0.3238,
-   "compress_mbps": 4.94,
-   "decompress_mbps": 88.8
+   "compress_mbps": 4.96,
+   "decompress_mbps": 87.76
   },
   {
    "compressor": "native",
@@ -504,7 +504,7 @@
    "level": 10,
    "out_size": 1191,
    "ratio": 0.3201,
-   "compress_mbps": 2.99,
+   "compress_mbps": 2.98,
    "decompress_mbps": null
   },
   {
@@ -514,8 +514,8 @@
    "level": 1,
    "out_size": 251793,
    "ratio": 0.2445,
-   "compress_mbps": 170.8,
-   "decompress_mbps": 389.08
+   "compress_mbps": 176.48,
+   "decompress_mbps": 390.21
   },
   {
    "compressor": "native",
@@ -524,8 +524,8 @@
    "level": 2,
    "out_size": 244112,
    "ratio": 0.2371,
-   "compress_mbps": 140.84,
-   "decompress_mbps": 380.19
+   "compress_mbps": 145.22,
+   "decompress_mbps": 380.68
   },
   {
    "compressor": "native",
@@ -534,8 +534,8 @@
    "level": 3,
    "out_size": 242564,
    "ratio": 0.2356,
-   "compress_mbps": 118.1,
-   "decompress_mbps": 407.22
+   "compress_mbps": 120.86,
+   "decompress_mbps": 408.83
   },
   {
    "compressor": "native",
@@ -544,8 +544,8 @@
    "level": 4,
    "out_size": 239953,
    "ratio": 0.233,
-   "compress_mbps": 101.03,
-   "decompress_mbps": 452.06
+   "compress_mbps": 101.7,
+   "decompress_mbps": 452.75
   },
   {
    "compressor": "native",
@@ -554,8 +554,8 @@
    "level": 5,
    "out_size": 218565,
    "ratio": 0.2123,
-   "compress_mbps": 55.01,
-   "decompress_mbps": 451.25
+   "compress_mbps": 54.92,
+   "decompress_mbps": 450.38
   },
   {
    "compressor": "native",
@@ -564,8 +564,8 @@
    "level": 6,
    "out_size": 202437,
    "ratio": 0.1966,
-   "compress_mbps": 40.33,
-   "decompress_mbps": 466.83
+   "compress_mbps": 40.68,
+   "decompress_mbps": 470.08
   },
   {
    "compressor": "native",
@@ -574,8 +574,8 @@
    "level": 7,
    "out_size": 201821,
    "ratio": 0.196,
-   "compress_mbps": 37.09,
-   "decompress_mbps": 472.52
+   "compress_mbps": 37.89,
+   "decompress_mbps": 472.73
   },
   {
    "compressor": "native",
@@ -584,8 +584,8 @@
    "level": 8,
    "out_size": 200869,
    "ratio": 0.1951,
-   "compress_mbps": 21.61,
-   "decompress_mbps": 490.67
+   "compress_mbps": 21.67,
+   "decompress_mbps": 488.49
   },
   {
    "compressor": "native",
@@ -594,8 +594,8 @@
    "level": 9,
    "out_size": 182511,
    "ratio": 0.1772,
-   "compress_mbps": 3.44,
-   "decompress_mbps": 485.93
+   "compress_mbps": 3.49,
+   "decompress_mbps": 487.64
   },
   {
    "compressor": "native",
@@ -604,7 +604,7 @@
    "level": 10,
    "out_size": 178069,
    "ratio": 0.1729,
-   "compress_mbps": 1.44,
+   "compress_mbps": 1.48,
    "decompress_mbps": null
   },
   {
@@ -614,8 +614,8 @@
    "level": 1,
    "out_size": 160674,
    "ratio": 0.3765,
-   "compress_mbps": 90.86,
-   "decompress_mbps": 222.85
+   "compress_mbps": 95.8,
+   "decompress_mbps": 221.44
   },
   {
    "compressor": "native",
@@ -624,8 +624,8 @@
    "level": 2,
    "out_size": 151578,
    "ratio": 0.3552,
-   "compress_mbps": 76.38,
-   "decompress_mbps": 241.87
+   "compress_mbps": 78.7,
+   "decompress_mbps": 239.81
   },
   {
    "compressor": "native",
@@ -634,8 +634,8 @@
    "level": 3,
    "out_size": 148848,
    "ratio": 0.3488,
-   "compress_mbps": 64.84,
-   "decompress_mbps": 269.31
+   "compress_mbps": 66.25,
+   "decompress_mbps": 267.59
   },
   {
    "compressor": "native",
@@ -645,7 +645,7 @@
    "out_size": 144750,
    "ratio": 0.3392,
    "compress_mbps": 42.37,
-   "decompress_mbps": 271.83
+   "decompress_mbps": 271.8
   },
   {
    "compressor": "native",
@@ -654,8 +654,8 @@
    "level": 5,
    "out_size": 144408,
    "ratio": 0.3384,
-   "compress_mbps": 34.35,
-   "decompress_mbps": 273.08
+   "compress_mbps": 33.95,
+   "decompress_mbps": 274.65
   },
   {
    "compressor": "native",
@@ -664,8 +664,8 @@
    "level": 6,
    "out_size": 144872,
    "ratio": 0.3395,
-   "compress_mbps": 31.78,
-   "decompress_mbps": 279.16
+   "compress_mbps": 31.82,
+   "decompress_mbps": 278.47
   },
   {
    "compressor": "native",
@@ -674,8 +674,8 @@
    "level": 7,
    "out_size": 144583,
    "ratio": 0.3388,
-   "compress_mbps": 28.78,
-   "decompress_mbps": 279.05
+   "compress_mbps": 28.93,
+   "decompress_mbps": 279.11
   },
   {
    "compressor": "native",
@@ -684,8 +684,8 @@
    "level": 8,
    "out_size": 144045,
    "ratio": 0.3375,
-   "compress_mbps": 23.96,
-   "decompress_mbps": 277.88
+   "compress_mbps": 23.98,
+   "decompress_mbps": 280.58
   },
   {
    "compressor": "native",
@@ -694,8 +694,8 @@
    "level": 9,
    "out_size": 140323,
    "ratio": 0.3288,
-   "compress_mbps": 4.27,
-   "decompress_mbps": 273.02
+   "compress_mbps": 4.28,
+   "decompress_mbps": 280.09
   },
   {
    "compressor": "native",
@@ -704,7 +704,7 @@
    "level": 10,
    "out_size": 138833,
    "ratio": 0.3253,
-   "compress_mbps": 2.52,
+   "compress_mbps": 2.53,
    "decompress_mbps": null
   },
   {
@@ -714,8 +714,8 @@
    "level": 1,
    "out_size": 212588,
    "ratio": 0.4412,
-   "compress_mbps": 76.51,
-   "decompress_mbps": 191.55
+   "compress_mbps": 81.01,
+   "decompress_mbps": 189.8
   },
   {
    "compressor": "native",
@@ -724,8 +724,8 @@
    "level": 2,
    "out_size": 202277,
    "ratio": 0.4198,
-   "compress_mbps": 64.56,
-   "decompress_mbps": 214.71
+   "compress_mbps": 66.53,
+   "decompress_mbps": 212.94
   },
   {
    "compressor": "native",
@@ -734,8 +734,8 @@
    "level": 3,
    "out_size": 199922,
    "ratio": 0.4149,
-   "compress_mbps": 56.16,
-   "decompress_mbps": 235.39
+   "compress_mbps": 57.36,
+   "decompress_mbps": 233.84
   },
   {
    "compressor": "native",
@@ -744,8 +744,8 @@
    "level": 4,
    "out_size": 193783,
    "ratio": 0.4022,
-   "compress_mbps": 32.65,
-   "decompress_mbps": 239.02
+   "compress_mbps": 32.67,
+   "decompress_mbps": 238.8
   },
   {
    "compressor": "native",
@@ -754,8 +754,8 @@
    "level": 5,
    "out_size": 193223,
    "ratio": 0.401,
-   "compress_mbps": 27.2,
-   "decompress_mbps": 235.78
+   "compress_mbps": 27.25,
+   "decompress_mbps": 235.61
   },
   {
    "compressor": "native",
@@ -764,8 +764,8 @@
    "level": 6,
    "out_size": 195643,
    "ratio": 0.406,
-   "compress_mbps": 27.88,
-   "decompress_mbps": 240.81
+   "compress_mbps": 27.98,
+   "decompress_mbps": 239.73
   },
   {
    "compressor": "native",
@@ -774,8 +774,8 @@
    "level": 7,
    "out_size": 195104,
    "ratio": 0.4049,
-   "compress_mbps": 24.69,
-   "decompress_mbps": 240.79
+   "compress_mbps": 25.06,
+   "decompress_mbps": 240.56
   },
   {
    "compressor": "native",
@@ -784,8 +784,8 @@
    "level": 8,
    "out_size": 194355,
    "ratio": 0.4033,
-   "compress_mbps": 20.39,
-   "decompress_mbps": 240.16
+   "compress_mbps": 20.45,
+   "decompress_mbps": 240.49
   },
   {
    "compressor": "native",
@@ -794,8 +794,8 @@
    "level": 9,
    "out_size": 189368,
    "ratio": 0.393,
-   "compress_mbps": 4.04,
-   "decompress_mbps": 241.37
+   "compress_mbps": 4.07,
+   "decompress_mbps": 241.19
   },
   {
    "compressor": "native",
@@ -814,8 +814,8 @@
    "level": 1,
    "out_size": 60161,
    "ratio": 0.1172,
-   "compress_mbps": 250.41,
-   "decompress_mbps": 577.63
+   "compress_mbps": 267.97,
+   "decompress_mbps": 580.16
   },
   {
    "compressor": "native",
@@ -824,8 +824,8 @@
    "level": 2,
    "out_size": 58606,
    "ratio": 0.1142,
-   "compress_mbps": 226.83,
-   "decompress_mbps": 603.38
+   "compress_mbps": 239.53,
+   "decompress_mbps": 605.65
   },
   {
    "compressor": "native",
@@ -834,8 +834,8 @@
    "level": 3,
    "out_size": 57685,
    "ratio": 0.1124,
-   "compress_mbps": 190.51,
-   "decompress_mbps": 629.25
+   "compress_mbps": 197.95,
+   "decompress_mbps": 631.59
   },
   {
    "compressor": "native",
@@ -844,8 +844,8 @@
    "level": 4,
    "out_size": 55586,
    "ratio": 0.1083,
-   "compress_mbps": 123.96,
-   "decompress_mbps": 649.84
+   "compress_mbps": 122.59,
+   "decompress_mbps": 647.96
   },
   {
    "compressor": "native",
@@ -854,8 +854,8 @@
    "level": 5,
    "out_size": 55097,
    "ratio": 0.1074,
-   "compress_mbps": 91.71,
-   "decompress_mbps": 672.31
+   "compress_mbps": 91.43,
+   "decompress_mbps": 670.15
   },
   {
    "compressor": "native",
@@ -864,8 +864,8 @@
    "level": 6,
    "out_size": 55674,
    "ratio": 0.1085,
-   "compress_mbps": 74.65,
-   "decompress_mbps": 695.63
+   "compress_mbps": 75.2,
+   "decompress_mbps": 690.49
   },
   {
    "compressor": "native",
@@ -874,8 +874,8 @@
    "level": 7,
    "out_size": 55495,
    "ratio": 0.1081,
-   "compress_mbps": 67.23,
-   "decompress_mbps": 708.08
+   "compress_mbps": 67.49,
+   "decompress_mbps": 703.66
   },
   {
    "compressor": "native",
@@ -884,8 +884,8 @@
    "level": 8,
    "out_size": 53384,
    "ratio": 0.104,
-   "compress_mbps": 42.81,
-   "decompress_mbps": 731.48
+   "compress_mbps": 42.64,
+   "decompress_mbps": 728.68
   },
   {
    "compressor": "native",
@@ -894,8 +894,8 @@
    "level": 9,
    "out_size": 52603,
    "ratio": 0.1025,
-   "compress_mbps": 5.83,
-   "decompress_mbps": 743.76
+   "compress_mbps": 5.87,
+   "decompress_mbps": 743.18
   },
   {
    "compressor": "native",
@@ -904,7 +904,7 @@
    "level": 10,
    "out_size": 52236,
    "ratio": 0.1018,
-   "compress_mbps": 3.76,
+   "compress_mbps": 3.81,
    "decompress_mbps": null
   },
   {
@@ -914,8 +914,8 @@
    "level": 1,
    "out_size": 14249,
    "ratio": 0.3726,
-   "compress_mbps": 64.06,
-   "decompress_mbps": 229.14
+   "compress_mbps": 67.34,
+   "decompress_mbps": 225.85
   },
   {
    "compressor": "native",
@@ -924,8 +924,8 @@
    "level": 2,
    "out_size": 13835,
    "ratio": 0.3618,
-   "compress_mbps": 59.39,
-   "decompress_mbps": 234.16
+   "compress_mbps": 62.49,
+   "decompress_mbps": 232.12
   },
   {
    "compressor": "native",
@@ -934,8 +934,8 @@
    "level": 3,
    "out_size": 13760,
    "ratio": 0.3598,
-   "compress_mbps": 57.04,
-   "decompress_mbps": 232.22
+   "compress_mbps": 59.67,
+   "decompress_mbps": 229.02
   },
   {
    "compressor": "native",
@@ -944,8 +944,8 @@
    "level": 4,
    "out_size": 13290,
    "ratio": 0.3475,
-   "compress_mbps": 46.56,
-   "decompress_mbps": 237.38
+   "compress_mbps": 46.31,
+   "decompress_mbps": 238.35
   },
   {
    "compressor": "native",
@@ -954,8 +954,8 @@
    "level": 5,
    "out_size": 13244,
    "ratio": 0.3463,
-   "compress_mbps": 39.81,
-   "decompress_mbps": 249.69
+   "compress_mbps": 39.82,
+   "decompress_mbps": 246.27
   },
   {
    "compressor": "native",
@@ -964,8 +964,8 @@
    "level": 6,
    "out_size": 12675,
    "ratio": 0.3315,
-   "compress_mbps": 21.38,
-   "decompress_mbps": 252.97
+   "compress_mbps": 21.09,
+   "decompress_mbps": 248.58
   },
   {
    "compressor": "native",
@@ -974,8 +974,8 @@
    "level": 7,
    "out_size": 12653,
    "ratio": 0.3309,
-   "compress_mbps": 20.55,
-   "decompress_mbps": 255.14
+   "compress_mbps": 20.45,
+   "decompress_mbps": 251.19
   },
   {
    "compressor": "native",
@@ -984,8 +984,8 @@
    "level": 8,
    "out_size": 12632,
    "ratio": 0.3303,
-   "compress_mbps": 17.11,
-   "decompress_mbps": 257.36
+   "compress_mbps": 16.88,
+   "decompress_mbps": 257.35
   },
   {
    "compressor": "native",
@@ -994,8 +994,8 @@
    "level": 9,
    "out_size": 12427,
    "ratio": 0.325,
-   "compress_mbps": 5.48,
-   "decompress_mbps": 261.83
+   "compress_mbps": 5.49,
+   "decompress_mbps": 257.63
   },
   {
    "compressor": "native",
@@ -1004,7 +1004,7 @@
    "level": 10,
    "out_size": 12273,
    "ratio": 0.3209,
-   "compress_mbps": 3.16,
+   "compress_mbps": 3.15,
    "decompress_mbps": null
   },
   {
@@ -1015,7 +1015,7 @@
    "out_size": 1800,
    "ratio": 0.4258,
    "compress_mbps": 27.93,
-   "decompress_mbps": 94.8
+   "decompress_mbps": 94.19
   },
   {
    "compressor": "native",
@@ -1024,8 +1024,8 @@
    "level": 2,
    "out_size": 1756,
    "ratio": 0.4154,
-   "compress_mbps": 27.4,
-   "decompress_mbps": 94.91
+   "compress_mbps": 27.74,
+   "decompress_mbps": 94.12
   },
   {
    "compressor": "native",
@@ -1034,8 +1034,8 @@
    "level": 3,
    "out_size": 1741,
    "ratio": 0.4119,
-   "compress_mbps": 27.31,
-   "decompress_mbps": 94.85
+   "compress_mbps": 27.5,
+   "decompress_mbps": 93.96
   },
   {
    "compressor": "native",
@@ -1044,8 +1044,8 @@
    "level": 4,
    "out_size": 1726,
    "ratio": 0.4083,
-   "compress_mbps": 24.05,
-   "decompress_mbps": 96.48
+   "compress_mbps": 23.92,
+   "decompress_mbps": 95.85
   },
   {
    "compressor": "native",
@@ -1054,8 +1054,8 @@
    "level": 5,
    "out_size": 1722,
    "ratio": 0.4074,
-   "compress_mbps": 23.75,
-   "decompress_mbps": 96.52
+   "compress_mbps": 23.76,
+   "decompress_mbps": 95.73
   },
   {
    "compressor": "native",
@@ -1064,8 +1064,8 @@
    "level": 6,
    "out_size": 1735,
    "ratio": 0.4105,
-   "compress_mbps": 20.95,
-   "decompress_mbps": 96.3
+   "compress_mbps": 20.93,
+   "decompress_mbps": 95.58
   },
   {
    "compressor": "native",
@@ -1074,8 +1074,8 @@
    "level": 7,
    "out_size": 1734,
    "ratio": 0.4102,
-   "compress_mbps": 20.96,
-   "decompress_mbps": 96.0
+   "compress_mbps": 20.97,
+   "decompress_mbps": 95.53
   },
   {
    "compressor": "native",
@@ -1084,8 +1084,8 @@
    "level": 8,
    "out_size": 1734,
    "ratio": 0.4102,
-   "compress_mbps": 20.96,
-   "decompress_mbps": 96.54
+   "compress_mbps": 21.02,
+   "decompress_mbps": 95.42
   },
   {
    "compressor": "native",
@@ -1094,8 +1094,8 @@
    "level": 9,
    "out_size": 1708,
    "ratio": 0.4041,
-   "compress_mbps": 5.49,
-   "decompress_mbps": 96.26
+   "compress_mbps": 5.51,
+   "decompress_mbps": 95.11
   },
   {
    "compressor": "native",
@@ -1104,7 +1104,7 @@
    "level": 10,
    "out_size": 1693,
    "ratio": 0.4005,
-   "compress_mbps": 3.34,
+   "compress_mbps": 3.35,
    "decompress_mbps": null
   },
   {
@@ -4414,8 +4414,8 @@
    "level": 1,
    "out_size": 4259644,
    "ratio": 0.4179,
-   "compress_mbps": 79.26,
-   "decompress_mbps": 194.03
+   "compress_mbps": 84.13,
+   "decompress_mbps": 193.47
   },
   {
    "compressor": "native",
@@ -4424,8 +4424,8 @@
    "level": 2,
    "out_size": 4029026,
    "ratio": 0.3953,
-   "compress_mbps": 66.61,
-   "decompress_mbps": 214.59
+   "compress_mbps": 69.5,
+   "decompress_mbps": 212.6
   },
   {
    "compressor": "native",
@@ -4434,8 +4434,8 @@
    "level": 3,
    "out_size": 3970599,
    "ratio": 0.3896,
-   "compress_mbps": 57.25,
-   "decompress_mbps": 235.2
+   "compress_mbps": 59.05,
+   "decompress_mbps": 235.78
   },
   {
    "compressor": "native",
@@ -4444,8 +4444,8 @@
    "level": 4,
    "out_size": 3851998,
    "ratio": 0.3779,
-   "compress_mbps": 34.79,
-   "decompress_mbps": 238.85
+   "compress_mbps": 35.87,
+   "decompress_mbps": 237.93
   },
   {
    "compressor": "native",
@@ -4454,8 +4454,8 @@
    "level": 5,
    "out_size": 3840481,
    "ratio": 0.3768,
-   "compress_mbps": 29.49,
-   "decompress_mbps": 247.28
+   "compress_mbps": 29.45,
+   "decompress_mbps": 235.75
   },
   {
    "compressor": "native",
@@ -4464,8 +4464,8 @@
    "level": 6,
    "out_size": 3878125,
    "ratio": 0.3805,
-   "compress_mbps": 29.48,
-   "decompress_mbps": 241.54
+   "compress_mbps": 29.79,
+   "decompress_mbps": 240.91
   },
   {
    "compressor": "native",
@@ -4474,8 +4474,8 @@
    "level": 7,
    "out_size": 3868436,
    "ratio": 0.3795,
-   "compress_mbps": 26.49,
-   "decompress_mbps": 243.77
+   "compress_mbps": 26.52,
+   "decompress_mbps": 241.0
   },
   {
    "compressor": "native",
@@ -4484,8 +4484,8 @@
    "level": 8,
    "out_size": 3854820,
    "ratio": 0.3782,
-   "compress_mbps": 21.44,
-   "decompress_mbps": 242.5
+   "compress_mbps": 21.49,
+   "decompress_mbps": 242.69
   },
   {
    "compressor": "native",
@@ -4494,8 +4494,8 @@
    "level": 9,
    "out_size": 3766619,
    "ratio": 0.3696,
-   "compress_mbps": 4.23,
-   "decompress_mbps": 253.02
+   "compress_mbps": 4.15,
+   "decompress_mbps": 252.66
   },
   {
    "compressor": "native",
@@ -4504,7 +4504,7 @@
    "level": 10,
    "out_size": 3711208,
    "ratio": 0.3641,
-   "compress_mbps": 2.45,
+   "compress_mbps": 2.48,
    "decompress_mbps": null
   },
   {
@@ -4514,8 +4514,8 @@
    "level": 1,
    "out_size": 21267086,
    "ratio": 0.4152,
-   "compress_mbps": 95.45,
-   "decompress_mbps": 212.43
+   "compress_mbps": 102.28,
+   "decompress_mbps": 215.52
   },
   {
    "compressor": "native",
@@ -4524,8 +4524,8 @@
    "level": 2,
    "out_size": 20833417,
    "ratio": 0.4067,
-   "compress_mbps": 84.92,
-   "decompress_mbps": 221.05
+   "compress_mbps": 91.39,
+   "decompress_mbps": 228.59
   },
   {
    "compressor": "native",
@@ -4534,8 +4534,8 @@
    "level": 3,
    "out_size": 20636431,
    "ratio": 0.4029,
-   "compress_mbps": 75.26,
-   "decompress_mbps": 235.75
+   "compress_mbps": 82.15,
+   "decompress_mbps": 235.42
   },
   {
    "compressor": "native",
@@ -4544,8 +4544,8 @@
    "level": 4,
    "out_size": 20356893,
    "ratio": 0.3974,
-   "compress_mbps": 55.87,
-   "decompress_mbps": 245.02
+   "compress_mbps": 56.48,
+   "decompress_mbps": 245.09
   },
   {
    "compressor": "native",
@@ -4554,8 +4554,8 @@
    "level": 5,
    "out_size": 20209289,
    "ratio": 0.3946,
-   "compress_mbps": 42.19,
-   "decompress_mbps": 253.03
+   "compress_mbps": 42.45,
+   "decompress_mbps": 255.61
   },
   {
    "compressor": "native",
@@ -4564,8 +4564,8 @@
    "level": 6,
    "out_size": 18875267,
    "ratio": 0.3685,
-   "compress_mbps": 30.36,
-   "decompress_mbps": 252.68
+   "compress_mbps": 30.22,
+   "decompress_mbps": 253.24
   },
   {
    "compressor": "native",
@@ -4574,8 +4574,8 @@
    "level": 7,
    "out_size": 18835212,
    "ratio": 0.3677,
-   "compress_mbps": 28.36,
-   "decompress_mbps": 261.07
+   "compress_mbps": 28.19,
+   "decompress_mbps": 259.41
   },
   {
    "compressor": "native",
@@ -4584,8 +4584,8 @@
    "level": 8,
    "out_size": 18777212,
    "ratio": 0.3666,
-   "compress_mbps": 19.52,
-   "decompress_mbps": 259.8
+   "compress_mbps": 19.64,
+   "decompress_mbps": 259.34
   },
   {
    "compressor": "native",
@@ -4594,8 +4594,8 @@
    "level": 9,
    "out_size": 18688252,
    "ratio": 0.3649,
-   "compress_mbps": 4.39,
-   "decompress_mbps": 259.37
+   "compress_mbps": 4.45,
+   "decompress_mbps": 261.63
   },
   {
    "compressor": "native",
@@ -4604,7 +4604,7 @@
    "level": 10,
    "out_size": 18541040,
    "ratio": 0.362,
-   "compress_mbps": 2.35,
+   "compress_mbps": 2.36,
    "decompress_mbps": null
   },
   {
@@ -4614,8 +4614,8 @@
    "level": 1,
    "out_size": 3864163,
    "ratio": 0.3876,
-   "compress_mbps": 99.65,
-   "decompress_mbps": 232.33
+   "compress_mbps": 105.63,
+   "decompress_mbps": 243.05
   },
   {
    "compressor": "native",
@@ -4624,8 +4624,8 @@
    "level": 2,
    "out_size": 3772158,
    "ratio": 0.3783,
-   "compress_mbps": 87.44,
-   "decompress_mbps": 256.98
+   "compress_mbps": 89.67,
+   "decompress_mbps": 244.74
   },
   {
    "compressor": "native",
@@ -4634,8 +4634,8 @@
    "level": 3,
    "out_size": 3733442,
    "ratio": 0.3744,
-   "compress_mbps": 76.11,
-   "decompress_mbps": 256.0
+   "compress_mbps": 78.6,
+   "decompress_mbps": 255.81
   },
   {
    "compressor": "native",
@@ -4644,8 +4644,8 @@
    "level": 4,
    "out_size": 3683603,
    "ratio": 0.3694,
-   "compress_mbps": 42.35,
-   "decompress_mbps": 245.14
+   "compress_mbps": 42.47,
+   "decompress_mbps": 245.24
   },
   {
    "compressor": "native",
@@ -4654,8 +4654,8 @@
    "level": 5,
    "out_size": 3677014,
    "ratio": 0.3688,
-   "compress_mbps": 33.52,
-   "decompress_mbps": 238.43
+   "compress_mbps": 33.85,
+   "decompress_mbps": 239.75
   },
   {
    "compressor": "native",
@@ -4664,8 +4664,8 @@
    "level": 6,
    "out_size": 3646607,
    "ratio": 0.3657,
-   "compress_mbps": 32.44,
-   "decompress_mbps": 246.98
+   "compress_mbps": 32.36,
+   "decompress_mbps": 248.57
   },
   {
    "compressor": "native",
@@ -4674,8 +4674,8 @@
    "level": 7,
    "out_size": 3642579,
    "ratio": 0.3653,
-   "compress_mbps": 29.72,
-   "decompress_mbps": 247.9
+   "compress_mbps": 29.64,
+   "decompress_mbps": 248.96
   },
   {
    "compressor": "native",
@@ -4684,8 +4684,8 @@
    "level": 8,
    "out_size": 3634763,
    "ratio": 0.3645,
-   "compress_mbps": 22.51,
-   "decompress_mbps": 254.11
+   "compress_mbps": 22.66,
+   "decompress_mbps": 255.57
   },
   {
    "compressor": "native",
@@ -4694,8 +4694,8 @@
    "level": 9,
    "out_size": 3581643,
    "ratio": 0.3592,
-   "compress_mbps": 4.8,
-   "decompress_mbps": 266.77
+   "compress_mbps": 4.83,
+   "decompress_mbps": 270.66
   },
   {
    "compressor": "native",
@@ -4704,7 +4704,7 @@
    "level": 10,
    "out_size": 3513006,
    "ratio": 0.3523,
-   "compress_mbps": 2.96,
+   "compress_mbps": 2.97,
    "decompress_mbps": null
   },
   {
@@ -4714,8 +4714,8 @@
    "level": 1,
    "out_size": 3785443,
    "ratio": 0.1128,
-   "compress_mbps": 298.15,
-   "decompress_mbps": 661.47
+   "compress_mbps": 319.41,
+   "decompress_mbps": 675.28
   },
   {
    "compressor": "native",
@@ -4724,8 +4724,8 @@
    "level": 2,
    "out_size": 3601032,
    "ratio": 0.1073,
-   "compress_mbps": 254.03,
-   "decompress_mbps": 744.62
+   "compress_mbps": 268.28,
+   "decompress_mbps": 753.55
   },
   {
    "compressor": "native",
@@ -4734,8 +4734,8 @@
    "level": 3,
    "out_size": 3447001,
    "ratio": 0.1027,
-   "compress_mbps": 195.39,
-   "decompress_mbps": 789.51
+   "compress_mbps": 206.83,
+   "decompress_mbps": 829.51
   },
   {
    "compressor": "native",
@@ -4744,8 +4744,8 @@
    "level": 4,
    "out_size": 3201209,
    "ratio": 0.0954,
-   "compress_mbps": 139.92,
-   "decompress_mbps": 847.84
+   "compress_mbps": 141.21,
+   "decompress_mbps": 851.21
   },
   {
    "compressor": "native",
@@ -4754,8 +4754,8 @@
    "level": 5,
    "out_size": 3091564,
    "ratio": 0.0921,
-   "compress_mbps": 96.66,
-   "decompress_mbps": 926.83
+   "compress_mbps": 97.16,
+   "decompress_mbps": 929.69
   },
   {
    "compressor": "native",
@@ -4764,8 +4764,8 @@
    "level": 6,
    "out_size": 3205217,
    "ratio": 0.0955,
-   "compress_mbps": 91.86,
-   "decompress_mbps": 981.74
+   "compress_mbps": 92.08,
+   "decompress_mbps": 937.6
   },
   {
    "compressor": "native",
@@ -4774,8 +4774,8 @@
    "level": 7,
    "out_size": 3146242,
    "ratio": 0.0938,
-   "compress_mbps": 81.27,
-   "decompress_mbps": 990.96
+   "compress_mbps": 82.16,
+   "decompress_mbps": 982.4
   },
   {
    "compressor": "native",
@@ -4784,8 +4784,8 @@
    "level": 8,
    "out_size": 3078031,
    "ratio": 0.0917,
-   "compress_mbps": 51.26,
-   "decompress_mbps": 993.85
+   "compress_mbps": 51.2,
+   "decompress_mbps": 1004.39
   },
   {
    "compressor": "native",
@@ -4795,7 +4795,7 @@
    "out_size": 3031645,
    "ratio": 0.0904,
    "compress_mbps": 3.56,
-   "decompress_mbps": 1006.98
+   "decompress_mbps": 1007.49
   },
   {
    "compressor": "native",
@@ -4804,7 +4804,7 @@
    "level": 10,
    "out_size": 2902212,
    "ratio": 0.0865,
-   "compress_mbps": 1.71,
+   "compress_mbps": 2.03,
    "decompress_mbps": null
   },
   {
@@ -4814,8 +4814,8 @@
    "level": 1,
    "out_size": 3357083,
    "ratio": 0.5457,
-   "compress_mbps": 36.06,
-   "decompress_mbps": 90.26
+   "compress_mbps": 72.16,
+   "decompress_mbps": 149.15
   },
   {
    "compressor": "native",
@@ -4824,8 +4824,8 @@
    "level": 2,
    "out_size": 3292412,
    "ratio": 0.5352,
-   "compress_mbps": 37.81,
-   "decompress_mbps": 88.86
+   "compress_mbps": 63.05,
+   "decompress_mbps": 142.35
   },
   {
    "compressor": "native",
@@ -4834,8 +4834,8 @@
    "level": 3,
    "out_size": 3273720,
    "ratio": 0.5321,
-   "compress_mbps": 38.16,
-   "decompress_mbps": 92.74
+   "compress_mbps": 59.02,
+   "decompress_mbps": 157.5
   },
   {
    "compressor": "native",
@@ -4844,8 +4844,8 @@
    "level": 4,
    "out_size": 3228052,
    "ratio": 0.5247,
-   "compress_mbps": 24.98,
-   "decompress_mbps": 119.4
+   "compress_mbps": 42.04,
+   "decompress_mbps": 165.21
   },
   {
    "compressor": "native",
@@ -4854,8 +4854,8 @@
    "level": 5,
    "out_size": 3223415,
    "ratio": 0.5239,
-   "compress_mbps": 23.12,
-   "decompress_mbps": 101.63
+   "compress_mbps": 37.85,
+   "decompress_mbps": 172.25
   },
   {
    "compressor": "native",
@@ -4864,8 +4864,8 @@
    "level": 6,
    "out_size": 3087517,
    "ratio": 0.5019,
-   "compress_mbps": 15.37,
-   "decompress_mbps": 107.94
+   "compress_mbps": 26.67,
+   "decompress_mbps": 175.04
   },
   {
    "compressor": "native",
@@ -4874,8 +4874,8 @@
    "level": 7,
    "out_size": 3082738,
    "ratio": 0.5011,
-   "compress_mbps": 14.99,
-   "decompress_mbps": 108.9
+   "compress_mbps": 25.26,
+   "decompress_mbps": 179.48
   },
   {
    "compressor": "native",
@@ -4884,8 +4884,8 @@
    "level": 8,
    "out_size": 3078530,
    "ratio": 0.5004,
-   "compress_mbps": 15.64,
-   "decompress_mbps": 158.34
+   "compress_mbps": 22.46,
+   "decompress_mbps": 175.02
   },
   {
    "compressor": "native",
@@ -4894,8 +4894,8 @@
    "level": 9,
    "out_size": 3049028,
    "ratio": 0.4956,
-   "compress_mbps": 4.69,
-   "decompress_mbps": 182.12
+   "compress_mbps": 5.15,
+   "decompress_mbps": 184.02
   },
   {
    "compressor": "native",
@@ -4904,7 +4904,7 @@
    "level": 10,
    "out_size": 3022127,
    "ratio": 0.4912,
-   "compress_mbps": 3.21,
+   "compress_mbps": 3.22,
    "decompress_mbps": null
   },
   {
@@ -4914,8 +4914,8 @@
    "level": 1,
    "out_size": 3838828,
    "ratio": 0.3806,
-   "compress_mbps": 111.92,
-   "decompress_mbps": 266.77
+   "compress_mbps": 116.42,
+   "decompress_mbps": 259.94
   },
   {
    "compressor": "native",
@@ -4924,8 +4924,8 @@
    "level": 2,
    "out_size": 3790968,
    "ratio": 0.3759,
-   "compress_mbps": 98.12,
-   "decompress_mbps": 274.52
+   "compress_mbps": 100.26,
+   "decompress_mbps": 274.32
   },
   {
    "compressor": "native",
@@ -4934,8 +4934,8 @@
    "level": 3,
    "out_size": 3760350,
    "ratio": 0.3728,
-   "compress_mbps": 84.99,
-   "decompress_mbps": 278.4
+   "compress_mbps": 86.75,
+   "decompress_mbps": 278.36
   },
   {
    "compressor": "native",
@@ -4944,8 +4944,8 @@
    "level": 4,
    "out_size": 3648458,
    "ratio": 0.3617,
-   "compress_mbps": 70.85,
-   "decompress_mbps": 295.07
+   "compress_mbps": 71.46,
+   "decompress_mbps": 293.18
   },
   {
    "compressor": "native",
@@ -4954,8 +4954,8 @@
    "level": 5,
    "out_size": 3648472,
    "ratio": 0.3617,
-   "compress_mbps": 65.03,
-   "decompress_mbps": 296.81
+   "compress_mbps": 65.38,
+   "decompress_mbps": 276.86
   },
   {
    "compressor": "native",
@@ -4964,8 +4964,8 @@
    "level": 6,
    "out_size": 3661305,
    "ratio": 0.363,
-   "compress_mbps": 44.24,
-   "decompress_mbps": 284.28
+   "compress_mbps": 44.54,
+   "decompress_mbps": 287.49
   },
   {
    "compressor": "native",
@@ -4974,8 +4974,8 @@
    "level": 7,
    "out_size": 3659614,
    "ratio": 0.3629,
-   "compress_mbps": 43.08,
-   "decompress_mbps": 291.61
+   "compress_mbps": 43.47,
+   "decompress_mbps": 291.63
   },
   {
    "compressor": "native",
@@ -4984,8 +4984,8 @@
    "level": 8,
    "out_size": 3659136,
    "ratio": 0.3628,
-   "compress_mbps": 42.78,
-   "decompress_mbps": 291.06
+   "compress_mbps": 43.15,
+   "decompress_mbps": 288.86
   },
   {
    "compressor": "native",
@@ -4994,8 +4994,8 @@
    "level": 9,
    "out_size": 3648156,
    "ratio": 0.3617,
-   "compress_mbps": 5.71,
-   "decompress_mbps": 302.6
+   "compress_mbps": 6.09,
+   "decompress_mbps": 305.52
   },
   {
    "compressor": "native",
@@ -5004,7 +5004,7 @@
    "level": 10,
    "out_size": 3647385,
    "ratio": 0.3616,
-   "compress_mbps": 3.48,
+   "compress_mbps": 3.51,
    "decompress_mbps": null
   },
   {
@@ -5014,8 +5014,8 @@
    "level": 1,
    "out_size": 2254442,
    "ratio": 0.3402,
-   "compress_mbps": 102.2,
-   "decompress_mbps": 223.47
+   "compress_mbps": 108.54,
+   "decompress_mbps": 245.42
   },
   {
    "compressor": "native",
@@ -5024,8 +5024,8 @@
    "level": 2,
    "out_size": 2090589,
    "ratio": 0.3155,
-   "compress_mbps": 85.93,
-   "decompress_mbps": 262.8
+   "compress_mbps": 89.23,
+   "decompress_mbps": 265.51
   },
   {
    "compressor": "native",
@@ -5034,8 +5034,8 @@
    "level": 3,
    "out_size": 2018042,
    "ratio": 0.3045,
-   "compress_mbps": 70.29,
-   "decompress_mbps": 301.51
+   "compress_mbps": 70.89,
+   "decompress_mbps": 303.3
   },
   {
    "compressor": "native",
@@ -5044,8 +5044,8 @@
    "level": 4,
    "out_size": 1890729,
    "ratio": 0.2853,
-   "compress_mbps": 35.46,
-   "decompress_mbps": 284.44
+   "compress_mbps": 35.98,
+   "decompress_mbps": 295.62
   },
   {
    "compressor": "native",
@@ -5054,8 +5054,8 @@
    "level": 5,
    "out_size": 1858234,
    "ratio": 0.2804,
-   "compress_mbps": 22.73,
-   "decompress_mbps": 282.11
+   "compress_mbps": 22.84,
+   "decompress_mbps": 308.96
   },
   {
    "compressor": "native",
@@ -5064,8 +5064,8 @@
    "level": 6,
    "out_size": 1869426,
    "ratio": 0.2821,
-   "compress_mbps": 30.06,
-   "decompress_mbps": 299.47
+   "compress_mbps": 30.34,
+   "decompress_mbps": 298.9
   },
   {
    "compressor": "native",
@@ -5074,8 +5074,8 @@
    "level": 7,
    "out_size": 1860657,
    "ratio": 0.2808,
-   "compress_mbps": 25.17,
-   "decompress_mbps": 303.0
+   "compress_mbps": 25.57,
+   "decompress_mbps": 306.71
   },
   {
    "compressor": "native",
@@ -5084,8 +5084,8 @@
    "level": 8,
    "out_size": 1826296,
    "ratio": 0.2756,
-   "compress_mbps": 13.95,
-   "decompress_mbps": 306.44
+   "compress_mbps": 14.07,
+   "decompress_mbps": 300.95
   },
   {
    "compressor": "native",
@@ -5094,8 +5094,8 @@
    "level": 9,
    "out_size": 1773469,
    "ratio": 0.2676,
-   "compress_mbps": 2.94,
-   "decompress_mbps": 323.67
+   "compress_mbps": 2.97,
+   "decompress_mbps": 327.2
   },
   {
    "compressor": "native",
@@ -5104,7 +5104,7 @@
    "level": 10,
    "out_size": 1718509,
    "ratio": 0.2593,
-   "compress_mbps": 1.57,
+   "compress_mbps": 1.6,
    "decompress_mbps": null
   },
   {
@@ -5114,8 +5114,8 @@
    "level": 1,
    "out_size": 6406301,
    "ratio": 0.2965,
-   "compress_mbps": 133.42,
-   "decompress_mbps": 337.08
+   "compress_mbps": 142.7,
+   "decompress_mbps": 338.95
   },
   {
    "compressor": "native",
@@ -5124,8 +5124,8 @@
    "level": 2,
    "out_size": 6136026,
    "ratio": 0.284,
-   "compress_mbps": 118.42,
-   "decompress_mbps": 358.48
+   "compress_mbps": 124.84,
+   "decompress_mbps": 358.32
   },
   {
    "compressor": "native",
@@ -5134,8 +5134,8 @@
    "level": 3,
    "out_size": 6008304,
    "ratio": 0.2781,
-   "compress_mbps": 101.92,
-   "decompress_mbps": 374.23
+   "compress_mbps": 105.81,
+   "decompress_mbps": 376.05
   },
   {
    "compressor": "native",
@@ -5144,8 +5144,8 @@
    "level": 4,
    "out_size": 5880892,
    "ratio": 0.2722,
-   "compress_mbps": 68.05,
-   "decompress_mbps": 392.16
+   "compress_mbps": 70.94,
+   "decompress_mbps": 392.52
   },
   {
    "compressor": "native",
@@ -5154,8 +5154,8 @@
    "level": 5,
    "out_size": 5834363,
    "ratio": 0.27,
-   "compress_mbps": 54.72,
-   "decompress_mbps": 398.62
+   "compress_mbps": 54.85,
+   "decompress_mbps": 398.49
   },
   {
    "compressor": "native",
@@ -5164,8 +5164,8 @@
    "level": 6,
    "out_size": 5418390,
    "ratio": 0.2508,
-   "compress_mbps": 43.38,
-   "decompress_mbps": 405.57
+   "compress_mbps": 44.23,
+   "decompress_mbps": 405.08
   },
   {
    "compressor": "native",
@@ -5174,8 +5174,8 @@
    "level": 7,
    "out_size": 5406915,
    "ratio": 0.2502,
-   "compress_mbps": 29.27,
-   "decompress_mbps": 350.35
+   "compress_mbps": 40.41,
+   "decompress_mbps": 402.53
   },
   {
    "compressor": "native",
@@ -5184,8 +5184,8 @@
    "level": 8,
    "out_size": 5387415,
    "ratio": 0.2493,
-   "compress_mbps": 24.81,
-   "decompress_mbps": 315.68
+   "compress_mbps": 32.28,
+   "decompress_mbps": 410.06
   },
   {
    "compressor": "native",
@@ -5195,7 +5195,7 @@
    "out_size": 5236015,
    "ratio": 0.2423,
    "compress_mbps": 4.84,
-   "decompress_mbps": 403.39
+   "decompress_mbps": 410.03
   },
   {
    "compressor": "native",
@@ -5204,7 +5204,7 @@
    "level": 10,
    "out_size": 5177683,
    "ratio": 0.2396,
-   "compress_mbps": 2.61,
+   "compress_mbps": 2.63,
    "decompress_mbps": null
   },
   {
@@ -5214,8 +5214,8 @@
    "level": 1,
    "out_size": 5612204,
    "ratio": 0.7739,
-   "compress_mbps": 56.84,
-   "decompress_mbps": 146.77
+   "compress_mbps": 58.79,
+   "decompress_mbps": 149.3
   },
   {
    "compressor": "native",
@@ -5224,8 +5224,8 @@
    "level": 2,
    "out_size": 5553137,
    "ratio": 0.7657,
-   "compress_mbps": 50.38,
-   "decompress_mbps": 154.57
+   "compress_mbps": 52.31,
+   "decompress_mbps": 155.47
   },
   {
    "compressor": "native",
@@ -5234,8 +5234,8 @@
    "level": 3,
    "out_size": 5533873,
    "ratio": 0.7631,
-   "compress_mbps": 45.72,
-   "decompress_mbps": 159.89
+   "compress_mbps": 47.36,
+   "decompress_mbps": 160.3
   },
   {
    "compressor": "native",
@@ -5244,8 +5244,8 @@
    "level": 4,
    "out_size": 5494383,
    "ratio": 0.7576,
-   "compress_mbps": 34.65,
-   "decompress_mbps": 165.95
+   "compress_mbps": 35.0,
+   "decompress_mbps": 165.86
   },
   {
    "compressor": "native",
@@ -5254,8 +5254,8 @@
    "level": 5,
    "out_size": 5489807,
    "ratio": 0.757,
-   "compress_mbps": 29.15,
-   "decompress_mbps": 144.88
+   "compress_mbps": 33.06,
+   "decompress_mbps": 162.39
   },
   {
    "compressor": "native",
@@ -5264,8 +5264,8 @@
    "level": 6,
    "out_size": 5346796,
    "ratio": 0.7373,
-   "compress_mbps": 19.62,
-   "decompress_mbps": 143.49
+   "compress_mbps": 22.82,
+   "decompress_mbps": 165.18
   },
   {
    "compressor": "native",
@@ -5274,8 +5274,8 @@
    "level": 7,
    "out_size": 5336745,
    "ratio": 0.7359,
-   "compress_mbps": 19.22,
-   "decompress_mbps": 140.14
+   "compress_mbps": 21.84,
+   "decompress_mbps": 166.08
   },
   {
    "compressor": "native",
@@ -5284,8 +5284,8 @@
    "level": 8,
    "out_size": 5330972,
    "ratio": 0.7351,
-   "compress_mbps": 18.24,
-   "decompress_mbps": 145.36
+   "compress_mbps": 20.58,
+   "decompress_mbps": 165.16
   },
   {
    "compressor": "native",
@@ -5294,8 +5294,8 @@
    "level": 9,
    "out_size": 5284606,
    "ratio": 0.7287,
-   "compress_mbps": 4.77,
-   "decompress_mbps": 165.66
+   "compress_mbps": 5.27,
+   "decompress_mbps": 163.67
   },
   {
    "compressor": "native",
@@ -5304,7 +5304,7 @@
    "level": 10,
    "out_size": 5262387,
    "ratio": 0.7257,
-   "compress_mbps": 3.73,
+   "compress_mbps": 3.78,
    "decompress_mbps": null
   },
   {
@@ -5314,8 +5314,8 @@
    "level": 1,
    "out_size": 13727247,
    "ratio": 0.3311,
-   "compress_mbps": 100.7,
-   "decompress_mbps": 250.38
+   "compress_mbps": 108.3,
+   "decompress_mbps": 251.34
   },
   {
    "compressor": "native",
@@ -5324,8 +5324,8 @@
    "level": 2,
    "out_size": 12920739,
    "ratio": 0.3117,
-   "compress_mbps": 85.1,
-   "decompress_mbps": 262.62
+   "compress_mbps": 92.14,
+   "decompress_mbps": 272.0
   },
   {
    "compressor": "native",
@@ -5334,8 +5334,8 @@
    "level": 3,
    "out_size": 12582079,
    "ratio": 0.3035,
-   "compress_mbps": 72.5,
-   "decompress_mbps": 277.52
+   "compress_mbps": 78.82,
+   "decompress_mbps": 291.35
   },
   {
    "compressor": "native",
@@ -5344,8 +5344,8 @@
    "level": 4,
    "out_size": 12177338,
    "ratio": 0.2937,
-   "compress_mbps": 35.58,
-   "decompress_mbps": 281.81
+   "compress_mbps": 50.54,
+   "decompress_mbps": 296.04
   },
   {
    "compressor": "native",
@@ -5354,8 +5354,8 @@
    "level": 5,
    "out_size": 12051075,
    "ratio": 0.2907,
-   "compress_mbps": 38.57,
-   "decompress_mbps": 296.43
+   "compress_mbps": 38.89,
+   "decompress_mbps": 301.07
   },
   {
    "compressor": "native",
@@ -5364,8 +5364,8 @@
    "level": 6,
    "out_size": 12220199,
    "ratio": 0.2948,
-   "compress_mbps": 38.57,
-   "decompress_mbps": 308.6
+   "compress_mbps": 39.03,
+   "decompress_mbps": 309.25
   },
   {
    "compressor": "native",
@@ -5374,8 +5374,8 @@
    "level": 7,
    "out_size": 12178598,
    "ratio": 0.2938,
-   "compress_mbps": 35.26,
-   "decompress_mbps": 310.25
+   "compress_mbps": 35.7,
+   "decompress_mbps": 310.63
   },
   {
    "compressor": "native",
@@ -5385,7 +5385,7 @@
    "out_size": 12096772,
    "ratio": 0.2918,
    "compress_mbps": 26.56,
-   "decompress_mbps": 298.91
+   "decompress_mbps": 312.25
   },
   {
    "compressor": "native",
@@ -5394,8 +5394,8 @@
    "level": 9,
    "out_size": 11806641,
    "ratio": 0.2848,
-   "compress_mbps": 3.88,
-   "decompress_mbps": 310.6
+   "compress_mbps": 3.91,
+   "decompress_mbps": 312.53
   },
   {
    "compressor": "native",
@@ -5404,7 +5404,7 @@
    "level": 10,
    "out_size": 11636945,
    "ratio": 0.2807,
-   "compress_mbps": 1.95,
+   "compress_mbps": 2.03,
    "decompress_mbps": null
   },
   {
@@ -5414,8 +5414,8 @@
    "level": 1,
    "out_size": 6438176,
    "ratio": 0.7597,
-   "compress_mbps": 49.67,
-   "decompress_mbps": 145.25
+   "compress_mbps": 52.66,
+   "decompress_mbps": 144.5
   },
   {
    "compressor": "native",
@@ -5424,8 +5424,8 @@
    "level": 2,
    "out_size": 6392132,
    "ratio": 0.7543,
-   "compress_mbps": 48.04,
-   "decompress_mbps": 146.82
+   "compress_mbps": 51.1,
+   "decompress_mbps": 145.61
   },
   {
    "compressor": "native",
@@ -5434,8 +5434,8 @@
    "level": 3,
    "out_size": 6392125,
    "ratio": 0.7543,
-   "compress_mbps": 48.08,
-   "decompress_mbps": 148.34
+   "compress_mbps": 50.89,
+   "decompress_mbps": 137.27
   },
   {
    "compressor": "native",
@@ -5444,8 +5444,8 @@
    "level": 4,
    "out_size": 6360604,
    "ratio": 0.7506,
-   "compress_mbps": 42.36,
-   "decompress_mbps": 134.66
+   "compress_mbps": 43.09,
+   "decompress_mbps": 133.4
   },
   {
    "compressor": "native",
@@ -5454,8 +5454,8 @@
    "level": 5,
    "out_size": 6360567,
    "ratio": 0.7506,
-   "compress_mbps": 42.46,
-   "decompress_mbps": 136.25
+   "compress_mbps": 43.15,
+   "decompress_mbps": 135.55
   },
   {
    "compressor": "native",
@@ -5464,8 +5464,8 @@
    "level": 6,
    "out_size": 6036758,
    "ratio": 0.7124,
-   "compress_mbps": 24.87,
-   "decompress_mbps": 136.56
+   "compress_mbps": 24.75,
+   "decompress_mbps": 136.88
   },
   {
    "compressor": "native",
@@ -5474,8 +5474,8 @@
    "level": 7,
    "out_size": 6036620,
    "ratio": 0.7123,
-   "compress_mbps": 24.53,
-   "decompress_mbps": 136.94
+   "compress_mbps": 24.69,
+   "decompress_mbps": 137.13
   },
   {
    "compressor": "native",
@@ -5484,8 +5484,8 @@
    "level": 8,
    "out_size": 6036614,
    "ratio": 0.7123,
-   "compress_mbps": 24.67,
-   "decompress_mbps": 137.35
+   "compress_mbps": 24.68,
+   "decompress_mbps": 137.18
   },
   {
    "compressor": "native",
@@ -5494,8 +5494,8 @@
    "level": 9,
    "out_size": 5952975,
    "ratio": 0.7025,
-   "compress_mbps": 6.28,
-   "decompress_mbps": 140.74
+   "compress_mbps": 6.31,
+   "decompress_mbps": 140.19
   },
   {
    "compressor": "native",
@@ -5504,7 +5504,7 @@
    "level": 10,
    "out_size": 5849157,
    "ratio": 0.6902,
-   "compress_mbps": 4.59,
+   "compress_mbps": 4.56,
    "decompress_mbps": null
   },
   {
@@ -5514,8 +5514,8 @@
    "level": 1,
    "out_size": 858525,
    "ratio": 0.1606,
-   "compress_mbps": 220.67,
-   "decompress_mbps": 385.82
+   "compress_mbps": 234.04,
+   "decompress_mbps": 508.03
   },
   {
    "compressor": "native",
@@ -5524,8 +5524,8 @@
    "level": 2,
    "out_size": 798553,
    "ratio": 0.1494,
-   "compress_mbps": 189.89,
-   "decompress_mbps": 513.56
+   "compress_mbps": 200.46,
+   "decompress_mbps": 570.84
   },
   {
    "compressor": "native",
@@ -5534,8 +5534,8 @@
    "level": 3,
    "out_size": 762011,
    "ratio": 0.1426,
-   "compress_mbps": 152.02,
-   "decompress_mbps": 634.42
+   "compress_mbps": 160.08,
+   "decompress_mbps": 567.36
   },
   {
    "compressor": "native",
@@ -5544,8 +5544,8 @@
    "level": 4,
    "out_size": 717301,
    "ratio": 0.1342,
-   "compress_mbps": 102.18,
-   "decompress_mbps": 625.54
+   "compress_mbps": 104.69,
+   "decompress_mbps": 567.55
   },
   {
    "compressor": "native",
@@ -5554,8 +5554,8 @@
    "level": 5,
    "out_size": 701552,
    "ratio": 0.1312,
-   "compress_mbps": 78.07,
-   "decompress_mbps": 682.31
+   "compress_mbps": 78.65,
+   "decompress_mbps": 617.36
   },
   {
    "compressor": "native",
@@ -5564,8 +5564,8 @@
    "level": 6,
    "out_size": 689796,
    "ratio": 0.129,
-   "compress_mbps": 72.26,
-   "decompress_mbps": 728.03
+   "compress_mbps": 71.05,
+   "decompress_mbps": 644.67
   },
   {
    "compressor": "native",
@@ -5574,8 +5574,8 @@
    "level": 7,
    "out_size": 680793,
    "ratio": 0.1274,
-   "compress_mbps": 63.63,
-   "decompress_mbps": 733.05
+   "compress_mbps": 63.97,
+   "decompress_mbps": 739.05
   },
   {
    "compressor": "native",
@@ -5584,8 +5584,8 @@
    "level": 8,
    "out_size": 662896,
    "ratio": 0.124,
-   "compress_mbps": 44.79,
-   "decompress_mbps": 748.64
+   "compress_mbps": 44.75,
+   "decompress_mbps": 743.54
   },
   {
    "compressor": "native",
@@ -5594,8 +5594,8 @@
    "level": 9,
    "out_size": 659422,
    "ratio": 0.1234,
-   "compress_mbps": 4.51,
-   "decompress_mbps": 646.37
+   "compress_mbps": 4.55,
+   "decompress_mbps": 649.87
   },
   {
    "compressor": "native",
@@ -5604,7 +5604,7 @@
    "level": 10,
    "out_size": 643101,
    "ratio": 0.1203,
-   "compress_mbps": 3.03,
+   "compress_mbps": 3.07,
    "decompress_mbps": null
   },
   {


### PR DESCRIPTION
This PR fuse the whole-stream token-frequency counting into the greedy matcher pass: `lz77ChainIterPMergedF` produces the packed tokens AND the two `tokenFreqsP` histograms in one walk (bumping at each push site with the same helpers, EOB pre-count included), and levels 1-3 dispatch through `deflateRawBaseF`/`deflateRawBasePF`, which size and emit the base candidate from the fused frequencies — eliminating the separate whole-stream `tokenFreqsP` re-read that followed the matcher (8.5% of L1 self time on dickens, plus the cache traffic of streaming a token array that reaches ~120 MB on mozilla back through the hierarchy). The fused histograms are proven equal to `tokenFreqsP` of the produced tokens, so every downstream sizing/emission proof rewrites through the existing anchors; output is byte-identical (15/15 file×level csize checks, non-empty-verified, plus the equality theorem). Levels 4+ keep the split-tier per-block walks, which the whole-stream fusion cannot serve. No `sorry`.

Measured (chungus2, same-worktree binaries, pinned 5-rep sandwich A/B, same-binary noise floors 0.15-0.22%, all 15 effects positive): mozilla L1 **+6.3%**, dickens L1 **+3.8%**, dickens L2 +1.4%. The Stage-0 isolated-walk probe predicted only 0.6-2.4% — the production win is larger because the fusion also removes the array re-read's cache pollution, which the isolated probe could not see; both probe and production A/B are reproducible via the committed `bench/ZipFreqFusion.lean`.

🤖 Prepared with Claude Code